### PR TITLE
Setting a new animal's DMI when she is added to the herd

### DIFF
--- a/RUFAS/routines/animal/animal_management.py
+++ b/RUFAS/routines/animal/animal_management.py
@@ -371,6 +371,10 @@ class AnimalManagement:
                 self.pens_needing_animals.append(pen)
                 del self.id_pen[i]
 
+        pen_population_before_additions = {}
+        for i, pen in enumerate(self.all_pens):
+            pen_population_before_additions[i] = len(pen.animals_in_pen)
+
         for animal in animals_added:
             if len(self.pens_needing_animals) == 0:
                 # if there hasn't yet been an animal removed from a pen for this
@@ -401,7 +405,8 @@ class AnimalManagement:
                 # self.all_pens[pen].animals_in_pen.append(animal)
                 self.cows.append(animal)
 
-            self.all_pens[pen].set_up_new_animal(animal, animal_p_conc, feed, temp)
+            self.all_pens[pen].set_up_new_animal(animal, animal_p_conc, feed,
+                                                 temp, pen_population_before_additions[pen])
 
         for pen in range(len(self.all_pens)):
             if len(self.all_pens[pen].animals_in_pen) > 0 and 'Cow' in self.all_pens[pen].classes_in_pen and self.all_pens[pen].ration == {}:
@@ -409,13 +414,25 @@ class AnimalManagement:
                 available_feeds.feed_nutrients(feed)
                 self.all_pens[pen].calc_avg_stats()
                 self.all_pens[pen].ration = self.all_pens[pen].calc_ration(feed, available_feeds)
+            else:
+                # Need to adjust the ration totals for the pen attributes now
+                # that all new animals have been added
+                for key in self.all_pens[pen].ration:
+                    if key != 'status' and key != 'objective':
+                        self.all_pens[pen].ration[key] = \
+                            (self.all_pens[pen].ration[key] /
+                             pen_population_before_additions[pen]) * len(
+                                self.all_pens[pen].animals_in_pen)
 
         for calf in calves_born:
             # TODO: this is the hard coded calf pen value
             pen = 0
             self.id_pen[calf.id] = pen
             self.calves.append(calf)
-            self.all_pens[pen].set_up_new_animal(calf, self.pasture_concentrate, feed, temp)
+            self.all_pens[pen].set_up_new_animal(calf,
+                                                 self.pasture_concentrate,
+                                                 feed, temp,
+                                                 pen_population_before_additions[pen])
             # self.all_pens[pen].animals_in_pen.append(calf)
 
     def pen_allocation(self):

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -202,7 +202,7 @@ class Pen:
                                        'NDF': 0, 'lignin': 0, 'ash': 0,
                                        'phosphorus': 0, 'potassium': 0, 'N': 0}
         self.ration_nutrient_conc = {}
-        self.dry_matter_intake = 0
+        self.dry_matter_intake = 0.0
 
         self.avg_growth = 0.0
 

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -252,6 +252,8 @@ class Pen:
         """
         self.id = pen_id
 
+        self.dry_matter_intake = 0
+
     def update_animals(self, new_animals):
         """
         Sets the list of animals to @new_animals and calculates the stocking
@@ -418,6 +420,7 @@ class Pen:
         self.ration_nutrient_amount = nutrient_amount
         self.ration_nutrient_conc = nutrient_conc
         self.MEdiet = ration_vals['ME_tot']
+        self.dry_matter_intake = nutrient_amount['dm']
 
         for animal in self.animals_in_pen:
             animal.set_ration(ration_per_animal, nutrient_amount['dm'])
@@ -595,6 +598,8 @@ class Pen:
         # set animal's ration to be the intake of all other animals in pen
         # if self.ration == {}:
         #     self.ration = self.calc_ration(feed, temp)
+
+        animal.dry_matter_intake = self.dry_matter_intake
 
         for key in self.ration:
             if key == 'status':

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -121,6 +121,9 @@ class Pen:
     ration_nutrient_conc : dict
         Contains the concentration of different nutrients in the current ration.
 
+    dry_matter_intake : float
+        The dry matter intake value of the animals in the pen.
+
     avg_growth : float
         The average growth of the animals in the pen.
 

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -199,6 +199,7 @@ class Pen:
                                        'NDF': 0, 'lignin': 0, 'ash': 0,
                                        'phosphorus': 0, 'potassium': 0, 'N': 0}
         self.ration_nutrient_conc = {}
+        self.dry_matter_intake = 0
 
         self.avg_growth = 0.0
 
@@ -251,8 +252,6 @@ class Pen:
             pen_id: The pen's unique pen ID, obtained from the input file.
         """
         self.id = pen_id
-
-        self.dry_matter_intake = 0
 
     def update_animals(self, new_animals):
         """

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -553,7 +553,7 @@ class Pen:
                 total_p_animal += animal.p_animal
             self.avg_p_animal = total_p_animal / len(self.animals_in_pen)
 
-    def set_up_new_animal(self, animal, p_comp, feed, temp):
+    def set_up_new_animal(self, animal, p_comp, feed, temp, num_animals_before_additions):
         """
         Sets the necessary attributes for @animal to be a replacement in this
         pen.
@@ -566,13 +566,14 @@ class Pen:
                 calf and that its p_animal attribute has already been calculated
             feed: instance of the Feed class defined in feed.py
             temp: temperature on the current day
+            num_animals_before_additions: the number of animals in this pen
+                before any new animals were added for the day
         """
-        num_animals = len(self.animals_in_pen)
-        if num_animals == 0:
+        if num_animals_before_additions == 0:
             # for the case that there are no animals currently in this pen.
             # Avoids a division by 0 error in below calculations
             # TODO is there a better way?
-            num_animals = 1
+            num_animals_before_additions = 1
 
         class_name = type(animal).__name__
         self.classes_in_pen.add(class_name)
@@ -608,12 +609,18 @@ class Pen:
                 animal.ration_formulation[key] = self.ration[key]
 
             else:  # feeds and price
-                animal.ration_formulation[key] = self.ration[key] / num_animals
+                animal.ration_formulation[key] = self.ration[key] / num_animals_before_additions
 
         # set animal's manure to be the average manure of all other
         # animals in pen
         for key in self.manure.keys():
-            animal.manure_excretion[key] = self.manure[key] / num_animals
+            animal.manure_excretion[key] = self.manure[key] / len(self.animals_in_pen)
+
+        # since the manure attribute is a total from all animals in the pen,
+        # we need to add the current animal's values to the total values for
+        # each manure key
+        for key in self.manure:
+            self.manure[key] += animal.manure_excretion[key]
 
         # set animal's nutrient requirements to be the average requirements of
         # all other animals in pen


### PR DESCRIPTION
When a new animal gets added to the herd on a day which the ration is not calculated, we set the ration formulation of the new animal to be the same as that of the animals in the pen she is added to. However, we don't set her dry matter intake. This PR makes that change.