### PR TITLE
Adding tests for carbon_cycling submodule

### DIFF
--- a/config/defintions.py
+++ b/config/defintions.py
@@ -1,0 +1,2 @@
+import os
+ROOT_DIR = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))

--- a/tests/routines/field/soil/carbon_cycling/carbon_cycle_tests.py
+++ b/tests/routines/field/soil/carbon_cycling/carbon_cycle_tests.py
@@ -1,0 +1,74 @@
+"""
+RUFAS: Ruminant Farm Systems Model
+File name: carbon_cycle_tests.py
+Description: Implements test cases
+Author(s): Jessica Tweneboah, jnt42@cornell.edu
+"""
+
+import pytest
+import json
+import logging
+import numpy as np
+
+from RUFAS.routines.field.soil import Soil
+from RUFAS.routines.field.soil.carbon_cycling import carbon_cycle
+from config.defintions import ROOT_DIR
+
+LOGGER = logging.getLogger(__name__)
+
+LOGGER.info("Read json file: ARL_soil_tillage.json")
+soil_file = open(ROOT_DIR + "/input/soil/ARL_soil_tillage.json")
+LOGGER.info("Convert from json file format to Python dictionary")
+soil_data = json.load(soil_file)
+
+
+def test_soil_carbon_aggregation():
+	LOGGER.info("Testing function: soil_carbon_aggregation")
+	test_soil = Soil(soil_data)
+	carbon_cycle.soil_carbon_aggregation(test_soil)
+
+	LOGGER.info("Checking number of layers")
+	assert len(test_soil.soil_layers) == 4
+
+	LOGGER.info("Checking changes to soil layers")
+	LOGGER.info("Checking Layer 0")
+	layer0 = test_soil.soil_layers[0]
+	np.testing.assert_almost_equal(1.0016132650989862, layer0.C_percent)
+	np.testing.assert_almost_equal(1.0016132650989862, layer0.org_C)
+	np.testing.assert_almost_equal(3750000, layer0.C)
+	np.testing.assert_almost_equal(3750, layer0.C_mg)
+	np.testing.assert_almost_equal(375000.0, layer0.C_g)
+	np.testing.assert_almost_equal(0.0, layer0.C_CO2_loss_decomp)
+	np.testing.assert_almost_equal(0.0, layer0.C_CO2_loss)
+
+	LOGGER.info("Checking Layer 1")
+	layer1 = test_soil.soil_layers[1]
+	np.testing.assert_almost_equal(0.3465675945436397, layer1.C_percent)
+	np.testing.assert_almost_equal(0.3465675945436397, layer1.org_C)
+	np.testing.assert_almost_equal(3750000, layer1.C)
+	np.testing.assert_almost_equal(3750, layer1.C_mg)
+	np.testing.assert_almost_equal(375000.0, layer1.C_g)
+	np.testing.assert_almost_equal(0.0, layer1.C_CO2_loss_decomp)
+	np.testing.assert_almost_equal(0.0, layer1.C_CO2_loss)
+
+	LOGGER.info("Checking Layer 2")
+	layer2 = test_soil.soil_layers[2]
+	np.testing.assert_almost_equal(1.845472440944882, layer2.C_percent)
+	np.testing.assert_almost_equal(1.845472440944882, layer2.org_C)
+	np.testing.assert_almost_equal(3750000, layer2.C)
+	np.testing.assert_almost_equal(3750, layer2.C_mg)
+	np.testing.assert_almost_equal(375000.0, layer2.C_g)
+	np.testing.assert_almost_equal(0.0, layer2.C_CO2_loss_decomp)
+	np.testing.assert_almost_equal(0.0, layer2.C_CO2_loss)
+
+	LOGGER.info("Checking Layer 3")
+	layer3 = test_soil.soil_layers[3]
+	np.testing.assert_almost_equal(0.2982581722739203, layer3.C_percent)
+	np.testing.assert_almost_equal(0.2982581722739203, layer3.org_C)
+	np.testing.assert_almost_equal(3750000, layer3.C)
+	np.testing.assert_almost_equal(3750, layer3.C_mg)
+	np.testing.assert_almost_equal(375000.0, layer3.C_g)
+	np.testing.assert_almost_equal(0.0, layer3.C_CO2_loss_decomp)
+	np.testing.assert_almost_equal(0.0, layer3.C_CO2_loss)
+
+	assert test_soil.curr_layer_depth == 0

