### PR TITLE
Pen Rework 

### DIFF
--- a/RUFAS/output_handler/reports/pen_report.py
+++ b/RUFAS/output_handler/reports/pen_report.py
@@ -14,9 +14,8 @@ class PensReport(BaseReportDriver):
     def __init__(self, data, state):
         super().__init__(data)
         for pen in state.animal_management.all_pens:
-            print(pen)
-            print(pen.animal_groups)
-            self.reports['pen_' + str(pen.id)] = PenReport(data, state.feed, pen, pen.id)
+            self.reports['pen_' +
+                         str(pen.id)] = PenReport(data, state.feed, pen.id)
 
         self.reports['pens_summary'] = PensSummary(data['pens_summary'])
 
@@ -36,12 +35,12 @@ class PensSummary(BaseReport):
 
 
 class PenReport(BaseReportDriver):
-    def __init__(self, data, feed, individual_pen, pen_id):
+    def __init__(self, data, feed, pen_id):
         super().__init__(data)
         self.pen_id = pen_id
         self.report_name = 'pen_' + str(pen_id)
         self.reports = {
-            'ration_report': self.RationReport(data['ration_report'], feed, individual_pen, self.pen_id),
+            'ration_report': self.RationReport(data['ration_report'], feed, self.pen_id),
             'growth_report': self.GrowthReport(data['growth_report'], self.pen_id),
             'manure_report': self.ManureReport(data['manure_report'], self.pen_id)
         }
@@ -56,7 +55,6 @@ class PenReport(BaseReportDriver):
             feed = state.feed
             pen = state.animal_management.all_pens[self.pen_id]
 
-            print(self.daily_variables)
             for variable in self.daily_variables:
                 self.daily_variables[variable][2].append(
                     eval(self.daily_variables[variable][0], globals(), locals()))
@@ -68,7 +66,8 @@ class PenReport(BaseReportDriver):
 
             for variable in self.annual_variables:
                 self.annual_variables[variable][2] = \
-                    eval(self.daily_variables[variable][0], globals(), locals())
+                    eval(self.daily_variables[variable]
+                         [0], globals(), locals())
 
     class GrowthReport(BasePenReport):
         def __init__(self, data, pen_id):
@@ -113,7 +112,7 @@ class PenReport(BaseReportDriver):
             self.manure_info = {}
 
     class RationReport(BasePenReport):
-        def __init__(self, data, feed, individual_pen, pen_id):
+        def __init__(self, data, feed, pen_id):
             super().__init__(data, pen_id)
             self.ration_interval = data['ration_interval']
 
@@ -121,30 +120,15 @@ class PenReport(BaseReportDriver):
                                     'j_day': ['time.day', '', []],
                                     'num_animals': ['len(pen.animals_in_pen)', '', []]
                                     }
-            # this subsets the pen's allotted feed given the animals type(s)
-            # that are present within the pen that is currently being
-            # simulated
-            individual_pen.animal_class_feed_subsetter(feed)
 
             all_feeds = feed.all_feed_ids
-            #print(all_feeds)
+            for feed_id in all_feeds:
+                feed_name = all_feeds[feed_id]['feed_name']
+                units = all_feeds[feed_id]['units']
 
-            #index at 0 because there is a nested list here for some unknown reason
-            print(individual_pen.feed_ids)
-            pen_id_list = individual_pen.feed_ids
-            print(pen_id_list)
-
-            pen_specific_feeds = {str(x): all_feeds[str(x)] for x in pen_id_list}
-
-
-
-            for feed_id in pen_id_list:
-                feed_name = pen_specific_feeds[str(feed_id)]['feed_name']
-                units = pen_specific_feeds[str(feed_id)]['units']
-
-                self.daily_variables[str(feed_id) + "(" + feed_name + ")"] = \
+                self.daily_variables[feed_id + "(" + feed_name + ")"] = \
                     [
-                        'pen.ration[\'%s\'] if pen.pen_populated and \'%s\' in pen.feed_ids else 0' % (
+                        'pen.ration[\'%s\'] if pen.pen_populated and \'%s\' in feed.available_feeds else 0' % (
                             feed_id, feed_id), units,
                         []]
 
@@ -152,7 +136,165 @@ class PenReport(BaseReportDriver):
                 'year': ['time.calendar_year', '', 0]
             }
 
-
         def produce_report_graphics(self):
             super().produce_report_graphics()
             graphics.ration_graphics(self)
+
+
+# """
+# RUFAS: Ruminant Farm Systems Model
+# File name: pen_report.py
+# Description:
+# Author(s): William Donovan, wmdonovan@wisc.edu
+# """
+
+# from .base_report_driver import BaseReportDriver
+# from .base_report import BaseReport
+# from .. import graphics
+
+
+# class PensReport(BaseReportDriver):
+#     def __init__(self, data, state):
+#         super().__init__(data)
+#         for pen in state.animal_management.all_pens:
+#             print(pen)
+#             print(pen.animal_groups)
+#             self.reports['pen_' + str(pen.id)] = PenReport(data, state.feed, pen, pen.id)
+
+#         self.reports['pens_summary'] = PensSummary(data['pens_summary'])
+
+
+# class PensSummary(BaseReport):
+#     def __init__(self, data):
+#         super().__init__(data)
+
+#         self.daily_variables = {
+#             'year': ['time.calendar_year', '', []],
+#             'j_day': ['time.day', '', []]
+#         }
+
+#         self.annual_variables = {
+#             'year': ['time.calendar_year', '', 0]
+#         }
+
+
+# class PenReport(BaseReportDriver):
+#     def __init__(self, data, feed, individual_pen, pen_id):
+#         super().__init__(data)
+#         self.pen_id = pen_id
+#         self.report_name = 'pen_' + str(pen_id)
+#         self.reports = {
+#             'ration_report': self.RationReport(data['ration_report'], feed, individual_pen, self.pen_id),
+#             'growth_report': self.GrowthReport(data['growth_report'], self.pen_id),
+#             'manure_report': self.ManureReport(data['manure_report'], self.pen_id)
+#         }
+
+#     class BasePenReport(BaseReport):
+#         def __init__(self, data, pen_id):
+#             super().__init__(data)
+#             self.pen_id = pen_id
+
+#         def daily_update(self, state, weather, time):
+#             animal_management = state.animal_management
+#             feed = state.feed
+#             pen = state.animal_management.all_pens[self.pen_id]
+
+#             print(self.daily_variables)
+#             for variable in self.daily_variables:
+#                 self.daily_variables[variable][2].append(
+#                     eval(self.daily_variables[variable][0], globals(), locals()))
+
+#         def annual_update(self, state, weather, time):
+#             animal_management = state.animal_management
+#             feed = state.feed
+#             pen = state.animal_management.all_pens[self.pen_id]
+
+#             for variable in self.annual_variables:
+#                 self.annual_variables[variable][2] = \
+#                     eval(self.daily_variables[variable][0], globals(), locals())
+
+#     class GrowthReport(BasePenReport):
+#         def __init__(self, data, pen_id):
+#             super().__init__(data, pen_id)
+
+#             self.daily_variables = {'year': ['time.calendar_year', '', []],
+#                                     'j_day': ['time.day', '', []],
+#                                     'num_animals_in_pen': ['len(pen.animals_in_pen)', '', []],
+#                                     'average_growth': ['pen.avg_growth', 'kg', []],
+#                                     'average_milk': ['pen.avg_milk', 'kg', []],
+#                                     'average_p_animal': ['pen.avg_p_animal', 'g', []],
+#                                     'average_p_req': ['pen.avg_p_req', 'g', []]
+#                                     }
+
+#             self.annual_variables = {'year': ['time.calendar_year', '', 0]
+#                                      }
+
+#     class ManureReport(BasePenReport):
+#         def __init__(self, data, pen_id):
+#             super().__init__(data, pen_id)
+
+#             self.daily_variables = {'year': ['time.calendar_year', '', []],
+#                                     'j_day': ['time.day', '', []],
+#                                     'num_animals': ['len(pen.animals_in_pen)', '', []],
+#                                     'manure': ['pen.manure[\'p_excrt_manure\']', 'kg', []],
+#                                     'urea_conc': ['pen.manure[\'U\']', 'mol/L', []],
+#                                     'ammoniacal_N_conc': ['pen.manure[\'TAN_s\']', 'mol/L', []],
+#                                     'manure_N': ['pen.manure[\'MN\']', 'g', []],
+#                                     'total_solids': ['pen.manure[\'TSd\']', 'kg', []],
+#                                     'manure_VSd': ['pen.manure[\'VSd\']', 'g', []],
+#                                     'manure_VSnond': ['pen.manure[\'VSnd\']', 'g', []],
+#                                     'WIP_frac': ['pen.manure[\'WIP_frac\']', 'g/g total man', []],
+#                                     'WOP_frac': ['pen.manure[\'WOP_frac\']', 'g/g total man', []],
+#                                     'manure_P': ['pen.manure[\'p_excrt_manure\']', 'g', []],
+#                                     'P_frac': ['pen.manure[\'p_frac\']', 'g/g total man', []],
+#                                     'K_manure': ['pen.manure[\'K_manure\']', 'g', []],
+#                                     'enteric_methane': ['pen.manure[\'CH4_manure\']', 'g', []]
+#                                     }
+
+#             self.annual_variables = {'year': ['time.calendar_year', '', 0]}
+
+#             self.manure_info = {}
+
+#     class RationReport(BasePenReport):
+#         def __init__(self, data, feed, individual_pen, pen_id):
+#             super().__init__(data, pen_id)
+#             self.ration_interval = data['ration_interval']
+
+#             self.daily_variables = {'year': ['time.calendar_year', '', []],
+#                                     'j_day': ['time.day', '', []],
+#                                     'num_animals': ['len(pen.animals_in_pen)', '', []]
+#                                     }
+#             # this subsets the pen's allotted feed given the animals type(s)
+#             # that are present within the pen that is currently being
+#             # simulated
+#             individual_pen.animal_class_feed_subsetter(feed)
+
+#             all_feeds = feed.all_feed_ids
+#             #print(all_feeds)
+
+#             #index at 0 because there is a nested list here for some unknown reason
+#             print(individual_pen.feed_ids)
+#             pen_id_list = individual_pen.feed_ids
+#             print(pen_id_list)
+
+#             pen_specific_feeds = {str(x): all_feeds[str(x)] for x in pen_id_list}
+
+
+#             for feed_id in pen_id_list:
+#                 feed_name = pen_specific_feeds[str(feed_id)]['feed_name']
+#                 units = pen_specific_feeds[str(feed_id)]['units']
+
+#                 self.daily_variables[str(feed_id) + "(" + feed_name + ")"] = \
+#                     [
+#                         'pen.ration[\'%s\'] if pen.pen_populated and \'%s\' in pen.feed_ids else 0' % (
+#                             feed_id, feed_id), units,
+#                         []]
+
+#             self.annual_variables = {
+#                 'year': ['time.calendar_year', '', 0]
+#             }
+
+
+#         def produce_report_graphics(self):
+#             super().produce_report_graphics()
+#             graphics.ration_graphics(self)

--- a/RUFAS/output_handler/reports/pen_report.py
+++ b/RUFAS/output_handler/reports/pen_report.py
@@ -14,7 +14,9 @@ class PensReport(BaseReportDriver):
     def __init__(self, data, state):
         super().__init__(data)
         for pen in state.animal_management.all_pens:
-            self.reports['pen_' + str(pen.id)] = PenReport(data, state.feed, pen.id)
+            print(pen)
+            print(pen.animal_groups)
+            self.reports['pen_' + str(pen.id)] = PenReport(data, state.feed, pen, pen.id)
 
         self.reports['pens_summary'] = PensSummary(data['pens_summary'])
 
@@ -34,12 +36,12 @@ class PensSummary(BaseReport):
 
 
 class PenReport(BaseReportDriver):
-    def __init__(self, data, feed, pen_id):
+    def __init__(self, data, feed, individual_pen, pen_id):
         super().__init__(data)
         self.pen_id = pen_id
         self.report_name = 'pen_' + str(pen_id)
         self.reports = {
-            'ration_report': self.RationReport(data['ration_report'], feed, self.pen_id),
+            'ration_report': self.RationReport(data['ration_report'], feed, individual_pen, self.pen_id),
             'growth_report': self.GrowthReport(data['growth_report'], self.pen_id),
             'manure_report': self.ManureReport(data['manure_report'], self.pen_id)
         }
@@ -54,6 +56,7 @@ class PenReport(BaseReportDriver):
             feed = state.feed
             pen = state.animal_management.all_pens[self.pen_id]
 
+            print(self.daily_variables)
             for variable in self.daily_variables:
                 self.daily_variables[variable][2].append(
                     eval(self.daily_variables[variable][0], globals(), locals()))
@@ -110,7 +113,7 @@ class PenReport(BaseReportDriver):
             self.manure_info = {}
 
     class RationReport(BasePenReport):
-        def __init__(self, data, feed, pen_id):
+        def __init__(self, data, feed, individual_pen, pen_id):
             super().__init__(data, pen_id)
             self.ration_interval = data['ration_interval']
 
@@ -118,21 +121,37 @@ class PenReport(BaseReportDriver):
                                     'j_day': ['time.day', '', []],
                                     'num_animals': ['len(pen.animals_in_pen)', '', []]
                                     }
+            # this subsets the pen's allotted feed given the animals type(s)
+            # that are present within the pen that is currently being
+            # simulated
+            individual_pen.animal_class_feed_subsetter(feed)
 
             all_feeds = feed.all_feed_ids
-            for feed_id in all_feeds:
-                feed_name = all_feeds[feed_id]['feed_name']
-                units = all_feeds[feed_id]['units']
+            #print(all_feeds)
 
