### PR TITLE
Added toggles for each module

### DIFF
--- a/Inputs/animal_management.json
+++ b/Inputs/animal_management.json
@@ -7,6 +7,13 @@
         "EndDate" : "2011:243",
         "output_dir": "Outputs/Sample_Farm_Outputs/"
     },
+    
+    "simulate_module":
+    {
+    	"animal": true,
+    	"soil": true,
+    	"crop": true
+    },
 
     "weather": "Inputs/barnyard_weather.csv",
 

--- a/Inputs/barnyard.json
+++ b/Inputs/barnyard.json
@@ -5,6 +5,13 @@
         "EndDate" : "2016:243",
         "output_dir": "Outputs/Sample_Farm_Outputs/"
     },
+    
+    "simulate_module":
+    {
+    	"animal": true,
+    	"soil": true,
+    	"crop": true
+    },
 
     "weather": "Inputs/barnyard_weather.csv",
 

--- a/Inputs/input_w_feedlib.json
+++ b/Inputs/input_w_feedlib.json
@@ -7,6 +7,13 @@
         "EndDate" : "2011:366",
         "output_dir": "Outputs/Sample_Farm_Outputs/"
     },
+    
+    "simulate_module":
+    {
+    	"animal": true,
+    	"soil": true,
+    	"crop": true
+    },
 
     "weather": "Inputs/crop_module_testWeather_3.4.csv",
 

--- a/Inputs/testing_manure.json
+++ b/Inputs/testing_manure.json
@@ -5,6 +5,13 @@
         "EndDate" : "2009:365",
         "output_dir": "Outputs/Sample_Farm_Outputs/"
     },
+    
+    "simulate_module":
+    {
+    	"animal": true,
+    	"soil": true,
+    	"crop": true
+    },
 
     "weather": "Inputs/crop_module_testWeather_3.4.csv",
 

--- a/Inputs/testing_ration_feed.json
+++ b/Inputs/testing_ration_feed.json
@@ -7,6 +7,13 @@
         "EndDate" : "2009:365",
         "output_dir": "Outputs/Sample_Farm_Outputs/"
     },
+    
+    "simulate_module":
+    {
+    	"animal": true,
+    	"soil": true,
+    	"crop": true
+    },
 
     "weather": "Inputs/crop_module_testWeather_3.4.csv",
 

--- a/RUFAS/classes.py
+++ b/RUFAS/classes.py
@@ -36,11 +36,15 @@ class State:
     the future or in an output report in the state object.
     """
 
-    def __init__(self, data, config):
-        self.soil = Soil(data['soil'], config)
-        self.feed = Feed(data['feed'])
-        self.animal_management = AnimalManagement(data['animal'], config, self.feed)
-        self.crop = Crop(data['crop'])
+    def __init__(self, data, config, toggle):
+        self.toggle = toggle
+        if self.toggle.soil:
+            self.soil = Soil(data['soil'], config)
+        if self.toggle.animal:
+            self.feed = Feed(data['feed'])
+            self.animal_management = AnimalManagement(data['animal'], config, self.feed)
+        if self.toggle.crop:
+            self.crop = Crop(data['crop'])
 
     # self.fieldOps = FieldOps()
     # self.herd = Herd()
@@ -52,11 +56,13 @@ class State:
     # ---------------------------------------------------------------------------
     def annual_reset(self):
         """Annual Reset"""
-
-        self.soil.annual_reset()
-        self.animal_management.annual_reset()
-        self.feed.annual_reset()
-        self.crop.annual_reset()
+        if self.toggle.soil:
+            self.soil.annual_reset()
+        if self.toggle.animal:
+            self.animal_management.annual_reset()
+            self.feed.annual_reset()
+        if self.toggle.crop:
+            self.crop.annual_reset()
 
     # self.fieldOps.annual_reset()
     # self.herd.annual_reset()
@@ -491,3 +497,10 @@ def is_leap_year(year):
         return True
     else:
         return False
+    
+    
+class Toggle:
+    def __init__(self, data):
+        self.animal = data['animal']
+        self.soil = data['soil']
+        self.crop = data['crop']

--- a/RUFAS/output/crop_summary.py
+++ b/RUFAS/output/crop_summary.py
@@ -11,12 +11,15 @@ from RUFAS.output.report_handler import BaseReportHandler
 
 class CropSummary(BaseReportHandler):
 
-    def __init__(self, data):
+    def __init__(self, data, toggle):
 
         #
         # Sets active, report_name, f_name using data
         #
         self.set_properties(data)
+        if not toggle.crop and self.active:
+            print('Crop Module set as not simulated in json file and crop_summary report is still active, setting crop_summary to not active.')
+            self.active = False
         self.fieldNames = None
 
         #

--- a/RUFAS/output/growth_report.py
+++ b/RUFAS/output/growth_report.py
@@ -17,10 +17,13 @@ from RUFAS.output.report_handler import BaseReportHandler
 class GrowthReport(BaseReportHandler):
     """Creates and prints to the file growth_report.csv"""
 
-    def __init__(self, data):
+    def __init__(self, data, toggle):
 
         # Sets active, report_name, f_name using data
         self.set_properties(data)
+        if not toggle.animal and self.active:
+            print('Animal Module set as not simulated in json file and growth_report is still active, setting growth_report to not active.')
+            self.active = False
 
         # Daily Outputs
         self.year = []

--- a/RUFAS/output/manure_report.py
+++ b/RUFAS/output/manure_report.py
@@ -17,10 +17,13 @@ from RUFAS.output.report_handler import BaseReportHandler
 class ManureReport(BaseReportHandler):
     """Creates and prints to the file manure_report.csv"""
 
-    def __init__(self, data):
+    def __init__(self, data, toggle):
 
         # Sets active, report_name, f_name using data
         self.set_properties(data)
+        if not toggle.animal and self.active:
+            print('Animal Module set as not simulated in json file and manure_report is still active, setting manure_report to not active.')
+            self.active = False
 
         # Daily Outputs
         self.year = []

--- a/RUFAS/output/output_handler.py
+++ b/RUFAS/output/output_handler.py
@@ -51,19 +51,19 @@ class OutputHandler():
     directly.
     """
 