--- a/tests/routines/field/soil/carbon_cycling/decomp_factors_tests.py
+++ b/tests/routines/field/soil/carbon_cycling/decomp_factors_tests.py
@@ -1,0 +1,70 @@
+"""
+RUFAS: Ruminant Farm Systems Model
+File name: decomp_factors_tests.py
+Description: Implements test cases
+Author(s): Jessica Tweneboah, jnt42@cornell.edu
+"""
+
+import pytest
+import json
+import logging
+import numpy as np
+
+from RUFAS.routines.field.soil.carbon_cycling import decomp_factors
+from RUFAS.routines.field.soil import Soil
+from config.defintions import ROOT_DIR
+from RUFAS.classes import Weather
+from RUFAS.classes import Config
+from RUFAS.classes import Time
+
+LOGGER = logging.getLogger(__name__)
+
+LOGGER.info("Read json file: ARL_soil_tillage.json")
+soil_file = open(ROOT_DIR + "/input/soil/ARL_soil_tillage.json")
+path_to_weather_file = ROOT_DIR + "/input/weather/ARL_weather.csv"
+
+LOGGER.info("Convert from json file format to Python dictionary")
+soil_data = json.load(soil_file)
+
+
+def test_temp_factor():
+	LOGGER.info("Testing function: temp_factor")
+	test_soil = Soil(soil_data)
+	test_config_data = {
+		"start_date": "1990:1",
+		"end_date": "2019:365",
+		"csv_dir": "output/CSVs/",
+		"graphic_dir": "output/graphics/",
+		"set_seed": False,
+		"seed": 0
+	}
+	test_config = Config(test_config_data, path_to_weather_file)
+	test_weather = Weather(path_to_weather_file, test_config)
+	test_time = Time(test_config)
+	decomp_factors.temp_factor(test_soil, test_weather, test_time)
+
+	LOGGER.info("Checking soil T_d")
+	np.testing.assert_almost_equal(0.06893050947285823, test_soil.T_d)
+
+
+def test_moisture_factor():
+	LOGGER.info("Testing function: moisture_factor")
+	test_soil = Soil(soil_data)
+	decomp_factors.moisture_factor(test_soil)
+
+	LOGGER.info("Checking changes to soil layers")
+	LOGGER.info("Checking Layer 0")
+	layer0 = test_soil.soil_layers[0]
+	np.testing.assert_almost_equal(1.0187946798566629e-05, layer0.M_d)
+
+	LOGGER.info("Checking Layer 1")
+	layer1 = test_soil.soil_layers[1]
+	np.testing.assert_almost_equal(1.0187946798566629e-05, layer1.M_d)
+
+	LOGGER.info("Checking Layer 2")
+	layer2 = test_soil.soil_layers[2]
+	np.testing.assert_almost_equal(1.0187946798566629e-05, layer2.M_d)
+
+	LOGGER.info("Checking Layer 3")
+	layer3 = test_soil.soil_layers[3]
+	np.testing.assert_almost_equal(1.0187946798566629e-05, layer3.M_d)

