### PR TITLE
Remove references to old testing framework

### DIFF
--- a/RUFAS/classes.py
+++ b/RUFAS/classes.py
@@ -89,9 +89,6 @@ class Config:
         self.start_day = int(self.start_full_date[1])
         self.end_day = int(self.end_full_date[1])
 
-        # boolean to determine if the tests should be run
-        self.run_tests = data['run_tests']
-
         # set seed attributes
         self.set_seed = data['set_seed']
         self.seed = data['seed']

--- a/RUFAS/simulation_engine.py
+++ b/RUFAS/simulation_engine.py
@@ -15,7 +15,6 @@ from RUFAS import routines, errors, classes
 from RUFAS.classes import Config, State, Weather, Time
 from RUFAS.util import get_base_dir, read_json_file
 from RUFAS.output_handler import OutputHandler
-from RUFAS.test import test_handler
 import random
 import numpy
 
@@ -154,9 +153,6 @@ def initialize_simulation(file_path: Path, data):
         if config.set_seed:
             random.seed(config.seed)
             numpy.random.seed(config.seed)
-
-        if config.run_tests:
-            test_handler.run_tests()
 
         weather = Weather(data['weather'], config)
         time = Time(config)

--- a/input/ARL.json
+++ b/input/ARL.json
@@ -5,7 +5,6 @@
         "end_date" : "2019:365",
         "csv_dir": "output/CSVs/",
         "graphic_dir": "output/graphics/",
-        "run_tests": false,
         "set_seed": false,
         "seed": 0
     },

--- a/input/LT.json
+++ b/input/LT.json
@@ -5,7 +5,6 @@
         "end_date" : "2019:365",
         "csv_dir": "output/CSVs/",
         "graphic_dir": "output/graphics/",
-        "run_tests": false,
         "set_seed": false,
         "seed": 0
     },

--- a/input/animal_management.json
+++ b/input/animal_management.json
@@ -5,7 +5,6 @@
         "end_date" : "2016:243",
         "csv_dir": "output/CSVs/",
         "graphic_dir": "output/graphics/",
-        "run_tests": false,
         "set_seed": false,
         "seed": 0
     },

--- a/input/barnyard.json
+++ b/input/barnyard.json
@@ -5,7 +5,6 @@
         "end_date" : "2016:243",
         "csv_dir": "output/CSVs/",
         "graphic_dir": "output/graphics/",
-        "run_tests": false,
         "set_seed": false,
         "seed": 0
     },


### PR DESCRIPTION
There were a few leftover references to the old testing framework, causing errors in master. I removed those here.