-    def __init__(self, data):
+    def __init__(self, data, toggle):
         """Initializes the report handlers with the given data"""
 
         # Instantiate Report Handler Objects here
         self.reports = {
-                        #'farm_summary': FarmSummary(data['farm_summary']),
-                        'soil_summary': SoilSummary(data['soil_summary']),
-                        'soil_nitrogen': SoilNitrogen(data['soil_nitrogen']),
-                        #'soil_phosphorus': SoilPhosphorus(data['soil_phosphorus']),
-                        'ration_report': RationReport(data['ration_report']),
-                        'crop_report': CropSummary(data['crop_report']),
-                        'manure_report': ManureReport(data['manure_report']),
-                        'growth_report': GrowthReport(data['growth_report'])
+                        #'farm_summary': FarmSummary(data['farm_summary'], toggle),
+                        'soil_summary': SoilSummary(data['soil_summary'], toggle),
+                        'soil_nitrogen': SoilNitrogen(data['soil_nitrogen'], toggle),
+                        #'soil_phosphorus': SoilPhosphorus(data['soil_phosphorus'], toggle),
+                        'ration_report': RationReport(data['ration_report'], toggle),
+                        'crop_report': CropSummary(data['crop_report'], toggle),
+                        'manure_report': ManureReport(data['manure_report'], toggle),
+                        'growth_report': GrowthReport(data['growth_report'], toggle)
                         }
 
     #---------------------------------------------------------------------------

--- a/RUFAS/output/ration_report.py
+++ b/RUFAS/output/ration_report.py
@@ -18,10 +18,13 @@ from RUFAS.output.report_handler import BaseReportHandler
 class RationReport(BaseReportHandler):
     """Creates and prints to the file ration_report.csv"""
 
-    def __init__(self, data):
+    def __init__(self, data, toggle):
 
         # Sets active, report_name, f_name using data
         self.set_properties(data)
+        if not toggle.animal and self.active:
+            print('Animal Module set as not simulated in json file and ration_report is still active, setting ration_report to not active.')
+            self.active = False
 
         # Daily Outputs
         self.year = []

--- a/RUFAS/output/soil_nitrogen.py
+++ b/RUFAS/output/soil_nitrogen.py
@@ -20,12 +20,15 @@ from RUFAS.output.report_handler import BaseReportHandler
 # -------------------------------------------------------------------------------
 class SoilNitrogen(BaseReportHandler):
 
-    def __init__(self, data):
+    def __init__(self, data, toggle):
 
         #
         # Sets active, report_name, f_name using data
         #
         self.set_properties(data)
+        if not toggle.soil and self.active:
+            print('Soil Module set as not simulated in json file and soil_nitrogen report is still active, setting soil_nitrogen report to not active.')
+            self.active = False
         self.fieldNames = None
 
         #