--- a/tests/routines/field/soil/carbon_cycling/pool_gas_partitioning_tests.py
+++ b/tests/routines/field/soil/carbon_cycling/pool_gas_partitioning_tests.py
@@ -1,0 +1,114 @@
+"""
+RUFAS: Ruminant Farm Systems Model
+File name: pool_gas_partitioning_tests.py
+Description: Implements test cases
+Author(s): Jessica Tweneboah, jnt42@cornell.edu
+"""
+
+import pytest
+import json
+import logging
+import numpy as np
+
+from RUFAS.routines.field.crop.crop_types.corn import Corn
+from RUFAS.routines.field.soil import Soil
+from RUFAS.routines.field.soil.carbon_cycling import residue_partitioning, decomp_factors, pool_gas_partitioning
+from config.defintions import ROOT_DIR
+from RUFAS.classes import Weather
+from RUFAS.classes import Config
+from RUFAS.classes import Time
+
+LOGGER = logging.getLogger(__name__)
+
+LOGGER.info("Read json file: ARL_soil_tillage.json")
+soil_file = open(ROOT_DIR + "/input/soil/ARL_soil_tillage.json")
+LOGGER.info("Read json file: ARL_rotation.json")
+crop_file = open(ROOT_DIR + "/input/crop/ARL_rotation.json")
+path_to_weather_file = ROOT_DIR + "/input/weather/ARL_weather.csv"
+
+LOGGER.info("Convert from json file format to Python dictionary")
+soil_data = json.load(soil_file)
+crop_data = json.load(crop_file)
+
+def test_update_all():
+    LOGGER.info("Testing function: update_all")
+    test_soil = Soil(soil_data)
+    test_config_data = {
+        "start_date": "1990:1",
+        "end_date": "2019:365",
+        "csv_dir": "output/CSVs/",
+        "graphic_dir": "output/graphics/",
+        "set_seed": False,
+        "seed": 0
+    }
+    test_config = Config(test_config_data, path_to_weather_file)
+    test_weather = Weather(path_to_weather_file, test_config)
+    test_time = Time(test_config)
+    corn89_data = crop_data["crops"]["corn_89"]
+    test_crop_type = Corn("corn_89", corn89_data)
+
+    decomp_factors.update_all(test_soil, test_weather, test_time)
+    residue_partitioning.update_all(soil=test_soil, crop_type=test_crop_type, weather=test_weather,
+                                              time=test_time)
+    pool_gas_partitioning.update_all(test_soil)
+
+    LOGGER.info("Checking changes to soil layers")
+    LOGGER.info("Checking Layer 0")
+    layer0 = test_soil.soil_layers[0]
+    np.testing.assert_almost_equal(0.01931215999095825, layer0.AG_met_to_C_active_loss)
+    np.testing.assert_almost_equal(0.015800858174420382, layer0.AG_met_to_C_active_act)
+    np.testing.assert_almost_equal(4.836322822029068e-05, layer0.AG_struct_to_C_active_loss)
+    np.testing.assert_almost_equal(5.911061226924417e-05, layer0.AG_struct_to_C_active_act)
+    np.testing.assert_almost_equal(3.224215214686045e-05, layer0.AG_struct_to_C_slow_loss)
+    np.testing.assert_almost_equal(7.523168834267439e-05, layer0.AG_struct_to_C_slow_act)
+    np.testing.assert_almost_equal(0.02414019998869781, layer0.BG_met_to_C_active_loss)
+    np.testing.assert_almost_equal(0.019751072718025477, layer0.BG_met_to_C_active_act)
+    np.testing.assert_almost_equal(0.005293287488430829, layer0.BG_struct_to_C_active_loss)
+    np.testing.assert_almost_equal(0.006469573596971014, layer0.BG_struct_to_C_active_act)
+    np.testing.assert_almost_equal(0.0035288583256205524, layer0.BG_struct_to_C_slow_loss)
+    np.testing.assert_almost_equal(0.008234002759781289, layer0.BG_struct_to_C_slow_act)
+
+    LOGGER.info("Checking Layer 1")
+    layer1 = test_soil.soil_layers[1]
+    np.testing.assert_almost_equal(0.01931215999095825, layer1.AG_met_to_C_active_loss)
+    np.testing.assert_almost_equal(0.015800858174420382, layer1.AG_met_to_C_active_act)
+    np.testing.assert_almost_equal(4.836322822029068e-05, layer1.AG_struct_to_C_active_loss)
+    np.testing.assert_almost_equal(5.911061226924417e-05, layer1.AG_struct_to_C_active_act)
+    np.testing.assert_almost_equal(3.224215214686045e-05, layer1.AG_struct_to_C_slow_loss)
+    np.testing.assert_almost_equal(7.523168834267439e-05, layer1.AG_struct_to_C_slow_act)
+    np.testing.assert_almost_equal(0.02414019998869781, layer1.BG_met_to_C_active_loss)
+    np.testing.assert_almost_equal(0.019751072718025477, layer1.BG_met_to_C_active_act)
+    np.testing.assert_almost_equal(0.005293287488430829, layer1.BG_struct_to_C_active_loss)
+    np.testing.assert_almost_equal(0.006469573596971014, layer1.BG_struct_to_C_active_act)
+    np.testing.assert_almost_equal(0.0035288583256205524, layer1.BG_struct_to_C_slow_loss)
+    np.testing.assert_almost_equal(0.008234002759781289, layer1.BG_struct_to_C_slow_act)
+
+    LOGGER.info("Checking Layer 2")
+    layer2 = test_soil.soil_layers[2]
+    np.testing.assert_almost_equal(0.01931215999095825, layer2.AG_met_to_C_active_loss)
+    np.testing.assert_almost_equal(0.015800858174420382, layer2.AG_met_to_C_active_act)
+    np.testing.assert_almost_equal(4.836322822029068e-05, layer2.AG_struct_to_C_active_loss)
+    np.testing.assert_almost_equal(5.911061226924417e-05, layer2.AG_struct_to_C_active_act)
+    np.testing.assert_almost_equal(3.224215214686045e-05, layer2.AG_struct_to_C_slow_loss)
+    np.testing.assert_almost_equal(7.523168834267439e-05, layer2.AG_struct_to_C_slow_act)
+    np.testing.assert_almost_equal(0.02414019998869781, layer2.BG_met_to_C_active_loss)
+    np.testing.assert_almost_equal(0.019751072718025477, layer2.BG_met_to_C_active_act)
+    np.testing.assert_almost_equal(0.005293287488430829, layer2.BG_struct_to_C_active_loss)
+    np.testing.assert_almost_equal(0.006469573596971014, layer2.BG_struct_to_C_active_act)
+    np.testing.assert_almost_equal(0.0035288583256205524, layer2.BG_struct_to_C_slow_loss)
+    np.testing.assert_almost_equal(0.008234002759781289, layer2.BG_struct_to_C_slow_act)
+
+    LOGGER.info("Checking Layer 3")
+    layer3 = test_soil.soil_layers[3]
+    np.testing.assert_almost_equal(0.01931215999095825, layer3.AG_met_to_C_active_loss)
+    np.testing.assert_almost_equal(0.015800858174420382, layer3.AG_met_to_C_active_act)
+    np.testing.assert_almost_equal(4.836322822029068e-05, layer3.AG_struct_to_C_active_loss)
+    np.testing.assert_almost_equal(5.911061226924417e-05, layer3.AG_struct_to_C_active_act)
+    np.testing.assert_almost_equal(3.224215214686045e-05, layer3.AG_struct_to_C_slow_loss)
+    np.testing.assert_almost_equal(7.523168834267439e-05, layer3.AG_struct_to_C_slow_act)
+    np.testing.assert_almost_equal(0.02414019998869781, layer3.BG_met_to_C_active_loss)
+    np.testing.assert_almost_equal(0.019751072718025477, layer3.BG_met_to_C_active_act)
+    np.testing.assert_almost_equal(0.005293287488430829, layer3.BG_struct_to_C_active_loss)
+    np.testing.assert_almost_equal(0.006469573596971014, layer3.BG_struct_to_C_active_act)
+    np.testing.assert_almost_equal(0.0035288583256205524, layer3.BG_struct_to_C_slow_loss)
+    np.testing.assert_almost_equal(0.008234002759781289, layer3.BG_struct_to_C_slow_act)