-                self.daily_variables[feed_id + "(" + feed_name + ")"] = \
+            #index at 0 because there is a nested list here for some unknown reason
+            print(individual_pen.feed_ids)
+            pen_id_list = individual_pen.feed_ids
+            print(pen_id_list)
+
+            pen_specific_feeds = {str(x): all_feeds[str(x)] for x in pen_id_list}
+
+
+
+            for feed_id in pen_id_list:
+                feed_name = pen_specific_feeds[str(feed_id)]['feed_name']
+                units = pen_specific_feeds[str(feed_id)]['units']
+
+                self.daily_variables[str(feed_id) + "(" + feed_name + ")"] = \
                     [
-                        'pen.ration[\'%s\'] if pen.pen_populated and \'%s\' in feed.available_feeds else 0' % (
+                        'pen.ration[\'%s\'] if pen.pen_populated and \'%s\' in pen.feed_ids else 0' % (
                             feed_id, feed_id), units,
                         []]
 
             self.annual_variables = {
                 'year': ['time.calendar_year', '', 0]
             }
+
 
         def produce_report_graphics(self):
             super().produce_report_graphics()

--- a/RUFAS/output_handler/reports/pen_report.py
+++ b/RUFAS/output_handler/reports/pen_report.py
@@ -56,15 +56,8 @@ class PenReport(BaseReportDriver):
             pen = state.animal_management.all_pens[self.pen_id]
 
             for variable in self.daily_variables:
-                # old variable evaluation code
-                # code_to_eval = self.daily_variables[variable][0]
-                # variable_values = self.daily_variables[variable][2]
-                # variable_values.append(
-                #     eval(code_to_eval, globals(), locals()))
-
-                variable_value = evaluate_variable(variable, time, pen, feed)
-                # self.daily_variables[variable][2] is a list containing all of the values for the given variable
-                self.daily_variables[variable][2].append(variable_value)
+                self.daily_variables[variable][2].append(
+                    eval(self.daily_variables[variable][0], globals(), locals()))
 
         def annual_update(self, state, weather, time):
             animal_management = state.animal_management
@@ -72,26 +65,22 @@ class PenReport(BaseReportDriver):
             pen = state.animal_management.all_pens[self.pen_id]
 
             for variable in self.annual_variables:
-                # old variable evaluation code
-                # code_to_eval = self.daily_variables[variable][0]
-                # variable_value = eval(code_to_eval, globals(), locals())
-                # self.annual_variables[variable][2] = variable_value
-
-                variable_value = evaluate_variable(variable, time, pen, feed)
-                # self.annual_variables[variable][2] is the value for the given variable
-                self.annual_variables[variable][2] = variable_value
+                self.annual_variables[variable][2] = \
+                    eval(self.daily_variables[variable]
+                         [0], globals(), locals())
 
     class GrowthReport(BasePenReport):
         def __init__(self, data, pen_id):
             super().__init__(data, pen_id)
 
-            daily_variables_lst = [('year', ''), ('j_day', ''), ('num_animals_in_pen', ''), ('average_growth', 'kg'),
-                                   ('average_milk', 'kg'), ('average_p_animal', 'g'), ('average_p_req', 'g')]
-
-            self.new_daily_variables = dict.fromkeys(daily_variables_lst, [])
-
-            # temporary fix - remap new structure to old
-            self.daily_variables = remap_variables_dict(self.new_daily_variables)
+            self.daily_variables = {'year': ['time.calendar_year', '', []],
+                                    'j_day': ['time.day', '', []],
+                                    'num_animals_in_pen': ['len(pen.animals_in_pen)', '', []],
+                                    'average_growth': ['pen.avg_growth', 'kg', []],
+                                    'average_milk': ['pen.avg_milk', 'kg', []],
+                                    'average_p_animal': ['pen.avg_p_animal', 'g', []],
+                                    'average_p_req': ['pen.avg_p_req', 'g', []]
+                                    }
 
             self.annual_variables = {'year': ['time.calendar_year', '', 0]
                                      }
@@ -100,17 +89,23 @@ class PenReport(BaseReportDriver):
         def __init__(self, data, pen_id):
             super().__init__(data, pen_id)
 
-            daily_variables_lst = [('year', ''), ('j_day', ''), ('num_animals', ''), ('manure', 'kg'),
-                                   ('urea_conc', 'mol/L'), ('ammoniacal_N_conc', 'mol/L'),
-                                   ('manure_N', 'g'), ('total_solids', 'kg'), ('manure_VSd', 'g'),
-                                   ('manure_VSnond', 'g'), ('WIP_frac', 'g/g total man'), ('WOP_frac', 'g/g total man'),
-                                   ('manure_P', 'g'), ('P_frac', 'g/g total man'), ('K_manure', 'g'),
-                                   ('enteric_methane', 'g')]
-
-            self.new_daily_variables = dict.fromkeys(daily_variables_lst, [])
-
-            # temporary fix - remap new structure to old
-            self.daily_variables = remap_variables_dict(self.new_daily_variables)
+            self.daily_variables = {'year': ['time.calendar_year', '', []],
+                                    'j_day': ['time.day', '', []],
+                                    'num_animals': ['len(pen.animals_in_pen)', '', []],
+                                    'manure': ['pen.manure[\'p_excrt_manure\']', 'kg', []],
+                                    'urea_conc': ['pen.manure[\'U\']', 'mol/L', []],
+                                    'ammoniacal_N_conc': ['pen.manure[\'TAN_s\']', 'mol/L', []],
+                                    'manure_N': ['pen.manure[\'MN\']', 'g', []],
+                                    'total_solids': ['pen.manure[\'TSd\']', 'kg', []],
+                                    'manure_VSd': ['pen.manure[\'VSd\']', 'g', []],
+                                    'manure_VSnond': ['pen.manure[\'VSnd\']', 'g', []],
+                                    'WIP_frac': ['pen.manure[\'WIP_frac\']', 'g/g total man', []],
+                                    'WOP_frac': ['pen.manure[\'WOP_frac\']', 'g/g total man', []],
+                                    'manure_P': ['pen.manure[\'p_excrt_manure\']', 'g', []],
+                                    'P_frac': ['pen.manure[\'p_frac\']', 'g/g total man', []],
+                                    'K_manure': ['pen.manure[\'K_manure\']', 'g', []],
+                                    'enteric_methane': ['pen.manure[\'CH4_manure\']', 'g', []]
+                                    }
 
             self.annual_variables = {'year': ['time.calendar_year', '', 0]}
 
@@ -121,12 +116,10 @@ class PenReport(BaseReportDriver):
             super().__init__(data, pen_id)
             self.ration_interval = data['ration_interval']
 
-            daily_variables_lst = [('year', ''), ('j_day', ''), ('num_animals', '')]
-
-            self.new_daily_variables = dict.fromkeys(daily_variables_lst, [])
-
-            # temporary fix - remap new structure to old
-            self.daily_variables = remap_variables_dict(self.new_daily_variables)
+            self.daily_variables = {'year': ['time.calendar_year', '', []],
+                                    'j_day': ['time.day', '', []],
+                                    'num_animals': ['len(pen.animals_in_pen)', '', []]
+                                    }
 
             all_feeds = feed.all_feed_ids
             for feed_id in all_feeds:
@@ -148,76 +141,161 @@ class PenReport(BaseReportDriver):
             graphics.ration_graphics(self)
 
 
-# temporary function to remap the new variable dict structure to the old structure
-# this is necessary because some of the output relies on the old structure
-def remap_variables_dict(variables_dict):
-    new_variables_dict = dict()
-    for variable, unit in variables_dict:
-        new_variables_dict[variable] = ['', unit, []]
-    return new_variables_dict
+# """
+# RUFAS: Ruminant Farm Systems Model
+# File name: pen_report.py
+# Description:
+# Author(s): William Donovan, wmdonovan@wisc.edu
+# """
+
+# from .base_report_driver import BaseReportDriver
+# from .base_report import BaseReport
+# from .. import graphics
 
 
-def evaluate_variable(variable, time, pen, feed):
-    """
-    Evaluates a daily or annual variable within the provided scope.
+# class PensReport(BaseReportDriver):
+#     def __init__(self, data, state):
+#         super().__init__(data)
+#         for pen in state.animal_management.all_pens:
+#             print(pen)
+#             print(pen.animal_groups)
+#             self.reports['pen_' + str(pen.id)] = PenReport(data, state.feed, pen, pen.id)
 
-    Args:
-        TODO: add better descriptions for the args
-        variable: the variable to evaluate
-        time: the time object to evaluate the variable with
-        pen: the pen object to evaluate the variable with
-        feed: the feed object to evaluate the variable with
+#         self.reports['pens_summary'] = PensSummary(data['pens_summary'])
 
-    Returns:
-        TODO: the type varies based on the variable, find a fix if possible
-        ___: the value of the variable after evaluation
-    """
-    if variable == 'year':
-        return time.calendar_year
-    elif variable == 'j_day':
-        return time.day
-    elif variable == 'num_animals_in_pen':
-        return len(pen.animals_in_pen)
-    elif variable == 'average_growth':
-        return pen.avg_growth
-    elif variable == 'average_milk':
-        return pen.avg_milk
-    elif variable == 'average_p_animal':
-        return pen.avg_p_animal
-    elif variable == 'average_p_req':
-        return pen.avg_p_req
-    elif variable == 'num_animals':
-        return len(pen.animals_in_pen)
-    elif variable == 'manure':
-        return pen.manure['p_excrt_manure']
-    elif variable == 'urea_conc':
-        return pen.manure['U']
-    elif variable == 'ammoniacal_N_conc':
-        return pen.manure['TAN_s']
-    elif variable == 'manure_N':
-        return pen.manure['MN']
-    elif variable == 'total_solids':
-        return pen.manure['TSd']
-    elif variable == 'manure_VSd':
-        return pen.manure['VSd']
-    elif variable == 'manure_VSnond':
-        return pen.manure['VSnd']
-    elif variable == 'WIP_frac':
-        return pen.manure['WIP_frac']
-    elif variable == 'WOP_frac':
-        return pen.manure['WOP_frac']
-    elif variable == 'manure_P':
-        return pen.manure['p_excrt_manure']
-    elif variable == 'P_frac':
-        return pen.manure['p_frac']
-    elif variable == 'K_manure':
-        return pen.manure['K_manure']
-    elif variable == 'enteric_methane':
-        return pen.manure['CH4_manure']
 
-    # variable is a type of feed
-    else:
-        # TODO: find a better way to get the feed_id
-        feed_id = variable.split('(')[0]
+# class PensSummary(BaseReport):
+#     def __init__(self, data):
+#         super().__init__(data)
 
-        return pen.ration[feed_id] if pen.pen_populated and feed_id in feed.available_feeds else 0
+#         self.daily_variables = {
+#             'year': ['time.calendar_year', '', []],
+#             'j_day': ['time.day', '', []]
+#         }
+
+#         self.annual_variables = {
+#             'year': ['time.calendar_year', '', 0]
+#         }
+
+
+# class PenReport(BaseReportDriver):
+#     def __init__(self, data, feed, individual_pen, pen_id):
+#         super().__init__(data)
+#         self.pen_id = pen_id
+#         self.report_name = 'pen_' + str(pen_id)
+#         self.reports = {
+#             'ration_report': self.RationReport(data['ration_report'], feed, individual_pen, self.pen_id),
+#             'growth_report': self.GrowthReport(data['growth_report'], self.pen_id),
+#             'manure_report': self.ManureReport(data['manure_report'], self.pen_id)
+#         }
+
+#     class BasePenReport(BaseReport):
+#         def __init__(self, data, pen_id):
+#             super().__init__(data)
+#             self.pen_id = pen_id
+
+#         def daily_update(self, state, weather, time):
+#             animal_management = state.animal_management
+#             feed = state.feed
+#             pen = state.animal_management.all_pens[self.pen_id]
+
+#             print(self.daily_variables)
+#             for variable in self.daily_variables:
+#                 self.daily_variables[variable][2].append(
+#                     eval(self.daily_variables[variable][0], globals(), locals()))
+
+#         def annual_update(self, state, weather, time):
+#             animal_management = state.animal_management
+#             feed = state.feed
+#             pen = state.animal_management.all_pens[self.pen_id]
+
+#             for variable in self.annual_variables:
+#                 self.annual_variables[variable][2] = \
+#                     eval(self.daily_variables[variable][0], globals(), locals())
+
+#     class GrowthReport(BasePenReport):
+#         def __init__(self, data, pen_id):
+#             super().__init__(data, pen_id)
+
+#             self.daily_variables = {'year': ['time.calendar_year', '', []],
+#                                     'j_day': ['time.day', '', []],
+#                                     'num_animals_in_pen': ['len(pen.animals_in_pen)', '', []],
+#                                     'average_growth': ['pen.avg_growth', 'kg', []],
+#                                     'average_milk': ['pen.avg_milk', 'kg', []],
+#                                     'average_p_animal': ['pen.avg_p_animal', 'g', []],
+#                                     'average_p_req': ['pen.avg_p_req', 'g', []]
+#                                     }
+
+#             self.annual_variables = {'year': ['time.calendar_year', '', 0]
+#                                      }
+
+#     class ManureReport(BasePenReport):
+#         def __init__(self, data, pen_id):
+#             super().__init__(data, pen_id)
+
+#             self.daily_variables = {'year': ['time.calendar_year', '', []],
+#                                     'j_day': ['time.day', '', []],
+#                                     'num_animals': ['len(pen.animals_in_pen)', '', []],
+#                                     'manure': ['pen.manure[\'p_excrt_manure\']', 'kg', []],
+#                                     'urea_conc': ['pen.manure[\'U\']', 'mol/L', []],
+#                                     'ammoniacal_N_conc': ['pen.manure[\'TAN_s\']', 'mol/L', []],
+#                                     'manure_N': ['pen.manure[\'MN\']', 'g', []],
+#                                     'total_solids': ['pen.manure[\'TSd\']', 'kg', []],
+#                                     'manure_VSd': ['pen.manure[\'VSd\']', 'g', []],
+#                                     'manure_VSnond': ['pen.manure[\'VSnd\']', 'g', []],
+#                                     'WIP_frac': ['pen.manure[\'WIP_frac\']', 'g/g total man', []],
+#                                     'WOP_frac': ['pen.manure[\'WOP_frac\']', 'g/g total man', []],
+#                                     'manure_P': ['pen.manure[\'p_excrt_manure\']', 'g', []],
+#                                     'P_frac': ['pen.manure[\'p_frac\']', 'g/g total man', []],
+#                                     'K_manure': ['pen.manure[\'K_manure\']', 'g', []],
+#                                     'enteric_methane': ['pen.manure[\'CH4_manure\']', 'g', []]
+#                                     }
+
+#             self.annual_variables = {'year': ['time.calendar_year', '', 0]}
+
+#             self.manure_info = {}
+
+#     class RationReport(BasePenReport):
+#         def __init__(self, data, feed, individual_pen, pen_id):
+#             super().__init__(data, pen_id)
+#             self.ration_interval = data['ration_interval']
+
+#             self.daily_variables = {'year': ['time.calendar_year', '', []],
+#                                     'j_day': ['time.day', '', []],
+#                                     'num_animals': ['len(pen.animals_in_pen)', '', []]
+#                                     }
+#             # this subsets the pen's allotted feed given the animals type(s)
+#             # that are present within the pen that is currently being
+#             # simulated
+#             individual_pen.animal_class_feed_subsetter(feed)
+
+#             all_feeds = feed.all_feed_ids
+#             #print(all_feeds)
+
+#             #index at 0 because there is a nested list here for some unknown reason
+#             print(individual_pen.feed_ids)
+#             pen_id_list = individual_pen.feed_ids
+#             print(pen_id_list)
+
+#             pen_specific_feeds = {str(x): all_feeds[str(x)] for x in pen_id_list}
+
+
+#             for feed_id in pen_id_list:
+#                 feed_name = pen_specific_feeds[str(feed_id)]['feed_name']
+#                 units = pen_specific_feeds[str(feed_id)]['units']
+
+#                 self.daily_variables[str(feed_id) + "(" + feed_name + ")"] = \
+#                     [
+#                         'pen.ration[\'%s\'] if pen.pen_populated and \'%s\' in pen.feed_ids else 0' % (
+#                             feed_id, feed_id), units,
+#                         []]
+
+#             self.annual_variables = {
+#                 'year': ['time.calendar_year', '', 0]
+#             }
+
+
+#         def produce_report_graphics(self):
+#             super().produce_report_graphics()
+#             graphics.ration_graphics(self)
+# yet another line to test whether my version control is fixed

--- a/RUFAS/output_handler/reports/pen_report.py
+++ b/RUFAS/output_handler/reports/pen_report.py
@@ -298,3 +298,4 @@ class PenReport(BaseReportDriver):
 #         def produce_report_graphics(self):
 #             super().produce_report_graphics()
 #             graphics.ration_graphics(self)
+# yet another line to test whether my version control is fixed

--- a/RUFAS/output_handler/reports/pen_report.py
+++ b/RUFAS/output_handler/reports/pen_report.py
@@ -56,6 +56,8 @@ class PenReport(BaseReportDriver):
             pen = state.animal_management.all_pens[self.pen_id]
 
             for variable in self.daily_variables:
+                # index 2 is the accumulator for the evauated variables
+                # index 0 is the string literal code representation of the variable
                 self.daily_variables[variable][2].append(
                     eval(self.daily_variables[variable][0], globals(), locals()))
 
@@ -65,6 +67,8 @@ class PenReport(BaseReportDriver):
             pen = state.animal_management.all_pens[self.pen_id]
 
             for variable in self.annual_variables:
+                # index 2 is the accumulator for the evauated variables
+                # index 0 is the string literal code representation of the variable
                 self.annual_variables[variable][2] = \
                     eval(self.daily_variables[variable]
                          [0], globals(), locals())
@@ -139,163 +143,3 @@ class PenReport(BaseReportDriver):
         def produce_report_graphics(self):
             super().produce_report_graphics()
             graphics.ration_graphics(self)
-
-
-# """
-# RUFAS: Ruminant Farm Systems Model
-# File name: pen_report.py
-# Description:
-# Author(s): William Donovan, wmdonovan@wisc.edu
-# """
-
-# from .base_report_driver import BaseReportDriver
-# from .base_report import BaseReport
-# from .. import graphics
-
-
-# class PensReport(BaseReportDriver):
-#     def __init__(self, data, state):
-#         super().__init__(data)
-#         for pen in state.animal_management.all_pens:
-#             print(pen)
-#             print(pen.animal_groups)
-#             self.reports['pen_' + str(pen.id)] = PenReport(data, state.feed, pen, pen.id)
-
-#         self.reports['pens_summary'] = PensSummary(data['pens_summary'])
-
-
-# class PensSummary(BaseReport):
-#     def __init__(self, data):
-#         super().__init__(data)
-
-#         self.daily_variables = {
-#             'year': ['time.calendar_year', '', []],
-#             'j_day': ['time.day', '', []]
-#         }
-
-#         self.annual_variables = {
-#             'year': ['time.calendar_year', '', 0]
-#         }
-
-
-# class PenReport(BaseReportDriver):
-#     def __init__(self, data, feed, individual_pen, pen_id):
-#         super().__init__(data)
-#         self.pen_id = pen_id
-#         self.report_name = 'pen_' + str(pen_id)
-#         self.reports = {
-#             'ration_report': self.RationReport(data['ration_report'], feed, individual_pen, self.pen_id),
-#             'growth_report': self.GrowthReport(data['growth_report'], self.pen_id),
-#             'manure_report': self.ManureReport(data['manure_report'], self.pen_id)
-#         }
-
-#     class BasePenReport(BaseReport):
-#         def __init__(self, data, pen_id):
-#             super().__init__(data)
-#             self.pen_id = pen_id
-
-#         def daily_update(self, state, weather, time):
-#             animal_management = state.animal_management
-#             feed = state.feed
-#             pen = state.animal_management.all_pens[self.pen_id]
-
-#             print(self.daily_variables)
-#             for variable in self.daily_variables:
-#                 self.daily_variables[variable][2].append(
-#                     eval(self.daily_variables[variable][0], globals(), locals()))
-
-#         def annual_update(self, state, weather, time):
-#             animal_management = state.animal_management
-#             feed = state.feed
-#             pen = state.animal_management.all_pens[self.pen_id]
-
-#             for variable in self.annual_variables:
-#                 self.annual_variables[variable][2] = \
-#                     eval(self.daily_variables[variable][0], globals(), locals())
-
-#     class GrowthReport(BasePenReport):
-#         def __init__(self, data, pen_id):
-#             super().__init__(data, pen_id)
-
-#             self.daily_variables = {'year': ['time.calendar_year', '', []],
-#                                     'j_day': ['time.day', '', []],
-#                                     'num_animals_in_pen': ['len(pen.animals_in_pen)', '', []],
-#                                     'average_growth': ['pen.avg_growth', 'kg', []],
-#                                     'average_milk': ['pen.avg_milk', 'kg', []],
-#                                     'average_p_animal': ['pen.avg_p_animal', 'g', []],
-#                                     'average_p_req': ['pen.avg_p_req', 'g', []]
-#                                     }
-
-#             self.annual_variables = {'year': ['time.calendar_year', '', 0]
-#                                      }
-
-#     class ManureReport(BasePenReport):
-#         def __init__(self, data, pen_id):
-#             super().__init__(data, pen_id)
-
-#             self.daily_variables = {'year': ['time.calendar_year', '', []],
-#                                     'j_day': ['time.day', '', []],
-#                                     'num_animals': ['len(pen.animals_in_pen)', '', []],
-#                                     'manure': ['pen.manure[\'p_excrt_manure\']', 'kg', []],
-#                                     'urea_conc': ['pen.manure[\'U\']', 'mol/L', []],
-#                                     'ammoniacal_N_conc': ['pen.manure[\'TAN_s\']', 'mol/L', []],
-#                                     'manure_N': ['pen.manure[\'MN\']', 'g', []],
-#                                     'total_solids': ['pen.manure[\'TSd\']', 'kg', []],
-#                                     'manure_VSd': ['pen.manure[\'VSd\']', 'g', []],
-#                                     'manure_VSnond': ['pen.manure[\'VSnd\']', 'g', []],
-#                                     'WIP_frac': ['pen.manure[\'WIP_frac\']', 'g/g total man', []],
-#                                     'WOP_frac': ['pen.manure[\'WOP_frac\']', 'g/g total man', []],
-#                                     'manure_P': ['pen.manure[\'p_excrt_manure\']', 'g', []],
-#                                     'P_frac': ['pen.manure[\'p_frac\']', 'g/g total man', []],
-#                                     'K_manure': ['pen.manure[\'K_manure\']', 'g', []],
-#                                     'enteric_methane': ['pen.manure[\'CH4_manure\']', 'g', []]
-#                                     }
-
-#             self.annual_variables = {'year': ['time.calendar_year', '', 0]}
-
-#             self.manure_info = {}
-
-#     class RationReport(BasePenReport):
-#         def __init__(self, data, feed, individual_pen, pen_id):
-#             super().__init__(data, pen_id)
-#             self.ration_interval = data['ration_interval']
-
-#             self.daily_variables = {'year': ['time.calendar_year', '', []],
-#                                     'j_day': ['time.day', '', []],
-#                                     'num_animals': ['len(pen.animals_in_pen)', '', []]
-#                                     }
-#             # this subsets the pen's allotted feed given the animals type(s)
-#             # that are present within the pen that is currently being
-#             # simulated
-#             individual_pen.animal_class_feed_subsetter(feed)
-
-#             all_feeds = feed.all_feed_ids
-#             #print(all_feeds)
-
-#             #index at 0 because there is a nested list here for some unknown reason
-#             print(individual_pen.feed_ids)
-#             pen_id_list = individual_pen.feed_ids
-#             print(pen_id_list)
-
-#             pen_specific_feeds = {str(x): all_feeds[str(x)] for x in pen_id_list}
-
-
-#             for feed_id in pen_id_list:
-#                 feed_name = pen_specific_feeds[str(feed_id)]['feed_name']
-#                 units = pen_specific_feeds[str(feed_id)]['units']
-
-#                 self.daily_variables[str(feed_id) + "(" + feed_name + ")"] = \
-#                     [
-#                         'pen.ration[\'%s\'] if pen.pen_populated and \'%s\' in pen.feed_ids else 0' % (
-#                             feed_id, feed_id), units,
-#                         []]
-
-#             self.annual_variables = {
-#                 'year': ['time.calendar_year', '', 0]
-#             }
-
-
-#         def produce_report_graphics(self):
-#             super().produce_report_graphics()
-#             graphics.ration_graphics(self)
-# yet another line to test whether my version control is fixed

--- a/RUFAS/output_handler/reports/pen_report.py
+++ b/RUFAS/output_handler/reports/pen_report.py
@@ -56,8 +56,15 @@ class PenReport(BaseReportDriver):
             pen = state.animal_management.all_pens[self.pen_id]
 
             for variable in self.daily_variables:
-                self.daily_variables[variable][2].append(
-                    eval(self.daily_variables[variable][0], globals(), locals()))
+                # old variable evaluation code
+                # code_to_eval = self.daily_variables[variable][0]
+                # variable_values = self.daily_variables[variable][2]
+                # variable_values.append(
+                #     eval(code_to_eval, globals(), locals()))
+
+                variable_value = evaluate_variable(variable, time, pen, feed)
+                # self.daily_variables[variable][2] is a list containing all of the values for the given variable
+                self.daily_variables[variable][2].append(variable_value)
 
         def annual_update(self, state, weather, time):
             animal_management = state.animal_management
@@ -65,22 +72,26 @@ class PenReport(BaseReportDriver):
             pen = state.animal_management.all_pens[self.pen_id]
 
             for variable in self.annual_variables:
-                self.annual_variables[variable][2] = \
-                    eval(self.daily_variables[variable]
-                         [0], globals(), locals())
+                # old variable evaluation code
+                # code_to_eval = self.daily_variables[variable][0]
+                # variable_value = eval(code_to_eval, globals(), locals())
+                # self.annual_variables[variable][2] = variable_value
+
+                variable_value = evaluate_variable(variable, time, pen, feed)
+                # self.annual_variables[variable][2] is the value for the given variable
+                self.annual_variables[variable][2] = variable_value
 
     class GrowthReport(BasePenReport):
         def __init__(self, data, pen_id):
             super().__init__(data, pen_id)
 
-            self.daily_variables = {'year': ['time.calendar_year', '', []],
-                                    'j_day': ['time.day', '', []],
-                                    'num_animals_in_pen': ['len(pen.animals_in_pen)', '', []],
-                                    'average_growth': ['pen.avg_growth', 'kg', []],
-                                    'average_milk': ['pen.avg_milk', 'kg', []],
-                                    'average_p_animal': ['pen.avg_p_animal', 'g', []],
-                                    'average_p_req': ['pen.avg_p_req', 'g', []]
-                                    }
+            daily_variables_lst = [('year', ''), ('j_day', ''), ('num_animals_in_pen', ''), ('average_growth', 'kg'),
+                                   ('average_milk', 'kg'), ('average_p_animal', 'g'), ('average_p_req', 'g')]
+
+            self.new_daily_variables = dict.fromkeys(daily_variables_lst, [])
+
+            # temporary fix - remap new structure to old
+            self.daily_variables = remap_variables_dict(self.new_daily_variables)
 
             self.annual_variables = {'year': ['time.calendar_year', '', 0]
                                      }
@@ -89,23 +100,17 @@ class PenReport(BaseReportDriver):
         def __init__(self, data, pen_id):
             super().__init__(data, pen_id)
 
-            self.daily_variables = {'year': ['time.calendar_year', '', []],
-                                    'j_day': ['time.day', '', []],
-                                    'num_animals': ['len(pen.animals_in_pen)', '', []],
-                                    'manure': ['pen.manure[\'p_excrt_manure\']', 'kg', []],
-                                    'urea_conc': ['pen.manure[\'U\']', 'mol/L', []],
-                                    'ammoniacal_N_conc': ['pen.manure[\'TAN_s\']', 'mol/L', []],
-                                    'manure_N': ['pen.manure[\'MN\']', 'g', []],
-                                    'total_solids': ['pen.manure[\'TSd\']', 'kg', []],
-                                    'manure_VSd': ['pen.manure[\'VSd\']', 'g', []],
-                                    'manure_VSnond': ['pen.manure[\'VSnd\']', 'g', []],
-                                    'WIP_frac': ['pen.manure[\'WIP_frac\']', 'g/g total man', []],
-                                    'WOP_frac': ['pen.manure[\'WOP_frac\']', 'g/g total man', []],
-                                    'manure_P': ['pen.manure[\'p_excrt_manure\']', 'g', []],
-                                    'P_frac': ['pen.manure[\'p_frac\']', 'g/g total man', []],
-                                    'K_manure': ['pen.manure[\'K_manure\']', 'g', []],
-                                    'enteric_methane': ['pen.manure[\'CH4_manure\']', 'g', []]
-                                    }
+            daily_variables_lst = [('year', ''), ('j_day', ''), ('num_animals', ''), ('manure', 'kg'),
+                                   ('urea_conc', 'mol/L'), ('ammoniacal_N_conc', 'mol/L'),
+                                   ('manure_N', 'g'), ('total_solids', 'kg'), ('manure_VSd', 'g'),
+                                   ('manure_VSnond', 'g'), ('WIP_frac', 'g/g total man'), ('WOP_frac', 'g/g total man'),
+                                   ('manure_P', 'g'), ('P_frac', 'g/g total man'), ('K_manure', 'g'),
+                                   ('enteric_methane', 'g')]
+
+            self.new_daily_variables = dict.fromkeys(daily_variables_lst, [])
+
+            # temporary fix - remap new structure to old
+            self.daily_variables = remap_variables_dict(self.new_daily_variables)
 
             self.annual_variables = {'year': ['time.calendar_year', '', 0]}
 
@@ -116,10 +121,12 @@ class PenReport(BaseReportDriver):
             super().__init__(data, pen_id)
             self.ration_interval = data['ration_interval']
 
-            self.daily_variables = {'year': ['time.calendar_year', '', []],
-                                    'j_day': ['time.day', '', []],
-                                    'num_animals': ['len(pen.animals_in_pen)', '', []]
-                                    }
+            daily_variables_lst = [('year', ''), ('j_day', ''), ('num_animals', '')]
+
+            self.new_daily_variables = dict.fromkeys(daily_variables_lst, [])
+
+            # temporary fix - remap new structure to old
+            self.daily_variables = remap_variables_dict(self.new_daily_variables)
 
             all_feeds = feed.all_feed_ids
             for feed_id in all_feeds:
@@ -141,161 +148,76 @@ class PenReport(BaseReportDriver):
             graphics.ration_graphics(self)
 
 
-# """
-# RUFAS: Ruminant Farm Systems Model
-# File name: pen_report.py
-# Description:
-# Author(s): William Donovan, wmdonovan@wisc.edu
-# """
-
-# from .base_report_driver import BaseReportDriver
-# from .base_report import BaseReport
-# from .. import graphics
+# temporary function to remap the new variable dict structure to the old structure
+# this is necessary because some of the output relies on the old structure
+def remap_variables_dict(variables_dict):
+    new_variables_dict = dict()
+    for variable, unit in variables_dict:
+        new_variables_dict[variable] = ['', unit, []]
+    return new_variables_dict
 
 
-# class PensReport(BaseReportDriver):
-#     def __init__(self, data, state):
-#         super().__init__(data)
-#         for pen in state.animal_management.all_pens:
-#             print(pen)
-#             print(pen.animal_groups)
-#             self.reports['pen_' + str(pen.id)] = PenReport(data, state.feed, pen, pen.id)
+def evaluate_variable(variable, time, pen, feed):
+    """
+    Evaluates a daily or annual variable within the provided scope.
 
-#         self.reports['pens_summary'] = PensSummary(data['pens_summary'])
+    Args:
+        TODO: add better descriptions for the args
+        variable: the variable to evaluate
+        time: the time object to evaluate the variable with
+        pen: the pen object to evaluate the variable with
+        feed: the feed object to evaluate the variable with
 
+    Returns:
+        TODO: the type varies based on the variable, find a fix if possible
+        ___: the value of the variable after evaluation
+    """
+    if variable == 'year':
+        return time.calendar_year
+    elif variable == 'j_day':
+        return time.day
+    elif variable == 'num_animals_in_pen':
+        return len(pen.animals_in_pen)
+    elif variable == 'average_growth':
+        return pen.avg_growth
+    elif variable == 'average_milk':
+        return pen.avg_milk
+    elif variable == 'average_p_animal':
+        return pen.avg_p_animal
+    elif variable == 'average_p_req':
+        return pen.avg_p_req
+    elif variable == 'num_animals':
+        return len(pen.animals_in_pen)
+    elif variable == 'manure':
+        return pen.manure['p_excrt_manure']
+    elif variable == 'urea_conc':
+        return pen.manure['U']
+    elif variable == 'ammoniacal_N_conc':
+        return pen.manure['TAN_s']
+    elif variable == 'manure_N':
+        return pen.manure['MN']
+    elif variable == 'total_solids':
+        return pen.manure['TSd']
+    elif variable == 'manure_VSd':
+        return pen.manure['VSd']
+    elif variable == 'manure_VSnond':
+        return pen.manure['VSnd']
+    elif variable == 'WIP_frac':
+        return pen.manure['WIP_frac']
+    elif variable == 'WOP_frac':
+        return pen.manure['WOP_frac']
+    elif variable == 'manure_P':
+        return pen.manure['p_excrt_manure']
+    elif variable == 'P_frac':
+        return pen.manure['p_frac']
+    elif variable == 'K_manure':
+        return pen.manure['K_manure']
+    elif variable == 'enteric_methane':
+        return pen.manure['CH4_manure']
 
-# class PensSummary(BaseReport):
-#     def __init__(self, data):
-#         super().__init__(data)
+    # variable is a type of feed
+    else:
+        # TODO: find a better way to get the feed_id
+        feed_id = variable.split('(')[0]
 
-#         self.daily_variables = {
-#             'year': ['time.calendar_year', '', []],
-#             'j_day': ['time.day', '', []]
-#         }
-
-#         self.annual_variables = {
-#             'year': ['time.calendar_year', '', 0]
-#         }
-
-
-# class PenReport(BaseReportDriver):
-#     def __init__(self, data, feed, individual_pen, pen_id):
-#         super().__init__(data)
-#         self.pen_id = pen_id
-#         self.report_name = 'pen_' + str(pen_id)
-#         self.reports = {
-#             'ration_report': self.RationReport(data['ration_report'], feed, individual_pen, self.pen_id),
-#             'growth_report': self.GrowthReport(data['growth_report'], self.pen_id),
-#             'manure_report': self.ManureReport(data['manure_report'], self.pen_id)
-#         }
-
-#     class BasePenReport(BaseReport):
-#         def __init__(self, data, pen_id):
-#             super().__init__(data)
-#             self.pen_id = pen_id
-
-#         def daily_update(self, state, weather, time):
-#             animal_management = state.animal_management
-#             feed = state.feed
-#             pen = state.animal_management.all_pens[self.pen_id]
-
-#             print(self.daily_variables)
-#             for variable in self.daily_variables:
-#                 self.daily_variables[variable][2].append(
-#                     eval(self.daily_variables[variable][0], globals(), locals()))
-
-#         def annual_update(self, state, weather, time):
-#             animal_management = state.animal_management
-#             feed = state.feed
-#             pen = state.animal_management.all_pens[self.pen_id]
-
-#             for variable in self.annual_variables:
-#                 self.annual_variables[variable][2] = \
-#                     eval(self.daily_variables[variable][0], globals(), locals())
-
-#     class GrowthReport(BasePenReport):
-#         def __init__(self, data, pen_id):
-#             super().__init__(data, pen_id)
-
-#             self.daily_variables = {'year': ['time.calendar_year', '', []],
-#                                     'j_day': ['time.day', '', []],
-#                                     'num_animals_in_pen': ['len(pen.animals_in_pen)', '', []],
-#                                     'average_growth': ['pen.avg_growth', 'kg', []],
-#                                     'average_milk': ['pen.avg_milk', 'kg', []],
-#                                     'average_p_animal': ['pen.avg_p_animal', 'g', []],
-#                                     'average_p_req': ['pen.avg_p_req', 'g', []]
-#                                     }
-
-#             self.annual_variables = {'year': ['time.calendar_year', '', 0]
-#                                      }
-
-#     class ManureReport(BasePenReport):
-#         def __init__(self, data, pen_id):
-#             super().__init__(data, pen_id)
-
-#             self.daily_variables = {'year': ['time.calendar_year', '', []],
-#                                     'j_day': ['time.day', '', []],
-#                                     'num_animals': ['len(pen.animals_in_pen)', '', []],
-#                                     'manure': ['pen.manure[\'p_excrt_manure\']', 'kg', []],
-#                                     'urea_conc': ['pen.manure[\'U\']', 'mol/L', []],
-#                                     'ammoniacal_N_conc': ['pen.manure[\'TAN_s\']', 'mol/L', []],
-#                                     'manure_N': ['pen.manure[\'MN\']', 'g', []],
-#                                     'total_solids': ['pen.manure[\'TSd\']', 'kg', []],
-#                                     'manure_VSd': ['pen.manure[\'VSd\']', 'g', []],
-#                                     'manure_VSnond': ['pen.manure[\'VSnd\']', 'g', []],
-#                                     'WIP_frac': ['pen.manure[\'WIP_frac\']', 'g/g total man', []],
-#                                     'WOP_frac': ['pen.manure[\'WOP_frac\']', 'g/g total man', []],
-#                                     'manure_P': ['pen.manure[\'p_excrt_manure\']', 'g', []],
-#                                     'P_frac': ['pen.manure[\'p_frac\']', 'g/g total man', []],
-#                                     'K_manure': ['pen.manure[\'K_manure\']', 'g', []],
-#                                     'enteric_methane': ['pen.manure[\'CH4_manure\']', 'g', []]
-#                                     }
-
-#             self.annual_variables = {'year': ['time.calendar_year', '', 0]}
-
-#             self.manure_info = {}
-
-#     class RationReport(BasePenReport):
-#         def __init__(self, data, feed, individual_pen, pen_id):
-#             super().__init__(data, pen_id)
-#             self.ration_interval = data['ration_interval']
-
-#             self.daily_variables = {'year': ['time.calendar_year', '', []],
-#                                     'j_day': ['time.day', '', []],
-#                                     'num_animals': ['len(pen.animals_in_pen)', '', []]
-#                                     }
-#             # this subsets the pen's allotted feed given the animals type(s)
-#             # that are present within the pen that is currently being
-#             # simulated
-#             individual_pen.animal_class_feed_subsetter(feed)
-
-#             all_feeds = feed.all_feed_ids
-#             #print(all_feeds)
-
-#             #index at 0 because there is a nested list here for some unknown reason
-#             print(individual_pen.feed_ids)
-#             pen_id_list = individual_pen.feed_ids
-#             print(pen_id_list)
-
-#             pen_specific_feeds = {str(x): all_feeds[str(x)] for x in pen_id_list}
-
-
-#             for feed_id in pen_id_list:
-#                 feed_name = pen_specific_feeds[str(feed_id)]['feed_name']
-#                 units = pen_specific_feeds[str(feed_id)]['units']
-
-#                 self.daily_variables[str(feed_id) + "(" + feed_name + ")"] = \
-#                     [
-#                         'pen.ration[\'%s\'] if pen.pen_populated and \'%s\' in pen.feed_ids else 0' % (
-#                             feed_id, feed_id), units,
-#                         []]
-
-#             self.annual_variables = {
-#                 'year': ['time.calendar_year', '', 0]
-#             }
-
-
-#         def produce_report_graphics(self):
-#             super().produce_report_graphics()
-#             graphics.ration_graphics(self)
-# yet another line to test whether my version control is fixed
+        return pen.ration[feed_id] if pen.pen_populated and feed_id in feed.available_feeds else 0

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -14,6 +14,7 @@ from RUFAS.routines.animal.ration.growing_heifer_ration import \
     optimize as growing_heifer_optimize
 from RUFAS.routines.animal.ration import cow_requirements as req
 from RUFAS.routines.animal.ration import ration_driver as ration_driver
+import copy
 
 
 class Pen:
@@ -166,49 +167,8 @@ class Pen:
                                        'phosphorus': 0, 'potassium': 0, 'N': 0}
         self.ration_nutrient_conc = {}
 