--- a/RUFAS/output/soil_phosphorus.py
+++ b/RUFAS/output/soil_phosphorus.py
@@ -24,6 +24,9 @@ class SoilPhosphorus(BaseReportHandler):
         # Sets active, report_name, f_name using data
         #
         self.set_properties(data)
+        if not toggle.soil and self.active:
+            print('Soil Module set as not simulated in json file and soil_phosphorus report is still active, setting soil_phosphorus report to not active.')
+            self.active = False
         self.fieldNames = None
 
         #

--- a/RUFAS/output/soil_summary.py
+++ b/RUFAS/output/soil_summary.py
@@ -19,12 +19,15 @@ from RUFAS.output.report_handler import BaseReportHandler
 #-------------------------------------------------------------------------------
 class SoilSummary(BaseReportHandler):
 
-    def __init__(self, data):
+    def __init__(self, data, toggle):
 
         #
         # Sets active, report_name, f_name using data
         #
         self.set_properties(data)
+        if not toggle.soil and self.active:
+            print('Soil Module set as not simulated in json file and soil_summary report is still active, setting soil_summary report to not active.')
+            self.active = False
         self.fieldNames = None
 
         #

--- a/RUFAS/simulation_engine.py
+++ b/RUFAS/simulation_engine.py
@@ -13,7 +13,7 @@ import time as timer
 from pathlib import Path
 
 from RUFAS import routines, errors
-from RUFAS.classes import Config, State, Weather, Time
+from RUFAS.classes import Config, Toggle, State, Weather, Time
 from RUFAS.output import OutputHandler, output_graphs
 
 
@@ -79,9 +79,12 @@ def daily_simulation():
     #
     # Daily routines
     #
-    routines.daily_animal_routine(state.animal_management, state.feed, weather, time)
-    routines.daily_soil_routine(state.soil, state.crop, weather, time)
-    routines.daily_crop_routine(state.crop, weather, time, state.soil)
+    if toggle.animal:
+        routines.daily_animal_routine(state.animal_management, state.feed, weather, time)
+    if toggle.soil:
+        routines.daily_soil_routine(state.soil, state.crop, weather, time)
+    if toggle.crop:
+        routines.daily_crop_routine(state.crop, weather, time, state.soil)
 
     #
     # Daily Output Updates
@@ -90,8 +93,9 @@ def daily_simulation():
     
     #print("simulating: " + time.to_str()) # Print out current day of simulation
     time.advance()
-    #have to increment simulation_day here so that the daily output has the correct simulation day
-    state.animal_management.simulation_day += 1 
+    if toggle.animal:
+        #have to increment simulation_day here so that the daily output has the correct simulation day
+        state.animal_management.simulation_day += 1 
 
 
 #-------------------------------------------------------------------------------
@@ -108,7 +112,8 @@ def annual_simulation():
     #
     # Pre-annual Routines
     #
-    routines.annual_crop_routine(state.crop, weather, time)
+    if toggle.crop:
+        routines.annual_crop_routine(state.crop, weather, time)
 
     while not time.end_year():
         daily_simulation()
@@ -143,7 +148,7 @@ def read_json_file(fPath:Path):
     #
     # Designate as module-global variables
     #
-    global config, state, output, weather, time
+    global config, toggle, state, output, weather, time
 
     with fPath.open('r') as f:
         data = json.load(f)
@@ -151,8 +156,9 @@ def read_json_file(fPath:Path):
         # Instantiate objects using dictionary data from .json file
         try:
             config = Config(data['config'], data['weather'])
-            state = State(data['farm'], config)
-            output = OutputHandler(data['output'])
+            toggle = Toggle(data['simulate_module'])
+            state = State(data['farm'], config, toggle)
+            output = OutputHandler(data['output'], toggle)
             weather = Weather(data['weather'], config.years, config.w_start_year,
                               config.w_start_day, config.start_year, config.start_day)
             time = Time(config.years, config.start_year)

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ def main():
     through and executes the simulation for each of the files in the list.
     """
 
-    print("\nRUFAS: Ruminant Farm Systems Model 2018")
+    print("\nRUFAS: Ruminant Farm Systems Model 2019")
 
     #
     # Prompt user for an input


### PR DESCRIPTION
Input files that have been updated to work with new changes: animal_management.json, barnyard.json, input_w_feedlib.json, testing_manure.json, testing_ration_feed.json.

If a module is set to inactive but the related output csv files are active in the "output" section of the json file, the reports for those csv files are automatically set to inactive.

Note: since they are dependent on each other, the soil and crop modules must be running together (one cannot run without the other)