--- a/tests/routines/field/soil/carbon_cycling/residue_partitioning.py
+++ b/tests/routines/field/soil/carbon_cycling/residue_partitioning.py
@@ -1,0 +1,58 @@
+"""
+RUFAS: Ruminant Farm Systems Model
+File name: residue_partitioning_tests.py
+Description: Implements test cases
+Author(s): Jessica Tweneboah, jnt42@cornell.edu
+"""
+
+import pytest
+import json
+import logging
+import numpy as np
+
+from RUFAS.routines.field.crop.crop_types.corn import Corn
+from RUFAS.routines.field.soil import Soil
+from RUFAS.routines.field.soil.carbon_cycling import residue_partitioning, decomp_factors
+from config.defintions import ROOT_DIR
+from RUFAS.classes import Weather
+from RUFAS.classes import Config
+from RUFAS.classes import Time
+
+LOGGER = logging.getLogger(__name__)
+
+LOGGER.info("Read json file: ARL_soil_tillage.json")
+soil_file = open(ROOT_DIR + "/input/soil/ARL_soil_tillage.json")
+LOGGER.info("Read json file: ARL_rotation.json")
+crop_file = open(ROOT_DIR + "/input/crop/ARL_rotation.json")
+path_to_weather_file = ROOT_DIR + "/input/weather/ARL_weather.csv"
+
+LOGGER.info("Convert from json file format to Python dictionary")
+soil_data = json.load(soil_file)
+crop_data = json.load(crop_file)
+
+
+def test_residue_partitioning():
+    LOGGER.info("Testing function: residue_partitioning")
+    test_soil = Soil(soil_data)
+    test_config_data = {
+        "start_date": "1990:1",
+        "end_date": "2019:365",
+        "csv_dir": "output/CSVs/",
+        "graphic_dir": "output/graphics/",
+        "set_seed": False,
+        "seed": 0
+    }
+    test_config = Config(test_config_data, path_to_weather_file)
+    test_weather = Weather(path_to_weather_file, test_config)
+    test_time = Time(test_config)
+    corn89_data = crop_data["crops"]["corn_89"]
+    test_crop_type = Corn("corn_89", corn89_data)
+
+    decomp_factors.temp_factor(test_soil, test_weather, test_time)
+    residue_partitioning.residue_partitioning(soil=test_soil, crop_type=test_crop_type, weather=test_weather, time=test_time)
+
+    LOGGER.info("Checking changes to soil")
+    np.testing.assert_almost_equal(17.0, test_soil.AG_lignin_res_percent)
+    np.testing.assert_almost_equal(0.425, test_soil.AG_L_to_N)
+
+


### PR DESCRIPTION
These are the unit tests I added for the carbon_cycling submodule. The tests are based solely on values provided in the following files: ARL_soil_tillage.json (soil file used for testing), ARL_rotation.json (crop file used for testing), ARL_weather.csv (weather file used for testing). 