-        self.manure = {"U": 0,
-                       "TAN_s": 0,
-                       "MN": 0,
-                       "Mkg": 0,
-                       "TSd": 0,
-                       "VSd": 0,
-                       "VSnd": 0,
-                       "WIP_frac": 0,
-                       "WOP_frac": 0,
-                       "p_excrt_manure": 0,
-                       "p_frac": 0,
-                       "K_manure": 0,
-                       "CH4_manure": 0
-                       }
-        self.calf_total = {"U": 0,
-                           "TAN_s": 0,
-                           "MN": 0,
-                           "Mkg": 0,
-                           "TSd": 0,
-                           "VSd": 0,
-                           "VSnd": 0,
-                           "WIP_frac": 0,
-                           "WOP_frac": 0,
-                           "p_excrt_manure": 0,
-                           "p_frac": 0,
-                           "K_manure": 0,
-                           "CH4_manure": 0
-                           }
-        self.heifer_total = {"U": 0,
-                             "TAN_s": 0,
-                             "MN": 0,
-                             "Mkg": 0,
-                             "TSd": 0,
-                             "VSd": 0,
-                             "VSnd": 0,
-                             "WIP_frac": 0,
-                             "WOP_frac": 0,
-                             "p_excrt_manure": 0,
-                             "p_frac": 0,
-                             "K_manure": 0,
-                             "CH4_manure": 0
-                             }
-        self.dry_total = {"U": 0,
+        # initial state for manure, calf_total, etc.
+        self.init_dict = {"U": 0,
                           "TAN_s": 0,
                           "MN": 0,
                           "Mkg": 0,
@@ -222,20 +182,12 @@ class Pen:
                           "K_manure": 0,
                           "CH4_manure": 0
                           }
-        self.lactating_total = {"U": 0,
-                                "TAN_s": 0,
-                                "MN": 0,
-                                "Mkg": 0,
-                                "TSd": 0,
-                                "VSd": 0,
-                                "VSnd": 0,
-                                "WIP_frac": 0,
-                                "WOP_frac": 0,
-                                "p_excrt_manure": 0,
-                                "p_frac": 0,
-                                "K_manure": 0,
-                                "CH4_manure": 0
-                                }
+
+        self.manure = copy.deepcopy(self.init_dict)
+        self.calf_total = copy.deepcopy(self.init_dict)
+        self.heifer_total = copy.deepcopy(self.init_dict)
+        self.dry_total = copy.deepcopy(self.init_dict)
+        self.lactating_total = copy.deepcopy(self.init_dict)
 
     # getters
     def get_id(self):
@@ -381,8 +333,6 @@ class Pen:
         """
         self.pen_type = pen_type
 
-
-
     def update_animals(self, new_animals):
         """
         Sets the list of animals to @new_animals and calculates the stocking
@@ -395,7 +345,8 @@ class Pen:
         for animal in new_animals:
             self.animals_in_pen.append(animal)
         self.pen_populated = not (len(self.animals_in_pen) == 0)
-        self.stocking_density = len(self.animals_in_pen) / self.num_stalls * 100
+        self.stocking_density = len(
+            self.animals_in_pen) / self.num_stalls * 100
         self.calc_daily_walking_dist()
 
         # sets the current animal classes in the pen
@@ -447,7 +398,8 @@ class Pen:
         for animal in self.animals_in_pen:
             curr_rqmts = animal.nutrient_rqmts
             if curr_rqmts == {}:
-                print(type(animal).__name__, animal.id, self.id, self.avg_calf_nutrient_rqmts)
+                print(type(animal).__name__, animal.id,
+                      self.id, self.avg_calf_nutrient_rqmts)
 
             for key in sum_dict.keys():
                 sum_dict[key] += curr_rqmts[key]['val']
@@ -532,11 +484,13 @@ class Pen:
             elif 'Cow' in self.classes_in_pen and \
                     self.animals_in_pen[0].milking:  # lactating cow
                 ration_per_animal, ration_vals = \
-                    ration_driver.ration_formulation(self, available_feeds, True)
+                    ration_driver.ration_formulation(
+                        self, available_feeds, True)
             elif 'Cow' in self.classes_in_pen and \
                     not self.animals_in_pen[0].milking:  # dry cow
                 ration_per_animal, ration_vals = \
-                    ration_driver.ration_formulation(self, available_feeds, False)
+                    ration_driver.ration_formulation(
+                        self, available_feeds, False)
 
             else:  # this should never occur
                 print('error in pen ration calculation')
@@ -631,84 +585,19 @@ class Pen:
 
     def reset_manure(self):
         # total manure excretion of the animals in the pen
-        self.manure = {"U": 0,
-                       "TAN_s": 0,
-                       "MN": 0,
-                       "Mkg": 0,
-                       "TSd": 0,
-                       "VSd": 0,
-                       "VSnd": 0,
-                       "WIP_frac": 0,
-                       "WOP_frac": 0,
-                       "p_excrt_manure": 0,
-                       "p_frac": 0,
-                       "K_manure": 0,
-                       "CH4_manure": 0
-                       }
+        self.manure = copy.deepcopy(self.init_dict)
 
         # total manure excretion of the calves in the pen
-        self.calf_total = {"U": 0,
-                           "TAN_s": 0,
-                           "MN": 0,
-                           "Mkg": 0,
-                           "TSd": 0,
-                           "VSd": 0,
-                           "VSnd": 0,
-                           "WIP_frac": 0,
-                           "WOP_frac": 0,
-                           "p_excrt_manure": 0,
-                           "p_frac": 0,
-                           "K_manure": 0,
-                           "CH4_manure": 0
-                           }
+        self.calf_total = copy.deepcopy(self.init_dict)
 
         # total manure excretion of the heifers in the pen
-        self.heifer_total = {"U": 0,
-                             "TAN_s": 0,
-                             "MN": 0,
-                             "Mkg": 0,
-                             "TSd": 0,
-                             "VSd": 0,
-                             "VSnd": 0,
-                             "WIP_frac": 0,
-                             "WOP_frac": 0,
-                             "p_excrt_manure": 0,
-                             "p_frac": 0,
-                             "K_manure": 0,
-                             "CH4_manure": 0
-                             }
+        self.heifer_total = copy.deepcopy(self.init_dict)
 
         # total manure excretion of the dry cows in the pen
-        self.dry_total = {"U": 0,
-                          "TAN_s": 0,
-                          "MN": 0,
-                          "Mkg": 0,
-                          "TSd": 0,
-                          "VSd": 0,
-                          "VSnd": 0,
-                          "WIP_frac": 0,
-                          "WOP_frac": 0,
-                          "p_excrt_manure": 0,
-                          "p_frac": 0,
-                          "K_manure": 0,
-                          "CH4_manure": 0
-                          }
+        self.dry_total = copy.deepcopy(self.init_dict)
 
         # total manure excretion of the lactating cows in the pen
-        self.lactating_total = {"U": 0,
-                                "TAN_s": 0,
-                                "MN": 0,
-                                "Mkg": 0,
-                                "TSd": 0,
-                                "VSd": 0,
-                                "VSnd": 0,
-                                "WIP_frac": 0,
-                                "WOP_frac": 0,
-                                "p_excrt_manure": 0,
-                                "p_frac": 0,
-                                "K_manure": 0,
-                                "CH4_manure": 0
-                                }
+        self.lactating_total = copy.deepcopy(self.init_dict)
 
     def calc_avg_growth(self):
         """

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -189,150 +189,6 @@ class Pen:
         self.dry_total = copy.deepcopy(self.init_dict)
         self.lactating_total = copy.deepcopy(self.init_dict)
 
-    # getters
-    def get_id(self):
-        """
-        Returns:
-            int : the id_number, the unique id number of the pen.
-        """
-        return self.id
-
-    def get_vertical_dist_to_parlor(self):
-        """
-        Returns:
-            float : the vertical distance to milking parlor, km.
-        """
-        return self.vertical_dist_to_parlor
-
-    def get_horizontal_dist_to_parlor(self):
-        """
-        Returns:
-            float : the horizontal distance to milking parlor, km.
-        """
-        return self.horizontal_dist_to_parlor
-
-    def get_num_stalls(self):
-        """
-        Returns:
-            int : the number of stalls in the pen.
-        """
-        return self.num_stalls
-
-    def get_housing_type(self):
-        """
-        Returns:
-            string : the housing type of the pen.
-        """
-        return self.housing_type
-
-    def get_bedding_type(self):
-        """
-        Returns:
-            string : the bedding type of the pen.
-        """
-        return self.bedding_type
-
-    def get_pen_type(self):
-        """
-        Returns:
-            string : the pen type: freestall or tiestall.
-        """
-        return self.pen_type
-
-    def get_manure_handling(self):
-        """
-        Returns the manure handling method used to clean the pen.
-        """
-        return self.manure_handling
-
-    def get_manure_separator(self):
-        """
-        Returns the manure separator that processes manure excreted in this pen.
-        """
-        return self.manure_separator
-
-    def get_manure_storage(self):
-        """
-        Returns the manure storage receptacle that stores manure excreted in this pen.
-        """
-        return self.get_manure_storage
-
-    def get_stocking_density(self):
-        """
-        Returns the stocking density of the pen.
-        """
-        return self.stocking_density
-
-    def get_avg_DBW(self):
-        """
-        Returns the average daily change in (delta) body weight of the animals in the pen.
-        """
-        return self.avg_DBW
-
-    # setters
-    def set_id(self, id):
-        """
-        Sets the pen's id to id.
-
-        Args:
-            id: The pen's unique pen ID, obtained from the input file.
-        """
-        self.id = id
-
-    def set_vertical_dist_to_parlor(self, vert_dist):
-        """
-        Sets the pen's vertical distance to milking parlor, measured in kilometers, to vert_dist.
-
-        Args:
-            vert_dist: The pen's vertical distance to milking parlor, measured in kilometers.
-        """
-        self.vertical_dist_to_parlor = vert_dist
-
-    def set_horizontal_dist_to_parlor(self, hori_dist):
-        """
-        Sets the pen's horizontal distance to milking parlor, measured in kilometers, to hori_dist.
-
-        Args:
-            hori_dist: The pen's horizontal distance to milking parlor, measured in kilometers.
-        """
-        self.horizontal_dist_to_parlor = hori_dist
-
-    def set_num_stalls(self, num_stalls):
-        """
-        Sets the number of stalls in the pen to num_stalls.
-
-        Args:
-            num_stalls: The number of stalls in the pen.
-        """
-        self.num_stalls = num_stalls
-
-    def set_housing_type(self, housing_type):
-        """
-        Sets the housing type of the pen to housing_type.
-
-        Args:
-            housing_type: The housing type of the pen.
-        """
-        self.housing_type = housing_type
-
-    def set_bedding_type(self, bedding_type):
-        """
-        Sets the bedding type of the pen to bedding_type.
-
-        Args:
-            bedding_type: The bedding type of the pen.
-        """
-        self.bedding_type = bedding_type
-
-    def set_pen_type(self, pen_type):
-        """
-        Sets the pen type of the pen to pen_type.
-
-        Args:
-            pen_type: The pen type of the pen.
-        """
-        self.pen_type = pen_type
-
     def update_animals(self, new_animals):
         """
         Sets the list of animals to @new_animals and calculates the stocking
@@ -740,3 +596,148 @@ class Pen:
         self.pen_populated = False
         # self.classes_in_pen = set()
         self.avg_p_animal = 0
+
+
+# getters
+    # def get_id(self):
+    #     """
+    #     Returns:
+    #         int : the id_number, the unique id number of the pen.
+    #     """
+    #     return self.id
+
+    # def get_vertical_dist_to_parlor(self):
+    #     """
+    #     Returns:
+    #         float : the vertical distance to milking parlor, km.
+    #     """
+    #     return self.vertical_dist_to_parlor
+
+    # def get_horizontal_dist_to_parlor(self):
+    #     """
+    #     Returns:
+    #         float : the horizontal distance to milking parlor, km.
+    #     """
+    #     return self.horizontal_dist_to_parlor
+
+    # def get_num_stalls(self):
+    #     """
+    #     Returns:
+    #         int : the number of stalls in the pen.
+    #     """
+    #     return self.num_stalls
+
+    # def get_housing_type(self):
+    #     """
+    #     Returns:
+    #         string : the housing type of the pen.
+    #     """
+    #     return self.housing_type
+
+    # def get_bedding_type(self):
+    #     """
+    #     Returns:
+    #         string : the bedding type of the pen.
+    #     """
+    #     return self.bedding_type
+
+    # def get_pen_type(self):
+    #     """
+    #     Returns:
+    #         string : the pen type: freestall or tiestall.
+    #     """
+    #     return self.pen_type
+
+    # def get_manure_handling(self):
+    #     """
+    #     Returns the manure handling method used to clean the pen.
+    #     """
+    #     return self.manure_handling
+
+    # def get_manure_separator(self):
+    #     """
+    #     Returns the manure separator that processes manure excreted in this pen.
+    #     """
+    #     return self.manure_separator
+
+    # def get_manure_storage(self):
+    #     """
+    #     Returns the manure storage receptacle that stores manure excreted in this pen.
+    #     """
+    #     return self.get_manure_storage
+
+    # def get_stocking_density(self):
+    #     """
+    #     Returns the stocking density of the pen.
+    #     """
+    #     return self.stocking_density
+
+    # def get_avg_DBW(self):
+    #     """
+    #     Returns the average daily change in (delta) body weight of the animals in the pen.
+    #     """
+    #     return self.avg_DBW
+
+    # # setters
+    # def set_id(self, id):
+    #     """
+    #     Sets the pen's id to id.
+
+    #     Args:
+    #         id: The pen's unique pen ID, obtained from the input file.
+    #     """
+    #     self.id = id
+
+    # def set_vertical_dist_to_parlor(self, vert_dist):
+    #     """
+    #     Sets the pen's vertical distance to milking parlor, measured in kilometers, to vert_dist.
+
+    #     Args:
+    #         vert_dist: The pen's vertical distance to milking parlor, measured in kilometers.
+    #     """
+    #     self.vertical_dist_to_parlor = vert_dist
+
+    # def set_horizontal_dist_to_parlor(self, hori_dist):
+    #     """
+    #     Sets the pen's horizontal distance to milking parlor, measured in kilometers, to hori_dist.
+
+    #     Args:
+    #         hori_dist: The pen's horizontal distance to milking parlor, measured in kilometers.
+    #     """
+    #     self.horizontal_dist_to_parlor = hori_dist
+
+    # def set_num_stalls(self, num_stalls):
+    #     """
+    #     Sets the number of stalls in the pen to num_stalls.
+
+    #     Args:
+    #         num_stalls: The number of stalls in the pen.
+    #     """
+    #     self.num_stalls = num_stalls
+
+    # def set_housing_type(self, housing_type):
+    #     """
+    #     Sets the housing type of the pen to housing_type.
+
+    #     Args:
+    #         housing_type: The housing type of the pen.
+    #     """
+    #     self.housing_type = housing_type
+
+    # def set_bedding_type(self, bedding_type):
+    #     """
+    #     Sets the bedding type of the pen to bedding_type.
+
+    #     Args:
+    #         bedding_type: The bedding type of the pen.
+    #     """
+    #     self.bedding_type = bedding_type
+
+    # def set_pen_type(self, pen_type):
+    #     """
+    #     Sets the pen type of the pen to pen_type.
+
+    #     Args:
+    #         pen_type: The pen type of the pen.
+    #     """
+    #     self.pen_type = pen_type

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -189,6 +189,42 @@ class Pen:
         self.dry_total = copy.deepcopy(self.init_dict)
         self.lactating_total = copy.deepcopy(self.init_dict)
 
+    # Getters
+
+    def get_id(self):
+        """
+        Returns:
+            int : the id_number, the unique id number of the pen.
+        """
+        return self.id
+
+    def get_pen_type(self):
+        """
+        Returns:
+            string : the pen type: freestall or tiestall.
+        """
+        return self.pen_type
+
+    # Setters
+
+    def set_id(self, pen_id):
+        """
+        Sets the pen's id to id.
+
+        Args:
+            pen_id: The pen's unique pen ID, obtained from the input file.
+        """
+        self.id = pen_id
+
+    def set_pen_type(self, pen_type):
+        """
+        Sets the pen type of the pen to pen_type.
+
+        Args:
+            pen_type: The pen type of the pen.
+        """
+        self.pen_type = pen_type
+
     def update_animals(self, new_animals):
         """
         Sets the list of animals to @new_animals and calculates the stocking
@@ -598,146 +634,3 @@ class Pen:
         self.avg_p_animal = 0
 
 
-# getters
-    # def get_id(self):
-    #     """
-    #     Returns:
-    #         int : the id_number, the unique id number of the pen.
-    #     """
-    #     return self.id
-
-    # def get_vertical_dist_to_parlor(self):
-    #     """
-    #     Returns:
-    #         float : the vertical distance to milking parlor, km.
-    #     """
-    #     return self.vertical_dist_to_parlor
-
-    # def get_horizontal_dist_to_parlor(self):
-    #     """
-    #     Returns:
-    #         float : the horizontal distance to milking parlor, km.
-    #     """
-    #     return self.horizontal_dist_to_parlor
-
-    # def get_num_stalls(self):
-    #     """
-    #     Returns:
-    #         int : the number of stalls in the pen.
-    #     """
-    #     return self.num_stalls
-
-    # def get_housing_type(self):
-    #     """
-    #     Returns:
-    #         string : the housing type of the pen.
-    #     """
-    #     return self.housing_type
-
-    # def get_bedding_type(self):
-    #     """
-    #     Returns:
-    #         string : the bedding type of the pen.
-    #     """
-    #     return self.bedding_type
-
-    # def get_pen_type(self):
-    #     """
-    #     Returns:
-    #         string : the pen type: freestall or tiestall.
-    #     """
-    #     return self.pen_type
-
-    # def get_manure_handling(self):
-    #     """
-    #     Returns the manure handling method used to clean the pen.
-    #     """
-    #     return self.manure_handling
-
-    # def get_manure_separator(self):
-    #     """
-    #     Returns the manure separator that processes manure excreted in this pen.
-    #     """
-    #     return self.manure_separator
-
-    # def get_manure_storage(self):
-    #     """
-    #     Returns the manure storage receptacle that stores manure excreted in this pen.
-    #     """
-    #     return self.get_manure_storage
-
-    # def get_stocking_density(self):
-    #     """
-    #     Returns the stocking density of the pen.
-    #     """
-    #     return self.stocking_density
-
-    # def get_avg_DBW(self):
-    #     """
-    #     Returns the average daily change in (delta) body weight of the animals in the pen.
-    #     """
-    #     return self.avg_DBW
-
-    # # setters
-    # def set_id(self, id):
-    #     """
-    #     Sets the pen's id to id.
-
-    #     Args:
-    #         id: The pen's unique pen ID, obtained from the input file.
-    #     """
-    #     self.id = id
-
-    # def set_vertical_dist_to_parlor(self, vert_dist):
-    #     """
-    #     Sets the pen's vertical distance to milking parlor, measured in kilometers, to vert_dist.
-
-    #     Args:
-    #         vert_dist: The pen's vertical distance to milking parlor, measured in kilometers.
-    #     """
-    #     self.vertical_dist_to_parlor = vert_dist
-
-    # def set_horizontal_dist_to_parlor(self, hori_dist):
-    #     """
-    #     Sets the pen's horizontal distance to milking parlor, measured in kilometers, to hori_dist.
-
-    #     Args:
-    #         hori_dist: The pen's horizontal distance to milking parlor, measured in kilometers.
-    #     """
-    #     self.horizontal_dist_to_parlor = hori_dist
-
-    # def set_num_stalls(self, num_stalls):
-    #     """
-    #     Sets the number of stalls in the pen to num_stalls.
-
-    #     Args:
-    #         num_stalls: The number of stalls in the pen.
-    #     """
-    #     self.num_stalls = num_stalls
-
-    # def set_housing_type(self, housing_type):
-    #     """
-    #     Sets the housing type of the pen to housing_type.
-
-    #     Args:
-    #         housing_type: The housing type of the pen.
-    #     """
-    #     self.housing_type = housing_type
-
-    # def set_bedding_type(self, bedding_type):
-    #     """
-    #     Sets the bedding type of the pen to bedding_type.
-
-    #     Args:
-    #         bedding_type: The bedding type of the pen.
-    #     """
-    #     self.bedding_type = bedding_type
-
-    # def set_pen_type(self, pen_type):
-    #     """
-    #     Sets the pen type of the pen to pen_type.
-
-    #     Args:
-    #         pen_type: The pen type of the pen.
-    #     """
-    #     self.pen_type = pen_type

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -98,6 +98,9 @@ class Pen:
     avg_growth : float
         Represents the average growth of the animals in the pen.
 
+    _manure_dict_template : dict
+        Represents the dictionary template for the manure attributes (manure, calf_total, etc)
+
     manure : dict
         Contains the total manure excretion of all animals in the pen.
 
@@ -110,7 +113,7 @@ class Pen:
     dry_total : dict
         Contains the total manure excretion of the dry cows in the pen.
 
-    lacatating_total : dict
+    lactating_total : dict
         Contains the total manure excretion of the lactating cows in the pen.
     """
 
@@ -155,6 +158,7 @@ class Pen:
 
         self.avg_BW = 0
         self.avg_DMIest = 0
+        self.avg_DBW = 0
 
         self.avg_nutrient_rqmts = {}
         self.avg_calf_nutrient_rqmts = {}
@@ -166,6 +170,13 @@ class Pen:
                                        'NDF': 0, 'lignin': 0, 'ash': 0,
                                        'phosphorus': 0, 'potassium': 0, 'N': 0}
         self.ration_nutrient_conc = {}
+
+        # TODO: add initial value
+        self.avg_growth = None
+
+        # TODO: add initial value and documentation in the docstring
+        # it also seems like this variable is never used - possibly remove it?
+        self.MEdiet = None
 
         # template for manure, calf_total, etc.
         self._manure_dict_template = {"U": 0,
@@ -182,6 +193,13 @@ class Pen:
                                       "K_manure": 0,
                                       "CH4_manure": 0
                                       }
+
+        # manure attributes are initialized in the reset_manure method
+        self.manure = None
+        self.calf_total = None
+        self.heifer_total = None
+        self.dry_total = None
+        self.lactating_total = None
 
         self.reset_manure()
 

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -224,7 +224,77 @@ class Pen:
                                 }
 
     # getters
+    def get_id(self):
+        """
+        Returns the id_number: the unique id number of the pen 
+        """
+        return self.id
 
+    def get_vertical_dist_to_parlor(self):
+        """
+        Returns the vertical distance to milking parlor, km 
+        """
+        return self.vertical_dist_to_parlor
+
+    def get_horizontal_dist_to_parlor(self):
+        """
+        Returns the horizontal distance to milking parlor, km
+        """
+        return self.horizontal_dist_to_parlor
+
+    def get_num_stalls(self):
+        """
+        Returns the number of stalls in the pen
+        """
+        return self.num_stalls
+
+    def get_housing_type(self):
+        """
+        Returns the housing type of the pen
+        """
+        return self.housing_type
+
+    def get_bedding_type(self):
+        """
+        Returns the bedding type of the pen
+        """
+        return self.bedding_type
+
+    def get_pen_type(self):
+        """
+        Returns the pen type: freestall or tiestall
+        """
+        return self.pen_type
+
+    def get_manure_handling(self):
+        """
+        Returns the manure handling method used to clean the pen
+        """
+        return self.manure_handling
+
+    def get_manure_separator(self):
+        """
+        Returns the manure separator that processes manure excreted in this pen
+        """
+        return self.manure_separator
+
+    def get_manure_storage(self):
+        """
+        Returns the manure storage receptacle that stores manure excreted in this pen
+        """
+        return self.get_manure_storage
+
+    def get_stocking_density(self):
+        """
+        Returns the stocking density of the pen
+        """
+        return self.stocking_density
+
+    def get_avg_DBW(self):
+        """
+        Returns the average daily change in (delta) body weight of the animals in the pen
+        """
+        return self.avg_DBW
 
     # setters
 

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -167,6 +167,22 @@ class Pen:
                                        'phosphorus': 0, 'potassium': 0, 'N': 0}
         self.ration_nutrient_conc = {}
 
+        # template for manure, calf_total, etc.
+        self._manure_dict_template = {"U": 0,
+                                      "TAN_s": 0,
+                                      "MN": 0,
+                                      "Mkg": 0,
+                                      "TSd": 0,
+                                      "VSd": 0,
+                                      "VSnd": 0,
+                                      "WIP_frac": 0,
+                                      "WOP_frac": 0,
+                                      "p_excrt_manure": 0,
+                                      "p_frac": 0,
+                                      "K_manure": 0,
+                                      "CH4_manure": 0
+                                      }
+
         self.reset_manure()
 
     def get_id(self):
@@ -451,28 +467,15 @@ class Pen:
         self.dry_total = dry_total
         self.lactating_total = lactating_total
 
-    def reset_manure(self):
-        # template for manure, calf_total, etc.
-        self._manure_excretion_dict_template = {"U": 0,
-                                                "TAN_s": 0,
-                                                "MN": 0,
-                                                "Mkg": 0,
-                                                "TSd": 0,
-                                                "VSd": 0,
-                                                "VSnd": 0,
-                                                "WIP_frac": 0,
-                                                "WOP_frac": 0,
-                                                "p_excrt_manure": 0,
-                                                "p_frac": 0,
-                                                "K_manure": 0,
-                                                "CH4_manure": 0
-                                                }
+    def _copy_manure_template(self):
+        return copy.deepcopy(self._manure_dict_template)
 
-        self.manure = copy.deepcopy(self.init_dict)
-        self.calf_total = copy.deepcopy(self.init_dict)
-        self.heifer_total = copy.deepcopy(self.init_dict)
-        self.dry_total = copy.deepcopy(self.init_dict)
-        self.lactating_total = copy.deepcopy(self.init_dict)
+    def reset_manure(self):
+        self.manure = self._copy_manure_template()
+        self.calf_total = self._copy_manure_template()
+        self.heifer_total = self._copy_manure_template()
+        self.dry_total = self._copy_manure_template()
+        self.lactating_total = self._copy_manure_template()
 
     def calc_avg_growth(self):
         """

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -26,69 +26,101 @@ class Pen:
     Attributes
     -------------
     id : int
-        Represents a pen's unique pen ID.
+        The pen's unique pen ID.
         Obtained from the input file.
 
     vertical_dist_to_parlor : float
-        Represents the vertical distance to milking parlor, measured in kilometers.
+        The vertical distance to milking parlor, measured in kilometers.
         Obtained from the input file.
 
     horizontal_dist_to_parlor : float
-        Represents the horizontal distance to milking parlor, measured in kilometers.
+        The horizontal distance to milking parlor, measured in kilometers.
         Obtained from the input file.
 
     num_stalls : int
-        Represents the number of stalls.
+        The number of stalls.
         Obtained from the input file.
 
     stocking_density : float
-        Represents the stocking density of the pen, and is calculated when animals in pen are
-        updated in update_animals()
+        The stocking density of the pen.
+        Calculated when animals in pen are updated in update_animals()
 
     housing_type : string
-        Represents the housing type of the pen.
+        The housing type of the pen.
         Obtained from the input file.
 
     bedding_type : string
-        Represents the bedding type of the pen.
+        The bedding type of the pen.
         Obtained from the input file.
 
     pen_type : string
-        Represents the pen type (freestall or tiestall).
+        The pen type (freestall or tiestall).
         Obtained from the input file.
 
+    TODO: make sure this description is correct
+    DBW : float
+        The daily change in (delta) body weight of the animals in the pen.
+        Used for ration formulation.
+
+    TODO: add description
+    daily_growth : float
+
+    manure_handling : string
+        The manure handling method used to clean the pen
+
+    manure_separator : string
+        The type of manure separator that processes manure excreted in the pen.
+
+    manure_storage : string
+        The type of manure storage receptacle that stores manure excreted in the pen.
+
+    TODO: make sure this description is correct
+    avg_p_intake : float
+        The average phosphorus intake of the animals in the pen.
+
+    TODO: make sure this description is correct
+    avg_p_req : float
+        The average phosphorus intake of the animals in the pen.
+
+    TODO: add description
+    avg_p_animal : float
+
     animals_in_pen : animal list
-        Represents the list of all animals in this pen.
+        The list of all animals in this pen.
 
     classes_in_pen : set
-        Represents the set (no repeats) of all the classes to which the animals in pen belong.
+        The set (no repeats) of all the classes to which the animals in the pen belong.
 
     pen_populated : bool
-        Is true iff there is at least 1 animal in the pen.
+        True iff there is at least 1 animal in the pen, and false otherwise.
 
     avg_DBW : float
-        Represents the average daily change in (delta) body weight of the
-        animals in the pen, and is used for ration formulation.
+        The average daily change in (delta) body weight of the animals in the pen.
+        Used for ration formulation.
 
     avg_BW : float
-        Represents the average body weight of the animals in the pen, and is used for ration formulation.
+        The average body weight of the animals in the pen.
+        Used for ration formulation.
 
     avg_DMIest : float
-        Represents the average dry matter intake estimation of the animals in the pen,
-        and is used for ration formulation
+        The average dry matter intake estimation of the animals in the pen.
+        Used for ration formulation
 
     avg_nutrient_rqmts : dict
+        Contains the average nutrient requirements of the animals in the pen.
+        Used for ration formulation
+
     avg_calf_nutrient_rqmts : dict
-        These variables represent the dictionaries containing the nutrient requirements in the pen, and
-        are used for ration formulation
+         Contains the average nutrient requirements of the calves in the pen.
+         Used for ration formulation
 
     avg_milk : float
-        Represents the average milk production of the animals in the pen, and is
-        used for (lactating cow) ration formulation
+        The average milk production of the animals in the pen.
+        Used for (lactating cow) ration formulation
 
     avg_CP_milk : float
-        Represents the average milk crude protein content of the animals in the pen, and is
-        used for (lactating cow) ration formulation
+        The average milk crude protein content of the animals in the pen.
+        Used for (lactating cow) ration formulation
 
     ration : dict
         Contains the ration for all the animals in the pen.
@@ -100,10 +132,10 @@ class Pen:
         Contains the concentration of different nutrients in the current ration.
 
     avg_growth : float
-        Represents the average growth of the animals in the pen.
+        The average growth of the animals in the pen.
 
     _manure_dict_template : dict
-        Represents the dictionary template for the manure attributes (manure, calf_total, etc)
+        The dictionary template for the manure attributes (manure, calf_total, etc)
 
     manure : dict
         Contains the total manure excretion of all animals in the pen.
@@ -135,8 +167,8 @@ class Pen:
             bedding_type: bedding type of the pen
             pen_type: freestall or tiestall
             manure_handling: the manure handling method used to clean the pen
-            manure_separator: the manure separator that processes manure excreted in this pen
-            manure_storage: the manure storage receptacle that stores manure excreted in this pen
+            manure_separator: the manure separator that processes manure excreted in the pen
+            manure_storage: the manure storage receptacle that stores manure excreted in the pen
         """
         self.id = id_number
 
@@ -147,7 +179,6 @@ class Pen:
         self.bedding_type = bedding_type
         self._pen_type = pen_type
 
-        # TODO: add documentation for the following 8 attributes
         self.DBW = 0.0
         self.daily_growth = 0.0
         self.manure_handling = manure_handling

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -26,50 +26,51 @@ class Pen:
     Attributes
     -------------
     id : int
-        This variable represents a pen's unique pen ID, gotten from the input file.
+        Represents a pen's unique pen ID, obtained from the input file.
 
     vertical_dist_to_parlor : float
-        This variable represents the vertical distance to milking parlor, measured in kilometers.
-        It is gotten from the input file.
+        Represents the vertical distance to milking parlor, measured in kilometers.
+        Obtained from the input file.
 
     horizontal_dist_to_parlor : float
-        This variable represents the horizontal distance to milking parlor, measured in kilometers.
-        It is gotten from the input file
+        Represents the horizontal distance to milking parlor, measured in kilometers.
+        Obtained from the input file.
 
     num_stalls : int
-        This variable represents the number of stalls, gotten from the input file.
+        Represents the number of stalls, obtained from the input file.
 
     stocking_density : float
-        This variable represents the stocking density of the pen, and is calculated when animals in pen are
+        Represents the stocking density of the pen, and is calculated when animals in pen are
         updated in update_animals()
 
     housing_type : string
-        This variable represents the housing type of the pen, gotten from the input file.
+        Represents the housing type of the pen, obtained from the input file.
 
     bedding_type : string
-        This variable represents the bedding type of the pen, gotten from the input file.
+        Represents the bedding type of the pen, obtained from the input file.
 
     pen_type : string
-        This variable represents the pen type (freestall or tiestall), gotten from the input file.
+        Represents the pen type (freestall or tiestall).
+        Obtained from the input file.
 
     animals_in_pen : animal list
-        This variable represents the list of all animals in this pen
+        Represents the list of all animals in this pen.
 
     classes_in_pen : set
-        This variable represents the set (no repeats) of all the classes to which the animals in pen belong.
+        Represents the set (no repeats) of all the classes to which the animals in pen belong.
 
     pen_populated : bool
-        This variable checks if len(self.animals_in_pen) == 0, that is, if there are any animals in the pen.
+        Is true iff there is at least 1 animal in the pen.
 
     avg_DBW : float
-        This variable represents the average daily change in (delta) body weight of the
+        Represents the average daily change in (delta) body weight of the
         animals in the pen, and is used for ration formulation.
 
     avg_BW : float
-        This variable represents the average body weight of the animals in the pen, and is used for ration formulation.
+        Represents the average body weight of the animals in the pen, and is used for ration formulation.
 
     avg_DMIest : float
-        This variable represents the average dry matter intake estimation of the animals in the pen,
+        Represents the average dry matter intake estimation of the animals in the pen,
         and is used for ration formulation
 
     avg_nutrient_rqmts : dict
@@ -78,40 +79,39 @@ class Pen:
         are used for ration formulation
 
     avg_milk : float
-        This variable represents the average milk production of the animals in the pen, and is
+        Represents the average milk production of the animals in the pen, and is
         used for (lactating cow) ration formulation
 
     avg_CP_milk : float
-        This variable represents the average milk crude protein content of the animals in the pen, and is
+        Represents the average milk crude protein content of the animals in the pen, and is
         used for (lactating cow) ration formulation
 
     ration : dict
-        This variable represents the dictionary containing the ration for all the animals in the pen.
+        Contains the ration for all the animals in the pen.
 
     ration_nutrient_amount : dict
-        This variable represents the total amount of different nutrients in the current ration.
+        Contains the total amount of different nutrients in the current ration.
 
     ration_nutrient_conc : dict
-        This variable represents the dictionary containing the concentration of different nutrients
-        in the current ration.
+        Contains the concentration of different nutrients in the current ration.
 
     avg_growth : float
-        This variable represents the average growth of the animals in the pen.
+        Represents the average growth of the animals in the pen.
 
     manure : dict
-        This variable represents a dictionary containing the total manure excretion of the animals in the pen.
+        Contains the total manure excretion of all animals in the pen.
 
     calf_total : dict
-        This variable represents a dictionary containing the total manure excretion of the calves in the pen.
+        Contains the total manure excretion of the calves in the pen.
 
     heifer_total : dict
-        This variable represents a dictionary containing the total manure excretion of the heifers in the pen.
+        Contains the total manure excretion of the heifers in the pen.
 
     dry_total : dict
-        This variable represents a dictionary containing the total manure excretion of the dry cows in the pen.
+        Contains the total manure excretion of the dry cows in the pen.
 
     lacatating_total : dict
-        This variable represents a dictionary containing the total manure excretion of the lactating cows in the pen.
+        Contains the total manure excretion of the lactating cows in the pen.
     """
 
     def __init__(self, id_number, vert_dist, horiz_dist, num_stalls, housing_type,
@@ -167,34 +167,12 @@ class Pen:
                                        'phosphorus': 0, 'potassium': 0, 'N': 0}
         self.ration_nutrient_conc = {}
 
-        # initial state for manure, calf_total, etc.
-        self.init_dict = {"U": 0,
-                          "TAN_s": 0,
-                          "MN": 0,
-                          "Mkg": 0,
-                          "TSd": 0,
-                          "VSd": 0,
-                          "VSnd": 0,
-                          "WIP_frac": 0,
-                          "WOP_frac": 0,
-                          "p_excrt_manure": 0,
-                          "p_frac": 0,
-                          "K_manure": 0,
-                          "CH4_manure": 0
-                          }
-
-        self.manure = copy.deepcopy(self.init_dict)
-        self.calf_total = copy.deepcopy(self.init_dict)
-        self.heifer_total = copy.deepcopy(self.init_dict)
-        self.dry_total = copy.deepcopy(self.init_dict)
-        self.lactating_total = copy.deepcopy(self.init_dict)
-
-    # Getters
+        self.reset_manure()
 
     def get_id(self):
         """
         Returns:
-            int : the id_number, the unique id number of the pen.
+            int : the id, the unique id number of the pen.
         """
         return self.id
 
@@ -204,8 +182,6 @@ class Pen:
             string : the pen type: freestall or tiestall.
         """
         return self.pen_type
-
-    # Setters
 
     def set_id(self, pen_id):
         """
@@ -476,19 +452,26 @@ class Pen:
         self.lactating_total = lactating_total
 
     def reset_manure(self):
-        # total manure excretion of the animals in the pen
+        # template for manure, calf_total, etc.
+        self._manure_excretion_dict_template = {"U": 0,
+                                                "TAN_s": 0,
+                                                "MN": 0,
+                                                "Mkg": 0,
+                                                "TSd": 0,
+                                                "VSd": 0,
+                                                "VSnd": 0,
+                                                "WIP_frac": 0,
+                                                "WOP_frac": 0,
+                                                "p_excrt_manure": 0,
+                                                "p_frac": 0,
+                                                "K_manure": 0,
+                                                "CH4_manure": 0
+                                                }
+
         self.manure = copy.deepcopy(self.init_dict)
-
-        # total manure excretion of the calves in the pen
         self.calf_total = copy.deepcopy(self.init_dict)
-
-        # total manure excretion of the heifers in the pen
         self.heifer_total = copy.deepcopy(self.init_dict)
-
-        # total manure excretion of the dry cows in the pen
         self.dry_total = copy.deepcopy(self.init_dict)
-
-        # total manure excretion of the lactating cows in the pen
         self.lactating_total = copy.deepcopy(self.init_dict)
 
     def calc_avg_growth(self):
@@ -632,5 +615,3 @@ class Pen:
         self.pen_populated = False
         # self.classes_in_pen = set()
         self.avg_p_animal = 0
-
-

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -57,14 +57,6 @@ class Pen:
         The pen type (freestall or tiestall).
         Obtained from the input file.
 
-    TODO: make sure this description is correct
-    DBW : float
-        The daily change in (delta) body weight of the animals in the pen.
-        Used for ration formulation.
-
-    TODO: add description
-    daily_growth : float
-
     manure_handling : string
         The manure handling method used to clean the pen
 
@@ -293,14 +285,8 @@ class Pen:
             temp: the temperature on the current day
         """
         for animal in self.animals_in_pen:
-            # currently, only lactating cows have ration calculations, so there
-            # are different arguments
-            if type(animal).__name__ == 'Cow':
-                # old hard coded variable updates from the deleted calc_requirements in
-                # cow.py
-                self.DBW = -0.4125
-                self.daily_growth = self.DBW
-            elif type(animal).__name__ == 'Calf':
+
+            if type(animal).__name__ == 'Calf':
                 animal.calc_nutrient_rqmts(feed, temp)
             else:
                 animal.calc_nutrient_rqmts()

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -21,41 +21,97 @@ class Pen:
     Manages a pen's operation. Stores the characteristics of the pen and the
     animals that are housed in it any point in the simulation. This class also
     keeps track of some key characteristics of the average animal in the pen.
+
+    Attributes
+    -------------
+    id : int
+        This variable represents a pen's unique pen ID, gotten from the input file.
+
+    vertical_dist_to_parlor : float
+        This variable represents the vertical distance to milking parlor, measured in kilometers.
+        It is gotten from the input file.
+
+    horizontal_dist_to_parlor : float
+        This variable represents the horizontal distance to milking parlor, measured in kilometers.
+        It is gotten from the input file
+
+    num_stalls : int
+        This variable represents the number of stalls, gotten from the input file.
+
+    stocking_density : float
+        This variable represents the stocking density of the pen, and is calculated when animals in pen are
+        updated in update_animals()
+
+    housing_type : string
+        This variable represents the housing type of the pen, gotten from the input file.
+
+    bedding_type : string
+        This variable represents the bedding type of the pen, gotten from the input file.
+
+    pen_type : string
+        This variable represents the pen type (freestall or tiestall), gotten from the input file.
+
+    animals_in_pen : animal list
+        This variable represents the list of all animals in this pen
+
+    classes_in_pen : set
+        This variable represents the set (no repeats) of all the classes to which the animals in pen belong.
+
+    pen_populated : bool
+        This variable checks if len(self.animals_in_pen) == 0, that is, if there are any animals in the pen.
+
+    avg_DBW : float
+        This variable represents the average daily change in (delta) body weight of the
+        animals in the pen, and is used for ration formulation.
+
+    avg_BW : float
+        This variable represents the average body weight of the animals in the pen, and is used for ration formulation.
+
+    avg_DMIest : float
+        This variable represents the average dry matter intake estimation of the animals in the pen,
+        and is used for ration formulation
+
+    avg_nutrient_rqmts : dict
+    avg_calf_nutrient_rqmts : dict
+        These variables represent the dictionaries containing the nutrient requirements in the pen, and
+        are used for ration formulation
+
+    avg_milk : float
+        This variable represents the average milk production of the animals in the pen, and is
+        used for (lactating cow) ration formulation
+
+    avg_CP_milk : float
+        This variable represents the average milk crude protein content of the animals in the pen, and is
+        used for (lactating cow) ration formulation
+
+    ration : dict
+        This variable represents the dictionary containing the ration for all the animals in the pen.
+
+    ration_nutrient_amount : dict
+        This variable represents the total amount of different nutrients in the current ration.
+
+    ration_nutrient_conc : dict
+        This variable represents the dictionary containing the concentration of different nutrients
+        in the current ration.
+
+    avg_growth : float
+        This variable represents the average growth of the animals in the pen.
+
+    manure : dict
+        This variable represents a dictionary containing the total manure excretion of the animals in the pen.
+
+    calf_total : dict
+        This variable represents a dictionary containing the total manure excretion of the calves in the pen.
+
+    heifer_total : dict
+        This variable represents a dictionary containing the total manure excretion of the heifers in the pen.
+
+    dry_total : dict
+        This variable represents a dictionary containing the total manure excretion of the dry cows in the pen.
+
+    lacatating_total : dict
+        This variable represents a dictionary containing the total manure excretion of the lactating cows in the pen.
     """
-    # the following attributes were moved from outside the class' initializer into the
-    # initializer to allow for them to be changed for each individual instance as required:
-    # id, animals_in_pen, pen_populated, classes_in_pen, vertical_dist_to_parlor, horizontal_dist_to_parlor,
-    # num_stalls, stocking_density, housing_type, bedding_type,
-
-    # unique pen ID, from input file
-    id = -1
-
-    # vertical distance to milking parlor, km, from input file
-    vertical_dist_to_parlor = 0
-
-    # horizontal distance to milking parlor, km, from input file
-    horizontal_dist_to_parlor = 0
-
-    # number of stalls, from input file
-    num_stalls = 0
-
-    # stocking density of pen, calculated when animals in pen are updated in
-    # update_animals()
-    stocking_density = 0
-
-    # housing type of the pen, from input file
-    housing_type = ""
-
-    # bedding type of the pen, from input file
-    bedding_type = ""
-
-    # freestall or tiestall, from input file
-    pen_type = ""
-
-    # average daily change in (delta) body weight of the animals in the pen,
-    # used for ration formulation
-    avg_DBW = 0
-
 
     def __init__(self, id_number, vert_dist, horiz_dist, num_stalls, housing_type,
                  bedding_type, pen_type, manure_handling, manure_separator, manure_storage):
@@ -84,66 +140,32 @@ class Pen:
         self.pen_type = pen_type
         self.DBW = 0.0
         self.daily_growth = 0.0
-
         self.manure_handling = manure_handling
         self.manure_separator = manure_separator
         self.manure_storage = manure_storage
-
         self.avg_p_intake = 0
         self.avg_p_req = 0
         self.avg_p_animal = 0
-
-        # __________________MOVED ATTRIBUTES IN___________________________
-
-        # list of all animals in this pen
         self.animals_in_pen = []
-
-        # boolean: False if len(self.animals_in_pen) == 0
-        # (i.e. there are no animals in the pen)
         self.pen_populated = False
 
-        # set (no repeats) of all the classes to which the animals in the pen belong
         self.classes_in_pen = set()
-
-        # stocking density of pen, calculated when animals in pen are updated in
-        # update_animals()
         self.stocking_density = 0
 
-        # average body weight of the animals in the pen, used for ration formulation
         self.avg_BW = 0
-
-        # average dry matter intake estimation of the animals in the pen,
-        # used for ration formulation
         self.avg_DMIest = 0
 
-        # average nutrient requirements of the animals in the pen, used for
-        # ration formulation
         self.avg_nutrient_rqmts = {}
         self.avg_calf_nutrient_rqmts = {}
-
-        # average milk production of the animals in the pen,
-        # used for (lactating cow) ration formulation
         self.avg_milk = 0
-
-        # average milk crude protein content of the animals in the pen,
-        # used for (lactating cow) ration formulation
         self.avg_CP_milk = 0
 
-        # ration for all the animals in the pen
         self.ration = {}
-
-        # total amount of different nutrients in current ration
         self.ration_nutrient_amount = {'dm': 0, 'CP': 0, 'ADF': 0,
                                        'NDF': 0, 'lignin': 0, 'ash': 0,
                                        'phosphorus': 0, 'potassium': 0, 'N': 0}
-
-        # concentration of different nutrients in current ration
         self.ration_nutrient_conc = {}
 
-        # average growth of the animals in the pen
-        self.avg_growth = 0
-
-        # total manure excretion of the animals in the pen
         self.manure = {"U": 0,
                        "TAN_s": 0,
                        "MN": 0,
@@ -158,8 +180,6 @@ class Pen:
                        "K_manure": 0,
                        "CH4_manure": 0
                        }
-
-        # total manure excretion of the calves in the pen
         self.calf_total = {"U": 0,
                            "TAN_s": 0,
                            "MN": 0,
@@ -174,8 +194,6 @@ class Pen:
                            "K_manure": 0,
                            "CH4_manure": 0
                            }
-
-        # total manure excretion of the heifers in the pen
         self.heifer_total = {"U": 0,
                              "TAN_s": 0,
                              "MN": 0,
@@ -190,8 +208,6 @@ class Pen:
                              "K_manure": 0,
                              "CH4_manure": 0
                              }
-
-        # total manure excretion of the dry cows in the pen
         self.dry_total = {"U": 0,
                           "TAN_s": 0,
                           "MN": 0,
@@ -206,8 +222,6 @@ class Pen:
                           "K_manure": 0,
                           "CH4_manure": 0
                           }
-
-        # total manure excretion of the lactating cows in the pen
         self.lactating_total = {"U": 0,
                                 "TAN_s": 0,
                                 "MN": 0,

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -26,7 +26,8 @@ class Pen:
     Attributes
     -------------
     id : int
-        Represents a pen's unique pen ID, obtained from the input file.
+        Represents a pen's unique pen ID.
+        Obtained from the input file.
 
     vertical_dist_to_parlor : float
         Represents the vertical distance to milking parlor, measured in kilometers.
@@ -37,17 +38,20 @@ class Pen:
         Obtained from the input file.
 
     num_stalls : int
-        Represents the number of stalls, obtained from the input file.
+        Represents the number of stalls.
+        Obtained from the input file.
 
     stocking_density : float
         Represents the stocking density of the pen, and is calculated when animals in pen are
         updated in update_animals()
 
     housing_type : string
-        Represents the housing type of the pen, obtained from the input file.
+        Represents the housing type of the pen.
+        Obtained from the input file.
 
     bedding_type : string
-        Represents the bedding type of the pen, obtained from the input file.
+        Represents the bedding type of the pen.
+        Obtained from the input file.
 
     pen_type : string
         Represents the pen type (freestall or tiestall).
@@ -141,29 +145,32 @@ class Pen:
         self.num_stalls = num_stalls
         self.housing_type = housing_type
         self.bedding_type = bedding_type
-        self.pen_type = pen_type
+        self._pen_type = pen_type
+
+        # TODO: add documentation for the following 8 attributes
         self.DBW = 0.0
         self.daily_growth = 0.0
         self.manure_handling = manure_handling
         self.manure_separator = manure_separator
         self.manure_storage = manure_storage
-        self.avg_p_intake = 0
-        self.avg_p_req = 0
-        self.avg_p_animal = 0
+        self.avg_p_intake = 0.0
+        self.avg_p_req = 0.0
+        self.avg_p_animal = 0.0
+
         self.animals_in_pen = []
         self.pen_populated = False
 
         self.classes_in_pen = set()
-        self.stocking_density = 0
+        self.stocking_density = 0.0
 
-        self.avg_BW = 0
-        self.avg_DMIest = 0
-        self.avg_DBW = 0
+        self.avg_BW = 0.0
+        self.avg_DMIest = 0.0
+        self.avg_DBW = 0.0
 
         self.avg_nutrient_rqmts = {}
         self.avg_calf_nutrient_rqmts = {}
-        self.avg_milk = 0
-        self.avg_CP_milk = 0
+        self.avg_milk = 0.0
+        self.avg_CP_milk = 0.0
 
         self.ration = {}
         self.ration_nutrient_amount = {'dm': 0, 'CP': 0, 'ADF': 0,
@@ -171,11 +178,9 @@ class Pen:
                                        'phosphorus': 0, 'potassium': 0, 'N': 0}
         self.ration_nutrient_conc = {}
 
-        # TODO: add initial value
-        self.avg_growth = None
+        self.avg_growth = 0.0
 
         # TODO: add initial value and documentation in the docstring
-        # it also seems like this variable is never used - possibly remove it?
         self.MEdiet = None
 
         # template for manure, calf_total, etc.
@@ -215,7 +220,7 @@ class Pen:
         Returns:
             string : the pen type: freestall or tiestall.
         """
-        return self.pen_type
+        return self._pen_type
 
     def set_id(self, pen_id):
         """
@@ -225,15 +230,6 @@ class Pen:
             pen_id: The pen's unique pen ID, obtained from the input file.
         """
         self.id = pen_id
-
-    def set_pen_type(self, pen_type):
-        """
-        Sets the pen type of the pen to pen_type.
-
-        Args:
-            pen_type: The pen type of the pen.
-        """
-        self.pen_type = pen_type
 
     def update_animals(self, new_animals):
         """
@@ -427,19 +423,17 @@ class Pen:
 
     def calc_manure(self, feed, methane_model):
         """
-        Calculates the total manure excretion of the animals in the pen.
+        Calculates the total manure excretion of the animals in the pen,
+         and updates the manure attributes to contain the new amounts.
 
         Args:
             feed: instance of the Feed class
             methane_model: methane model used for methane emission calculations
-
-        Returns:
-            a dictionary for the total manure of the animals in the pen
         """
-        ME_intake = self.MEdiet
+
         for animal in self.animals_in_pen:
             if type(animal).__name__ == 'Cow':
-                animal.calc_manure_excretion(feed, methane_model, ME_intake)
+                animal.calc_manure_excretion(feed, methane_model, self.MEdiet)
             else:
                 animal.calc_manure_excretion(feed)
 

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -58,7 +58,7 @@ class Pen:
         Obtained from the input file.
 
     manure_handling : string
-        The manure handling method used to clean the pen
+        The manure handling method used to clean the pen.
 
     manure_separator : string
         The type of manure separator that processes manure excreted in the pen.
@@ -66,17 +66,14 @@ class Pen:
     manure_storage : string
         The type of manure storage receptacle that stores manure excreted in the pen.
 
-    TODO: make sure this description is correct
     avg_p_intake : float
         The average phosphorus intake of the animals in the pen.
 
-    TODO: make sure this description is correct
     avg_p_req : float
         The average phosphorus requirements of the animals in the pen.
 
-    TODO: add description
     avg_p_animal : float
-                            The average phosphorus content/mass of the animals in the pen
+        The average phosphorus content/mass of the animals in the pen.
 
     animals_in_pen : animal list
         The list of all animals in this pen.
@@ -127,6 +124,9 @@ class Pen:
     avg_growth : float
         The average growth of the animals in the pen.
 
+    MEdiet : float
+        The metabolizable energy concentration of the diet fed to the pen.
+
     _manure_dict_template : dict
         The dictionary template for the manure attributes (manure, calf_total, etc)
 
@@ -172,8 +172,6 @@ class Pen:
         self.bedding_type = bedding_type
         self._pen_type = pen_type
 
-        self.DBW = 0.0
-        self.daily_growth = 0.0
         self.manure_handling = manure_handling
         self.manure_separator = manure_separator
         self.manure_storage = manure_storage
@@ -204,8 +202,7 @@ class Pen:
 
         self.avg_growth = 0.0
 
-        # TODO: add initial value and documentation in the docstring
-        self.MEdiet = None
+        self.MEdiet = 0.0
 
         # template for manure, calf_total, etc.
         self._manure_dict_template = {"U": 0,

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -22,18 +22,13 @@ class Pen:
     animals that are housed in it any point in the simulation. This class also
     keeps track of some key characteristics of the average animal in the pen.
     """
+    # the following attributes were moved from outside the class' initializer into the
+    # initializer to allow for them to be changed for each individual instance as required:
+    # id, animals_in_pen, pen_populated, classes_in_pen, vertical_dist_to_parlor, horizontal_dist_to_parlor,
+    # num_stalls, stocking_density, housing_type, bedding_type,
+
     # unique pen ID, from input file
     id = -1
-
-    # list of all animals in this pen
-    animals_in_pen = []
-
-    # boolean: False if len(self.animals_in_pen) == 0
-    # (i.e. there are no animals in the pen)
-    pen_populated = False
-
-    # set (no repeats) of all the classes to which the animals in the pen belong
-    classes_in_pen = set()
 
     # vertical distance to milking parlor, km, from input file
     vertical_dist_to_parlor = 0
@@ -57,123 +52,10 @@ class Pen:
     # freestall or tiestall, from input file
     pen_type = ""
 
-    # average nutrient requirements of the animals in the pen, used for
-    # ration formulation
-    avg_nutrient_rqmts = {}
-    avg_calf_nutrient_rqmts = {}
-
-    # average body weight of the animals in the pen, used for ration formulation
-    avg_BW = 0
-
-    # average dry matter intake estimation of the animals in the pen,
-    # used for ration formulation
-    avg_DMIest = 0
-
     # average daily change in (delta) body weight of the animals in the pen,
     # used for ration formulation
     avg_DBW = 0
 
-    # average milk production of the animals in the pen,
-    # used for (lactating cow) ration formulation
-    avg_milk = 0
-
-    # average milk crude protein content of the animals in the pen,
-    # used for (lactating cow) ration formulation
-    avg_CP_milk = 0
-
-    # ration for all the animals in the pen
-    ration = {}
-
-    # total amount of different nutrients in current ration
-    ration_nutrient_amount = {'dm': 0, 'CP': 0, 'ADF': 0,
-                              'NDF': 0, 'lignin': 0, 'ash': 0,
-                              'phosphorus': 0, 'potassium': 0, 'N': 0}
-
-    # concentration of different nutrients in current ration
-    ration_nutrient_conc = {}
-
-    # total manure excretion of the animals in the pen
-    manure = {"U": 0,
-              "TAN_s": 0,
-              "MN": 0,
-              "Mkg": 0,
-              "TSd": 0,
-              "VSd": 0,
-              "VSnd": 0,
-              "WIP_frac": 0,
-              "WOP_frac": 0,
-              "p_excrt_manure": 0,
-              "p_frac": 0,
-              "K_manure": 0,
-              "CH4_manure": 0
-              }
-
-    # total manure excretion of the calves in the pen
-    calf_total = {"U": 0,
-                  "TAN_s": 0,
-                  "MN": 0,
-                  "Mkg": 0,
-                  "TSd": 0,
-                  "VSd": 0,
-                  "VSnd": 0,
-                  "WIP_frac": 0,
-                  "WOP_frac": 0,
-                  "p_excrt_manure": 0,
-                  "p_frac": 0,
-                  "K_manure": 0,
-                  "CH4_manure": 0
-                  }
-
-    # total manure excretion of the heifers in the pen
-    heifer_total = {"U": 0,
-                    "TAN_s": 0,
-                    "MN": 0,
-                    "Mkg": 0,
-                    "TSd": 0,
-                    "VSd": 0,
-                    "VSnd": 0,
-                    "WIP_frac": 0,
-                    "WOP_frac": 0,
-                    "p_excrt_manure": 0,
-                    "p_frac": 0,
-                    "K_manure": 0,
-                    "CH4_manure": 0
-                    }
-
-    # total manure excretion of the dry cows in the pen
-    dry_total = {"U": 0,
-                 "TAN_s": 0,
-                 "MN": 0,
-                 "Mkg": 0,
-                 "TSd": 0,
-                 "VSd": 0,
-                 "VSnd": 0,
-                 "WIP_frac": 0,
-                 "WOP_frac": 0,
-                 "p_excrt_manure": 0,
-                 "p_frac": 0,
-                 "K_manure": 0,
-                 "CH4_manure": 0
-                 }
-
-    # total manure excretion of the lactating cows in the pen
-    lactating_total = {"U": 0,
-                       "TAN_s": 0,
-                       "MN": 0,
-                       "Mkg": 0,
-                       "TSd": 0,
-                       "VSd": 0,
-                       "VSnd": 0,
-                       "WIP_frac": 0,
-                       "WOP_frac": 0,
-                       "p_excrt_manure": 0,
-                       "p_frac": 0,
-                       "K_manure": 0,
-                       "CH4_manure": 0
-                       }
-
-    # average growth of the animals in the pen
-    avg_growth = 0
 
     def __init__(self, id_number, vert_dist, horiz_dist, num_stalls, housing_type,
                  bedding_type, pen_type, manure_handling, manure_separator, manure_storage):
@@ -210,6 +92,142 @@ class Pen:
         self.avg_p_intake = 0
         self.avg_p_req = 0
         self.avg_p_animal = 0
+
+        # __________________MOVED ATTRIBUTES IN___________________________
+
+        # list of all animals in this pen
+        self.animals_in_pen = []
+
+        # boolean: False if len(self.animals_in_pen) == 0
+        # (i.e. there are no animals in the pen)
+        self.pen_populated = False
+
+        # set (no repeats) of all the classes to which the animals in the pen belong
+        self.classes_in_pen = set()
+
+        # stocking density of pen, calculated when animals in pen are updated in
+        # update_animals()
+        self.stocking_density = 0
+
+        # average body weight of the animals in the pen, used for ration formulation
+        self.avg_BW = 0
+
+        # average dry matter intake estimation of the animals in the pen,
+        # used for ration formulation
+        self.avg_DMIest = 0
+
+        # average nutrient requirements of the animals in the pen, used for
+        # ration formulation
+        self.avg_nutrient_rqmts = {}
+        self.avg_calf_nutrient_rqmts = {}
+
+        # average milk production of the animals in the pen,
+        # used for (lactating cow) ration formulation
+        self.avg_milk = 0
+
+        # average milk crude protein content of the animals in the pen,
+        # used for (lactating cow) ration formulation
+        self.avg_CP_milk = 0
+
+        # ration for all the animals in the pen
+        self.ration = {}
+
+        # total amount of different nutrients in current ration
+        self.ration_nutrient_amount = {'dm': 0, 'CP': 0, 'ADF': 0,
+                                       'NDF': 0, 'lignin': 0, 'ash': 0,
+                                       'phosphorus': 0, 'potassium': 0, 'N': 0}
+
+        # concentration of different nutrients in current ration
+        self.ration_nutrient_conc = {}
+
+        # average growth of the animals in the pen
+        self.avg_growth = 0
+
+        # total manure excretion of the animals in the pen
+        self.manure = {"U": 0,
+                       "TAN_s": 0,
+                       "MN": 0,
+                       "Mkg": 0,
+                       "TSd": 0,
+                       "VSd": 0,
+                       "VSnd": 0,
+                       "WIP_frac": 0,
+                       "WOP_frac": 0,
+                       "p_excrt_manure": 0,
+                       "p_frac": 0,
+                       "K_manure": 0,
+                       "CH4_manure": 0
+                       }
+
+        # total manure excretion of the calves in the pen
+        self.calf_total = {"U": 0,
+                           "TAN_s": 0,
+                           "MN": 0,
+                           "Mkg": 0,
+                           "TSd": 0,
+                           "VSd": 0,
+                           "VSnd": 0,
+                           "WIP_frac": 0,
+                           "WOP_frac": 0,
+                           "p_excrt_manure": 0,
+                           "p_frac": 0,
+                           "K_manure": 0,
+                           "CH4_manure": 0
+                           }
+
+        # total manure excretion of the heifers in the pen
+        self.heifer_total = {"U": 0,
+                             "TAN_s": 0,
+                             "MN": 0,
+                             "Mkg": 0,
+                             "TSd": 0,
+                             "VSd": 0,
+                             "VSnd": 0,
+                             "WIP_frac": 0,
+                             "WOP_frac": 0,
+                             "p_excrt_manure": 0,
+                             "p_frac": 0,
+                             "K_manure": 0,
+                             "CH4_manure": 0
+                             }
+
+        # total manure excretion of the dry cows in the pen
+        self.dry_total = {"U": 0,
+                          "TAN_s": 0,
+                          "MN": 0,
+                          "Mkg": 0,
+                          "TSd": 0,
+                          "VSd": 0,
+                          "VSnd": 0,
+                          "WIP_frac": 0,
+                          "WOP_frac": 0,
+                          "p_excrt_manure": 0,
+                          "p_frac": 0,
+                          "K_manure": 0,
+                          "CH4_manure": 0
+                          }
+
+        # total manure excretion of the lactating cows in the pen
+        self.lactating_total = {"U": 0,
+                                "TAN_s": 0,
+                                "MN": 0,
+                                "Mkg": 0,
+                                "TSd": 0,
+                                "VSd": 0,
+                                "VSnd": 0,
+                                "WIP_frac": 0,
+                                "WOP_frac": 0,
+                                "p_excrt_manure": 0,
+                                "p_frac": 0,
+                                "K_manure": 0,
+                                "CH4_manure": 0
+                                }
+
+    # getters
+
+
+    # setters
+
 
     def update_animals(self, new_animals):
         """

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -72,10 +72,11 @@ class Pen:
 
     TODO: make sure this description is correct
     avg_p_req : float
-        The average phosphorus intake of the animals in the pen.
+        The average phosphorus requirements of the animals in the pen.
 
     TODO: add description
     avg_p_animal : float
+                            The average phosphorus content/mass of the animals in the pen
 
     animals_in_pen : animal list
         The list of all animals in this pen.

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -226,77 +226,147 @@ class Pen:
     # getters
     def get_id(self):
         """
-        Returns the id_number: the unique id number of the pen 
+        Returns:
+            int : the id_number, the unique id number of the pen.
         """
         return self.id
 
     def get_vertical_dist_to_parlor(self):
         """
-        Returns the vertical distance to milking parlor, km 
+        Returns:
+            float : the vertical distance to milking parlor, km.
         """
         return self.vertical_dist_to_parlor
 
     def get_horizontal_dist_to_parlor(self):
         """
-        Returns the horizontal distance to milking parlor, km
+        Returns:
+            float : the horizontal distance to milking parlor, km.
         """
         return self.horizontal_dist_to_parlor
 
     def get_num_stalls(self):
         """
-        Returns the number of stalls in the pen
+        Returns:
+            int : the number of stalls in the pen.
         """
         return self.num_stalls
 
     def get_housing_type(self):
         """
-        Returns the housing type of the pen
+        Returns:
+            string : the housing type of the pen.
         """
         return self.housing_type
 
     def get_bedding_type(self):
         """
-        Returns the bedding type of the pen
+        Returns:
+            string : the bedding type of the pen.
         """
         return self.bedding_type
 
     def get_pen_type(self):
         """
-        Returns the pen type: freestall or tiestall
+        Returns:
+            string : the pen type: freestall or tiestall.
         """
         return self.pen_type
 
     def get_manure_handling(self):
         """
-        Returns the manure handling method used to clean the pen
+        Returns the manure handling method used to clean the pen.
         """
         return self.manure_handling
 
     def get_manure_separator(self):
         """
-        Returns the manure separator that processes manure excreted in this pen
+        Returns the manure separator that processes manure excreted in this pen.
         """
         return self.manure_separator
 
     def get_manure_storage(self):
         """
-        Returns the manure storage receptacle that stores manure excreted in this pen
+        Returns the manure storage receptacle that stores manure excreted in this pen.
         """
         return self.get_manure_storage
 
     def get_stocking_density(self):
         """
-        Returns the stocking density of the pen
+        Returns the stocking density of the pen.
         """
         return self.stocking_density
 
     def get_avg_DBW(self):
         """
-        Returns the average daily change in (delta) body weight of the animals in the pen
+        Returns the average daily change in (delta) body weight of the animals in the pen.
         """
         return self.avg_DBW
 
     # setters
+    def set_id(self, id):
+        """
+        Sets the pen's id to id.
+
+        Args:
+            id: The pen's unique pen ID, obtained from the input file.
+        """
+        self.id = id
+
+    def set_vertical_dist_to_parlor(self, vert_dist):
+        """
+        Sets the pen's vertical distance to milking parlor, measured in kilometers, to vert_dist.
+
+        Args:
+            vert_dist: The pen's vertical distance to milking parlor, measured in kilometers.
+        """
+        self.vertical_dist_to_parlor = vert_dist
+
+    def set_horizontal_dist_to_parlor(self, hori_dist):
+        """
+        Sets the pen's horizontal distance to milking parlor, measured in kilometers, to hori_dist.
+
+        Args:
+            hori_dist: The pen's horizontal distance to milking parlor, measured in kilometers.
+        """
+        self.horizontal_dist_to_parlor = hori_dist
+
+    def set_num_stalls(self, num_stalls):
+        """
+        Sets the number of stalls in the pen to num_stalls.
+
+        Args:
+            num_stalls: The number of stalls in the pen.
+        """
+        self.num_stalls = num_stalls
+
+    def set_housing_type(self, housing_type):
+        """
+        Sets the housing type of the pen to housing_type.
+
+        Args:
+            housing_type: The housing type of the pen.
+        """
+        self.housing_type = housing_type
+
+    def set_bedding_type(self, bedding_type):
+        """
+        Sets the bedding type of the pen to bedding_type.
+
+        Args:
+            bedding_type: The bedding type of the pen.
+        """
+        self.bedding_type = bedding_type
+
+    def set_pen_type(self, pen_type):
+        """
+        Sets the pen type of the pen to pen_type.
+
+        Args:
+            pen_type: The pen type of the pen.
+        """
+        self.pen_type = pen_type
+
 
 
     def update_animals(self, new_animals):


### PR DESCRIPTION
This pull request includes a rework of the Pen class which focuses on fixing the variable initializations as well as adding Sphinx style documentation.


**Problem:** 
Some of the attributes for the Pen class were declared outside of the initializer, and thus, the attributes maintained the same value for all instances of the class.

This caused some calculations relating to the pens to use the wrong values; instead of using the values tied to any specific instance, all instances of the pen class would share the same values for certain attributes because some attributes were declared outside of the class initializer.

**Fix:**
The attributes that were declared outside of the initializer were moved into the initializer. Any calculation involving an instance of the Pen class now uses the attributes corresponding to that instance.

**Additional Changes:**

Getters and setters were added for the “id” and “pen_type” instance attributes. The usage in other files for these two attributes has not yet been changed, but in the future, the getters and setters will be used instead of directly accessing the attributes. The rest of the variables remain the same.

Documentation was added detailing all of the Pen class attributes including the type and a short description. 

Some of the Pen class attributes involving dictionaries that contained the same fields were re-written to reduce line count. Instead of each attribute containing its own initialization of the same dictionary, a single dictionary was created, and each attribute was initialized to a deep copy of the dictionary.

Getters and setters were created for the other Pen class attributes as well, however, most were deemed unnecessary and removed. In the future, if any of these getters or setters need to be added, they can be found here: 

https://docs.google.com/document/d/1q6cxTo51KCaM3dtiPrtBWWqtMbAajhXgY7p0jfgg8bQ/edit?usp=sharing 
