### PR TITLE
Remove Path wrapper around connection to database file in DatabaseReader

### DIFF
--- a/RUFAS/util.py
+++ b/RUFAS/util.py
@@ -72,7 +72,7 @@ class DatabaseReader:
 
         try:
             # Forms a connection to the database
-            conn = sqlite3.connect(Path(self.db_file))
+            conn = sqlite3.connect(self.db_file)
             conn.row_factory = sqlite3.Row
             c = conn.cursor()
 


### PR DESCRIPTION
According to the [Python documentation](https://docs.python.org/3/library/sqlite3.html#sqlite3.connect), `sqlite3.connect()` takes as an argument a path-like object, where "a path-like object is either a [str](https://docs.python.org/3/library/stdtypes.html#str) or [bytes](https://docs.python.org/3/library/stdtypes.html#bytes) object representing a path, or an object implementing the [os.PathLike](https://docs.python.org/3/library/os.html#os.PathLike) protocol." Previously, the line of code to connect to a generic database in util.DatabaseReader wrapped the file name in a `Path` object. According to the Python documentation, "depending on your system, instantiating a `Path` will return either a `PosixPath` or a `WindowsPath` object." There have been a few cases where this call has caused issues for both Windows and Mac users, so this line of code now just uses the string.