### PR TITLE
Animal life cycle refactoring

### DIFF
--- a/RUFAS/routines/animal/animal_typed_dicts.py
+++ b/RUFAS/routines/animal/animal_typed_dicts.py
@@ -1,0 +1,247 @@
+from typing import Dict
+from typing import List
+from typing import TypedDict
+from typing import Union
+from typing_extensions import NotRequired
+
+
+class HerdInfoTypedDict(TypedDict):
+    """List of expected keys for herd information dictionary"""
+    calf_num: int
+    heiferI_num: int
+    heiferII_num: int
+    heiferIII_num: int
+    cow_num: int
+    replace_num: int
+    herd_num: int
+    herd_init: bool
+    breed: str
+
+
+class PenTypedDict(TypedDict):
+    """List of expected keys for pen information dictionary"""
+    id: int
+    animal_combination: str
+    vertical_dist_to_milking_parlor: float
+    horizontal_dist_to_milking_parlor: float
+    number_of_stalls: float
+    housing_type: str
+    bedding_type: str
+    pen_type: str
+    manure_handling: str
+    manure_separator: str
+    manure_storage: str
+    max_stocking_density: float
+
+
+class AnimalBaseInitArgsTypedDict(TypedDict):
+    """List of expected keys for animal base initialization arguments dictionary"""
+
+    id: int
+    breed: str
+    birth_date: str
+    days_born: int
+    birth_weight: float
+    p_init: int
+    body_weight_history: NotRequired[List]
+    pen_history: NotRequired[List]
+    conceptus_weight: NotRequired[float]
+    calf_birth_weight: NotRequired[float]
+
+
+class CalfValuesTypedDict(TypedDict):
+    """List of expected keys for calf values dictionary"""
+    id: int
+    breed: str
+    birth_date: int
+    days_born: int
+    birth_weight: float
+    p_init: int
+    body_weight: float
+    wean_weight: float
+    mature_body_weight: float
+    events: str
+
+
+class HeiferIValuesTypedDict(TypedDict):
+    """List of expected keys for heifer I values dictionary"""
+    id: int
+    breed: str
+    birth_date: int
+    days_born: int
+    birth_weight: float
+    body_weight: float
+    wean_weight: float
+    mature_body_weight: float
+    events: str
+
+
+class HeiferIIValuesTypedDict(TypedDict):
+    id: int
+    breed: str
+    birth_date: int
+    days_born: int
+    birth_weight: float
+    body_weight: float
+    wean_weight: float
+    mature_body_weight: float
+    events: str
+
+    repro_program: str
+    tai_method_h: str
+    synch_ed_method_h: str
+    estrus_count: int
+    estrus_day: int
+    tai_program_start_day_h: int
+    synch_ed_program_start_day_h: int
+    synch_ed_estrus_day: int
+    synch_ed_stop_day: int
+    conception_rate: float
+    ai_day: int
+    abortion_day: int
+    days_in_preg: int
+    gestation_length: int
+    p_gest_for_calf: int
+    calf_birth_weight: float
+
+
+class AnimalConfigTypedDict(TypedDict):
+    """
+    Keeps track of all the attributes stored in the animal config object used
+    in `animal_management.py`.
+
+    This list of attributes should also match the attributes provided by the
+    `animal_management_animal.json`.
+
+    """
+    # management decisions
+    breeding_start_day_h: int
+    heifer_repro_cull_time: int
+    heifer_repro_method: str
+    cow_repro_method: str
+    semen_type: str
+    days_in_preg_when_dry: int
+    lactation_curve: str
+    repro_cull_time: int
+    do_not_breed_time: int
+    cull_milk_production: int
+    cow_times_milked_per_day: int
+
+    # farm level -> calf
+    male_calf_rate_sexed_semen: float
+    male_calf_rate_conventional_semen: float
+    keep_female_calf_rate: int
+    wean_day: int
+    wean_length: int
+    milk_type: str
+
+    # farm level -> repro -> ED_related
+    estrus_detection_rate_h: float
+    estrus_insemination_rate_h: float
+    estrus_conception_rate_h: float
+    estrus_detection_rate_h_synch: float
+    heifer_synchED_protocol: str
+    estrus_detection_rate: float
+    estrus_insemination_rate: float
+    estrus_conception_rate: float
+
+    # farm level -> repro -> TAI_related
+    heifer_TAI_protocol: str
+    TAI_conception_rate_h: float
+    m5dCG2P_conception_rate: float
+    m5dCGP_conception_rate: float
+    heifer_user_defined_tai_cr: float
+    cow_presynch_protocol: str
+    cow_TAI_protocol: str
+    ovsynch56_conception_rate: float
+    ovsynch48_conception_rate: float
+    cosynch72_conception_rate: float
+    cosynch5d_conception_rate: float
+    cow_user_defined_tai_cr: float
+    cow_resynch_protocol: str
+    user_define_tai_length: int
+
+    # TODO: For these two variables, either leave them like this or
+    # add another typed dict for each
+    ED_related: Dict[str, Union[float, str]]
+    TAI_related: Dict[str, Union[float, str]]
+
+    # remaining attributes in farm level -> repro
+    voluntary_waiting_period: int
+    tai_program_start_day: int
+    conception_rate_decrease: float
+    avg_gestation_len: int
+    std_gestation_len: int
+    prefresh_day: int
+    num_21_days_repro: int
+    calving_interval: int
+    user_input_calving_interval: bool
+
+    # farm level -> bodyweight
+    birth_weight_avg_ho: float
+    birth_weight_std_ho: float
+    birth_weight_avg_je: float
+    birth_weight_std_je: float
+    target_heifer_preg_day: int
+    mature_body_weight_avg: float
+    mature_body_weight_std: float
+
+    # from_literature -> repro
+    avg_estrus_cycle_heifer: float
+    std_estrus_cycle_heifer: float
+    preg_check_day_1: int
+    preg_loss_rate_1: float
+    preg_check_day_2: int
+    preg_loss_rate_2: float
+    preg_check_day_3: int
+    preg_loss_rate_3: float
+    avg_estrus_cycle_return: float
+    std_estrus_cycle_return: float
+    avg_estrus_cycle_cow: float
+    std_estrus_cycle_cow: float
+    avg_estrus_cycle_p: float
+    std_estrus_cycle_p: float
+
+    # from_literature -> milking
+    wood_l: List[List[float]]
+    wood_m: List[List[float]]
+    wood_n: List[List[float]]
+    wood_l_std: List[List[float]]
+    wood_m_std: List[List[float]]
+    wood_n_std: List[List[float]]
+
+    # from_literature -> culling
+    parity_death_prob: List[float]
+    death_cull_prob: List[float]
+    parity_cull_prob: List[float]
+    mastitis_cull_prob: List[float]
+    feet_leg_cull_prob: List[float]
+    injury_cull_prob: List[float]
+    disease_cull_prob: List[float]
+    udder_cull_prob: List[float]
+    unkown_cull_prob: List[float]  # TODO: Fix this typo in `animal_management_animal.json` and here
+    cull_day_count: List[float]
+
+    # from_literature -> life_cycle
+    still_birth_rate: float
+
+
+class InitializationDBSummaryTypedDict(TypedDict):
+    num_calf: int
+    num_heiferI: int
+    num_heiferII: int
+    num_heiferIII: int
+    num_cow: int
+    num_replacement: int
+
+    avg_calf_age: float
+    avg_heiferI_age: float
+    avg_heiferII_age: float
+    avg_heiferIII_age: float
+    avg_cow_age: float
+    avg_replacement_age: float
+
+    cow_avg_days_in_preg: float
+    cow_avg_days_in_milk: float
+    cow_avg_parity: float
+    cow_avg_CI: float

--- a/RUFAS/routines/animal/animal_typed_dicts.py
+++ b/RUFAS/routines/animal/animal_typed_dicts.py
@@ -175,7 +175,7 @@ class AnimalConfigTypedDict(TypedDict):
     prefresh_day: int
     num_21_days_repro: int
     calving_interval: int
-    user_input_calving_interval: bool
+    use_input_calving_interval: bool
 
     # farm level -> bodyweight
     birth_weight_avg_ho: float

--- a/RUFAS/routines/animal/clustering_pen_grouping.py
+++ b/RUFAS/routines/animal/clustering_pen_grouping.py
@@ -10,6 +10,8 @@ Description: This file's main function is grouping(list, pens) (line 44) which
     Jorge Barrientos (jab924@cornell.edu).
 Author(s): Chris VanKerkhove, cjv47@cornell.edu
 """
+import math
+
 ################################################################################
 import pandas as pd
 import numpy as np
@@ -140,7 +142,8 @@ def grouping(cow_list, pens, stocking_density):
     # Adding pen_assignment number to list based on percentile
     for i in range(len(percentile)):
         key = 0
-        while percentile[i] <= index[key-1] or percentile[i] > index[key]:
+        while percentile[i] <= index[key-1] or (
+            percentile[i] > index[key] and not math.isclose(percentile[i], index[key], rel_tol=1e-09)):
             key += 1
         pen_assignment.append(key)
 

--- a/RUFAS/routines/animal/life_cycle/life_cycle.py
+++ b/RUFAS/routines/animal/life_cycle/life_cycle.py
@@ -8,145 +8,167 @@ Description: The class which manages the life cycle of the animals. This
 Author(s): Manfei Li, mli497@wisc.edu
            Militsa Sotirova, militsasotirova@gmail.com
 """
+from collections import defaultdict
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
+
+from RUFAS.routines.animal.animal_typed_dicts import AnimalConfigTypedDict
+from RUFAS.routines.animal.animal_typed_dicts import InitializationDBSummaryTypedDict
+from RUFAS.routines.animal.life_cycle import animal_constants
+from RUFAS.routines.animal.life_cycle.animal_base import AnimalBase
+from RUFAS.routines.animal.life_cycle.animal_initialization import AnimalInitialization
 from RUFAS.routines.animal.life_cycle.calf import Calf
+from RUFAS.routines.animal.life_cycle.cow import Cow
 from RUFAS.routines.animal.life_cycle.heiferI import HeiferI
 from RUFAS.routines.animal.life_cycle.heiferII import HeiferII
 from RUFAS.routines.animal.life_cycle.heiferIII import HeiferIII
-from RUFAS.routines.animal.life_cycle.cow import Cow
-from RUFAS.routines.animal.life_cycle.animal_base import AnimalBase
-from RUFAS.routines.animal.life_cycle.animal_initialization import AnimalInitialization
-from RUFAS.routines.animal.life_cycle import animal_constants as const
+from RUFAS.util import Utility
 
 
 class LifeCycleManager:
     """
     Manages the life cycles of the animals.
     """
-    # statistics
-    sold_heifers = []
-    culled_heifers = []
-    culled_cows = []
 
-    calf_num = 0
-    calf_percent = 0
-    heiferI_num = 0
-    heiferI_percent = 0
-    heiferII_num = 0
-    heiferII_percent = 0
-    heiferIII_num = 0
-    heiferIII_percent = 0
-    cow_num = 0
-    cow_percent = 0
-    sold_calf_num = 0
-    sold_heifer_num = 0
-    bought_heifer_num = 0
-    culled_heifer_num = 0
-    culled_cow_num = 0
-
+    # The following class variables are used in HerdReport.
     num_cow_for_parity = {
         '1': 0,
         '2': 0,
         '3': 0,
         'greater_than_3': 0
     }
-    percent_cow_for_parity = {
-        '1': 0,
-        '2': 0,
-        '3': 0,
-        'greater_than_3': 0
-    }
-    avg_age_for_parity = {
-        '1': 0,
-        '2': 0,
-        '3': 0,
-        'greater_than_3': 0
-    }
-    avg_age_for_calving = {
-        '1': 0,
-        '2': 0,
-        '3': 0,
-        'greater_than_3': 0
-    }
-
-    preg_check_num = 0
-    GnRH_injection_num = 0
-    PGF_injection_num = 0
-
-    open_cow_num = 0
-    dry_cow_num = 0
-    milking_cow_num = 0
-    preg_cow_num = 0
-    vwp_cow_num = 0
-    dry_cow_percent = 0
-    milking_cow_percent = 0
-    preg_cow_percent = 0
-    non_preg_cow_percent = 0
-    daily_milk_production = 0
-    avg_days_in_milk = 0
-    avg_days_in_preg = 0
-    avg_cow_body_weight = 0
-    avg_parity_num = 0
-    avg_calving_interval = 0
-    avg_breeding_to_preg_time = 0
     avg_calving_to_preg_time = {
-        '1': 0,
-        '2': 0,
-        '3': 0,
-        'greater_than_3': 0
+        '1': 0.0,
+        '2': 0.0,
+        '3': 0.0,
+        'greater_than_3': 0.0
     }
-    avg_heifer_culling_age = 0
-    avg_cow_culling_age = 0
-    avg_mature_body_weight = 0
-
-    cull_reason_stats = {
-        const.DEATH_CULL: 0,
-        const.LOW_PROD_CULL: 0,
-        const.LAMENESS_CULL: 0,
-        const.INJURY_CULL: 0,
-        const.MASTITIS_CULL: 0,
-        const.DISEASE_CULL: 0,
-        const.UDDER_CULL: 0,
-        const.UNKNOWN_CULL: 0
+    cull_reason_stats: Dict[str, int] = {
+        animal_constants.DEATH_CULL: 0,
+        animal_constants.LOW_PROD_CULL: 0,
+        animal_constants.LAMENESS_CULL: 0,
+        animal_constants.INJURY_CULL: 0,
+        animal_constants.MASTITIS_CULL: 0,
+        animal_constants.DISEASE_CULL: 0,
+        animal_constants.UDDER_CULL: 0,
+        animal_constants.UNKNOWN_CULL: 0
     }
-    cull_reason_stats_percent = {
-        const.DEATH_CULL: 0,
-        const.LOW_PROD_CULL: 0,
-        const.LAMENESS_CULL: 0,
-        const.INJURY_CULL: 0,
-        const.MASTITIS_CULL: 0,
-        const.DISEASE_CULL: 0,
-        const.UDDER_CULL: 0,
-        const.UNKNOWN_CULL: 0
-    }
-    cull_reason_stats_range = {}
-    parity_culling_stats_range = {}
 
-    ai_num = 0
-    semen_num = 0
-
-    config = None
-
-    replacement_market = []
-
-    herd_num = 0
-
-    animal_initializer = None
-
-    def __init__(self, data):
+    def __init__(self, data: AnimalConfigTypedDict):
         """
         Initializes the necessary configuration data.
 
         Args:
             data: life cycle data from the input JSON file
-        """
-        self.config = data
-        self.avg_daily_cow_milking = 0
-        self.initialize_db_summary = {}
-        self.avg_CI = 0
 
-    def initialize_herd(self, herd_num, calf_num, heiferI_num, heiferII_num,
-                        heiferIII_num, cow_num, replace_num, herd_init, breed,
-                        config):
+        """
+        self.animal_config = data  # animal_config in animal_management
+        self.avg_daily_cow_milking = 0.0
+        self.initialize_db_summary: Optional[InitializationDBSummaryTypedDict] = None
+        self.avg_CI = 0.0
+
+        self.sold_heifers: List[HeiferIII] = []
+        self.culled_heifers: List[HeiferII] = []
+        self.culled_cows: List[Cow] = []
+
+        self.herd_num = 0
+        self.calf_num = 0
+        self.heiferI_num = 0
+        self.heiferII_num = 0
+        self.heiferIII_num = 0
+        self.cow_num = 0
+
+        self.sold_calf_num = 0
+        self.sold_heifer_num = 0
+        self.bought_heifer_num = 0
+        self.culled_heifer_num = 0
+        self.culled_cow_num = 0
+
+        self.calf_percent = 0.0
+        self.heiferI_percent = 0.0
+        self.heiferII_percent = 0.0
+        self.heiferIII_percent = 0.0
+        self.cow_percent = 0.0
+
+        self.preg_check_num_h = 0
+        self.preg_check_num = 0
+        self.CIDR_count = 0
+        self.GnRH_injection_num_h = 0
+        self.PGF_injection_num_h = 0
+        self.GnRH_injection_num = 0
+        self.PGF_injection_num = 0
+
+        self.ai_num_h = 0
+        self.semen_num_h = 0
+        self.ed_period_h = 0
+        self.ai_num = 0
+        self.semen_num = 0
+
+        self.open_cow_num = 0
+        self.preg_cow_num = 0
+        self.vwp_cow_num = 0
+        self.milking_cow_num = 0
+        self.dry_cow_num = 0
+
+        self.dry_cow_percent = 0.0
+        self.milking_cow_percent = 0.0
+        self.preg_cow_percent = 0.0
+        self.non_preg_cow_percent = 0.0
+
+        self.daily_milk_production = 0
+        self.avg_days_in_milk = 0.0
+        self.avg_days_in_preg = 0.0
+        self.avg_cow_body_weight = 0.0
+        self.avg_parity_num = 0.0
+
+        self.avg_calving_interval = 0.0
+        self.avg_breeding_to_preg_time = 0.0
+        self.avg_heifer_culling_age = 0.0
+        self.avg_cow_culling_age = 0.0
+        self.avg_mature_body_weight = 0.0
+
+        self.cull_reason_stats_range: Dict[str, int] = defaultdict(int)
+        self.parity_culling_stats_range: Dict[Union[int, str], int] = defaultdict(int)
+
+        self.avg_age_for_calving = {
+            '1': 0.0,
+            '2': 0.0,
+            '3': 0.0,
+            'greater_than_3': 0.0
+        }
+        self.avg_age_for_parity = {
+            '1': 0.0,
+            '2': 0.0,
+            '3': 0.0,
+            'greater_than_3': 0.0
+        }
+        self.cull_reason_stats_percent: Dict[str, float] = {
+            animal_constants.DEATH_CULL: 0.0,
+            animal_constants.LOW_PROD_CULL: 0.0,
+            animal_constants.LAMENESS_CULL: 0.0,
+            animal_constants.INJURY_CULL: 0.0,
+            animal_constants.MASTITIS_CULL: 0.0,
+            animal_constants.DISEASE_CULL: 0.0,
+            animal_constants.UDDER_CULL: 0.0,
+            animal_constants.UNKNOWN_CULL: 0.0
+        }
+        self.percent_cow_for_parity = {
+            '1': 0.0,
+            '2': 0.0,
+            '3': 0.0,
+            'greater_than_3': 0.0
+        }
+
+        self.replacement_market: List[Cow] = []
+        self.animal_initializer: Optional[AnimalInitialization] = None
+
+    # TODO: Annotate config after removing all the imports in all the __init__.py files
+    def initialize_herd(self, herd_num: int, calf_num: int, heiferI_num: int, heiferII_num: int,
+                        heiferIII_num: int, cow_num: int, replace_num: int, herd_init: bool, breed: str,
+                        config) -> Tuple[List[Calf], List[HeiferI], List[HeiferII], List[HeiferIII], List[Cow]]:
         """
         Generates a replacement herd to simulate the market, for the herd to get
          replacements. Initializes the herd.
@@ -172,42 +194,71 @@ class LifeCycleManager:
             heiferIIIs: list of heiferIIIs for the simulation
             cows: list of cows for the simulation
         """
-        self.animal_initializer = AnimalInitialization(self.config['calving_interval'], breed,
+        self.animal_initializer = AnimalInitialization(self.animal_config['calving_interval'], breed,
                                                        config.set_seed, herd_init)
-
-        if self.config['use_input_calving_interval']:
-            self.avg_CI = self.config['calving_interval']
-        else:
-            self.initialize_db_summary = \
-                self.animal_initializer.initialization_db_summary()
-            self.avg_CI = self.initialize_db_summary['cow_avg_CI']
         self.herd_num = herd_num
+        self._set_avg_CI(self.animal_config, self.animal_initializer)
 
-        calves = self.animal_initializer.get_calves(calf_num, breed)
-        for calf in calves:
-            calf.events.add_event(calf.days_born, 0, const.INIT_HERD)
-
-        heiferIs = self.animal_initializer.get_heiferIs(heiferI_num, breed)
-        for heiferI in heiferIs:
-            heiferI.events.add_event(heiferI.days_born, 0, const.INIT_HERD)
-
-        heiferIIs = self.animal_initializer.get_heiferIIs(heiferII_num, breed)
-        for heiferII in heiferIIs:
-            heiferII.events.add_event(heiferII.days_born, 0, const.INIT_HERD)
-
-        heiferIIIs = self.animal_initializer.get_heiferIIIs(heiferIII_num, breed)
-        for heiferIII in heiferIIIs:
-            heiferIII.events.add_event(heiferIII.days_born, 0, const.INIT_HERD)
-
-        cows = self.animal_initializer.get_cows(cow_num, breed)
-        for cow in cows:
-            cow.events.add_event(cow.days_born, 0, const.INIT_HERD)
+        calves = self._get_calves(calf_num, breed, self.animal_initializer)
+        heiferIs = self._get_heiferIs(heiferI_num, breed, self.animal_initializer)
+        heiferIIs = self._get_heiferIIs(heiferII_num, breed, self.animal_initializer)
+        heiferIIIs = self._get_heiferIIIs(heiferIII_num, breed, self.animal_initializer)
+        cows = self._get_cows(cow_num, breed, self.animal_initializer)
 
         self.replacement_market = self.animal_initializer.get_replacement_cows(replace_num, breed)
+
         return calves, heiferIs, heiferIIs, heiferIIIs, cows
 
-    def daily_update(self, date, calves, heiferIs, heiferIIs,
-                     heiferIIIs, cows):
+    # TODO: In the animal_management_animal.json,
+    #  the user_input_calving_interval attribute is set to false while the
+    #  calving_interval attribute is present, maybe set that to true instead?
+    def _set_avg_CI(self, animal_config: AnimalConfigTypedDict,
+                    animal_initializer: AnimalInitialization) -> None:
+        if 'user_input_calving_interval' in animal_config:
+            self.avg_CI = animal_config['calving_interval']
+        else:
+            self.initialize_db_summary = animal_initializer.initialization_db_summary()
+            self.avg_CI = self.initialize_db_summary['cow_avg_CI']
+
+    @staticmethod
+    def _get_calves(calf_num: int, breed: str, animal_initializer: AnimalInitialization) -> List[Calf]:
+        calves = animal_initializer.get_calves(calf_num, breed)
+        for calf in calves:
+            calf.events.add_event(calf.days_born, 0, animal_constants.INIT_HERD)
+        return calves
+
+    @staticmethod
+    def _get_heiferIs(heiferI_num: int, breed: str, animal_initializer) -> List[HeiferI]:
+        heiferIs = animal_initializer.get_heiferIs(heiferI_num, breed)
+        for heiferI in heiferIs:
+            heiferI.events.add_event(heiferI.days_born, 0, animal_constants.INIT_HERD)
+        return heiferIs
+
+    @staticmethod
+    def _get_heiferIIs(heiferII_num: int, breed: str, animal_initializer: AnimalInitialization) -> List[HeiferII]:
+        heiferIIs = animal_initializer.get_heiferIIs(heiferII_num, breed)
+        for heiferII in heiferIIs:
+            heiferII.events.add_event(heiferII.days_born, 0, animal_constants.INIT_HERD)
+        return heiferIIs
+
+    @staticmethod
+    def _get_heiferIIIs(heiferIII_num: int, breed: str, animal_initializer: AnimalInitialization) -> List[HeiferIII]:
+        heiferIIIs = animal_initializer.get_heiferIIIs(heiferIII_num, breed)
+        for heiferIII in heiferIIIs:
+            heiferIII.events.add_event(heiferIII.days_born, 0, animal_constants.INIT_HERD)
+        return heiferIIIs
+
+    @staticmethod
+    def _get_cows(cow_num: int, breed: str, animal_initializer: AnimalInitialization) -> List[Cow]:
+        cows = animal_initializer.get_cows(cow_num, breed)
+        for cow in cows:
+            cow.events.add_event(cow.days_born, 0, animal_constants.INIT_HERD)
+        return cows
+
+    def daily_update(self, sim_day: int, calves: List[Calf], heiferIs: List[HeiferI],
+                     heiferIIs: List[HeiferII], heiferIIIs: List[HeiferIII], cows: List[Cow]) \
+            -> Tuple[List[Cow], List[int], List[Calf], List[Calf],
+                     List[HeiferI], List[HeiferII], List[HeiferIII], List[Cow]]:
         """
         Updates the status of the animals.
 
@@ -217,7 +268,7 @@ class LifeCycleManager:
             heiferIIs: list of HeiferII objects to be updated
             heiferIs: list of HeiferI objects to be updated
             calves: list of Calf objects to be updated
-            date: day number
+            sim_day: day number
 
         Returns:
             animals_added: list of animals added from replacement herd
@@ -230,379 +281,432 @@ class LifeCycleManager:
             cows: updated list of cows
 
         """
-        ids_removed = []
-        animals_added = []
-        calves_born = []
-
-        self.calf_num = 0
-        self.heiferI_num = 0
-        self.heiferII_num = 0
-        self.heiferIII_num = 0
-        self.cow_num = 0
-        self.sold_calf_num = 0
-        self.sold_heifer_num = 0
-        self.bought_heifer_num = 0
-        self.culled_heifer_num = 0
-        self.culled_cow_num = 0
+        ids_removed: List[int] = []
+        animals_added: List[Cow] = []
+        calves_born: List[Calf] = []
         total_animal_num = 0
+        preg_heifer_num = 0  # TODO: Seems unused after calculation
 
-        self.preg_check_num = 0
-        self.GnRH_injection_num = 0
-        self.PGF_injection_num = 0
-        self.ai_num = 0
+        self._reset_parity()
+        self._reset_cull_reason_stats()
 
-        self.daily_milk_production = 0
-        self.open_cow_num = 0
-        self.preg_cow_num = 0
-        self.vwp_cow_num = 0
-        self.milking_cow_num = 0
-        self.dry_cow_num = 0
-        self.avg_days_in_milk = 0
-        self.avg_days_in_preg = 0
-        self.avg_cow_body_weight = 0
-        self.avg_parity_num = 0
-        self.avg_calving_interval = 0
-        self.avg_breeding_to_preg_time = 0
-        self.avg_heifer_culling_age = 0
-        self.avg_cow_culling_age = 0
-        self.avg_mature_body_weight = 0
+        total_animal_num = self._calf_to_heiferI(sim_day, calves, heiferIs, total_animal_num)
+        total_animal_num = self._heiferI_to_heiferII(sim_day, heiferIs, heiferIIs, total_animal_num)
+        total_animal_num, preg_heifer_num = self._heiferII_to_heiferIII(sim_day, heiferIIs, heiferIIIs,
+                                                                        preg_heifer_num, total_animal_num)
+        total_animal_num = self._heiferIII_to_cow(sim_day, heiferIIIs, cows, total_animal_num)
 
-        preg_heifer_num = 0
-        calving_interval_available_num = 0
-        calving_age_available_num = {
-            '1': 0,
-            '2': 0,
-            '3': 0,
-            'greater_than_3': 0
-        }
-        calving_to_preg_time_available_num = {
-            '1': 0,
-            '2': 0,
-            '3': 0,
-            'greater_than_3': 0
-        }
+        self._check_if_heifers_need_to_be_sold(heiferIIIs, cows, ids_removed)
+        self._check_if_replacement_heifers_needed(sim_day, heiferIIIs, cows, animals_added)
 
-        for parity in self.num_cow_for_parity:
-            self.num_cow_for_parity[parity] = 0
-            self.percent_cow_for_parity[parity] = 0
-            self.avg_age_for_parity[parity] = 0
-            self.avg_age_for_calving[parity] = 0
-            self.avg_calving_to_preg_time[parity] = 0
+        total_animal_num = self._cull_cows_and_record_stats(sim_day, cows, calves_born,
+                                                            ids_removed, total_animal_num)
 
-        for cull_reason in self.cull_reason_stats:
-            self.cull_reason_stats[cull_reason] = 0
-            self.cull_reason_stats_percent[cull_reason] = 0
+        self._calc_herd_percentages(total_animal_num)
+        self._calc_cow_percentages()
+        self._calc_cull_reason_stats_percent()
+        self._calc_percent_cow_per_parity()
 
-        # calf to heiferI
-        for index, calf in enumerate(calves):
-            wean_day = calf.update(date)
+        return animals_added, ids_removed, calves_born, calves, heiferIs, \
+               heiferIIs, heiferIIIs, cows
+
+    def _reset_parity(self) -> None:
+        for parity in LifeCycleManager.num_cow_for_parity:
+            LifeCycleManager.num_cow_for_parity[parity] = 0
+            LifeCycleManager.avg_calving_to_preg_time[parity] = 0
+            self.percent_cow_for_parity[parity] = 0.0
+            self.avg_age_for_parity[parity] = 0.0
+            self.avg_age_for_calving[parity] = 0.0
+
+    def _reset_cull_reason_stats(self) -> None:
+        for cull_reason in LifeCycleManager.cull_reason_stats:
+            LifeCycleManager.cull_reason_stats[cull_reason] = 0
+            self.cull_reason_stats_percent[cull_reason] = 0.0
+
+    def _calf_to_heiferI(self, sim_day: int, calves: List[Calf],
+                         heiferIs: List[HeiferI], total_animal_num: int) -> int:
+        removed_calves_idx: List[int] = []
+
+        for idx, calf in enumerate(calves):
+            wean_day = calf.update(sim_day)
             if wean_day:
-                args = calf.get_calf_values()
-                args.update({
-                    'body_weight_history': calf.body_weight_history,
-                    'pen_history': calf.pen_history
-                })
-                new_heiferI = HeiferI(args)
-                heiferIs.append(new_heiferI)
-                del calves[index]
+                self._wean_calf(calf, heiferIs)
+                removed_calves_idx.append(idx)
             else:
                 self.calf_num += 1
-                total_animal_num, self.avg_mature_body_weight = \
-                    self.calc_average(total_animal_num,
-                                       self.avg_mature_body_weight, calf.mature_body_weight)
+                temp = Utility.calc_average(total_animal_num, self.avg_mature_body_weight,
+                                            calf.mature_body_weight)
+                total_animal_num, self.avg_mature_body_weight = temp
 
-        # heiferI to heiferII, assign repro programs
-        for index, heiferI in enumerate(heiferIs):
-            second_stage = heiferI.update(date)
+        Utility.remove_items_from_list_by_indices(calves, removed_calves_idx)
+        return total_animal_num
+
+    @staticmethod
+    def _wean_calf(calf: Calf, heiferIs: List[HeiferI]) -> None:
+        calf_vals = calf.get_calf_values()
+        calf_vals.update({
+            'body_weight_history': calf.body_weight_history,
+            'pen_history': calf.pen_history
+        })
+        new_heiferI = HeiferI(calf_vals)
+        heiferIs.append(new_heiferI)
+
+    def _heiferI_to_heiferII(self, sim_day: int, heiferIs: List[HeiferI], heiferIIs: List[HeiferII],
+                             total_animal_num: int) -> int:
+        removed_heiferIs_idx: List[int] = []
+
+        for idx, heiferI in enumerate(heiferIs):
+            second_stage = heiferI.update(sim_day)
             if second_stage:
-                args = heiferI.get_heiferI_values()
-                args.update({
-                    'body_weight_history': heiferI.body_weight_history,
-                    'pen_history': heiferI.pen_history
-                     })
-                args.update(repro_program=AnimalBase.config['heifer_repro_method'])
-                args.update(tai_method_h=AnimalBase.config['heifer_TAI_protocol'])
-                args.update(synch_ed_method_h=AnimalBase.config['heifer_synchED_protocol'])
-                new_heiferII = HeiferII(args)
-                heiferIIs.append(new_heiferII)
-                del heiferIs[index]
+                self._move_heiferI_to_second_stage(heiferI, heiferIIs)
+                removed_heiferIs_idx.append(idx)
             else:
                 self.heiferI_num += 1
-                total_animal_num, self.avg_mature_body_weight = \
-                    self.calc_average(total_animal_num,
-                                       self.avg_mature_body_weight, heiferI.mature_body_weight)
+                temp = Utility.calc_average(total_animal_num, self.avg_mature_body_weight, heiferI.mature_body_weight)
+                total_animal_num, self.avg_mature_body_weight = temp
 
-        # heiferII to heiferIII
-        for index, heiferII in enumerate(heiferIIs):
-            cull_stage, third_stage = heiferII.update(date)
+        Utility.remove_items_from_list_by_indices(heiferIs, removed_heiferIs_idx)
+        return total_animal_num
+
+    @staticmethod
+    def _move_heiferI_to_second_stage(heiferI: HeiferI, heiferIIs: List[HeiferII]) -> None:
+        heiferI_vals = heiferI.get_heiferI_values()
+        heiferI_vals.update({
+            'body_weight_history': heiferI.body_weight_history,
+            'pen_history': heiferI.pen_history
+        })
+        heiferI_vals.update(repro_program=AnimalBase.config['heifer_repro_method'])
+        heiferI_vals.update(tai_method_h=AnimalBase.config['heifer_TAI_protocol'])
+        heiferI_vals.update(synch_ed_method_h=AnimalBase.config['heifer_synchED_protocol'])
+        new_heiferII = HeiferII(heiferI_vals)
+        heiferIIs.append(new_heiferII)
+
+    def _heiferII_to_heiferIII(self, sim_day: int, heiferIIs: List[HeiferII],
+                               heiferIIIs: List[HeiferIII], preg_heifer_num: int,
+                               total_animal_num: int) -> Tuple[int, int]:
+        removed_heiferIIs_idx: List[int] = []
+
+        for idx, heiferII in enumerate(heiferIIs):
+            cull_stage, third_stage = heiferII.update(sim_day)
             if cull_stage:
-                self.culled_heifer_num, self.avg_heifer_culling_age = \
-                    self.calc_average(self.culled_heifer_num,
-                                       self.avg_heifer_culling_age, heiferII.days_born)
+                temp = Utility.calc_average(self.culled_heifer_num, self.avg_heifer_culling_age, heiferII.days_born)
+                self.culled_heifer_num, self.avg_heifer_culling_age = temp
                 self.culled_heifers.append(heiferII)
-                del heiferIIs[index]
+                removed_heiferIIs_idx.append(idx)
             elif third_stage:
-                args = heiferII.get_heiferII_values()
-                args.update({
-                    'body_weight_history': heiferII.body_weight_history,
-                    'pen_history': heiferII.pen_history,
-                    'conceptus_weight': heiferII.conceptus_weight,
-                    'calf_birth_weight': heiferII.calf_birth_weight
-                })
-                new_heiferIII = HeiferIII(args)
-                heiferIIIs.append(new_heiferIII)
-                del heiferIIs[index]
+                self._move_heiferII_to_third_stage(heiferII, heiferIIIs)
+                removed_heiferIIs_idx.append(idx)
             else:
-                self.heiferII_num += 1
-                total_animal_num, self.avg_mature_body_weight = \
-                    self.calc_average(total_animal_num,
-                                       self.avg_mature_body_weight, heiferII.mature_body_weight)
-                if heiferII.breeding_to_preg_time != 0:
-                    preg_heifer_num, self.avg_breeding_to_preg_time = \
-                        self.calc_average(preg_heifer_num,
-                                           self.avg_breeding_to_preg_time,
-                                           heiferII.breeding_to_preg_time)
+                total_animal_num, preg_heifer_num = \
+                    self._keep_heiferII_as_pregnant(heiferII, total_animal_num, preg_heifer_num)
 
-        # heiferIII to cow, assign repro programs
-        for index, heiferIII in enumerate(heiferIIIs):
+        Utility.remove_items_from_list_by_indices(heiferIIs, removed_heiferIIs_idx)
+        return total_animal_num, preg_heifer_num
 
-            # TODO why can cows be added to the list of HeiferIII's so that the
-            #  following if statement is necessary?
-            if type(heiferIII).__name__ == 'HeiferIII':
-                cow_stage = heiferIII.update(date)
-            else:
-                cow_stage = heiferIII.update(date, self.avg_CI)
+    @staticmethod
+    def _move_heiferII_to_third_stage(heiferII: HeiferII, heiferIIIs: List[HeiferIII]) -> None:
+        heiferII_vals = heiferII.get_heiferII_values()
+        heiferII_vals.update({
+            'body_weight_history': heiferII.body_weight_history,
+            'pen_history': heiferII.pen_history,
+            'conceptus_weight': heiferII.conceptus_weight,
+            'calf_birth_weight': heiferII.calf_birth_weight
+        })
+        new_heiferIII = HeiferIII(heiferII_vals)
+        heiferIIIs.append(new_heiferIII)
 
+    def _keep_heiferII_as_pregnant(self, heiferII: HeiferII, total_animal_num: int, preg_heifer_num: int):
+        self.heiferII_num += 1
+        temp = Utility.calc_average(total_animal_num, self.avg_mature_body_weight,
+                                    heiferII.mature_body_weight)
+        total_animal_num, self.avg_mature_body_weight = temp
+        if heiferII.breeding_to_preg_time != 0:
+            temp2 = Utility.calc_average(preg_heifer_num, self.avg_breeding_to_preg_time,
+                                         heiferII.breeding_to_preg_time)
+            preg_heifer_num, self.avg_breeding_to_preg_time = temp2
+        self._extract_repro_stats_from_heiferII(heiferII)
+        return total_animal_num, preg_heifer_num
+
+    def _extract_repro_stats_from_heiferII(self, heiferII: HeiferII) -> None:
+        # self.CIDR_count += heiferII.CIDR_count  # TODO: add CIDR count to heiferII
+        self.GnRH_injection_num_h += heiferII.GnRH_injections
+        self.PGF_injection_num_h += heiferII.PGF_injections
+        self.preg_check_num_h += heiferII.preg_diagnoses
+        self.semen_num_h += heiferII.semen_num
+        self.ai_num_h += heiferII.AI_times
+        self.ed_period_h += heiferII.ED_days
+
+    def _heiferIII_to_cow(self, sim_day: int, heiferIIIs: List[HeiferIII], cows: List[Cow],
+                          total_animal_num: int) -> int:
+        removed_heiferIIIs_idx: List[int] = []
+
+        for idx, heiferIII in enumerate(heiferIIIs):
+            # TODO: Review this
+            # if type(heiferIII) is HeiferIII:
+            #     cow_stage = heiferIII.update(sim_day)
+            # else:
+            #     cow_stage = heiferIII.update(sim_day, self.avg_CI)
+            cow_stage = heiferIII.update(sim_day)
             if cow_stage:
-                args = heiferIII.get_heiferIII_values()
-                args.update({
-                    'body_weight_history': heiferIII.body_weight_history,
-                    'pen_history': heiferIII.pen_history,
-                    'conceptus_weight': heiferIII.conceptus_weight,
-                    'calf_birth_weight': heiferIII.calf_birth_weight
-                     })
-                args.update(repro_program=AnimalBase.config['cow_repro_method'])
-                args.update(presynch_method=AnimalBase.config['cow_presynch_protocol'])
-                args.update(tai_method_c=AnimalBase.config['cow_TAI_protocol'])
-                args.update(resynch_method=AnimalBase.config['cow_resynch_protocol'])
-                new_cow = Cow(args)
-                cows.append(new_cow)
-                del heiferIIIs[index]
+                self._move_heiferIII_to_cow_stage(heiferIII, cows)
+                removed_heiferIIIs_idx.append(idx)
             else:
                 self.heiferIII_num += 1
-                total_animal_num, self.avg_mature_body_weight = \
-                    self.calc_average(total_animal_num,
-                                       self.avg_mature_body_weight, heiferIII.mature_body_weight)
+                temp = Utility.calc_average(total_animal_num, self.avg_mature_body_weight,
+                                            heiferIII.mature_body_weight)
+                total_animal_num, self.avg_mature_body_weight = temp
 
-        # if the number of heifers is more than needed for the herd, sell
-        # those as replacement
-        while len(heiferIIIs) + len(cows) > self.herd_num * 1.03 and len(heiferIIIs) > 0:
+        Utility.remove_items_from_list_by_indices(heiferIIIs, removed_heiferIIIs_idx)
+        return total_animal_num
+
+    @staticmethod
+    def _move_heiferIII_to_cow_stage(heiferIII, cows):
+        args = heiferIII.get_heiferIII_values()
+        args.update({
+            'body_weight_history': heiferIII.body_weight_history,
+            'pen_history': heiferIII.pen_history,
+            'conceptus_weight': heiferIII.conceptus_weight,
+            'calf_birth_weight': heiferIII.calf_birth_weight
+        })
+        args.update(repro_program=AnimalBase.config['cow_repro_method'])
+        args.update(presynch_method=AnimalBase.config['cow_presynch_protocol'])
+        args.update(tai_method_c=AnimalBase.config['cow_TAI_protocol'])
+        args.update(resynch_method=AnimalBase.config['cow_resynch_protocol'])
+        new_cow = Cow(args)
+        cows.append(new_cow)
+
+    def _check_if_heifers_need_to_be_sold(self, heiferIIIs: List[HeiferIII], cows: List[Cow],
+                                          ids_removed: List[int]) -> None:
+        # if the number of heifers is more than needed for the herd,
+        # sell those as replacement
+        ratio = 1.03  # TODO: use a better name
+        while len(heiferIIIs) + len(cows) > self.herd_num * ratio and len(heiferIIIs) > 0:
             removed = heiferIIIs.pop()
             ids_removed.append(removed.id)
             self.sold_heifers.append(removed)
             self.sold_heifer_num += 1
 
+    def _check_if_replacement_heifers_needed(self, sim_day: int, heiferIIIs: List[HeiferIII], cows: List[Cow],
+                                             animals_added: List[Cow]) -> None:
         # if the number of heifers is less than needed for the herd,
         # buy replacement from the market
-        while len(cows) + len(heiferIIIs) + self.bought_heifer_num < self.herd_num * 1.01 and \
-                date > 1:
-            self.replacement_market[0].events.add_event(
-                self.replacement_market[0].days_born, date, const.ENTER_HERD)
-            self.replacement_market[0].set_p_purchased()
-            animals_added.append(self.replacement_market[0])
+        ratio = 1.01  # TODO: use a better name
+        while len(cows) + len(heiferIIIs) + self.bought_heifer_num < self.herd_num * ratio \
+                and sim_day > 1:
+            replacement = self.replacement_market.pop(0)
+            replacement.events.add_event(replacement.days_born, sim_day, animal_constants.ENTER_HERD)
+            replacement.set_p_purchased()
+            animals_added.append(replacement)
             self.bought_heifer_num += 1
-            del self.replacement_market[0]
+
+    def _cull_cows_and_record_stats(self, sim_day: int, cows: List[Cow], calves_born: List[Calf],
+                                    ids_removed: List[int], total_animal_num: int) -> int:
+        calving_interval_avail_num = 0
+        calving_age_avail_num = {
+            '1': 0,
+            '2': 0,
+            '3': 0,
+            'greater_than_3': 0
+        }
+        calf_to_preg_time_avail_num = {
+            '1': 0,
+            '2': 0,
+            '3': 0,
+            'greater_than_3': 0
+        }
+        removed_cows_idx: List[int] = []
 
         # cow culling action and stats
         for index, cow in enumerate(cows):
-            _, _, _, culled, new_born = cow.update(date, self.avg_CI)
+            _, _, _, culled, new_born = cow.update(sim_day, self.avg_CI)
 
             # culled cows, calculate slaughter value and record culling reasons
             if culled:
-                if cow.cull_reason in self.cull_reason_stats_range:
-                    self.cull_reason_stats_range[cow.cull_reason] += 1
-                else:
-                    self.cull_reason_stats_range[cow.cull_reason] = 1
-                parity = cow.calves if cow.calves <= 3 else '4+'
-                if cow.calves in self.parity_culling_stats_range:
-                    self.parity_culling_stats_range[parity] += 1
-                else:
-                    self.parity_culling_stats_range[parity] = 1
-
-                self.culled_cows.append(cow)
-                self.cull_reason_stats[cow.cull_reason] += 1
-                self.culled_cow_num, self.avg_cow_culling_age = \
-                    self.calc_average(self.culled_cow_num,
-                                       self.avg_cow_culling_age, cow.days_born)
-
-                # print(len(culled_cows))
+                self._cull_cow(cow)
                 ids_removed.append(cow.id)
-                del cows[index]
-
+                removed_cows_idx.append(index)
             else:
-                _, self.avg_cow_body_weight = self.calc_average(
-                    self.cow_num, self.avg_cow_body_weight, cow.body_weight)
-                self.cow_num, self.avg_parity_num = self.calc_average(
-                    self.cow_num, self.avg_parity_num, cow.calves)
-                total_animal_num, self.avg_mature_body_weight = \
-                    self.calc_average(total_animal_num,
-                                       self.avg_mature_body_weight, cow.mature_body_weight)
-
-                if cow.milking:
-                    self.daily_milk_production += cow.estimated_daily_milk_produced
-                    self.milking_cow_num, self.avg_days_in_milk = \
-                        self.calc_average(self.milking_cow_num,
-                                           self.avg_days_in_milk, cow.days_in_milk)
-                else:
-                    self.dry_cow_num += 1
-
-                if cow.days_in_milk < self.config['voluntary_waiting_period']:
-                    self.vwp_cow_num += 1
-                    if cow.days_in_preg == 0:
-                        self.open_cow_num += 1
-
-                if cow.days_in_preg > 0:
-                    self.preg_cow_num, self.avg_days_in_preg = \
-                        self.calc_average(self.preg_cow_num,
-                                           self.avg_days_in_preg, cow.days_in_preg)
-
-                if 0 < cow.calves <= 3:
-                    self.num_cow_for_parity[str(cow.calves)], \
-                    self.avg_age_for_parity[str(cow.calves)] = \
-                        self.calc_average(
-                            self.num_cow_for_parity[str(cow.calves)],
-                            self.avg_age_for_parity[str(cow.calves)],
-                            cow.days_born)
-                    calving_age = cow.events.get_most_recent_date(const.NEW_BIRTH)
-                    if calving_age != -1:
-                        calving_age_available_num[str(cow.calves)], \
-                        self.avg_age_for_calving[str(cow.calves)] = \
-                            self.calc_average(
-                                calving_age_available_num[str(cow.calves)],
-                                self.avg_age_for_calving[str(cow.calves)],
-                                calving_age)
-                    if cow.calving_to_preg_time != 0:
-                        calving_to_preg_time_available_num[str(cow.calves)], \
-                        self.avg_calving_to_preg_time[str(cow.calves)] = \
-                            self.calc_average(
-                                calving_to_preg_time_available_num[str(cow.calves)],
-                                self.avg_calving_to_preg_time[str(cow.calves)],
-                                cow.calving_to_preg_time)
-                else:
-                    self.num_cow_for_parity['greater_than_3'], \
-                    self.avg_age_for_parity['greater_than_3'] = self.calc_average(
-                        self.num_cow_for_parity['greater_than_3'],
-                        self.avg_age_for_parity['greater_than_3'], cow.days_born)
-                    calving_age = cow.events.get_most_recent_date(const.NEW_BIRTH)
-                    if calving_age != -1:
-                        calving_age_available_num['greater_than_3'], \
-                        self.avg_age_for_calving['greater_than_3'] = \
-                            self.calc_average(
-                                calving_age_available_num['greater_than_3'],
-                                self.avg_age_for_calving['greater_than_3'],
-                                calving_age)
-                    if cow.calving_to_preg_time != 0:
-                        calving_to_preg_time_available_num['greater_than_3'], \
-                        self.avg_calving_to_preg_time['greater_than_3'] = \
-                            self.calc_average(
-                                calving_to_preg_time_available_num['greater_than_3'],
-                                self.avg_calving_to_preg_time['greater_than_3'],
-                                cow.calving_to_preg_time)
-
-                if cow.CI != 0:
-                    calving_interval_available_num, \
-                    self.avg_calving_interval = self.calc_average(
-                        calving_interval_available_num,
-                        self.avg_calving_interval, cow.CI)
-
-                self.GnRH_injection_num += cow.GnRH_injections
-                self.PGF_injection_num += cow.PGF_injections
-                self.preg_check_num += cow.preg_diagnoses
-                self.semen_num += cow.semen_num
-                self.ai_num += cow.AI_times
+                total_animal_num = self._handle_cow_body_weight(cow, total_animal_num)
+                self._handle_cow_milking(cow)
+                self._handle_cow_days_in_milk(cow)
+                self._handle_cow_days_in_preg(cow)
+                self._handle_cow_calves(cow, calving_age_avail_num, calf_to_preg_time_avail_num)
+                calving_interval_avail_num = self._handle_cow_ci(cow, calving_interval_avail_num)
+                self._extract_repro_stats_from_cow(cow)
 
             if new_born:
-                args = {
-                    'id': self.animal_initializer.next_id(),
-                    'breed': 'HO',
-                    'birth_date': date,
-                    'days_born': 0,
-                    'p_init': cow.p_gest_for_calf,
-                    'birth_weight': cow.calf_birth_weight
-                }
-                # at parturition, the sum of P absorbed for gestation rqmts is
-                # subtracted from the animal value. the sum of P absorbed for
-                # gestation is equal to the initial animal P value for the calf
-                # (A.1G.A.4)
-                cow.p_animal = cow.p_animal - cow.p_gest_for_calf + \
-                               cow.p_growth + cow.dP_reserves
+                self._handle_new_born(sim_day, cow, calves_born)
 
-                new_calf = Calf(args)
-                cow.p_gest_for_calf = 0
-                cow.calf_birth_weight = 0
+        Utility.remove_items_from_list_by_indices(cows, removed_cows_idx)
+        return total_animal_num
 
-                if not (new_calf.culled or new_calf.sold):
-                    new_calf.events.add_event(
-                        new_calf.days_born, date, const.ENTER_HERD)
-                    # calves.append(new_calf)
-                    calves_born.append(new_calf)
-                if new_calf.sold:
-                    self.sold_calf_num += 1
+    def _cull_cow(self, cow: Cow) -> None:
+        self.culled_cows.append(cow)
+        self.cull_reason_stats_range[cow.cull_reason] += 1
+        LifeCycleManager.cull_reason_stats[cow.cull_reason] += 1
 
-        if total_animal_num == 0:
-            self.calf_percent = 0
-            self.heiferI_percent = 0
-            self.heiferII_percent = 0
-            self.heiferIII_percent = 0
-            self.cow_percent = 0
+        parity = cow.calves if cow.calves <= 3 else '4+'
+        self.parity_culling_stats_range[parity] += 1
+
+        temp = Utility.calc_average(self.culled_cow_num, self.avg_cow_culling_age, cow.days_born)
+        self.culled_cow_num, self.avg_cow_culling_age = temp
+
+    def _handle_cow_body_weight(self, cow: Cow, total_animal_num: int) -> int:
+        _, self.avg_cow_body_weight = Utility.calc_average(
+                self.cow_num, self.avg_cow_body_weight, cow.body_weight)
+        self.cow_num, self.avg_parity_num = Utility.calc_average(
+                self.cow_num, self.avg_parity_num, cow.calves)
+
+        temp = Utility.calc_average(total_animal_num, self.avg_mature_body_weight, cow.mature_body_weight)
+        total_animal_num, self.avg_mature_body_weight = temp
+        return total_animal_num
+
+    def _handle_cow_milking(self, cow: Cow) -> None:
+        if cow.milking:
+            self.daily_milk_production += cow.estimated_daily_milk_produced
+            temp = Utility.calc_average(self.milking_cow_num, self.avg_days_in_milk, cow.days_in_milk)
+            self.milking_cow_num, self.avg_days_in_milk = temp
         else:
-            self.calf_percent = self.calf_num / total_animal_num * 100
-            self.heiferI_percent = self.heiferI_num / total_animal_num * 100
-            self.heiferII_percent = self.heiferII_num / total_animal_num * 100
-            self.heiferIII_percent = self.heiferIII_num / total_animal_num * 100
-            self.cow_percent = self.cow_num / total_animal_num * 100
+            self.dry_cow_num += 1
 
-        if self.cow_num == 0:
-            self.dry_cow_percent = 0
-            self.milking_cow_percent = 0
-            self.preg_cow_percent = 0
-            self.non_preg_cow_percent = 0
+    def _handle_cow_days_in_milk(self, cow: Cow) -> None:
+        if cow.days_in_milk < self.animal_config['voluntary_waiting_period']:
+            self.vwp_cow_num += 1
+            if cow.days_in_preg == 0:
+                self.open_cow_num += 1
+
+    def _handle_cow_days_in_preg(self, cow: Cow) -> None:
+        if cow.days_in_preg > 0:
+            temp = Utility.calc_average(self.preg_cow_num, self.avg_days_in_preg, cow.days_in_preg)
+            self.preg_cow_num, self.avg_days_in_preg = temp
+
+    def _handle_cow_calves(self, cow: Cow, calving_age_avail_num, calf_to_preg_time_avail_num) -> None:
+        if 0 < cow.calves <= 3:
+            key = str(cow.calves)
         else:
-            self.dry_cow_percent = self.dry_cow_num / self.cow_num * 100
-            self.milking_cow_percent = self.milking_cow_num / self.cow_num * 100
-            self.preg_cow_percent = self.preg_cow_num / self.cow_num * 100
-            self.non_preg_cow_percent = (self.open_cow_num + self.vwp_cow_num) / self.cow_num * 100
+            key = 'greater_than_3'
 
-        for cull_reason in self.cull_reason_stats:
-            if self.culled_cow_num != 0:
-                self.cull_reason_stats_percent[cull_reason] = \
-                    self.cull_reason_stats[cull_reason] / \
-                    self.culled_cow_num * 100
-        for parity in self.num_cow_for_parity:
-            if self.cow_num == 0:
-                self.percent_cow_for_parity[parity] = 0
-            else:
-                self.percent_cow_for_parity[parity] = \
-                    self.num_cow_for_parity[parity] / self.cow_num * 100
+        parity_counts = LifeCycleManager.num_cow_for_parity
+        temp = Utility.calc_average(parity_counts[key], self.avg_age_for_parity[key], cow.days_born)
+        parity_counts[key], self.avg_age_for_parity[key] = temp
 
-        return animals_added, ids_removed, calves_born, calves, heiferIs, \
-               heiferIIs, heiferIIIs, cows
+        calving_age = cow.events.get_most_recent_date(animal_constants.NEW_BIRTH)
+        if calving_age != -1:
+            temp2 = Utility.calc_average(calving_age_avail_num[key], self.avg_age_for_calving[key], calving_age)
+            calving_age_avail_num[key], self.avg_age_for_calving[key] = temp2
 
-    @staticmethod
-    def calc_average(num_values, cur_avg, new_value):
+        if cow.calving_to_preg_time != 0:
+            avg_times = LifeCycleManager.avg_calving_to_preg_time
+            temp3 = Utility.calc_average(calf_to_preg_time_avail_num[key], avg_times[key], cow.calving_to_preg_time)
+            calf_to_preg_time_avail_num[key], avg_times[key] = temp3
+
+    def _handle_cow_ci(self, cow: Cow, calving_interval_avail_num: int) -> int:
+        if cow.CI != 0:
+            temp = Utility.calc_average(calving_interval_avail_num, self.avg_calving_interval, cow.CI)
+            calving_interval_avail_num, self.avg_calving_interval = temp
+        return calving_interval_avail_num
+
+    def _extract_repro_stats_from_cow(self, cow: Cow) -> None:
+        self.GnRH_injection_num += cow.GnRH_injections
+        self.PGF_injection_num += cow.PGF_injections
+        self.preg_check_num += cow.preg_diagnoses
+        self.semen_num += cow.semen_num
+        self.ai_num += cow.AI_times
+
+    def _handle_new_born(self, sim_day: int, cow: Cow, calves_born: List[Calf]) -> None:
+        args = {
+            'id': self.animal_initializer.next_id(),
+            'breed': 'HO',
+            'birth_date': sim_day,
+            'days_born': 0,
+            'p_init': cow.p_gest_for_calf,
+            'birth_weight': cow.calf_birth_weight
+        }
+        # at parturition, the sum of P absorbed for gestation rqmts is
+        # subtracted from the animal value. the sum of P absorbed for
+        # gestation is equal to the initial animal P value for the calf
+        # (A.1G.A.4)
+        cow.p_animal = cow.p_animal - cow.p_gest_for_calf + \
+                       cow.p_growth + cow.dP_reserves
+        new_calf = Calf(args)
+        cow.p_gest_for_calf = 0
+        cow.calf_birth_weight = 0
+        if not (new_calf.culled or new_calf.sold):
+            new_calf.events.add_event(new_calf.days_born, sim_day, animal_constants.ENTER_HERD)
+            # calves.append(new_calf)
+            calves_born.append(new_calf)
+        if new_calf.sold:
+            self.sold_calf_num += 1
+
+    def _calc_herd_percentages(self, total_animal_num: int) -> None:
         """
-        Calcuate the new average given the number of values, the current average, and the new value.
+        Calculate percentage of each animal class in the herd
 
         Args:
-            num_values: number of values for the current average
-            cur_avg: the current average value
-            new_value: the new value to be averaged
+            total_animal_num:
 
-        Return:
-            new_num_values: the new number of values for the new average
-            new_avg: the new average value calculated
+        Returns:
+
         """
-        new_num_values = num_values + 1
-        new_avg = (cur_avg * num_values + new_value) / new_num_values
 
-        return new_num_values, new_avg
+        if total_animal_num == 0:
+            self.calf_percent = 0.0
+            self.heiferI_percent = 0.0
+            self.heiferII_percent = 0.0
+            self.heiferIII_percent = 0.0
+            self.cow_percent = 0.0
+        else:
+            pc = Utility.percent_calculator(denominator=total_animal_num)
+            self.calf_percent = pc(self.calf_num)
+            self.heiferI_percent = pc(self.heiferI_num)
+            self.heiferII_percent = pc(self.heiferII_num)
+            self.heiferIII_percent = pc(self.heiferIII_num)
+            self.cow_percent = pc(self.cow_num)
+
+    def _calc_cow_percentages(self) -> None:
+        """
+        Calculate percentages of different kinds of cows
+
+        Returns:
+
+        """
+
+        if self.cow_num == 0:
+            self.dry_cow_percent = 0.0
+            self.milking_cow_percent = 0.0
+            self.preg_cow_percent = 0.0
+            self.non_preg_cow_percent = 0.0
+        else:
+            pc = Utility.percent_calculator(denominator=self.cow_num)
+            self.dry_cow_percent = pc(self.dry_cow_num)
+            self.milking_cow_percent = pc(self.milking_cow_num)
+            self.preg_cow_percent = pc(self.preg_cow_num)
+            self.non_preg_cow_percent = pc(self.open_cow_num + self.vwp_cow_num)
+
+    def _calc_cull_reason_stats_percent(self) -> None:
+        """
+        Calculate the percentage of culled cows for each cull reason
+
+        Returns:
+
+        """
+
+        for cull_reason in LifeCycleManager.cull_reason_stats:
+            if self.culled_cow_num != 0:
+                cow_frac = LifeCycleManager.cull_reason_stats[cull_reason] / self.culled_cow_num
+                self.cull_reason_stats_percent[cull_reason] = cow_frac * 100
+
+    def _calc_percent_cow_per_parity(self) -> None:
+        """
+        Calculate the percentage of cows for each parity number
+
+        Returns:
+
+        """
+
+        for parity in LifeCycleManager.num_cow_for_parity:
+            if self.cow_num == 0:
+                self.percent_cow_for_parity[parity] = 0.0
+            else:
+                cow_frac = LifeCycleManager.num_cow_for_parity[parity] / self.cow_num
+                self.percent_cow_for_parity[parity] = cow_frac * 100

--- a/RUFAS/routines/animal/life_cycle/life_cycle.py
+++ b/RUFAS/routines/animal/life_cycle/life_cycle.py
@@ -214,7 +214,7 @@ class LifeCycleManager:
     #  calving_interval attribute is present, maybe set that to true instead?
     def _set_avg_CI(self, animal_config: AnimalConfigTypedDict,
                     animal_initializer: AnimalInitialization) -> None:
-        if 'user_input_calving_interval' in animal_config:
+        if 'user_input_calving_interval' in animal_config and animal_config['user_input_calving_interval']:
             self.avg_CI = animal_config['calving_interval']
         else:
             self.initialize_db_summary = animal_initializer.initialization_db_summary()

--- a/RUFAS/routines/animal/life_cycle/life_cycle.py
+++ b/RUFAS/routines/animal/life_cycle/life_cycle.py
@@ -37,7 +37,6 @@ class LifeCycleManager:
     """
     Manages the life cycles of the animals.
     """
-
     # The following class variables are used in HerdReport.
     num_cow_for_parity = {
         '1': 0,
@@ -591,6 +590,7 @@ class LifeCycleManager:
                 Utility.calc_average(self.preg_cow_num, self.avg_days_in_preg, cow.days_in_preg)
 
     def _handle_cow_calves(self, cow: Cow, calving_age_avail_num, calf_to_preg_time_avail_num) -> None:
+        """Adjusts the average cow age per parity, average calving age, and average time from calf to pregnant."""
         if 0 < cow.calves <= 3:
             key = str(cow.calves)
         else:
@@ -664,29 +664,22 @@ class LifeCycleManager:
             self.sold_calf_num += 1
 
     def _calc_herd_percentages(self, total_animal_num: int) -> None:
-        """
-        Calculate percentage of each animal class in the herd
+        """Calculates percentage of each animal class in the herd.
+
+        When the total number of animals is 0, it is assumed that the count of
+        each animal class has already been set to or initialized with 0.
 
         Args:
-            total_animal_num:
-
-        Returns:
+            total_animal_num: The total number of animals in the herd.
 
         """
-
-        if total_animal_num == 0:
-            self.calf_percent = 0.0
-            self.heiferI_percent = 0.0
-            self.heiferII_percent = 0.0
-            self.heiferIII_percent = 0.0
-            self.cow_percent = 0.0
-        else:
-            pc = Utility.percent_calculator(denominator=total_animal_num)
-            self.calf_percent = pc(self.calf_num)
-            self.heiferI_percent = pc(self.heiferI_num)
-            self.heiferII_percent = pc(self.heiferII_num)
-            self.heiferIII_percent = pc(self.heiferIII_num)
-            self.cow_percent = pc(self.cow_num)
+        denominator = total_animal_num if total_animal_num > 0 else 1
+        pc = Utility.percent_calculator(denominator)
+        self.calf_percent = pc(self.calf_num)
+        self.heiferI_percent = pc(self.heiferI_num)
+        self.heiferII_percent = pc(self.heiferII_num)
+        self.heiferIII_percent = pc(self.heiferIII_num)
+        self.cow_percent = pc(self.cow_num)
 
     def _calc_cow_percentages(self) -> None:
         """

--- a/RUFAS/routines/animal/life_cycle/life_cycle.py
+++ b/RUFAS/routines/animal/life_cycle/life_cycle.py
@@ -284,11 +284,15 @@ class LifeCycleManager:
         self._reset_parity()
         self._reset_cull_reason_stats()
 
-        total_animal_num = self._calf_to_heiferI(sim_day, calves, heiferIs, total_animal_num)
-        total_animal_num = self._heiferI_to_heiferII(sim_day, heiferIs, heiferIIs, total_animal_num)
-        total_animal_num, preg_heifer_num = self._heiferII_to_heiferIII(sim_day, heiferIIs, heiferIIIs,
-                                                                        preg_heifer_num, total_animal_num)
-        total_animal_num = self._heiferIII_to_cow(sim_day, heiferIIIs, cows, total_animal_num)
+        total_animal_num = self._evaluate_calves_for_weaning(sim_day, calves, heiferIs, total_animal_num)
+        total_animal_num = self._evaluate_heiferIs_for_transitioning_to_heiferIIs(sim_day, heiferIs, heiferIIs,
+                                                                                  total_animal_num)
+        total_animal_num, preg_heifer_num = self._evaluate_heiferIIs_for_transitioning_to_heiferIIIs(sim_day, heiferIIs,
+                                                                                                     heiferIIIs,
+                                                                                                     preg_heifer_num,
+                                                                                                     total_animal_num)
+        total_animal_num = self._evaluate_heiferIIIs_for_transitioning_to_cows(sim_day, heiferIIIs, cows,
+                                                                               total_animal_num)
 
         self._check_if_heifers_need_to_be_sold(heiferIIIs, cows, ids_removed)
         self._check_if_replacement_heifers_needed(sim_day, heiferIIIs, cows, animals_added)
@@ -296,15 +300,16 @@ class LifeCycleManager:
         total_animal_num = self._cull_cows_and_record_stats(sim_day, cows, calves_born,
                                                             ids_removed, total_animal_num)
 
-        self._calc_herd_percentages(total_animal_num)
-        self._calc_cow_percentages()
-        self._calc_cull_reason_stats_percent()
-        self._calc_percent_cow_per_parity()
+        self._calculate_herd_percentages(total_animal_num)
+        self._calculate_cow_percentages()
+        self._calculate_cull_reason_stats_percent()
+        self._calculate_percent_cow_per_parity()
 
         return (animals_added, ids_removed, calves_born, calves, heiferIs,
                 heiferIIs, heiferIIIs, cows)
 
     def _reset_parity(self) -> None:
+        """Resets parity-based attributes."""
         for parity in LifeCycleManager.num_cow_for_parity:
             LifeCycleManager.num_cow_for_parity[parity] = 0
             LifeCycleManager.avg_calving_to_preg_time[parity] = 0
@@ -313,30 +318,52 @@ class LifeCycleManager:
             self.avg_age_for_calving[parity] = 0.0
 
     def _reset_cull_reason_stats(self) -> None:
+        """Resets cull reason-based attributes."""
         for cull_reason in LifeCycleManager.cull_reason_stats:
             LifeCycleManager.cull_reason_stats[cull_reason] = 0
             self.cull_reason_stats_percent[cull_reason] = 0.0
 
-    def _calf_to_heiferI(self, sim_day: int, calves: List[Calf],
-                         heiferIs: List[HeiferI], total_animal_num: int) -> int:
+    def _evaluate_calves_for_weaning(self, sim_day: int, calves: List[Calf],
+                                     heiferIs: List[HeiferI], total_animal_num: int) -> int:
+        """Evaluates calves for weaning.
+
+        If a calf is to be weaned, it will be removed from the calves list and
+        get added to the heiferIs list.
+
+        Args:
+            sim_day: The current simulation day.
+            calves: The list of calves.
+            heiferIs: The list of heiferIs.
+            total_animal_num: The current total number of animals.
+
+        Returns:
+            The newly updated total number of animals.
+
+        """
         removed_calves_idx: List[int] = []
 
         for idx, calf in enumerate(calves):
-            wean_day = calf.update(sim_day)
-            if wean_day:
-                self._wean_calf(calf, heiferIs)
+            is_heiferI_stage = calf.update(sim_day)
+            if is_heiferI_stage:
+                self._convert_calf_to_heiferI(calf, heiferIs)
                 removed_calves_idx.append(idx)
             else:
                 self.calf_num += 1
-                temp = Utility.calc_average(total_animal_num, self.avg_mature_body_weight,
-                                            calf.mature_body_weight)
-                total_animal_num, self.avg_mature_body_weight = temp
+                total_animal_num, self.avg_mature_body_weight = \
+                    Utility.calc_average(total_animal_num, self.avg_mature_body_weight, calf.mature_body_weight)
 
         Utility.remove_items_from_list_by_indices(calves, removed_calves_idx)
         return total_animal_num
 
     @staticmethod
-    def _wean_calf(calf: Calf, heiferIs: List[HeiferI]) -> None:
+    def _convert_calf_to_heiferI(calf: Calf, heiferIs: List[HeiferI]) -> None:
+        """Converts a calf to a heiferI and appends it to the heiferIs list.
+
+        Args:
+            calf: The calf to be converted.
+            heiferIs: The list of heiferIs.
+
+        """
         calf_vals = calf.get_calf_values()
         calf_vals.update({
             'body_weight_history': calf.body_weight_history,
@@ -345,25 +372,48 @@ class LifeCycleManager:
         new_heiferI = HeiferI(calf_vals)
         heiferIs.append(new_heiferI)
 
-    def _heiferI_to_heiferII(self, sim_day: int, heiferIs: List[HeiferI], heiferIIs: List[HeiferII],
-                             total_animal_num: int) -> int:
+    def _evaluate_heiferIs_for_transitioning_to_heiferIIs(self, sim_day: int, heiferIs: List[HeiferI],
+                                                          heiferIIs: List[HeiferII],
+                                                          total_animal_num: int) -> int:
+        """Evaluates heiferIs for transitioning to heiferIIs.
+
+        If a heiferI transitions to a heiferII, it will be removed
+        from the heiferIs list and get added to the heiferIIs list.
+
+        Args:
+            sim_day: The current simulation day.
+            heiferIs: The list of heiferIs.
+            heiferIIs: The list of heiferIIs.
+            total_animal_num: The current total number of animals.
+
+        Returns:
+            The newly updated total number of animals.
+
+        """
         removed_heiferIs_idx: List[int] = []
 
         for idx, heiferI in enumerate(heiferIs):
-            second_stage = heiferI.update(sim_day)
-            if second_stage:
-                self._move_heiferI_to_second_stage(heiferI, heiferIIs)
+            is_heiferII_stage = heiferI.update(sim_day)
+            if is_heiferII_stage:
+                self._convert_heiferI_to_heiferII(heiferI, heiferIIs)
                 removed_heiferIs_idx.append(idx)
             else:
                 self.heiferI_num += 1
-                temp = Utility.calc_average(total_animal_num, self.avg_mature_body_weight, heiferI.mature_body_weight)
-                total_animal_num, self.avg_mature_body_weight = temp
+                total_animal_num, self.avg_mature_body_weight = \
+                    Utility.calc_average(total_animal_num, self.avg_mature_body_weight, heiferI.mature_body_weight)
 
         Utility.remove_items_from_list_by_indices(heiferIs, removed_heiferIs_idx)
         return total_animal_num
 
     @staticmethod
-    def _move_heiferI_to_second_stage(heiferI: HeiferI, heiferIIs: List[HeiferII]) -> None:
+    def _convert_heiferI_to_heiferII(heiferI: HeiferI, heiferIIs: List[HeiferII]) -> None:
+        """Converts a heiferI to a heiferII and appends it to the heiferIIs list.
+
+        Args:
+            heiferI: The heiferI to be converted.
+            heiferIIs: The list of heiferIIs.
+
+        """
         heiferI_vals = heiferI.get_heiferI_values()
         heiferI_vals.update({
             'body_weight_history': heiferI.body_weight_history,
@@ -375,30 +425,54 @@ class LifeCycleManager:
         new_heiferII = HeiferII(heiferI_vals)
         heiferIIs.append(new_heiferII)
 
-    def _heiferII_to_heiferIII(self, sim_day: int, heiferIIs: List[HeiferII],
-                               heiferIIIs: List[HeiferIII], preg_heifer_num: int,
-                               total_animal_num: int) -> Tuple[int, int]:
+    def _evaluate_heiferIIs_for_transitioning_to_heiferIIIs(self, sim_day: int, heiferIIs: List[HeiferII],
+                                                            heiferIIIs: List[HeiferIII], preg_heifer_num: int,
+                                                            total_animal_num: int) -> Tuple[int, int]:
+        """Evaluates heiferIIs for transitioning to heiferIIIs.
+
+        If a heiferII is to be culled or transitions to a heiferIII, it will be removed
+        from the heiferIIs list and get added to the culled heifers or heiferIIIs list, respectively.
+
+        Args:
+            sim_day: The current simulation day.
+            heiferIIs: The list of heiferIIs.
+            heiferIIIs: The list of heiferIIIs.
+            preg_heifer_num: The current number of pregnant heifers.
+            total_animal_num: The current total number of animals.
+
+        Returns:
+            The newly updated total number of animals and the newly updated number of pregnant heifers.
+
+        """
         removed_heiferIIs_idx: List[int] = []
 
         for idx, heiferII in enumerate(heiferIIs):
-            cull_stage, third_stage = heiferII.update(sim_day)
-            if cull_stage:
-                temp = Utility.calc_average(self.culled_heifer_num, self.avg_heifer_culling_age, heiferII.days_born)
-                self.culled_heifer_num, self.avg_heifer_culling_age = temp
+            is_cull_stage, is_heiferIII_stage = heiferII.update(sim_day)
+            if is_cull_stage:
+                self.culled_heifer_num, self.avg_heifer_culling_age = \
+                    Utility.calc_average(self.culled_heifer_num, self.avg_heifer_culling_age, heiferII.days_born)
                 self.culled_heifers.append(heiferII)
                 removed_heiferIIs_idx.append(idx)
-            elif third_stage:
-                self._move_heiferII_to_third_stage(heiferII, heiferIIIs)
+            elif is_heiferIII_stage:
+                self._convert_heiferII_to_heiferIII(heiferII, heiferIIIs)
                 removed_heiferIIs_idx.append(idx)
             else:
                 total_animal_num, preg_heifer_num = \
                     self._remain_heiferII(heiferII, total_animal_num, preg_heifer_num)
+                self._extract_repro_stats_from_heiferII(heiferII)
 
         Utility.remove_items_from_list_by_indices(heiferIIs, removed_heiferIIs_idx)
         return total_animal_num, preg_heifer_num
 
     @staticmethod
-    def _move_heiferII_to_third_stage(heiferII: HeiferII, heiferIIIs: List[HeiferIII]) -> None:
+    def _convert_heiferII_to_heiferIII(heiferII: HeiferII, heiferIIIs: List[HeiferIII]) -> None:
+        """Converts a heiferII to a heiferIII and appends it to the heiferIIIs list.
+
+        Args:
+            heiferII: The heiferII to be converted.
+            heiferIIIs: The list of heiferIIIs.
+
+        """
         heiferII_vals = heiferII.get_heiferII_values()
         heiferII_vals.update({
             'body_weight_history': heiferII.body_weight_history,
@@ -410,18 +484,36 @@ class LifeCycleManager:
         heiferIIIs.append(new_heiferIII)
 
     def _remain_heiferII(self, heiferII: HeiferII, total_animal_num: int, preg_heifer_num: int):
+        """Updates relevant stats by keeping a heiferII as is.
+
+        The following attributes are updated: heiferII_num, avg_mature_body_weight,
+        and avg_preg_heifer_body_weight.
+
+        Args:
+            heiferII: The heiferII to be maintained.
+            total_animal_num: The current total number of animals.
+
+        Returns:
+            The newly updated total number of animals and pregnant heifer number.
+
+        """
         self.heiferII_num += 1
-        temp = Utility.calc_average(total_animal_num, self.avg_mature_body_weight,
-                                    heiferII.mature_body_weight)
-        total_animal_num, self.avg_mature_body_weight = temp
+        total_animal_num, self.avg_mature_body_weight = \
+            Utility.calc_average(total_animal_num, self.avg_mature_body_weight,
+                                 heiferII.mature_body_weight)
         if heiferII.breeding_to_preg_time != 0:
-            temp2 = Utility.calc_average(preg_heifer_num, self.avg_breeding_to_preg_time,
-                                         heiferII.breeding_to_preg_time)
-            preg_heifer_num, self.avg_breeding_to_preg_time = temp2
-        self._extract_repro_stats_from_heiferII(heiferII)
+            preg_heifer_num, self.avg_breeding_to_preg_time = \
+                Utility.calc_average(preg_heifer_num, self.avg_breeding_to_preg_time,
+                                     heiferII.breeding_to_preg_time)
         return total_animal_num, preg_heifer_num
 
     def _extract_repro_stats_from_heiferII(self, heiferII: HeiferII) -> None:
+        """Extracts the reproductive stats from a heiferII.
+
+        Args:
+            heiferII: The heiferII to extract the stats from.
+
+        """
         # self.CIDR_count += heiferII.CIDR_count  # TODO: add CIDR count to heiferII
         self.GnRH_injection_num_h += heiferII.GnRH_injections
         self.PGF_injection_num_h += heiferII.PGF_injections
@@ -430,14 +522,26 @@ class LifeCycleManager:
         self.ai_num_h += heiferII.AI_times
         self.ed_period_h += heiferII.ED_days
 
-    def _heiferIII_to_cow(self, sim_day: int, heiferIIIs: List[HeiferIII], cows: List[Cow],
-                          total_animal_num: int) -> int:
+    def _evaluate_heiferIIIs_for_transitioning_to_cows(self, sim_day: int, heiferIIIs: List[HeiferIII], cows: List[Cow],
+                                                       total_animal_num: int) -> int:
+        """Evaluates heiferIIIs for transitioning to cows.
+
+        Args:
+            sim_day: The current simulation day.
+            heiferIIIs: The list of heiferIIIs.
+            cows: The list of cows.
+            total_animal_num: The current total number of animals.
+
+        Returns:
+            The newly updated total number of animals.
+
+        """
         removed_heiferIIIs_idx: List[int] = []
 
         for idx, heiferIII in enumerate(heiferIIIs):
-            cow_stage = heiferIII.update(sim_day)
-            if cow_stage:
-                self._move_heiferIII_to_cow_stage(heiferIII, cows)
+            is_cow_stage = heiferIII.update(sim_day)
+            if is_cow_stage:
+                self._convert_heiferIII_to_cow(heiferIII, cows)
                 removed_heiferIIIs_idx.append(idx)
             else:
                 self.heiferIII_num += 1
@@ -449,7 +553,14 @@ class LifeCycleManager:
         return total_animal_num
 
     @staticmethod
-    def _move_heiferIII_to_cow_stage(heiferIII, cows):
+    def _convert_heiferIII_to_cow(heiferIII, cows) -> None:
+        """Converts a heiferIII to a cow and appends it to the cows list.
+
+        Args:
+            heiferIII: The heiferIII to be converted.
+            cows: The list of cows.
+
+        """
         args = heiferIII.get_heiferIII_values()
         args.update({
             'body_weight_history': heiferIII.body_weight_history,
@@ -466,8 +577,17 @@ class LifeCycleManager:
 
     def _check_if_heifers_need_to_be_sold(self, heiferIIIs: List[HeiferIII], cows: List[Cow],
                                           ids_removed: List[int]) -> None:
-        # If the number of heifers exceeds what is needed for the herd,
-        # sell those as replacement
+        """Checks if any heifers need to be sold.
+
+        If the number of heifers exceeds what is needed for the herd,
+        sell those as replacement
+
+        Args:
+            heiferIIIs: The list of heiferIIIs.
+            cows: The list of cows.
+            ids_removed: The list of ids of animals removed from the herd.
+
+        """
         sell_threshold = 1.03
         while len(heiferIIIs) + len(cows) > self.herd_num * sell_threshold and len(heiferIIIs) > 0:
             removed_heiferIII = heiferIIIs.pop()
@@ -477,8 +597,18 @@ class LifeCycleManager:
 
     def _check_if_replacement_heifers_needed(self, sim_day: int, heiferIIIs: List[HeiferIII], cows: List[Cow],
                                              animals_added: List[Cow]) -> None:
-        # if the number of heifers is less than needed for the herd,
-        # buy replacement from the market
+        """Checks if replacement heifers are needed.
+
+        If the number of heifers is less than what is needed for the herd,
+        add replacement heifers.
+
+        Args:
+            sim_day: The current simulation day.
+            heiferIIIs: The list of heiferIIIs.
+            cows: The list of cows.
+            animals_added: The list of animals added to the herd.
+
+        """
         buy_threshold = 1.01
         while len(cows) + len(heiferIIIs) + self.bought_heifer_num < self.herd_num * buy_threshold \
                 and sim_day > 1:
@@ -490,6 +620,19 @@ class LifeCycleManager:
 
     def _cull_cows_and_record_stats(self, sim_day: int, cows: List[Cow], calves_born: List[Calf],
                                     ids_removed: List[int], total_animal_num: int) -> int:
+        """Culls cows and records stats.
+
+        Args:
+            sim_day: The current simulation day.
+            cows: The list of cows.
+            calves_born: The list of calves born.
+            ids_removed: The list of ids of animals removed from the herd.
+            total_animal_num: The current total number of animals in the herd.
+
+        Returns:
+            The newly updated total number of animals in the herd.
+
+        """
         calving_interval_avail_num = 0
         calving_age_avail_num = {
             '1': 0,
@@ -529,15 +672,20 @@ class LifeCycleManager:
         return total_animal_num
 
     def _cull_cow(self, cow: Cow) -> None:
+        """Culls a cow and records the culling reason.
+
+        Args:
+            cow: The cow to be culled.
+
+        """
         self.culled_cows.append(cow)
         self.cull_reason_stats_range[cow.cull_reason] += 1
         LifeCycleManager.cull_reason_stats[cow.cull_reason] += 1
 
         parity = cow.calves if cow.calves <= 3 else '4+'
         self.parity_culling_stats_range[parity] += 1
-
-        temp = Utility.calc_average(self.culled_cow_num, self.avg_cow_culling_age, cow.days_born)
-        self.culled_cow_num, self.avg_cow_culling_age = temp
+        self.culled_cow_num, self.avg_cow_culling_age = \
+            Utility.calc_average(self.culled_cow_num, self.avg_cow_culling_age, cow.days_born)
 
     def _handle_cow_body_weight_and_parity(self, cow: Cow, total_animal_num: int) -> int:
         """Adjusts the average cow body weight, average parity number, and average mature body weight
@@ -555,8 +703,8 @@ class LifeCycleManager:
         self.cow_num, self.avg_parity_num = Utility.calc_average(
                 self.cow_num, self.avg_parity_num, cow.calves)
 
-        temp = Utility.calc_average(total_animal_num, self.avg_mature_body_weight, cow.mature_body_weight)
-        total_animal_num, self.avg_mature_body_weight = temp
+        total_animal_num, self.avg_mature_body_weight = \
+            Utility.calc_average(total_animal_num, self.avg_mature_body_weight, cow.mature_body_weight)
         return total_animal_num
 
     def _handle_cow_milking(self, cow: Cow) -> None:
@@ -663,7 +811,7 @@ class LifeCycleManager:
         if new_calf.sold:
             self.sold_calf_num += 1
 
-    def _calc_herd_percentages(self, total_animal_num: int) -> None:
+    def _calculate_herd_percentages(self, total_animal_num: int) -> None:
         """Calculates percentage of each animal class in the herd.
 
         When the total number of animals is 0, it is assumed that the count of
@@ -681,50 +829,25 @@ class LifeCycleManager:
         self.heiferIII_percent = pc(self.heiferIII_num)
         self.cow_percent = pc(self.cow_num)
 
-    def _calc_cow_percentages(self) -> None:
-        """
-        Calculate percentages of different kinds of cows
+    def _calculate_cow_percentages(self) -> None:
+        """Calculates percentages of different kinds of cows"""
+        denominator = self.cow_num if self.cow_num > 0 else 1
+        pc = Utility.percent_calculator(denominator)
+        self.dry_cow_percent = pc(self.dry_cow_num)
+        self.milking_cow_percent = pc(self.milking_cow_num)
+        self.preg_cow_percent = pc(self.preg_cow_num)
+        self.non_preg_cow_percent = pc(self.open_cow_num + self.vwp_cow_num)
 
-        Returns:
-
-        """
-
-        if self.cow_num == 0:
-            self.dry_cow_percent = 0.0
-            self.milking_cow_percent = 0.0
-            self.preg_cow_percent = 0.0
-            self.non_preg_cow_percent = 0.0
-        else:
-            pc = Utility.percent_calculator(denominator=self.cow_num)
-            self.dry_cow_percent = pc(self.dry_cow_num)
-            self.milking_cow_percent = pc(self.milking_cow_num)
-            self.preg_cow_percent = pc(self.preg_cow_num)
-            self.non_preg_cow_percent = pc(self.open_cow_num + self.vwp_cow_num)
-
-    def _calc_cull_reason_stats_percent(self) -> None:
-        """
-        Calculate the percentage of culled cows for each cull reason
-
-        Returns:
-
-        """
-
+    def _calculate_cull_reason_stats_percent(self) -> None:
+        """Calculates the percentage of culled cows for each cull reason."""
+        denominator = self.cow_num if self.cow_num > 0 else 1
+        pc = Utility.percent_calculator(denominator)
         for cull_reason in LifeCycleManager.cull_reason_stats:
-            if self.culled_cow_num != 0:
-                cow_frac = LifeCycleManager.cull_reason_stats[cull_reason] / self.culled_cow_num
-                self.cull_reason_stats_percent[cull_reason] = cow_frac * 100
+            self.cull_reason_stats_percent[cull_reason] = pc(LifeCycleManager.cull_reason_stats[cull_reason])
 
-    def _calc_percent_cow_per_parity(self) -> None:
-        """
-        Calculate the percentage of cows for each parity number
-
-        Returns:
-
-        """
-
+    def _calculate_percent_cow_per_parity(self) -> None:
+        """Calculates the percentage of cows for each parity number."""
+        denominator = self.cow_num if self.cow_num > 0 else 1
+        pc = Utility.percent_calculator(denominator)
         for parity in LifeCycleManager.num_cow_for_parity:
-            if self.cow_num == 0:
-                self.percent_cow_for_parity[parity] = 0.0
-            else:
-                cow_frac = LifeCycleManager.num_cow_for_parity[parity] / self.cow_num
-                self.percent_cow_for_parity[parity] = cow_frac * 100
+            self.percent_cow_for_parity[parity] = pc(LifeCycleManager.num_cow_for_parity[parity])

--- a/RUFAS/routines/animal/life_cycle/life_cycle.py
+++ b/RUFAS/routines/animal/life_cycle/life_cycle.py
@@ -123,7 +123,7 @@ class LifeCycleManager:
         self.preg_cow_percent = 0.0
         self.non_preg_cow_percent = 0.0
 
-        self.daily_milk_production = 0
+        self.daily_milk_production = 0.0
         self.avg_days_in_milk = 0.0
         self.avg_days_in_preg = 0.0
         self.avg_cow_body_weight = 0.0
@@ -302,8 +302,8 @@ class LifeCycleManager:
         self._calc_cull_reason_stats_percent()
         self._calc_percent_cow_per_parity()
 
-        return animals_added, ids_removed, calves_born, calves, heiferIs, \
-               heiferIIs, heiferIIIs, cows
+        return (animals_added, ids_removed, calves_born, calves, heiferIs,
+                heiferIIs, heiferIIIs, cows)
 
     def _reset_parity(self) -> None:
         for parity in LifeCycleManager.num_cow_for_parity:
@@ -518,10 +518,9 @@ class LifeCycleManager:
             else:
                 total_animal_num = self._handle_cow_body_weight_and_parity(cow, total_animal_num)
                 self._handle_cow_milking(cow)
-                self._handle_cow_days_in_milk(cow)
                 self._handle_cow_days_in_preg(cow)
                 self._handle_cow_calves(cow, calving_age_avail_num, calf_to_preg_time_avail_num)
-                calving_interval_avail_num = self._handle_cow_ci(cow, calving_interval_avail_num)
+                calving_interval_avail_num = self._handle_cow_CI(cow, calving_interval_avail_num)
                 self._extract_repro_stats_from_cow(cow)
 
             if new_born:
@@ -567,27 +566,29 @@ class LifeCycleManager:
         Args:
             cow: A Cow object.
 
-        Returns:
-            None
-
         """
         if cow.milking:
             self.daily_milk_production += cow.estimated_daily_milk_produced
-            temp = Utility.calc_average(self.milking_cow_num, self.avg_days_in_milk, cow.days_in_milk)
-            self.milking_cow_num, self.avg_days_in_milk = temp
+            self.milking_cow_num, self.avg_days_in_milk = \
+                Utility.calc_average(self.milking_cow_num, self.avg_days_in_milk, cow.days_in_milk)
 
             if cow.days_in_milk < self.animal_config['voluntary_waiting_period']:
                 self.vwp_cow_num += 1
-
-            if cow.days_in_preg == 0:
-                self.open_cow_num += 1
         else:
             self.dry_cow_num += 1
 
     def _handle_cow_days_in_preg(self, cow: Cow) -> None:
-        if cow.days_in_preg > 0:
-            temp = Utility.calc_average(self.preg_cow_num, self.avg_days_in_preg, cow.days_in_preg)
-            self.preg_cow_num, self.avg_days_in_preg = temp
+        """Adjusts the average days in pregnancy.
+
+        Args:
+            cow: A Cow object.
+
+        """
+        if cow.days_in_preg == 0:
+            self.open_cow_num += 1
+        elif cow.days_in_preg > 0:
+            self.preg_cow_num, self.avg_days_in_preg = \
+                Utility.calc_average(self.preg_cow_num, self.avg_days_in_preg, cow.days_in_preg)
 
     def _handle_cow_calves(self, cow: Cow, calving_age_avail_num, calf_to_preg_time_avail_num) -> None:
         if 0 < cow.calves <= 3:
@@ -596,26 +597,42 @@ class LifeCycleManager:
             key = 'greater_than_3'
 
         parity_counts = LifeCycleManager.num_cow_for_parity
-        temp = Utility.calc_average(parity_counts[key], self.avg_age_for_parity[key], cow.days_born)
-        parity_counts[key], self.avg_age_for_parity[key] = temp
+        parity_counts[key], self.avg_age_for_parity[key] = \
+            Utility.calc_average(parity_counts[key], self.avg_age_for_parity[key], cow.days_born)
 
         calving_age = cow.events.get_most_recent_date(animal_constants.NEW_BIRTH)
         if calving_age != -1:
-            temp2 = Utility.calc_average(calving_age_avail_num[key], self.avg_age_for_calving[key], calving_age)
-            calving_age_avail_num[key], self.avg_age_for_calving[key] = temp2
+            calving_age_avail_num[key], self.avg_age_for_calving[key] = \
+                Utility.calc_average(calving_age_avail_num[key], self.avg_age_for_calving[key], calving_age)
 
         if cow.calving_to_preg_time != 0:
             avg_times = LifeCycleManager.avg_calving_to_preg_time
-            temp3 = Utility.calc_average(calf_to_preg_time_avail_num[key], avg_times[key], cow.calving_to_preg_time)
-            calf_to_preg_time_avail_num[key], avg_times[key] = temp3
+            calf_to_preg_time_avail_num[key], avg_times[key] = \
+                Utility.calc_average(calf_to_preg_time_avail_num[key], avg_times[key], cow.calving_to_preg_time)
 
-    def _handle_cow_ci(self, cow: Cow, calving_interval_avail_num: int) -> int:
+    def _handle_cow_CI(self, cow: Cow, calving_interval_avail_num: int) -> int:
+        """Adjusts the average calving interval.
+
+        Args:
+            cow: A Cow object.
+            calving_interval_avail_num: The number of cows with a calving interval.
+
+        Returns:
+            calving_interval_avail_num: The newly updated number of cows with a calving interval.
+
+        """
         if cow.CI != 0:
-            temp = Utility.calc_average(calving_interval_avail_num, self.avg_calving_interval, cow.CI)
-            calving_interval_avail_num, self.avg_calving_interval = temp
+            calving_interval_avail_num, self.avg_calving_interval = \
+                Utility.calc_average(calving_interval_avail_num, self.avg_calving_interval, cow.CI)
         return calving_interval_avail_num
 
     def _extract_repro_stats_from_cow(self, cow: Cow) -> None:
+        """Extracts the reproduction statistics from a cow and updates life cycle manager.
+
+        Args:
+            cow: A Cow object.
+
+        """
         self.GnRH_injection_num += cow.GnRH_injections
         self.PGF_injection_num += cow.PGF_injections
         self.preg_check_num += cow.preg_diagnoses
@@ -635,8 +652,7 @@ class LifeCycleManager:
         # subtracted from the animal value. the sum of P absorbed for
         # gestation is equal to the initial animal P value for the calf
         # (A.1G.A.4)
-        cow.p_animal = cow.p_animal - cow.p_gest_for_calf + \
-                       cow.p_growth + cow.dP_reserves
+        cow.p_animal = cow.p_animal - cow.p_gest_for_calf + cow.p_growth + cow.dP_reserves
         new_calf = Calf(args)
         cow.p_gest_for_calf = 0
         cow.calf_birth_weight = 0

--- a/RUFAS/routines/animal/life_cycle/life_cycle.py
+++ b/RUFAS/routines/animal/life_cycle/life_cycle.py
@@ -9,10 +9,13 @@ Author(s): Manfei Li, mli497@wisc.edu
            Militsa Sotirova, militsasotirova@gmail.com
 """
 from collections import defaultdict
+from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import Type
+from typing import TypeVar
 from typing import Union
 
 from RUFAS.routines.animal.animal_typed_dicts import AnimalConfigTypedDict
@@ -26,6 +29,8 @@ from RUFAS.routines.animal.life_cycle.heiferI import HeiferI
 from RUFAS.routines.animal.life_cycle.heiferII import HeiferII
 from RUFAS.routines.animal.life_cycle.heiferIII import HeiferIII
 from RUFAS.util import Utility
+
+GenericAnimal = TypeVar("GenericAnimal", bound=Union[Calf, HeiferI, HeiferII, HeiferIII, Cow])
 
 
 class LifeCycleManager:
@@ -174,7 +179,7 @@ class LifeCycleManager:
          replacements. Initializes the herd.
 
         Args:
-            breed: TODO: needs description
+            breed: The breed of the herd.
             config: stores (among other things) information on whether the seed
                 has been set by the user
             herd_init: boolean - true to populate database with new animals,
@@ -197,66 +202,56 @@ class LifeCycleManager:
         self.animal_initializer = AnimalInitialization(self.animal_config['calving_interval'], breed,
                                                        config.set_seed, herd_init)
         self.herd_num = herd_num
-        self._set_avg_CI(self.animal_config, self.animal_initializer)
+        self._set_avg_CI()
 
-        calves = self._get_calves(calf_num, breed, self.animal_initializer)
-        heiferIs = self._get_heiferIs(heiferI_num, breed, self.animal_initializer)
-        heiferIIs = self._get_heiferIIs(heiferII_num, breed, self.animal_initializer)
-        heiferIIIs = self._get_heiferIIIs(heiferIII_num, breed, self.animal_initializer)
-        cows = self._get_cows(cow_num, breed, self.animal_initializer)
-
+        calves = self._get_animals(Calf, calf_num, breed)
+        heiferIs = self._get_animals(HeiferI, heiferI_num, breed)
+        heiferIIs = self._get_animals(HeiferII, heiferII_num, breed)
+        heiferIIIs = self._get_animals(HeiferIII, heiferIII_num, breed)
+        cows = self._get_animals(Cow, cow_num, breed)
         self.replacement_market = self.animal_initializer.get_replacement_cows(replace_num, breed)
-
         return calves, heiferIs, heiferIIs, heiferIIIs, cows
 
     # TODO: In the animal_management_animal.json,
-    #  the user_input_calving_interval attribute is set to false while the
+    #  the use_input_calving_interval attribute is set to false while the
     #  calving_interval attribute is present, maybe set that to true instead?
-    def _set_avg_CI(self, animal_config: AnimalConfigTypedDict,
-                    animal_initializer: AnimalInitialization) -> None:
-        if 'user_input_calving_interval' in animal_config and animal_config['user_input_calving_interval']:
-            self.avg_CI = animal_config['calving_interval']
+    def _set_avg_CI(self) -> None:
+        if 'use_input_calving_interval' in self.animal_config and self.animal_config['use_input_calving_interval']:
+            self.avg_CI = self.animal_config['calving_interval']
         else:
-            self.initialize_db_summary = animal_initializer.initialization_db_summary()
+            self.initialize_db_summary = self.animal_initializer.initialization_db_summary()
             self.avg_CI = self.initialize_db_summary['cow_avg_CI']
 
-    @staticmethod
-    def _get_calves(calf_num: int, breed: str, animal_initializer: AnimalInitialization) -> List[Calf]:
-        calves = animal_initializer.get_calves(calf_num, breed)
-        for calf in calves:
-            calf.events.add_event(calf.days_born, 0, animal_constants.INIT_HERD)
-        return calves
+    def _get_animals(self, animal_type: Type[GenericAnimal], num: int, breed: str) -> List[GenericAnimal]:
+        """Gets a list of animals of a given type.
 
-    @staticmethod
-    def _get_heiferIs(heiferI_num: int, breed: str, animal_initializer) -> List[HeiferI]:
-        heiferIs = animal_initializer.get_heiferIs(heiferI_num, breed)
-        for heiferI in heiferIs:
-            heiferI.events.add_event(heiferI.days_born, 0, animal_constants.INIT_HERD)
-        return heiferIs
+        Args:
+            animal_type: The type of animal to get.
+            num: The number of animals to get.
+            breed: The breed of the animal.
 
-    @staticmethod
-    def _get_heiferIIs(heiferII_num: int, breed: str, animal_initializer: AnimalInitialization) -> List[HeiferII]:
-        heiferIIs = animal_initializer.get_heiferIIs(heiferII_num, breed)
-        for heiferII in heiferIIs:
-            heiferII.events.add_event(heiferII.days_born, 0, animal_constants.INIT_HERD)
-        return heiferIIs
+        Returns:
+            A list of animals of the given type.
 
-    @staticmethod
-    def _get_heiferIIIs(heiferIII_num: int, breed: str, animal_initializer: AnimalInitialization) -> List[HeiferIII]:
-        heiferIIIs = animal_initializer.get_heiferIIIs(heiferIII_num, breed)
-        for heiferIII in heiferIIIs:
-            heiferIII.events.add_event(heiferIII.days_born, 0, animal_constants.INIT_HERD)
-        return heiferIIIs
+        """
+        animal_getter_by_animal_type: Dict[Type[GenericAnimal], Callable[[int, str], List[GenericAnimal]]] = {
+            Calf: self.animal_initializer.get_calves,
+            HeiferI: self.animal_initializer.get_heiferIs,
+            HeiferII: self.animal_initializer.get_heiferIIs,
+            HeiferIII: self.animal_initializer.get_heiferIIIs,
+            Cow: self.animal_initializer.get_cows
+        }
+        animals = animal_getter_by_animal_type[animal_type](num, breed)
+        for animal in animals:
+            animal.events.add_event(animal.days_born, 0, animal_constants.INIT_HERD)
+        return animals
 
-    @staticmethod
-    def _get_cows(cow_num: int, breed: str, animal_initializer: AnimalInitialization) -> List[Cow]:
-        cows = animal_initializer.get_cows(cow_num, breed)
-        for cow in cows:
-            cow.events.add_event(cow.days_born, 0, animal_constants.INIT_HERD)
-        return cows
-
-    def daily_update(self, sim_day: int, calves: List[Calf], heiferIs: List[HeiferI],
-                     heiferIIs: List[HeiferII], heiferIIIs: List[HeiferIII], cows: List[Cow]) \
+    def daily_update(self, sim_day: int,
+                     calves: List[Calf],
+                     heiferIs: List[HeiferI],
+                     heiferIIs: List[HeiferII],
+                     heiferIIIs: List[HeiferIII],
+                     cows: List[Cow]) \
             -> Tuple[List[Cow], List[int], List[Calf], List[Calf],
                      List[HeiferI], List[HeiferII], List[HeiferIII], List[Cow]]:
         """

--- a/RUFAS/routines/animal/life_cycle/life_cycle.py
+++ b/RUFAS/routines/animal/life_cycle/life_cycle.py
@@ -393,7 +393,7 @@ class LifeCycleManager:
                 removed_heiferIIs_idx.append(idx)
             else:
                 total_animal_num, preg_heifer_num = \
-                    self._keep_heiferII_as_pregnant(heiferII, total_animal_num, preg_heifer_num)
+                    self._remain_heiferII(heiferII, total_animal_num, preg_heifer_num)
 
         Utility.remove_items_from_list_by_indices(heiferIIs, removed_heiferIIs_idx)
         return total_animal_num, preg_heifer_num
@@ -410,7 +410,7 @@ class LifeCycleManager:
         new_heiferIII = HeiferIII(heiferII_vals)
         heiferIIIs.append(new_heiferIII)
 
-    def _keep_heiferII_as_pregnant(self, heiferII: HeiferII, total_animal_num: int, preg_heifer_num: int):
+    def _remain_heiferII(self, heiferII: HeiferII, total_animal_num: int, preg_heifer_num: int):
         self.heiferII_num += 1
         temp = Utility.calc_average(total_animal_num, self.avg_mature_body_weight,
                                     heiferII.mature_body_weight)
@@ -436,11 +436,6 @@ class LifeCycleManager:
         removed_heiferIIIs_idx: List[int] = []
 
         for idx, heiferIII in enumerate(heiferIIIs):
-            # TODO: Review this
-            # if type(heiferIII) is HeiferIII:
-            #     cow_stage = heiferIII.update(sim_day)
-            # else:
-            #     cow_stage = heiferIII.update(sim_day, self.avg_CI)
             cow_stage = heiferIII.update(sim_day)
             if cow_stage:
                 self._move_heiferIII_to_cow_stage(heiferIII, cows)
@@ -472,21 +467,21 @@ class LifeCycleManager:
 
     def _check_if_heifers_need_to_be_sold(self, heiferIIIs: List[HeiferIII], cows: List[Cow],
                                           ids_removed: List[int]) -> None:
-        # if the number of heifers is more than needed for the herd,
+        # If the number of heifers exceeds what is needed for the herd,
         # sell those as replacement
-        ratio = 1.03  # TODO: use a better name
-        while len(heiferIIIs) + len(cows) > self.herd_num * ratio and len(heiferIIIs) > 0:
-            removed = heiferIIIs.pop()
-            ids_removed.append(removed.id)
-            self.sold_heifers.append(removed)
+        sell_threshold = 1.03
+        while len(heiferIIIs) + len(cows) > self.herd_num * sell_threshold and len(heiferIIIs) > 0:
+            removed_heiferIII = heiferIIIs.pop()
+            ids_removed.append(removed_heiferIII.id)
+            self.sold_heifers.append(removed_heiferIII)
             self.sold_heifer_num += 1
 
     def _check_if_replacement_heifers_needed(self, sim_day: int, heiferIIIs: List[HeiferIII], cows: List[Cow],
                                              animals_added: List[Cow]) -> None:
         # if the number of heifers is less than needed for the herd,
         # buy replacement from the market
-        ratio = 1.01  # TODO: use a better name
-        while len(cows) + len(heiferIIIs) + self.bought_heifer_num < self.herd_num * ratio \
+        buy_threshold = 1.01
+        while len(cows) + len(heiferIIIs) + self.bought_heifer_num < self.herd_num * buy_threshold \
                 and sim_day > 1:
             replacement = self.replacement_market.pop(0)
             replacement.events.add_event(replacement.days_born, sim_day, animal_constants.ENTER_HERD)
@@ -521,7 +516,7 @@ class LifeCycleManager:
                 ids_removed.append(cow.id)
                 removed_cows_idx.append(index)
             else:
-                total_animal_num = self._handle_cow_body_weight(cow, total_animal_num)
+                total_animal_num = self._handle_cow_body_weight_and_parity(cow, total_animal_num)
                 self._handle_cow_milking(cow)
                 self._handle_cow_days_in_milk(cow)
                 self._handle_cow_days_in_preg(cow)
@@ -546,7 +541,7 @@ class LifeCycleManager:
         temp = Utility.calc_average(self.culled_cow_num, self.avg_cow_culling_age, cow.days_born)
         self.culled_cow_num, self.avg_cow_culling_age = temp
 
-    def _handle_cow_body_weight(self, cow: Cow, total_animal_num: int) -> int:
+    def _handle_cow_body_weight_and_parity(self, cow: Cow, total_animal_num: int) -> int:
         """Adjusts the average cow body weight, average parity number, and average mature body weight
 
         Args:
@@ -580,14 +575,14 @@ class LifeCycleManager:
             self.daily_milk_production += cow.estimated_daily_milk_produced
             temp = Utility.calc_average(self.milking_cow_num, self.avg_days_in_milk, cow.days_in_milk)
             self.milking_cow_num, self.avg_days_in_milk = temp
-        else:
-            self.dry_cow_num += 1
 
-    def _handle_cow_days_in_milk(self, cow: Cow) -> None:
-        if cow.days_in_milk < self.animal_config['voluntary_waiting_period']:
-            self.vwp_cow_num += 1
+            if cow.days_in_milk < self.animal_config['voluntary_waiting_period']:
+                self.vwp_cow_num += 1
+
             if cow.days_in_preg == 0:
                 self.open_cow_num += 1
+        else:
+            self.dry_cow_num += 1
 
     def _handle_cow_days_in_preg(self, cow: Cow) -> None:
         if cow.days_in_preg > 0:

--- a/RUFAS/routines/animal/life_cycle/life_cycle.py
+++ b/RUFAS/routines/animal/life_cycle/life_cycle.py
@@ -547,6 +547,16 @@ class LifeCycleManager:
         self.culled_cow_num, self.avg_cow_culling_age = temp
 
     def _handle_cow_body_weight(self, cow: Cow, total_animal_num: int) -> int:
+        """Adjusts the average cow body weight, average parity number, and average mature body weight
+
+        Args:
+            cow (Cow): A Cow object.
+            total_animal_num: The total number of animals in the herd.
+
+        Returns:
+            total_animal_num: The newly updated total number of animals in the herd.
+
+        """
         _, self.avg_cow_body_weight = Utility.calc_average(
                 self.cow_num, self.avg_cow_body_weight, cow.body_weight)
         self.cow_num, self.avg_parity_num = Utility.calc_average(
@@ -557,6 +567,15 @@ class LifeCycleManager:
         return total_animal_num
 
     def _handle_cow_milking(self, cow: Cow) -> None:
+        """Adjusts the daily milk production quantity, average days in milking.
+
+        Args:
+            cow: A Cow object.
+
+        Returns:
+            None
+
+        """
         if cow.milking:
             self.daily_milk_production += cow.estimated_daily_milk_produced
             temp = Utility.calc_average(self.milking_cow_num, self.avg_days_in_milk, cow.days_in_milk)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest
 pytest-mock
 scipy
 pytest-lazy-fixture
+typing_extensions

--- a/tests/test_animal_life_cycle.py
+++ b/tests/test_animal_life_cycle.py
@@ -47,6 +47,7 @@ def test_set_avg_CI(mocker: MockerFixture, life_cycle_manager: LifeCycleManager)
         'calving_interval': custom_avg_CI
     }
     mock_animal_config = mocker.MagicMock(autospec=AnimalConfigTypedDict)
+    mock_animal_config.__contains__.side_effect = mock_animal_config_data.__contains__
     mock_animal_config.__getitem__.side_effect = mock_animal_config_data.__getitem__
     mock_animal_initializer = mocker.MagicMock(autospec=AnimalInitialization)
 
@@ -508,7 +509,7 @@ def test_extract_repro_stats_from_heiferII(mocker: MockerFixture,
 
     # After
     spy_extract_repro_stats.assert_called_once_with(mock_heiferII)
-    assert life_cycle_manager.CIDR_count == mock_data['CIDR_count']
+    # assert life_cycle_manager.CIDR_count == mock_data['CIDR_count']
     assert life_cycle_manager.GnRH_injection_num_h == mock_data['GnRH_injections']
     assert life_cycle_manager.PGF_injection_num_h == mock_data['PGF_injections']
     assert life_cycle_manager.preg_check_num_h == mock_data['preg_diagnoses']

--- a/tests/test_animal_life_cycle.py
+++ b/tests/test_animal_life_cycle.py
@@ -1,14 +1,18 @@
 import collections
-from typing import Dict, List
+from typing import Dict
+from typing import List
 from typing import Type
 
 import pytest
-from pytest import approx, fixture
+from pytest import approx
+from pytest import fixture
 from pytest_mock import MockerFixture
 
 from RUFAS.classes import Config
-from RUFAS.routines.animal.animal_typed_dicts import AnimalConfigTypedDict, HerdInfoTypedDict
-from RUFAS.routines.animal.life_cycle.animal_constants import ENTER_HERD, INIT_HERD, LOW_PROD_CULL
+from RUFAS.routines.animal.animal_typed_dicts import AnimalConfigTypedDict
+from RUFAS.routines.animal.life_cycle.animal_constants import ENTER_HERD
+from RUFAS.routines.animal.life_cycle.animal_constants import INIT_HERD
+from RUFAS.routines.animal.life_cycle.animal_constants import LOW_PROD_CULL
 from RUFAS.routines.animal.life_cycle.animal_initialization import AnimalInitialization
 from RUFAS.routines.animal.life_cycle.calf import Calf
 from RUFAS.routines.animal.life_cycle.cow import Cow
@@ -820,12 +824,81 @@ def test_cull_cow(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -
     assert life_cycle_manager.avg_cow_culling_age == approx(100.0)
 
 
-def test_handle_cow_body_weight():
-    pass
+def test_handle_cow_body_weight(mocker: MockerFixture,
+                                life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _handle_cow_body_weight() in file life_cycle.py"""
+    # Arrange
+    total_animal_num = 100
+    mock_cow = mocker.MagicMock(autospec=Cow)
+    mock_cow.body_weight = 1100.0
+    mock_cow.calves = 20
+    mock_cow.mature_body_weight = 1300.0
+
+    life_cycle_manager.cow_num = 10
+    life_cycle_manager.avg_cow_body_weight = 1000.0
+    life_cycle_manager.avg_parity_num = 2.0
+    life_cycle_manager.avg_mature_body_weight = 1200.0
+
+    expected_new_cow_num = 11
+    expected_new_avg_cow_body_weight = (life_cycle_manager.avg_cow_body_weight *
+                                        life_cycle_manager.cow_num +
+                                        mock_cow.body_weight) / expected_new_cow_num
+    expected_new_avg_parity_num = (life_cycle_manager.avg_parity_num *
+                                   life_cycle_manager.cow_num +
+                                   mock_cow.calves) / expected_new_cow_num
+
+    expected_new_total_animal_num = total_animal_num + 1
+    expected_new_avg_mature_body_weight = (life_cycle_manager.avg_mature_body_weight *
+                                           total_animal_num +
+                                           mock_cow.mature_body_weight) / expected_new_total_animal_num
+    spy_handle_cow_body_weight = mocker.spy(life_cycle_manager, '_handle_cow_body_weight')
+
+    # Act
+    new_total_animal_num = life_cycle_manager._handle_cow_body_weight(mock_cow, total_animal_num)
+
+    # Assert
+    assert new_total_animal_num == expected_new_total_animal_num
+    assert life_cycle_manager.cow_num == expected_new_cow_num
+    assert life_cycle_manager.avg_cow_body_weight == approx(expected_new_avg_cow_body_weight)
+    assert life_cycle_manager.avg_parity_num == approx(expected_new_avg_parity_num)
+    assert life_cycle_manager.avg_mature_body_weight == approx(expected_new_avg_mature_body_weight)
+    spy_handle_cow_body_weight.assert_called_once_with(mock_cow, total_animal_num)
 
 
-def test_handle_cow_milking():
-    pass
+@pytest.mark.parametrize('is_cow_milking', [True, False])
+def test_handle_cow_milking(mocker: MockerFixture,
+                            life_cycle_manager: LifeCycleManager,
+                            is_cow_milking: bool) -> None:
+    # Arrange
+    mock_cow = mocker.MagicMock(autospec=Cow)
+    mock_cow.milking = is_cow_milking
+    mock_cow.estimated_daily_milk_produced = 15
+    mock_cow.days_in_milk = 8
+
+    life_cycle_manager.daily_milk_production = 100
+    life_cycle_manager.milking_cow_num = 20
+    life_cycle_manager.avg_days_in_milk = 7
+    life_cycle_manager.dry_cow_num = 9
+
+    expected_new_daily_milk_production = (life_cycle_manager.daily_milk_production +
+                                          mock_cow.estimated_daily_milk_produced)
+    expected_new_milking_cow_num = life_cycle_manager.milking_cow_num + 1
+    expected_new_avg_days_in_milk = (life_cycle_manager.avg_days_in_milk * life_cycle_manager.milking_cow_num +
+                                     mock_cow.days_in_milk) / expected_new_milking_cow_num
+    expected_new_dry_cow_num = life_cycle_manager.dry_cow_num + 1
+    spy_handle_cow_milking = mocker.spy(life_cycle_manager, '_handle_cow_milking')
+
+    # Act
+    life_cycle_manager._handle_cow_milking(mock_cow)
+
+    # Assert
+    spy_handle_cow_milking.assert_called_once_with(mock_cow)
+    if is_cow_milking:
+        assert life_cycle_manager.daily_milk_production == expected_new_daily_milk_production
+        assert life_cycle_manager.milking_cow_num == expected_new_milking_cow_num
+        assert life_cycle_manager.avg_days_in_milk == approx(expected_new_avg_days_in_milk)
+    else:
+        assert life_cycle_manager.dry_cow_num == expected_new_dry_cow_num
 
 
 def test__handle_cow_days_in_milk():

--- a/tests/test_animal_life_cycle.py
+++ b/tests/test_animal_life_cycle.py
@@ -142,19 +142,19 @@ def test_initialize_herd(mocker: MockerFixture, life_cycle_manager: LifeCycleMan
     mocker.patch('RUFAS.routines.animal.life_cycle.life_cycle.AnimalInitialization',
                  return_value=mock_animal_initializer)
 
-    mock_set_avg_CI = mocker.patch.object(life_cycle_manager, '_set_avg_CI')
-    mock_get_animals = mocker.patch.object(life_cycle_manager, '_get_animals')
+    patch_set_avg_CI = mocker.patch.object(life_cycle_manager, '_set_avg_CI')
+    patch_get_animals = mocker.patch.object(life_cycle_manager, '_get_animals')
 
     results = life_cycle_manager.initialize_herd(**herd_data)
 
     assert life_cycle_manager.herd_num == herd_data['herd_num']
-    mock_set_avg_CI.assert_called_once()
-    assert mock_get_animals.call_count == 5
-    assert mock_get_animals.call_args_list[0] == mocker.call(Calf, herd_data['calf_num'], breed)
-    assert mock_get_animals.call_args_list[1] == mocker.call(HeiferI, herd_data['heiferI_num'], breed)
-    assert mock_get_animals.call_args_list[2] == mocker.call(HeiferII, herd_data['heiferII_num'], breed)
-    assert mock_get_animals.call_args_list[3] == mocker.call(HeiferIII, herd_data['heiferIII_num'], breed)
-    assert mock_get_animals.call_args_list[4] == mocker.call(Cow, herd_data['cow_num'], breed)
+    patch_set_avg_CI.assert_called_once()
+    assert patch_get_animals.call_count == 5
+    assert patch_get_animals.call_args_list[0] == mocker.call(Calf, herd_data['calf_num'], breed)
+    assert patch_get_animals.call_args_list[1] == mocker.call(HeiferI, herd_data['heiferI_num'], breed)
+    assert patch_get_animals.call_args_list[2] == mocker.call(HeiferII, herd_data['heiferII_num'], breed)
+    assert patch_get_animals.call_args_list[3] == mocker.call(HeiferIII, herd_data['heiferIII_num'], breed)
+    assert patch_get_animals.call_args_list[4] == mocker.call(Cow, herd_data['cow_num'], breed)
     mock_animal_initializer.get_replacement_cows.assert_called_once_with(herd_data['replace_num'], breed)
     assert life_cycle_manager.replacement_market == mock_replacement_cows
     assert len(results) == 5
@@ -205,8 +205,8 @@ def test_reset_cull_reason_stats(life_cycle_manager: LifeCycleManager) -> None:
         assert life_cycle_manager.cull_reason_stats_percent[cull_reason] == approx(0.0)
 
 
-def test_wean_calf(mocker: MockerFixture) -> None:
-    """Unit test for function _wean_calf in file life_cycle.py"""
+def test_convert_calf_to_heiferI(mocker: MockerFixture) -> None:
+    """Unit test for function _convert_calf_to_heiferI in file life_cycle.py"""
     calf_body_weight_history = [10.0, 20.0]
     calf_pen_history = [mocker.MagicMock(autospec=Pen) for _ in range(2)]
 
@@ -221,7 +221,7 @@ def test_wean_calf(mocker: MockerFixture) -> None:
     mock_new_heiferI = mocker.MagicMock(autospec=HeiferI)
     mocker.patch('RUFAS.routines.animal.life_cycle.life_cycle.HeiferI',
                  return_value=mock_new_heiferI)
-    LifeCycleManager._wean_calf(mock_calf, heiferIs)
+    LifeCycleManager._convert_calf_to_heiferI(mock_calf, heiferIs)
 
     mock_calf_vals.update.assert_called_once_with({
         'body_weight_history': calf_body_weight_history,
@@ -231,12 +231,12 @@ def test_wean_calf(mocker: MockerFixture) -> None:
     assert heiferIs[0] == mock_new_heiferI  # check identity
 
 
-def test_calf_to_heiferI(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
-    """Unit test for function _calf_to_heiferI in file life_cycle.py"""
+def test_evaluate_calves_for_weaning(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _evaluate_calves_for_weaning in file life_cycle.py"""
     sim_day = 10
     mock_weaned_calf = mocker.MagicMock(autospec=Calf)
     mock_weaned_calf.update.return_value = True
-    mock_wean_calf = mocker.patch.object(life_cycle_manager, '_wean_calf')
+    patch_convert_calf_to_heiferI = mocker.patch.object(life_cycle_manager, '_convert_calf_to_heiferI')
 
     mock_matured_calf = mocker.MagicMock(autospec=Calf)
     mock_matured_calf.update.return_value = False
@@ -248,10 +248,11 @@ def test_calf_to_heiferI(mocker: MockerFixture, life_cycle_manager: LifeCycleMan
     total_animal_num = 0
     life_cycle_manager.avg_mature_body_weight = 0.0
 
-    new_total_animal_num = life_cycle_manager._calf_to_heiferI(sim_day, mock_calves, heiferIs, total_animal_num)
+    new_total_animal_num = life_cycle_manager._evaluate_calves_for_weaning(sim_day, mock_calves, heiferIs,
+                                                                           total_animal_num)
 
     mock_weaned_calf.update.assert_called_once_with(sim_day)
-    mock_wean_calf.assert_called_once_with(mock_weaned_calf, heiferIs)
+    patch_convert_calf_to_heiferI.assert_called_once_with(mock_weaned_calf, heiferIs)
 
     mock_matured_calf.update.assert_called_once_with(sim_day)
     assert life_cycle_manager.calf_num == 1
@@ -262,8 +263,8 @@ def test_calf_to_heiferI(mocker: MockerFixture, life_cycle_manager: LifeCycleMan
     assert life_cycle_manager.avg_mature_body_weight == approx(mature_body_weight)
 
 
-def test_move_heiferI_to_second_stage(mocker: MockerFixture) -> None:
-    """Unit test for function _move_heiferI_to_second_stage in file life_cycle.py"""
+def test_convert_heiferI_to_heiferII(mocker: MockerFixture) -> None:
+    """Unit test for function _convert_heiferI_to_heiferII in file life_cycle.py"""
     heiferI_body_weight_history = [30.0, 40.0]
     heiferI_pen_history = [mocker.MagicMock(autospec=Pen) for _ in range(2)]
 
@@ -289,7 +290,7 @@ def test_move_heiferI_to_second_stage(mocker: MockerFixture) -> None:
     }
     mocker.patch('RUFAS.routines.animal.life_cycle.life_cycle.AnimalBase.config', animal_base_config)
 
-    LifeCycleManager._move_heiferI_to_second_stage(mock_heiferI, heiferIIs)
+    LifeCycleManager._convert_heiferI_to_heiferII(mock_heiferI, heiferIIs)
 
     assert mock_heiferI_vals.update.mock_calls == [
         mocker.call({
@@ -305,13 +306,14 @@ def test_move_heiferI_to_second_stage(mocker: MockerFixture) -> None:
     assert heiferIIs[0] == mock_new_heiferII  # check identity
 
 
-def test_heiferI_to_heiferII(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
-    """Unit test for function _heiferI_to_heiferII in file life_cycle.py"""
+def test_evaluate_heiferIs_for_transitioning_to_heiferIIs(mocker: MockerFixture,
+                                                          life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _evaluate_heiferIs_for_transitioning_to_heiferIIs in file life_cycle.py"""
     sim_day = 100
     mock_heiferI_second_stage = mocker.MagicMock(autospec=HeiferI)
     mock_heiferI_second_stage.update.return_value = True
-    mock_move_heiferI_to_second_stage = mocker.patch.object(life_cycle_manager,
-                                                            '_move_heiferI_to_second_stage')
+    patch_convert_heiferI_to_heiferII = mocker.patch.object(life_cycle_manager,
+                                                            '_convert_heiferI_to_heiferII')
 
     mock_matured_heiferI = mocker.MagicMock(autospec=HeiferI)
     mock_matured_heiferI.update.return_value = False
@@ -323,12 +325,12 @@ def test_heiferI_to_heiferII(mocker: MockerFixture, life_cycle_manager: LifeCycl
     total_animal_num = 0
     life_cycle_manager.avg_mature_body_weight = 0.0
 
-    new_total_animal_num = life_cycle_manager._heiferI_to_heiferII(sim_day, mock_heiferIs,
-                                                                   mock_heiferIIs,
-                                                                   total_animal_num)
+    new_total_animal_num = life_cycle_manager._evaluate_heiferIs_for_transitioning_to_heiferIIs(sim_day, mock_heiferIs,
+                                                                                                mock_heiferIIs,
+                                                                                                total_animal_num)
 
     mock_heiferI_second_stage.update.assert_called_once_with(sim_day)
-    mock_move_heiferI_to_second_stage.assert_called_once_with(mock_heiferI_second_stage, mock_heiferIIs)
+    patch_convert_heiferI_to_heiferII.assert_called_once_with(mock_heiferI_second_stage, mock_heiferIIs)
 
     mock_matured_heiferI.update.assert_called_once_with(sim_day)
     assert life_cycle_manager.heiferI_num == 1
@@ -339,8 +341,8 @@ def test_heiferI_to_heiferII(mocker: MockerFixture, life_cycle_manager: LifeCycl
     assert life_cycle_manager.avg_mature_body_weight == approx(mature_body_weight)
 
 
-def test_move_heiferII_to_third_stage(mocker: MockerFixture) -> None:
-    """Unit test for function _move_heiferII_to_third_stage in file life_cycle.py"""
+def test_convert_heiferII_to_heiferIII(mocker: MockerFixture) -> None:
+    """Unit test for function _convert_heiferII_to_heiferIII in file life_cycle.py"""
     heiferII_body_weight_history = [50.0, 60.0]
     heiferII_pen_history = [mocker.MagicMock(autospec=Pen) for _ in range(2)]
     heiferII_conceptus_weight = 10.0
@@ -359,7 +361,7 @@ def test_move_heiferII_to_third_stage(mocker: MockerFixture) -> None:
     mock_new_heiferIII = mocker.MagicMock(autospec=HeiferIII)
     mocker.patch('RUFAS.routines.animal.life_cycle.life_cycle.HeiferIII',
                  return_value=mock_new_heiferIII)
-    LifeCycleManager._move_heiferII_to_third_stage(mock_heiferII, heiferIIIs)
+    LifeCycleManager._convert_heiferII_to_heiferIII(mock_heiferII, heiferIIIs)
 
     mock_heiferII_vals.update.assert_called_once_with({
         'body_weight_history': heiferII_body_weight_history,
@@ -416,12 +418,10 @@ def test_extract_repro_stats_from_heiferII(mocker: MockerFixture,
     assert life_cycle_manager.ed_period_h == mock_data['ED_days']
 
 
-def test_keep_heiferII_as_pregnant(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
-    """Unit test for function _keep_heiferII_as_pregnant in file life_cycle.py"""
-    # Set up
+def test_remain_heiferII(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _remain_heiferII in file life_cycle.py"""
+    # Arrange
     mock_heiferII = mocker.MagicMock(autospec=HeiferII)
-    spy_extract_repro_stats = mocker.spy(life_cycle_manager, '_extract_repro_stats_from_heiferII')
-
     total_animal_num = 10
     life_cycle_manager.avg_mature_body_weight = 20.0
     mock_heiferII.mature_body_weight = 42.0
@@ -430,7 +430,7 @@ def test_keep_heiferII_as_pregnant(mocker: MockerFixture, life_cycle_manager: Li
     life_cycle_manager.avg_breeding_to_preg_time = 20.0
     mock_heiferII.breeding_to_preg_time = 42.0
 
-    # Before
+    # Assert before
     assert life_cycle_manager.heiferII_num == 0
     assert life_cycle_manager.avg_mature_body_weight == approx(20.0)
     assert life_cycle_manager.avg_breeding_to_preg_time == approx(20.0)
@@ -439,17 +439,17 @@ def test_keep_heiferII_as_pregnant(mocker: MockerFixture, life_cycle_manager: Li
     result = life_cycle_manager._remain_heiferII(mock_heiferII, total_animal_num, preg_heifer_num)
     new_total_animal_num, new_preg_heifer_num = result
 
-    # After
+    # Assert after
     assert life_cycle_manager.heiferII_num == 1
     assert new_total_animal_num == 11
     assert life_cycle_manager.avg_mature_body_weight == approx(22.0)
     assert new_preg_heifer_num == 11
     assert life_cycle_manager.avg_breeding_to_preg_time == approx(22.0)
-    spy_extract_repro_stats.assert_called_once()
 
 
-def test_heiferII_to_heiferIII(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
-    """Unit test for function _heiferII_to_heiferIII in file life_cycle.py"""
+def test_evaluate_heiferIIs_for_transitioning_to_heiferIIIs(mocker: MockerFixture,
+                                                            life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _evaluate_heiferIIs_for_transitioning_to_heiferIIIs in file life_cycle.py"""
     # Set up
     sim_day = 300
     mock_heiferII_cull_stage = mocker.MagicMock(autospec=HeiferII)
@@ -461,14 +461,14 @@ def test_heiferII_to_heiferIII(mocker: MockerFixture, life_cycle_manager: LifeCy
 
     mock_heiferII_third_stage = mocker.MagicMock(autospec=HeiferII)
     mock_heiferII_third_stage.update.return_value = [False, True]  # cull_stage = False, third_stage = True
-    mock_move_heiferII_to_third_stage = mocker.patch.object(life_cycle_manager,
-                                                            '_move_heiferII_to_third_stage')
+    patch_convert_heiferII_to_heiferIII = mocker.patch.object(life_cycle_manager,
+                                                              '_convert_heiferII_to_heiferIII')
 
     mock_heiferII_pregnant_stage = mocker.MagicMock(autospec=HeiferII)
     mock_heiferII_pregnant_stage.update.return_value = [False, False]  # cull_stage = False, third_stage = False
-    mock_keep_heiferII_as_pregnant = mocker.patch.object(life_cycle_manager,
-                                                         '_remain_heiferII')
-    mock_keep_heiferII_as_pregnant.return_value = (1, 1)  # new_total_animal_num = 1, new_preg_heifer_num = 1
+    patch_remain_heiferII = mocker.patch.object(life_cycle_manager,
+                                                '_remain_heiferII')
+    patch_remain_heiferII.return_value = (1, 1)  # new_total_animal_num = 1, new_preg_heifer_num = 1
     total_animal_num = 0
     preg_heifer_num = 0
 
@@ -483,9 +483,9 @@ def test_heiferII_to_heiferIII(mocker: MockerFixture, life_cycle_manager: LifeCy
     assert len(life_cycle_manager.culled_heifers) == 0
 
     # Act
-    result = life_cycle_manager._heiferII_to_heiferIII(sim_day, mock_heiferIIs,
-                                                       mock_heiferIIIs, preg_heifer_num,
-                                                       total_animal_num)
+    result = life_cycle_manager._evaluate_heiferIIs_for_transitioning_to_heiferIIIs(sim_day, mock_heiferIIs,
+                                                                                    mock_heiferIIIs, preg_heifer_num,
+                                                                                    total_animal_num)
     new_total_animal_num, new_preg_heifer_num = result
 
     # After
@@ -495,10 +495,10 @@ def test_heiferII_to_heiferIII(mocker: MockerFixture, life_cycle_manager: LifeCy
     assert life_cycle_manager.culled_heifers[0] == mock_heiferII_cull_stage
     mock_heiferII_cull_stage.update.assert_called_once_with(sim_day)
 
-    mock_move_heiferII_to_third_stage.assert_called_once_with(mock_heiferII_third_stage, mock_heiferIIIs)
+    patch_convert_heiferII_to_heiferIII.assert_called_once_with(mock_heiferII_third_stage, mock_heiferIIIs)
 
-    mock_keep_heiferII_as_pregnant.assert_called_once_with(mock_heiferII_pregnant_stage,
-                                                           total_animal_num, preg_heifer_num)
+    patch_remain_heiferII.assert_called_once_with(mock_heiferII_pregnant_stage,
+                                                  total_animal_num, preg_heifer_num)
     assert new_total_animal_num == 1
     assert new_preg_heifer_num == 1
     assert len(mock_heiferIIs) == 1
@@ -506,7 +506,7 @@ def test_heiferII_to_heiferIII(mocker: MockerFixture, life_cycle_manager: LifeCy
 
 
 def test_move_heiferIII_to_cow_stage(mocker: MockerFixture) -> None:
-    """Unit test for function _move_heiferIII_to_cow_stage in file life_cycle.py"""
+    """Unit test for function _convert_heiferIII_to_cow in file life_cycle.py"""
     # Arrange
     heiferIII_body_weight_history = [30.0, 40.0]
     heiferIII_pen_history = [mocker.MagicMock(autospec=Pen) for _ in range(2)]
@@ -540,7 +540,7 @@ def test_move_heiferIII_to_cow_stage(mocker: MockerFixture) -> None:
     mocker.patch('RUFAS.routines.animal.life_cycle.life_cycle.AnimalBase.config', animal_base_config)
 
     # Act
-    LifeCycleManager._move_heiferIII_to_cow_stage(mock_heiferIII, cows)
+    LifeCycleManager._convert_heiferIII_to_cow(mock_heiferIII, cows)
 
     # Assert
     assert mock_heiferIII_vals.update.mock_calls == [
@@ -560,13 +560,13 @@ def test_move_heiferIII_to_cow_stage(mocker: MockerFixture) -> None:
     assert cows[0] == mock_new_cow  # check identity
 
 
-def test_heiferIII_to_cow(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
-    """Unit test for function _heiferIII_to_cow in file life_cycle.py"""
+def test_transition_heiferIII_to_cow(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _evaluate_heiferIIIs_for_transitioning_to_cows in file life_cycle.py"""
     sim_day = 400
     mock_heiferIII_cow_stage = mocker.MagicMock(autospec=HeiferIII)
     mock_heiferIII_cow_stage.update.return_value = True
-    mock_move_heiferIII_to_cow_stage = mocker.patch.object(life_cycle_manager,
-                                                           '_move_heiferIII_to_cow_stage')
+    patch_convert_heiferIII_to_cow = mocker.patch.object(life_cycle_manager,
+                                                         '_convert_heiferIII_to_cow')
 
     mock_matured_heiferIII = mocker.MagicMock(autospec=HeiferIII)
     mock_matured_heiferIII.update.return_value = False
@@ -584,13 +584,13 @@ def test_heiferIII_to_cow(mocker: MockerFixture, life_cycle_manager: LifeCycleMa
     assert life_cycle_manager.avg_mature_body_weight == approx(0.0)
 
     # Act
-    new_total_animal_num = life_cycle_manager._heiferIII_to_cow(sim_day, mock_heiferIIIs,
-                                                                mock_cows,
-                                                                total_animal_num)
+    new_total_animal_num = life_cycle_manager._evaluate_heiferIIIs_for_transitioning_to_cows(sim_day, mock_heiferIIIs,
+                                                                                             mock_cows,
+                                                                                             total_animal_num)
 
     # Assert after
     mock_heiferIII_cow_stage.update.assert_called_once_with(sim_day)
-    mock_move_heiferIII_to_cow_stage.assert_called_once_with(mock_heiferIII_cow_stage, mock_cows)
+    patch_convert_heiferIII_to_cow.assert_called_once_with(mock_heiferIII_cow_stage, mock_cows)
 
     mock_matured_heiferIII.update.assert_called_once_with(sim_day)
     assert life_cycle_manager.heiferIII_num == 1
@@ -784,8 +784,7 @@ def test_check_if_replacement_heifers_needed(mocker: MockerFixture,
 
 
 def test_cull_cow(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
-    """Unit test for function _cull_cow in file life_cycle.py"""
-
+    """Unit test for function _cull_cow() in file life_cycle.py"""
     # Arrange
     mock_cow: Cow = mocker.MagicMock(autospec=Cow)
     mock_cow.cull_reason = LOW_PROD_CULL
@@ -870,6 +869,7 @@ def test_handle_cow_body_weight_and_parity(mocker: MockerFixture,
 def test_handle_cow_milking(mocker: MockerFixture,
                             life_cycle_manager: LifeCycleManager,
                             is_cow_milking: bool) -> None:
+    """Unit test for function _handle_cow_milking() in file life_cycle.py"""
     # Arrange
     mock_cow = mocker.MagicMock(autospec=Cow)
     mock_cow.milking = is_cow_milking
@@ -966,7 +966,6 @@ def test_handle_cow_CI(mocker: MockerFixture, life_cycle_manager: LifeCycleManag
 
 def test_extract_repro_stats_from_cow(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
     """Unit test for function _extract_repro_stats_from_cow() in file life_cycle.py"""
-
     # Arrange
     mock_cow = mocker.MagicMock(autospec=Cow)
     mock_cow.GnRH_injections = 1
@@ -999,6 +998,10 @@ def test_extract_repro_stats_from_cow(mocker: MockerFixture, life_cycle_manager:
     assert life_cycle_manager.preg_check_num == expected_preg_check_num
     assert life_cycle_manager.semen_num == expected_semen_num
     assert life_cycle_manager.ai_num == expected_ai_num
+
+
+def test_handle_new_born(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
+    pass
 
 
 @pytest.mark.parametrize('cow_calves', [1, 2, 3, 4])
@@ -1044,11 +1047,11 @@ def test_handle_cow_calves(mocker: MockerFixture, life_cycle_manager: LifeCycleM
 
 
 @pytest.mark.parametrize('total_animal_num', [0, 50, 100])
-def test_calc_herd_percentages(mocker: MockerFixture, life_cycle_manager: LifeCycleManager,
-                               total_animal_num: int) -> None:
-    """Unit test for function _calc_herd_percentages() in file life_cycle.py."""
-    calf_num = heiferI_num = heiferII_num = heiferIII_num = cow_num = 0
+def test_calculate_herd_percentages(mocker: MockerFixture, life_cycle_manager: LifeCycleManager,
+                                    total_animal_num: int) -> None:
+    """Unit test for function _calculate_herd_percentages() in file life_cycle.py."""
     # Arrange
+    calf_num = heiferI_num = heiferII_num = heiferIII_num = cow_num = 0
     if total_animal_num > 0:
         life_cycle_manager.calf_num = calf_num = int(0.2 * total_animal_num)
         life_cycle_manager.heiferI_num = heiferI_num = int(0.2 * total_animal_num)
@@ -1056,10 +1059,10 @@ def test_calc_herd_percentages(mocker: MockerFixture, life_cycle_manager: LifeCy
         life_cycle_manager.heiferIII_num = heiferIII_num = int(0.2 * total_animal_num)
         life_cycle_manager.cow_num = cow_num = (total_animal_num - calf_num - heiferI_num
                                                 - heiferII_num - heiferIII_num)
-    spy_calc_herd_percentages = mocker.spy(life_cycle_manager, '_calc_herd_percentages')
+    spy_calc_herd_percentages = mocker.spy(life_cycle_manager, '_calculate_herd_percentages')
 
     # Act
-    life_cycle_manager._calc_herd_percentages(total_animal_num)
+    life_cycle_manager._calculate_herd_percentages(total_animal_num)
 
     # Assert
     spy_calc_herd_percentages.assert_called_once_with(total_animal_num)
@@ -1075,3 +1078,103 @@ def test_calc_herd_percentages(mocker: MockerFixture, life_cycle_manager: LifeCy
         assert life_cycle_manager.heiferII_percent == approx(0.0)
         assert life_cycle_manager.heiferIII_percent == approx(0.0)
         assert life_cycle_manager.cow_percent == approx(0.0)
+
+
+@pytest.mark.parametrize('cow_num', [0, 50, 100])
+def test_calc_cow_percentages(mocker: MockerFixture, life_cycle_manager: LifeCycleManager,
+                              cow_num: int) -> None:
+    """Unit test for function _calculate_cow_percentages() in file life_cycle.py."""
+    # Arrange
+    dry_cow_num = milking_cow_num = preg_cow_num = open_cow_num = vwp_cow_num = 0
+    life_cycle_manager.cow_num = cow_num
+    if cow_num > 0:
+        life_cycle_manager.dry_cow_num = dry_cow_num = int(0.2 * cow_num)
+        life_cycle_manager.milking_cow_num = milking_cow_num = int(0.2 * cow_num)
+        life_cycle_manager.preg_cow_num = preg_cow_num = int(0.2 * cow_num)
+        life_cycle_manager.open_cow_num = open_cow_num = int(0.2 * cow_num)
+        life_cycle_manager.vwp_cow_num = vwp_cow_num = (cow_num - dry_cow_num - milking_cow_num
+                                                        - preg_cow_num - open_cow_num)
+    spy_calc_cow_percentages = mocker.spy(life_cycle_manager, '_calculate_cow_percentages')
+
+    # Act
+    life_cycle_manager._calculate_cow_percentages()
+
+    # Assert
+    spy_calc_cow_percentages.assert_called_once()
+    if cow_num > 0:
+        assert life_cycle_manager.dry_cow_percent == approx(dry_cow_num * 100.0 / cow_num)
+        assert life_cycle_manager.milking_cow_percent == approx(milking_cow_num * 100.0 / cow_num)
+        assert life_cycle_manager.preg_cow_percent == approx(preg_cow_num * 100.0 / cow_num)
+        assert life_cycle_manager.non_preg_cow_percent == approx((open_cow_num + vwp_cow_num)
+                                                                 * 100.0 / cow_num)
+    elif cow_num == 0:
+        assert life_cycle_manager.dry_cow_percent == approx(0.0)
+        assert life_cycle_manager.milking_cow_percent == approx(0.0)
+        assert life_cycle_manager.preg_cow_percent == approx(0.0)
+        assert life_cycle_manager.non_preg_cow_percent == approx(0.0)
+
+
+@pytest.mark.parametrize('cow_num', [0, 50, 100])
+def test_calc_cull_reason_stats_percent(mocker: MockerFixture, life_cycle_manager: LifeCycleManager,
+                                        cow_num: int) -> None:
+    """Unit test for function _calculate_cull_reason_stats_percent() in file life_cycle.py."""
+    # Arrange
+    life_cycle_manager.cow_num = cow_num
+    num_reasons = len(LifeCycleManager.cull_reason_stats)
+    LifeCycleManager.cull_reason_stats.update({
+        animal_constants.DEATH_CULL: int(cow_num / num_reasons),
+        animal_constants.LOW_PROD_CULL: int(cow_num / num_reasons),
+        animal_constants.LAMENESS_CULL: int(cow_num / num_reasons),
+        animal_constants.INJURY_CULL: int(cow_num / num_reasons),
+        animal_constants.MASTITIS_CULL: int(cow_num / num_reasons),
+        animal_constants.DISEASE_CULL: int(cow_num / num_reasons),
+        animal_constants.UDDER_CULL: int(cow_num / num_reasons),
+        animal_constants.UNKNOWN_CULL: 0  # Initialized with 0
+    })
+    LifeCycleManager.cull_reason_stats[animal_constants.UNKNOWN_CULL] = \
+        cow_num - sum(LifeCycleManager.cull_reason_stats.values())
+
+    spy_calc_cull_reason_stats_percent = mocker.spy(life_cycle_manager, '_calculate_cull_reason_stats_percent')
+
+    # Act
+    life_cycle_manager._calculate_cull_reason_stats_percent()
+
+    # Assert
+    spy_calc_cull_reason_stats_percent.assert_called_once()
+    for cull_reason in life_cycle_manager.cull_reason_stats_percent:
+        if cow_num > 0:
+            assert life_cycle_manager.cull_reason_stats_percent[cull_reason] == \
+                   approx(LifeCycleManager.cull_reason_stats[cull_reason] * 100.0 / cow_num)
+        elif cow_num == 0:
+            assert life_cycle_manager.cull_reason_stats_percent[cull_reason] == approx(0.0)
+
+
+@pytest.mark.parametrize('cow_num', [0, 50, 100])
+def test_calc_percent_cow_per_parity(mocker: MockerFixture, life_cycle_manager: LifeCycleManager,
+                                     cow_num: int) -> None:
+    """Unit test for function _calculate_percent_cow_per_parity() in file life_cycle.py."""
+    # Arrange
+    life_cycle_manager.cow_num = cow_num
+    num_parities = len(LifeCycleManager.num_cow_for_parity)
+    LifeCycleManager.num_cow_for_parity.update({
+        '1': int(cow_num / num_parities),
+        '2': int(cow_num / num_parities),
+        '3': int(cow_num / num_parities),
+        'greater_than_3': 0
+    })
+    LifeCycleManager.num_cow_for_parity['greater_than_3'] = \
+        cow_num - sum(LifeCycleManager.num_cow_for_parity.values())
+
+    spy_calc_percent_cow_per_parity = mocker.spy(life_cycle_manager, '_calculate_percent_cow_per_parity')
+
+    # Act
+    life_cycle_manager._calculate_percent_cow_per_parity()
+
+    # Assert
+    spy_calc_percent_cow_per_parity.assert_called_once()
+    for parity in life_cycle_manager.num_cow_for_parity:
+        if cow_num > 0:
+            assert life_cycle_manager.percent_cow_for_parity[parity] == \
+                   approx(LifeCycleManager.num_cow_for_parity[parity] * 100.0 / cow_num)
+        elif cow_num == 0:
+            assert life_cycle_manager.percent_cow_for_parity[parity] == approx(0.0)

--- a/tests/test_animal_life_cycle.py
+++ b/tests/test_animal_life_cycle.py
@@ -435,7 +435,7 @@ def test_keep_heiferII_as_pregnant(mocker: MockerFixture, life_cycle_manager: Li
     assert life_cycle_manager.avg_breeding_to_preg_time == approx(20.0)
 
     # Act
-    result = life_cycle_manager._keep_heiferII_as_pregnant(mock_heiferII, total_animal_num, preg_heifer_num)
+    result = life_cycle_manager._remain_heiferII(mock_heiferII, total_animal_num, preg_heifer_num)
     new_total_animal_num, new_preg_heifer_num = result
 
     # After
@@ -466,7 +466,7 @@ def test_heiferII_to_heiferIII(mocker: MockerFixture, life_cycle_manager: LifeCy
     mock_heiferII_pregnant_stage = mocker.MagicMock(autospec=HeiferII)
     mock_heiferII_pregnant_stage.update.return_value = [False, False]  # cull_stage = False, third_stage = False
     mock_keep_heiferII_as_pregnant = mocker.patch.object(life_cycle_manager,
-                                                         '_keep_heiferII_as_pregnant')
+                                                         '_remain_heiferII')
     mock_keep_heiferII_as_pregnant.return_value = (1, 1)  # new_total_animal_num = 1, new_preg_heifer_num = 1
     total_animal_num = 0
     preg_heifer_num = 0
@@ -824,9 +824,9 @@ def test_cull_cow(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -
     assert life_cycle_manager.avg_cow_culling_age == approx(100.0)
 
 
-def test_handle_cow_body_weight(mocker: MockerFixture,
-                                life_cycle_manager: LifeCycleManager) -> None:
-    """Unit test for function _handle_cow_body_weight() in file life_cycle.py"""
+def test_handle_cow_body_weight_and_parity(mocker: MockerFixture,
+                                           life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _handle_cow_body_weight_and_parity() in file life_cycle.py"""
     # Arrange
     total_animal_num = 100
     mock_cow = mocker.MagicMock(autospec=Cow)
@@ -851,10 +851,10 @@ def test_handle_cow_body_weight(mocker: MockerFixture,
     expected_new_avg_mature_body_weight = (life_cycle_manager.avg_mature_body_weight *
                                            total_animal_num +
                                            mock_cow.mature_body_weight) / expected_new_total_animal_num
-    spy_handle_cow_body_weight = mocker.spy(life_cycle_manager, '_handle_cow_body_weight')
+    spy_handle_cow_body_weight = mocker.spy(life_cycle_manager, '_handle_cow_body_weight_and_parity')
 
     # Act
-    new_total_animal_num = life_cycle_manager._handle_cow_body_weight(mock_cow, total_animal_num)
+    new_total_animal_num = life_cycle_manager._handle_cow_body_weight_and_parity(mock_cow, total_animal_num)
 
     # Assert
     assert new_total_animal_num == expected_new_total_animal_num
@@ -874,17 +874,25 @@ def test_handle_cow_milking(mocker: MockerFixture,
     mock_cow.milking = is_cow_milking
     mock_cow.estimated_daily_milk_produced = 15
     mock_cow.days_in_milk = 8
+    mock_cow.days_in_preg = 0
 
     life_cycle_manager.daily_milk_production = 100
     life_cycle_manager.milking_cow_num = 20
     life_cycle_manager.avg_days_in_milk = 7
-    life_cycle_manager.dry_cow_num = 9
+    life_cycle_manager.vwp_cow_num = 2
+    life_cycle_manager.animal_config = {
+        'voluntary_waiting_period': 9,
+    }
+    life_cycle_manager.dry_cow_num = 5
 
     expected_new_daily_milk_production = (life_cycle_manager.daily_milk_production +
                                           mock_cow.estimated_daily_milk_produced)
     expected_new_milking_cow_num = life_cycle_manager.milking_cow_num + 1
     expected_new_avg_days_in_milk = (life_cycle_manager.avg_days_in_milk * life_cycle_manager.milking_cow_num +
                                      mock_cow.days_in_milk) / expected_new_milking_cow_num
+    expected_vwp_cow_num = 3
+    expected_open_cow_num = 1
+
     expected_new_dry_cow_num = life_cycle_manager.dry_cow_num + 1
     spy_handle_cow_milking = mocker.spy(life_cycle_manager, '_handle_cow_milking')
 
@@ -897,33 +905,7 @@ def test_handle_cow_milking(mocker: MockerFixture,
         assert life_cycle_manager.daily_milk_production == expected_new_daily_milk_production
         assert life_cycle_manager.milking_cow_num == expected_new_milking_cow_num
         assert life_cycle_manager.avg_days_in_milk == approx(expected_new_avg_days_in_milk)
+        assert life_cycle_manager.vwp_cow_num == expected_vwp_cow_num
+        assert life_cycle_manager.open_cow_num == expected_open_cow_num
     else:
         assert life_cycle_manager.dry_cow_num == expected_new_dry_cow_num
-
-
-def test__handle_cow_days_in_milk():
-    pass
-
-
-def test_handle_cow_days_in_preg():
-    pass
-
-
-def test_handle_cow_calves():
-    pass
-
-
-def test_handle_cow_ci():
-    pass
-
-
-def test_extract_repro_stats_from_cow():
-    pass
-
-
-def test_handle_new_born():
-    pass
-
-
-def test__cull_cows_and_record_stats(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
-    pass

--- a/tests/test_animal_life_cycle.py
+++ b/tests/test_animal_life_cycle.py
@@ -872,9 +872,8 @@ def test_handle_cow_milking(mocker: MockerFixture,
     # Arrange
     mock_cow = mocker.MagicMock(autospec=Cow)
     mock_cow.milking = is_cow_milking
-    mock_cow.estimated_daily_milk_produced = 15
+    mock_cow.estimated_daily_milk_produced = 15.0
     mock_cow.days_in_milk = 8
-    mock_cow.days_in_preg = 0
 
     life_cycle_manager.daily_milk_production = 100
     life_cycle_manager.milking_cow_num = 20
@@ -890,9 +889,7 @@ def test_handle_cow_milking(mocker: MockerFixture,
     expected_new_milking_cow_num = life_cycle_manager.milking_cow_num + 1
     expected_new_avg_days_in_milk = (life_cycle_manager.avg_days_in_milk * life_cycle_manager.milking_cow_num +
                                      mock_cow.days_in_milk) / expected_new_milking_cow_num
-    expected_vwp_cow_num = 3
-    expected_open_cow_num = 1
-
+    expected_vwp_cow_num = life_cycle_manager.vwp_cow_num + 1
     expected_new_dry_cow_num = life_cycle_manager.dry_cow_num + 1
     spy_handle_cow_milking = mocker.spy(life_cycle_manager, '_handle_cow_milking')
 
@@ -906,6 +903,98 @@ def test_handle_cow_milking(mocker: MockerFixture,
         assert life_cycle_manager.milking_cow_num == expected_new_milking_cow_num
         assert life_cycle_manager.avg_days_in_milk == approx(expected_new_avg_days_in_milk)
         assert life_cycle_manager.vwp_cow_num == expected_vwp_cow_num
-        assert life_cycle_manager.open_cow_num == expected_open_cow_num
     else:
         assert life_cycle_manager.dry_cow_num == expected_new_dry_cow_num
+
+
+@pytest.mark.parametrize('days_in_preg', [0, 1, 8])
+def test_handle_cow_days_in_preg(mocker: MockerFixture, life_cycle_manager: LifeCycleManager,
+                                 days_in_preg: int) -> None:
+    """Unit test for function _handle_cow_days_in_preg() in file life_cycle.py"""
+    # Arrange
+    mock_cow = mocker.MagicMock(autospec=Cow)
+    mock_cow.days_in_preg = days_in_preg
+
+    life_cycle_manager.preg_cow_num = 20
+    life_cycle_manager.avg_days_in_preg = 7.0
+    life_cycle_manager.open_cow_num = 5
+
+    expected_new_pregnant_cow_num = life_cycle_manager.preg_cow_num + 1
+    expected_new_avg_days_in_preg = (life_cycle_manager.avg_days_in_preg * life_cycle_manager.preg_cow_num +
+                                     mock_cow.days_in_preg) / expected_new_pregnant_cow_num
+    expected_new_open_cow_num = life_cycle_manager.open_cow_num + 1
+    spy_handle_cow_days_in_preg = mocker.spy(life_cycle_manager, '_handle_cow_days_in_preg')
+
+    # Act
+    life_cycle_manager._handle_cow_days_in_preg(mock_cow)
+
+    # Assert
+    spy_handle_cow_days_in_preg.assert_called_once_with(mock_cow)
+    if mock_cow.days_in_preg > 0:
+        assert life_cycle_manager.preg_cow_num == expected_new_pregnant_cow_num
+        assert life_cycle_manager.avg_days_in_preg == approx(expected_new_avg_days_in_preg)
+    else:
+        assert life_cycle_manager.open_cow_num == expected_new_open_cow_num
+
+
+@pytest.mark.parametrize('cow_CI', [0, 1])
+def test_handle_cow_CI(mocker: MockerFixture, life_cycle_manager: LifeCycleManager,
+                       cow_CI: int) -> None:
+    """Unit test for function _handle_cow_CI() in file life_cycle.py"""
+    # Arrange
+    mock_cow = mocker.MagicMock(autospec=Cow)
+    mock_cow.CI = cow_CI
+    calving_interval_avail_num = 5
+    life_cycle_manager.avg_calving_interval = 7.0
+    expected_new_calving_interval_avail_num = calving_interval_avail_num + 1
+    expected_new_avg_calving_interval = (life_cycle_manager.avg_calving_interval * calving_interval_avail_num +
+                                         mock_cow.CI) / expected_new_calving_interval_avail_num
+    spy_handle_cow_CI = mocker.spy(life_cycle_manager, '_handle_cow_CI')
+
+    # Act
+    new_calving_interval_avail_num = life_cycle_manager._handle_cow_CI(mock_cow, calving_interval_avail_num)
+
+    # Assert
+    spy_handle_cow_CI.assert_called_once_with(mock_cow, calving_interval_avail_num)
+    if mock_cow.CI != 0:
+        assert new_calving_interval_avail_num == expected_new_calving_interval_avail_num
+        assert life_cycle_manager.avg_calving_interval == approx(expected_new_avg_calving_interval)
+    else:
+        assert new_calving_interval_avail_num == calving_interval_avail_num
+
+
+def test_extract_repro_stats_from_cow(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _extract_repro_stats_from_cow() in file life_cycle.py"""
+
+    # Arrange
+    mock_cow = mocker.MagicMock(autospec=Cow)
+    mock_cow.GnRH_injections = 1
+    mock_cow.PGF_injections = 2
+    mock_cow.preg_diagnoses = 3
+    mock_cow.semen_num = 4
+    mock_cow.AI_times = 5
+
+    life_cycle_manager.GnRH_injection_num = 1
+    life_cycle_manager.PGF_injection_num = 1
+    life_cycle_manager.preg_check_num = 1
+    life_cycle_manager.semen_num = 1
+    life_cycle_manager.ai_num = 1
+
+    expected_GnRH_injection_num = life_cycle_manager.GnRH_injection_num + mock_cow.GnRH_injections
+    expected_PGF_injections = life_cycle_manager.PGF_injection_num + mock_cow.PGF_injections
+    expected_preg_check_num = life_cycle_manager.preg_check_num + mock_cow.preg_diagnoses
+    expected_semen_num = life_cycle_manager.semen_num + mock_cow.semen_num
+    expected_ai_num = life_cycle_manager.ai_num + mock_cow.AI_times
+
+    spy_extract_repro_stats_from_cow = mocker.spy(life_cycle_manager, '_extract_repro_stats_from_cow')
+
+    # Act
+    life_cycle_manager._extract_repro_stats_from_cow(mock_cow)
+
+    # Assert
+    spy_extract_repro_stats_from_cow.assert_called_once_with(mock_cow)
+    assert life_cycle_manager.GnRH_injection_num == expected_GnRH_injection_num
+    assert life_cycle_manager.PGF_injection_num == expected_PGF_injections
+    assert life_cycle_manager.preg_check_num == expected_preg_check_num
+    assert life_cycle_manager.semen_num == expected_semen_num
+    assert life_cycle_manager.ai_num == expected_ai_num

--- a/tests/test_animal_life_cycle.py
+++ b/tests/test_animal_life_cycle.py
@@ -1,6 +1,8 @@
 import collections
 from typing import Dict, List
+from typing import Type
 
+import pytest
 from pytest import approx, fixture
 from pytest_mock import MockerFixture
 
@@ -13,13 +15,108 @@ from RUFAS.routines.animal.life_cycle.cow import Cow
 from RUFAS.routines.animal.life_cycle.heiferI import HeiferI
 from RUFAS.routines.animal.life_cycle.heiferII import HeiferII
 from RUFAS.routines.animal.life_cycle.heiferIII import HeiferIII
+from RUFAS.routines.animal.life_cycle.life_cycle import GenericAnimal
 from RUFAS.routines.animal.life_cycle.life_cycle import LifeCycleManager
 from RUFAS.routines.animal.pen import Pen
 
 
 @fixture
-def herd_data() -> HerdInfoTypedDict:
-    return {
+def life_cycle_manager(mocker: MockerFixture) -> LifeCycleManager:
+    return LifeCycleManager(data=mocker.MagicMock(autospec=AnimalConfigTypedDict))
+
+
+@pytest.mark.parametrize(
+        'user_input_calving_interval, custom_avg_CI, cow_avg_CI',
+        [
+            (True, 400.0, -1.0),
+            (False, -1.0, 500.0)
+        ]
+)
+def test_set_avg_CI(mocker: MockerFixture,
+                    life_cycle_manager: LifeCycleManager,
+                    user_input_calving_interval: bool,
+                    custom_avg_CI: float,
+                    cow_avg_CI: float) -> None:
+    """Unit test for function _set_avg_CI() in file life_cycle.py"""
+    # Arrange
+    mock_animal_config = {
+        'use_input_calving_interval': user_input_calving_interval,
+        'calving_interval': custom_avg_CI
+    }
+    life_cycle_manager.animal_config = mock_animal_config
+
+    mock_init_db_summary = {
+        'cow_avg_CI': cow_avg_CI
+    }
+    mock_animal_initializer = mocker.MagicMock(autospec=AnimalInitialization)
+    mock_animal_initializer.initialization_db_summary.return_value = mock_init_db_summary
+    life_cycle_manager.animal_initializer = mock_animal_initializer
+    spy_set_avg_CI = mocker.spy(life_cycle_manager, '_set_avg_CI')
+
+    # Assert before
+    assert life_cycle_manager.avg_CI == approx(0.0)
+
+    # Act
+    life_cycle_manager._set_avg_CI()
+
+    # Assert after
+    spy_set_avg_CI.assert_called_once()
+    if user_input_calving_interval:
+        assert life_cycle_manager.avg_CI == approx(custom_avg_CI)
+    else:
+        assert life_cycle_manager.avg_CI == approx(cow_avg_CI)
+        mock_animal_initializer.initialization_db_summary.assert_called_once()
+
+
+@pytest.mark.parametrize(
+        'animal_type',
+        [Calf, HeiferI, HeiferII, HeiferIII, Cow])
+def test_get_animals(mocker: MockerFixture,
+                     life_cycle_manager: LifeCycleManager,
+                     animal_type: Type[GenericAnimal]) -> None:
+    """Unit test for function _get_animals() in file life_cycle.py"""
+    # Arrange
+    animal_num = 10
+    breed = 'HO'
+    days_born = 50
+    mock_animals = []
+    for i in range(animal_num):
+        mock_new_animal = mocker.MagicMock(autospec=animal_type)
+        mock_new_animal.breed = breed
+        mock_new_animal.days_born = days_born
+        mock_animals.append(mock_new_animal)
+    mock_animal_initializer = mocker.MagicMock(autospec=AnimalInitialization)
+
+    animal_getter_by_animal_type = {
+        Calf: mock_animal_initializer.get_calves,
+        HeiferI: mock_animal_initializer.get_heiferIs,
+        HeiferII: mock_animal_initializer.get_heiferIIs,
+        HeiferIII: mock_animal_initializer.get_heiferIIIs,
+        Cow: mock_animal_initializer.get_cows
+    }
+    animal_getter_by_animal_type[animal_type].return_value = mock_animals
+
+    spy_get_animals = mocker.spy(life_cycle_manager, '_get_animals')
+    life_cycle_manager.animal_initializer = mock_animal_initializer
+
+    # Act
+    animals = life_cycle_manager._get_animals(animal_type, animal_num, breed)
+
+    # Assert
+    assert len(animals) == animal_num
+    for animal in animals:
+        assert animal.breed == breed
+        animal.events.add_event.assert_called_once_with(days_born, 0, INIT_HERD)
+
+    spy_get_animals.assert_called_once_with(animal_type, animal_num, breed)
+    animal_getter_by_animal_type[animal_type].assert_called_once_with(animal_num, breed)
+
+
+def test_initialize_herd(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function initialize_herd() in file life_cycle.py"""
+    mock_config = mocker.MagicMock(autospec=Config)
+    breed = 'HO'
+    herd_data = {
         'calf_num': 80,
         'heiferI_num': 440,
         'heiferII_num': 380,
@@ -28,236 +125,32 @@ def herd_data() -> HerdInfoTypedDict:
         'replace_num': 5000,
         'herd_num': 1000,
         'herd_init': False,
-        'breed': 'HO'
+        'breed': breed,
+        'config': mock_config
     }
 
-
-@fixture
-def life_cycle_manager(mocker: MockerFixture) -> LifeCycleManager:
-    return LifeCycleManager(data=mocker.MagicMock(autospec=AnimalConfigTypedDict))
-
-
-def test_set_avg_CI(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
-    """Unit test for function _set_avg_CI in file life_cycle.py"""
-    # Given user input calving interval,
-    # the function should correctly set the user-specified average calving interval.
-    custom_avg_CI = 400.0
-    mock_animal_config_data = {
-        'user_input_calving_interval': True,
-        'calving_interval': custom_avg_CI
-    }
-    mock_animal_config = mocker.MagicMock(autospec=AnimalConfigTypedDict)
-    mock_animal_config.__contains__.side_effect = mock_animal_config_data.__contains__
-    mock_animal_config.__getitem__.side_effect = mock_animal_config_data.__getitem__
-    mock_animal_initializer = mocker.MagicMock(autospec=AnimalInitialization)
-
-    spy_set_avg_CI = mocker.spy(life_cycle_manager, '_set_avg_CI')
-    assert life_cycle_manager.avg_CI == approx(0.0)
-
-    life_cycle_manager._set_avg_CI(mock_animal_config, mock_animal_initializer)
-
-    assert life_cycle_manager.avg_CI == approx(custom_avg_CI)
-    spy_set_avg_CI.assert_called_once()
-
-
-def test_set_avg_CI_2(mocker: MockerFixture, life_cycle_manager) -> None:
-    """Unit test for function _set_avg_CI in file life_cycle.py"""
-    # Given no user input calving interval,
-    # the function should use the cow average calving interval by default.
-    cow_avg_CI = 500.0
-    mock_animal_config_data = {
-        'user_input_calving_interval': False
-    }
-    mock_animal_config = mocker.MagicMock(autospec=AnimalConfigTypedDict)
-    mock_animal_config.__getitem__.side_effect = mock_animal_config_data.__getitem__
-    mock_init_db_summary = {
-        'cow_avg_CI': cow_avg_CI
-    }
-    mock_animal_initializer = mocker.MagicMock(autospec=AnimalInitialization)
-    mock_animal_initializer.initialization_db_summary.return_value = mock_init_db_summary
-
-    spy_get_avg_CI = mocker.spy(life_cycle_manager, '_set_avg_CI')
-    assert life_cycle_manager.avg_CI == approx(0.0)
-
-    life_cycle_manager._set_avg_CI(mock_animal_config, mock_animal_initializer)
-
-    assert life_cycle_manager.avg_CI == approx(cow_avg_CI)
-    spy_get_avg_CI.assert_called_once()
-    mock_animal_initializer.initialization_db_summary.assert_called_once()
-
-
-def test_get_calves(mocker: MockerFixture, life_cycle_manager) -> None:
-    """Unit test for function _get_calves in file life_cycle.py"""
-    calf_num = 10
-    breed = 'HO'
-    days_born = 50
-    mock_calves = []
-    for i in range(calf_num):
-        mock_new_calf = mocker.MagicMock(autospec=Calf)
-        mock_new_calf.breed = breed
-        mock_new_calf.days_born = days_born
-        mock_calves.append(mock_new_calf)
-    mock_animal_initializer = mocker.MagicMock(autospec=AnimalInitialization)
-    mock_animal_initializer.get_calves.return_value = mock_calves
-    spy_get_calves = mocker.spy(life_cycle_manager, '_get_calves')
-
-    calves = life_cycle_manager._get_calves(calf_num, breed, mock_animal_initializer)
-
-    assert len(calves) == calf_num
-    for calf in calves:
-        assert calf.breed == breed
-        calf.events.add_event.assert_called_once_with(days_born, 0, INIT_HERD)
-
-    spy_get_calves.assert_called_once_with(calf_num, breed, mock_animal_initializer)
-    mock_animal_initializer.get_calves.assert_called_once_with(calf_num, breed)
-
-
-def test_get_heiferIs(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
-    """Unit test for function _get_heiferIs in file life_cycle.py"""
-    heiferI_num = 10
-    breed = 'HO'
-    days_born = 350
-    mock_heiferIs = []
-    for i in range(heiferI_num):
-        mock_new_heiferI = mocker.MagicMock(autospec=HeiferI)
-        mock_new_heiferI.breed = breed
-        mock_new_heiferI.days_born = days_born
-        mock_heiferIs.append(mock_new_heiferI)
-    mock_animal_initializer = mocker.MagicMock(autospec=AnimalInitialization)
-    mock_animal_initializer.get_heiferIs.return_value = mock_heiferIs
-    spy_get_heiferIs = mocker.spy(life_cycle_manager, '_get_heiferIs')
-
-    heiferIs = life_cycle_manager._get_heiferIs(heiferI_num, breed, mock_animal_initializer)
-
-    assert len(heiferIs) == heiferI_num
-    for heiferI in heiferIs:
-        assert heiferI.breed == breed
-        heiferI.events.add_event.assert_called_once_with(days_born, 0, INIT_HERD)
-
-    spy_get_heiferIs.assert_called_once_with(heiferI_num, breed, mock_animal_initializer)
-    mock_animal_initializer.get_heiferIs.assert_called_once_with(heiferI_num, breed)
-
-
-def test_get_heiferIIs(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
-    """Unit test for function _get_heiferIIs in file life_cycle.py"""
-    heiferII_num = 10
-    breed = 'HO'
-    days_born = 800
-    mock_heiferIIs = []
-    for i in range(heiferII_num):
-        mock_new_heiferII = mocker.MagicMock(autospec=HeiferII)
-        mock_new_heiferII.breed = breed
-        mock_new_heiferII.days_born = days_born
-        mock_heiferIIs.append(mock_new_heiferII)
-    mock_animal_initializer = mocker.MagicMock(autospec=AnimalInitialization)
-    mock_animal_initializer.get_heiferIIs.return_value = mock_heiferIIs
-    spy_get_heiferIIs = mocker.spy(life_cycle_manager, '_get_heiferIIs')
-
-    heiferIIs = life_cycle_manager._get_heiferIIs(heiferII_num, breed, mock_animal_initializer)
-
-    assert len(heiferIIs) == heiferII_num
-    for heiferII in heiferIIs:
-        assert heiferII.breed == breed
-        heiferII.events.add_event.assert_called_once_with(days_born, 0, INIT_HERD)
-
-    spy_get_heiferIIs.assert_called_once_with(heiferII_num, breed, mock_animal_initializer)
-    mock_animal_initializer.get_heiferIIs.assert_called_once_with(heiferII_num, breed)
-
-
-def test_get_heiferIIIs(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
-    """Unit test for function _get_heiferIIIs in file life_cycle.py"""
-    heiferIII_num = 10
-    breed = 'HO'
-    days_born = 650
-    mock_heiferIIIs = []
-    for i in range(heiferIII_num):
-        mock_new_heiferIII = mocker.MagicMock(autospec=HeiferIII)
-        mock_new_heiferIII.breed = breed
-        mock_new_heiferIII.days_born = days_born
-        mock_heiferIIIs.append(mock_new_heiferIII)
-    mock_animal_initializer = mocker.MagicMock(autospec=AnimalInitialization)
-    mock_animal_initializer.get_heiferIIIs.return_value = mock_heiferIIIs
-    spy_get_heiferIIIs = mocker.spy(life_cycle_manager, '_get_heiferIIIs')
-
-    heiferIIIs = life_cycle_manager._get_heiferIIIs(heiferIII_num, breed, mock_animal_initializer)
-
-    assert len(heiferIIIs) == heiferIII_num
-    for heiferIII in heiferIIIs:
-        assert heiferIII.breed == breed
-        heiferIII.events.add_event.assert_called_once_with(days_born, 0, INIT_HERD)
-
-    spy_get_heiferIIIs.assert_called_once_with(heiferIII_num, breed, mock_animal_initializer)
-    mock_animal_initializer.get_heiferIIIs.assert_called_once_with(heiferIII_num, breed)
-
-
-def test_get_cows(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
-    """Unit test for function _get_cows in file life_cycle.py"""
-    cow_num = 10
-    breed = 'HO'
-    days_born = 2200
-    mock_cows = []
-    for i in range(cow_num):
-        mock_new_cow = mocker.MagicMock(autospec=Cow)
-        mock_new_cow.breed = breed
-        mock_new_cow.days_born = days_born
-        mock_cows.append(mock_new_cow)
-    mock_animal_initializer = mocker.MagicMock(autospec=AnimalInitialization)
-    mock_animal_initializer.get_cows.return_value = mock_cows
-    spy_get_cows = mocker.spy(life_cycle_manager, '_get_cows')
-
-    cows = life_cycle_manager._get_cows(cow_num, breed, mock_animal_initializer)
-
-    assert len(cows) == cow_num
-    for cow in cows:
-        assert cow.breed == breed
-        cow.events.add_event.assert_called_once_with(days_born, 0, INIT_HERD)
-
-    spy_get_cows.assert_called_once_with(cow_num, breed, mock_animal_initializer)
-    mock_animal_initializer.get_cows.assert_called_once_with(cow_num, breed)
-
-
-def test_initialize_herd(mocker: MockerFixture, life_cycle_manager: LifeCycleManager,
-                         herd_data: HerdInfoTypedDict) -> None:
-    """Unit test for function initialize_herd in file life_cycle.py"""
-    herd_num = herd_data['herd_num']
-    calf_num = herd_data['calf_num']
-    heiferI_num = herd_data['heiferI_num']
-    heiferII_num = herd_data['heiferII_num']
-    heiferIII_num = herd_data['heiferIII_num']
-    cow_num = herd_data['cow_num']
-    replace_num = herd_data['replace_num']
-    herd_init = herd_data['herd_init']
-    breed = herd_data['breed']
-    mock_config = mocker.MagicMock(autospec=Config)
-
-    mock_animal_config = mocker.MagicMock(autospec=AnimalConfigTypedDict)
-    mocker.patch.object(life_cycle_manager, 'animal_config', mock_animal_config)
+    life_cycle_manager.animal_config = mocker.MagicMock(autospec=AnimalConfigTypedDict)
 
     mock_animal_initializer = mocker.MagicMock(autospec=AnimalInitialization)
-    mock_replacement_cows = [mocker.MagicMock(autospec=Cow) for _ in range(replace_num)]
+    mock_replacement_cows = [mocker.MagicMock(autospec=Cow) for _ in range(herd_data['replace_num'])]
     mock_animal_initializer.get_replacement_cows.return_value = mock_replacement_cows
     mocker.patch('RUFAS.routines.animal.life_cycle.life_cycle.AnimalInitialization',
                  return_value=mock_animal_initializer)
 
     mock_set_avg_CI = mocker.patch.object(life_cycle_manager, '_set_avg_CI')
-    mock_get_calves = mocker.patch.object(life_cycle_manager, '_get_calves')
-    mock_get_heiferIs = mocker.patch.object(life_cycle_manager, '_get_heiferIs')
-    mock_get_heiferIIs = mocker.patch.object(life_cycle_manager, '_get_heiferIIs')
-    mock_get_heiferIIIs = mocker.patch.object(life_cycle_manager, '_get_heiferIIIs')
-    mock_get_cows = mocker.patch.object(life_cycle_manager, '_get_cows')
+    mock_get_animals = mocker.patch.object(life_cycle_manager, '_get_animals')
 
-    results = life_cycle_manager.initialize_herd(herd_num, calf_num, heiferI_num, heiferII_num,
-                                                 heiferIII_num, cow_num, replace_num, herd_init,
-                                                 breed, mock_config)
+    results = life_cycle_manager.initialize_herd(**herd_data)
 
     assert life_cycle_manager.herd_num == herd_data['herd_num']
-    mock_set_avg_CI.assert_called_once_with(mock_animal_config, mock_animal_initializer)
-    mock_get_calves.assert_called_once_with(calf_num, breed, mock_animal_initializer)
-    mock_get_heiferIs.assert_called_once_with(heiferI_num, breed, mock_animal_initializer)
-    mock_get_heiferIIs.assert_called_once_with(heiferII_num, breed, mock_animal_initializer)
-    mock_get_heiferIIIs.assert_called_once_with(heiferIII_num, breed, mock_animal_initializer)
-    mock_get_cows.assert_called_once_with(cow_num, breed, mock_animal_initializer)
-    mock_animal_initializer.get_replacement_cows.assert_called_once_with(replace_num, breed)
+    mock_set_avg_CI.assert_called_once()
+    assert mock_get_animals.call_count == 5
+    assert mock_get_animals.call_args_list[0] == mocker.call(Calf, herd_data['calf_num'], breed)
+    assert mock_get_animals.call_args_list[1] == mocker.call(HeiferI, herd_data['heiferI_num'], breed)
+    assert mock_get_animals.call_args_list[2] == mocker.call(HeiferII, herd_data['heiferII_num'], breed)
+    assert mock_get_animals.call_args_list[3] == mocker.call(HeiferIII, herd_data['heiferIII_num'], breed)
+    assert mock_get_animals.call_args_list[4] == mocker.call(Cow, herd_data['cow_num'], breed)
+    mock_animal_initializer.get_replacement_cows.assert_called_once_with(herd_data['replace_num'], breed)
     assert life_cycle_manager.replacement_market == mock_replacement_cows
     assert len(results) == 5
 

--- a/tests/test_animal_life_cycle.py
+++ b/tests/test_animal_life_cycle.py
@@ -10,6 +10,7 @@ from pytest_mock import MockerFixture
 
 from RUFAS.classes import Config
 from RUFAS.routines.animal.animal_typed_dicts import AnimalConfigTypedDict
+from RUFAS.routines.animal.life_cycle import animal_constants
 from RUFAS.routines.animal.life_cycle.animal_constants import ENTER_HERD
 from RUFAS.routines.animal.life_cycle.animal_constants import INIT_HERD
 from RUFAS.routines.animal.life_cycle.animal_constants import LOW_PROD_CULL
@@ -998,3 +999,79 @@ def test_extract_repro_stats_from_cow(mocker: MockerFixture, life_cycle_manager:
     assert life_cycle_manager.preg_check_num == expected_preg_check_num
     assert life_cycle_manager.semen_num == expected_semen_num
     assert life_cycle_manager.ai_num == expected_ai_num
+
+
+@pytest.mark.parametrize('cow_calves', [1, 2, 3, 4])
+def test_handle_cow_calves(mocker: MockerFixture, life_cycle_manager: LifeCycleManager,
+                           cow_calves: int) -> None:
+    """Unit test for function _handle_cow_calves() in file life_cycle.py."""
+    # Arrange
+    mock_cow = mocker.MagicMock(autospec=Cow)
+    mock_cow.calves = cow_calves
+    key = 'greater_than_3' if cow_calves > 3 else str(cow_calves)
+    calving_age_avail_num = {
+        '1': 0,
+        '2': 0,
+        '3': 0,
+        'greater_than_3': 0
+    }
+    calf_to_preg_time_avail_num = calving_age_avail_num.copy()
+    spy_handle_cow_calves = mocker.spy(life_cycle_manager, '_handle_cow_calves')
+
+    mock_cow.days_born = 300
+    expected_avg_age_for_parity_for_key = 300.0
+
+    mock_cow.events.get_most_recent_date.return_value = 100
+    expected_avg_age_for_calving_for_key = 100.0
+
+    mock_cow.calving_to_preg_time = 200
+    expected_avg_calving_to_preg_time = 200.0
+
+    # Act
+    life_cycle_manager._handle_cow_calves(mock_cow, calving_age_avail_num, calf_to_preg_time_avail_num)
+
+    # Assert
+    spy_handle_cow_calves.assert_called_once_with(mock_cow, calving_age_avail_num, calf_to_preg_time_avail_num)
+    assert life_cycle_manager.num_cow_for_parity[key] == 1
+    assert life_cycle_manager.avg_age_for_parity[key] == approx(expected_avg_age_for_parity_for_key)
+
+    mock_cow.events.get_most_recent_date.assert_called_once_with(animal_constants.NEW_BIRTH)
+    assert calving_age_avail_num[key] == 1
+    assert life_cycle_manager.avg_age_for_calving[key] == approx(expected_avg_age_for_calving_for_key)
+
+    assert calf_to_preg_time_avail_num[key] == 1
+    assert life_cycle_manager.avg_calving_to_preg_time[key] == approx(expected_avg_calving_to_preg_time)
+
+
+@pytest.mark.parametrize('total_animal_num', [0, 50, 100])
+def test_calc_herd_percentages(mocker: MockerFixture, life_cycle_manager: LifeCycleManager,
+                               total_animal_num: int) -> None:
+    """Unit test for function _calc_herd_percentages() in file life_cycle.py."""
+    calf_num = heiferI_num = heiferII_num = heiferIII_num = cow_num = 0
+    # Arrange
+    if total_animal_num > 0:
+        life_cycle_manager.calf_num = calf_num = int(0.2 * total_animal_num)
+        life_cycle_manager.heiferI_num = heiferI_num = int(0.2 * total_animal_num)
+        life_cycle_manager.heiferII_num = heiferII_num = int(0.2 * total_animal_num)
+        life_cycle_manager.heiferIII_num = heiferIII_num = int(0.2 * total_animal_num)
+        life_cycle_manager.cow_num = cow_num = (total_animal_num - calf_num - heiferI_num
+                                                - heiferII_num - heiferIII_num)
+    spy_calc_herd_percentages = mocker.spy(life_cycle_manager, '_calc_herd_percentages')
+
+    # Act
+    life_cycle_manager._calc_herd_percentages(total_animal_num)
+
+    # Assert
+    spy_calc_herd_percentages.assert_called_once_with(total_animal_num)
+    if total_animal_num > 0:
+        assert life_cycle_manager.calf_percent == approx(calf_num * 100.0 / total_animal_num)
+        assert life_cycle_manager.heiferI_percent == approx(heiferI_num * 100.0 / total_animal_num)
+        assert life_cycle_manager.heiferII_percent == approx(heiferII_num * 100.0 / total_animal_num)
+        assert life_cycle_manager.heiferIII_percent == approx(heiferIII_num * 100.0 / total_animal_num)
+        assert life_cycle_manager.cow_percent == approx(cow_num * 100.0 / total_animal_num)
+    elif total_animal_num == 0:
+        assert life_cycle_manager.calf_percent == approx(0.0)
+        assert life_cycle_manager.heiferI_percent == approx(0.0)
+        assert life_cycle_manager.heiferII_percent == approx(0.0)
+        assert life_cycle_manager.heiferIII_percent == approx(0.0)
+        assert life_cycle_manager.cow_percent == approx(0.0)

--- a/tests/test_animal_life_cycle.py
+++ b/tests/test_animal_life_cycle.py
@@ -1,0 +1,962 @@
+import collections
+from typing import Dict, List
+
+from pytest import approx, fixture
+from pytest_mock import MockerFixture
+
+from RUFAS.classes import Config
+from RUFAS.routines.animal.animal_typed_dicts import AnimalConfigTypedDict, HerdInfoTypedDict
+from RUFAS.routines.animal.life_cycle.animal_constants import ENTER_HERD, INIT_HERD, LOW_PROD_CULL
+from RUFAS.routines.animal.life_cycle.animal_initialization import AnimalInitialization
+from RUFAS.routines.animal.life_cycle.calf import Calf
+from RUFAS.routines.animal.life_cycle.cow import Cow
+from RUFAS.routines.animal.life_cycle.heiferI import HeiferI
+from RUFAS.routines.animal.life_cycle.heiferII import HeiferII
+from RUFAS.routines.animal.life_cycle.heiferIII import HeiferIII
+from RUFAS.routines.animal.life_cycle.life_cycle import LifeCycleManager
+from RUFAS.routines.animal.pen import Pen
+
+
+@fixture
+def herd_data() -> HerdInfoTypedDict:
+    return {
+        'calf_num': 80,
+        'heiferI_num': 440,
+        'heiferII_num': 380,
+        'heiferIII_num': 50,
+        'cow_num': 1000,
+        'replace_num': 5000,
+        'herd_num': 1000,
+        'herd_init': False,
+        'breed': 'HO'
+    }
+
+
+@fixture
+def life_cycle_manager(mocker: MockerFixture) -> LifeCycleManager:
+    return LifeCycleManager(data=mocker.MagicMock(autospec=AnimalConfigTypedDict))
+
+
+def test_set_avg_CI(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _set_avg_CI in file life_cycle.py"""
+    # Given user input calving interval,
+    # the function should correctly set the user-specified average calving interval.
+    custom_avg_CI = 400.0
+    mock_animal_config_data = {
+        'user_input_calving_interval': True,
+        'calving_interval': custom_avg_CI
+    }
+    mock_animal_config = mocker.MagicMock(autospec=AnimalConfigTypedDict)
+    mock_animal_config.__getitem__.side_effect = mock_animal_config_data.__getitem__
+    mock_animal_initializer = mocker.MagicMock(autospec=AnimalInitialization)
+
+    spy_set_avg_CI = mocker.spy(life_cycle_manager, '_set_avg_CI')
+    assert life_cycle_manager.avg_CI == approx(0.0)
+
+    life_cycle_manager._set_avg_CI(mock_animal_config, mock_animal_initializer)
+
+    assert life_cycle_manager.avg_CI == approx(custom_avg_CI)
+    spy_set_avg_CI.assert_called_once()
+
+
+def test_set_avg_CI_2(mocker: MockerFixture, life_cycle_manager) -> None:
+    """Unit test for function _set_avg_CI in file life_cycle.py"""
+    # Given no user input calving interval,
+    # the function should use the cow average calving interval by default.
+    cow_avg_CI = 500.0
+    mock_animal_config_data = {
+        'user_input_calving_interval': False
+    }
+    mock_animal_config = mocker.MagicMock(autospec=AnimalConfigTypedDict)
+    mock_animal_config.__getitem__.side_effect = mock_animal_config_data.__getitem__
+    mock_init_db_summary = {
+        'cow_avg_CI': cow_avg_CI
+    }
+    mock_animal_initializer = mocker.MagicMock(autospec=AnimalInitialization)
+    mock_animal_initializer.initialization_db_summary.return_value = mock_init_db_summary
+
+    spy_get_avg_CI = mocker.spy(life_cycle_manager, '_set_avg_CI')
+    assert life_cycle_manager.avg_CI == approx(0.0)
+
+    life_cycle_manager._set_avg_CI(mock_animal_config, mock_animal_initializer)
+
+    assert life_cycle_manager.avg_CI == approx(cow_avg_CI)
+    spy_get_avg_CI.assert_called_once()
+    mock_animal_initializer.initialization_db_summary.assert_called_once()
+
+
+def test_get_calves(mocker: MockerFixture, life_cycle_manager) -> None:
+    """Unit test for function _get_calves in file life_cycle.py"""
+    calf_num = 10
+    breed = 'HO'
+    days_born = 50
+    mock_calves = []
+    for i in range(calf_num):
+        mock_new_calf = mocker.MagicMock(autospec=Calf)
+        mock_new_calf.breed = breed
+        mock_new_calf.days_born = days_born
+        mock_calves.append(mock_new_calf)
+    mock_animal_initializer = mocker.MagicMock(autospec=AnimalInitialization)
+    mock_animal_initializer.get_calves.return_value = mock_calves
+    spy_get_calves = mocker.spy(life_cycle_manager, '_get_calves')
+
+    calves = life_cycle_manager._get_calves(calf_num, breed, mock_animal_initializer)
+
+    assert len(calves) == calf_num
+    for calf in calves:
+        assert calf.breed == breed
+        calf.events.add_event.assert_called_once_with(days_born, 0, INIT_HERD)
+
+    spy_get_calves.assert_called_once_with(calf_num, breed, mock_animal_initializer)
+    mock_animal_initializer.get_calves.assert_called_once_with(calf_num, breed)
+
+
+def test_get_heiferIs(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _get_heiferIs in file life_cycle.py"""
+    heiferI_num = 10
+    breed = 'HO'
+    days_born = 350
+    mock_heiferIs = []
+    for i in range(heiferI_num):
+        mock_new_heiferI = mocker.MagicMock(autospec=HeiferI)
+        mock_new_heiferI.breed = breed
+        mock_new_heiferI.days_born = days_born
+        mock_heiferIs.append(mock_new_heiferI)
+    mock_animal_initializer = mocker.MagicMock(autospec=AnimalInitialization)
+    mock_animal_initializer.get_heiferIs.return_value = mock_heiferIs
+    spy_get_heiferIs = mocker.spy(life_cycle_manager, '_get_heiferIs')
+
+    heiferIs = life_cycle_manager._get_heiferIs(heiferI_num, breed, mock_animal_initializer)
+
+    assert len(heiferIs) == heiferI_num
+    for heiferI in heiferIs:
+        assert heiferI.breed == breed
+        heiferI.events.add_event.assert_called_once_with(days_born, 0, INIT_HERD)
+
+    spy_get_heiferIs.assert_called_once_with(heiferI_num, breed, mock_animal_initializer)
+    mock_animal_initializer.get_heiferIs.assert_called_once_with(heiferI_num, breed)
+
+
+def test_get_heiferIIs(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _get_heiferIIs in file life_cycle.py"""
+    heiferII_num = 10
+    breed = 'HO'
+    days_born = 800
+    mock_heiferIIs = []
+    for i in range(heiferII_num):
+        mock_new_heiferII = mocker.MagicMock(autospec=HeiferII)
+        mock_new_heiferII.breed = breed
+        mock_new_heiferII.days_born = days_born
+        mock_heiferIIs.append(mock_new_heiferII)
+    mock_animal_initializer = mocker.MagicMock(autospec=AnimalInitialization)
+    mock_animal_initializer.get_heiferIIs.return_value = mock_heiferIIs
+    spy_get_heiferIIs = mocker.spy(life_cycle_manager, '_get_heiferIIs')
+
+    heiferIIs = life_cycle_manager._get_heiferIIs(heiferII_num, breed, mock_animal_initializer)
+
+    assert len(heiferIIs) == heiferII_num
+    for heiferII in heiferIIs:
+        assert heiferII.breed == breed
+        heiferII.events.add_event.assert_called_once_with(days_born, 0, INIT_HERD)
+
+    spy_get_heiferIIs.assert_called_once_with(heiferII_num, breed, mock_animal_initializer)
+    mock_animal_initializer.get_heiferIIs.assert_called_once_with(heiferII_num, breed)
+
+
+def test_get_heiferIIIs(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _get_heiferIIIs in file life_cycle.py"""
+    heiferIII_num = 10
+    breed = 'HO'
+    days_born = 650
+    mock_heiferIIIs = []
+    for i in range(heiferIII_num):
+        mock_new_heiferIII = mocker.MagicMock(autospec=HeiferIII)
+        mock_new_heiferIII.breed = breed
+        mock_new_heiferIII.days_born = days_born
+        mock_heiferIIIs.append(mock_new_heiferIII)
+    mock_animal_initializer = mocker.MagicMock(autospec=AnimalInitialization)
+    mock_animal_initializer.get_heiferIIIs.return_value = mock_heiferIIIs
+    spy_get_heiferIIIs = mocker.spy(life_cycle_manager, '_get_heiferIIIs')
+
+    heiferIIIs = life_cycle_manager._get_heiferIIIs(heiferIII_num, breed, mock_animal_initializer)
+
+    assert len(heiferIIIs) == heiferIII_num
+    for heiferIII in heiferIIIs:
+        assert heiferIII.breed == breed
+        heiferIII.events.add_event.assert_called_once_with(days_born, 0, INIT_HERD)
+
+    spy_get_heiferIIIs.assert_called_once_with(heiferIII_num, breed, mock_animal_initializer)
+    mock_animal_initializer.get_heiferIIIs.assert_called_once_with(heiferIII_num, breed)
+
+
+def test_get_cows(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _get_cows in file life_cycle.py"""
+    cow_num = 10
+    breed = 'HO'
+    days_born = 2200
+    mock_cows = []
+    for i in range(cow_num):
+        mock_new_cow = mocker.MagicMock(autospec=Cow)
+        mock_new_cow.breed = breed
+        mock_new_cow.days_born = days_born
+        mock_cows.append(mock_new_cow)
+    mock_animal_initializer = mocker.MagicMock(autospec=AnimalInitialization)
+    mock_animal_initializer.get_cows.return_value = mock_cows
+    spy_get_cows = mocker.spy(life_cycle_manager, '_get_cows')
+
+    cows = life_cycle_manager._get_cows(cow_num, breed, mock_animal_initializer)
+
+    assert len(cows) == cow_num
+    for cow in cows:
+        assert cow.breed == breed
+        cow.events.add_event.assert_called_once_with(days_born, 0, INIT_HERD)
+
+    spy_get_cows.assert_called_once_with(cow_num, breed, mock_animal_initializer)
+    mock_animal_initializer.get_cows.assert_called_once_with(cow_num, breed)
+
+
+def test_initialize_herd(mocker: MockerFixture, life_cycle_manager: LifeCycleManager,
+                         herd_data: HerdInfoTypedDict) -> None:
+    """Unit test for function initialize_herd in file life_cycle.py"""
+    herd_num = herd_data['herd_num']
+    calf_num = herd_data['calf_num']
+    heiferI_num = herd_data['heiferI_num']
+    heiferII_num = herd_data['heiferII_num']
+    heiferIII_num = herd_data['heiferIII_num']
+    cow_num = herd_data['cow_num']
+    replace_num = herd_data['replace_num']
+    herd_init = herd_data['herd_init']
+    breed = herd_data['breed']
+    mock_config = mocker.MagicMock(autospec=Config)
+
+    mock_animal_config = mocker.MagicMock(autospec=AnimalConfigTypedDict)
+    mocker.patch.object(life_cycle_manager, 'animal_config', mock_animal_config)
+
+    mock_animal_initializer = mocker.MagicMock(autospec=AnimalInitialization)
+    mock_replacement_cows = [mocker.MagicMock(autospec=Cow) for _ in range(replace_num)]
+    mock_animal_initializer.get_replacement_cows.return_value = mock_replacement_cows
+    mocker.patch('RUFAS.routines.animal.life_cycle.life_cycle.AnimalInitialization',
+                 return_value=mock_animal_initializer)
+
+    mock_set_avg_CI = mocker.patch.object(life_cycle_manager, '_set_avg_CI')
+    mock_get_calves = mocker.patch.object(life_cycle_manager, '_get_calves')
+    mock_get_heiferIs = mocker.patch.object(life_cycle_manager, '_get_heiferIs')
+    mock_get_heiferIIs = mocker.patch.object(life_cycle_manager, '_get_heiferIIs')
+    mock_get_heiferIIIs = mocker.patch.object(life_cycle_manager, '_get_heiferIIIs')
+    mock_get_cows = mocker.patch.object(life_cycle_manager, '_get_cows')
+
+    results = life_cycle_manager.initialize_herd(herd_num, calf_num, heiferI_num, heiferII_num,
+                                                 heiferIII_num, cow_num, replace_num, herd_init,
+                                                 breed, mock_config)
+
+    assert life_cycle_manager.herd_num == herd_data['herd_num']
+    mock_set_avg_CI.assert_called_once_with(mock_animal_config, mock_animal_initializer)
+    mock_get_calves.assert_called_once_with(calf_num, breed, mock_animal_initializer)
+    mock_get_heiferIs.assert_called_once_with(heiferI_num, breed, mock_animal_initializer)
+    mock_get_heiferIIs.assert_called_once_with(heiferII_num, breed, mock_animal_initializer)
+    mock_get_heiferIIIs.assert_called_once_with(heiferIII_num, breed, mock_animal_initializer)
+    mock_get_cows.assert_called_once_with(cow_num, breed, mock_animal_initializer)
+    mock_animal_initializer.get_replacement_cows.assert_called_once_with(replace_num, breed)
+    assert life_cycle_manager.replacement_market == mock_replacement_cows
+    assert len(results) == 5
+
+
+def test_reset_parity(life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _reset_parity in file life_cycle.py"""
+    parities = LifeCycleManager.num_cow_for_parity
+    preg_times = LifeCycleManager.avg_calving_to_preg_time
+    count_per_parity = 10
+    avg_calving_to_preg_time_default = 10.0
+    avg_age_for_parity_default = 200.0
+    avg_age_for_calving_default = 100.0
+    cow_num = len(parities) * count_per_parity
+    for parity in parities:
+        parities[parity] = count_per_parity
+        preg_times[parity] = avg_calving_to_preg_time_default
+        life_cycle_manager.percent_cow_for_parity[parity] = \
+            count_per_parity * 100 / cow_num
+        life_cycle_manager.avg_age_for_parity[parity] = avg_age_for_parity_default
+        life_cycle_manager.avg_age_for_calving[parity] = avg_age_for_calving_default
+
+    life_cycle_manager._reset_parity()
+
+    for parity in parities:
+        assert parities[parity] == 0
+        assert preg_times[parity] == 0
+        assert life_cycle_manager.percent_cow_for_parity[parity] == approx(0.0)
+        assert life_cycle_manager.avg_age_for_parity[parity] == approx(0.0)
+        assert life_cycle_manager.avg_age_for_calving[parity] == approx(0.0)
+
+
+def test_reset_cull_reason_stats(life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _reset_cull_reason_stats in file life_cycle.py"""
+    stats = LifeCycleManager.cull_reason_stats
+    num_reasons = len(stats)
+    count_per_reason = 10
+    life_cycle_manager.culled_cow_num = num_reasons * count_per_reason
+    for cull_reason in stats:
+        stats[cull_reason] = count_per_reason
+        life_cycle_manager.cull_reason_stats_percent[cull_reason] = \
+            count_per_reason * 100.0 / life_cycle_manager.culled_cow_num
+
+    life_cycle_manager._reset_cull_reason_stats()
+
+    for cull_reason in stats:
+        assert stats[cull_reason] == 0
+        assert life_cycle_manager.cull_reason_stats_percent[cull_reason] == approx(0.0)
+
+
+def test_wean_calf(mocker: MockerFixture) -> None:
+    """Unit test for function _wean_calf in file life_cycle.py"""
+    calf_body_weight_history = [10.0, 20.0]
+    calf_pen_history = [mocker.MagicMock(autospec=Pen) for _ in range(2)]
+
+    mock_calf = mocker.MagicMock(autospec=Calf)
+    mock_calf.body_weight_history = calf_body_weight_history
+    mock_calf.pen_history = calf_pen_history
+
+    mock_calf_vals = mocker.MagicMock(autospec=Dict)
+    mock_calf.get_calf_values.return_value = mock_calf_vals
+
+    heiferIs: List[HeiferI] = []
+    mock_new_heiferI = mocker.MagicMock(autospec=HeiferI)
+    mocker.patch('RUFAS.routines.animal.life_cycle.life_cycle.HeiferI',
+                 return_value=mock_new_heiferI)
+    LifeCycleManager._wean_calf(mock_calf, heiferIs)
+
+    mock_calf_vals.update.assert_called_once_with({
+        'body_weight_history': calf_body_weight_history,
+        'pen_history': calf_pen_history
+    })
+    assert len(heiferIs) == 1
+    assert heiferIs[0] == mock_new_heiferI  # check identity
+
+
+def test_calf_to_heiferI(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _calf_to_heiferI in file life_cycle.py"""
+    sim_day = 10
+    mock_weaned_calf = mocker.MagicMock(autospec=Calf)
+    mock_weaned_calf.update.return_value = True
+    mock_wean_calf = mocker.patch.object(life_cycle_manager, '_wean_calf')
+
+    mock_matured_calf = mocker.MagicMock(autospec=Calf)
+    mock_matured_calf.update.return_value = False
+    mock_matured_calf.mature_body_weight = mature_body_weight = 200.0
+
+    mock_calves: List[Calf] = [mock_weaned_calf, mock_matured_calf]
+    heiferIs: List[HeiferI] = []
+    life_cycle_manager.calf_num = 0
+    total_animal_num = 0
+    life_cycle_manager.avg_mature_body_weight = 0.0
+
+    new_total_animal_num = life_cycle_manager._calf_to_heiferI(sim_day, mock_calves, heiferIs, total_animal_num)
+
+    mock_weaned_calf.update.assert_called_once_with(sim_day)
+    mock_wean_calf.assert_called_once_with(mock_weaned_calf, heiferIs)
+
+    mock_matured_calf.update.assert_called_once_with(sim_day)
+    assert life_cycle_manager.calf_num == 1
+
+    assert len(mock_calves) == 1
+    assert mock_calves[0] == mock_matured_calf
+    assert new_total_animal_num == 1
+    assert life_cycle_manager.avg_mature_body_weight == approx(mature_body_weight)
+
+
+def test_move_heiferI_to_second_stage(mocker: MockerFixture) -> None:
+    """Unit test for function _move_heiferI_to_second_stage in file life_cycle.py"""
+    heiferI_body_weight_history = [30.0, 40.0]
+    heiferI_pen_history = [mocker.MagicMock(autospec=Pen) for _ in range(2)]
+
+    mock_heiferI = mocker.MagicMock(autospec=HeiferI)
+    mock_heiferI.body_weight_history = heiferI_body_weight_history
+    mock_heiferI.pen_history = heiferI_pen_history
+
+    mock_heiferI_vals = mocker.MagicMock(autospec=Dict)
+    mock_heiferI.get_heiferI_values.return_value = mock_heiferI_vals
+
+    heiferIIs: List[HeiferII] = []
+    mock_new_heiferII = mocker.MagicMock(autospec=HeiferII)
+    mocker.patch('RUFAS.routines.animal.life_cycle.life_cycle.HeiferII',
+                 return_value=mock_new_heiferII)
+
+    heifer_repro_method = 'TAI'
+    heifer_TAI_protocol = 'd5CG2P'
+    heifer_synchedED_protocol = '2P'
+    animal_base_config = {
+        "heifer_repro_method": heifer_repro_method,
+        "heifer_TAI_protocol": heifer_TAI_protocol,
+        "heifer_synchED_protocol": heifer_synchedED_protocol
+    }
+    mocker.patch('RUFAS.routines.animal.life_cycle.life_cycle.AnimalBase.config', animal_base_config)
+
+    LifeCycleManager._move_heiferI_to_second_stage(mock_heiferI, heiferIIs)
+
+    assert mock_heiferI_vals.update.mock_calls == [
+        mocker.call({
+            'body_weight_history': heiferI_body_weight_history,
+            'pen_history': heiferI_pen_history
+        }),
+        mocker.call(repro_program=heifer_repro_method),
+        mocker.call(tai_method_h=heifer_TAI_protocol),
+        mocker.call(synch_ed_method_h=heifer_synchedED_protocol)
+    ]
+
+    assert len(heiferIIs) == 1
+    assert heiferIIs[0] == mock_new_heiferII  # check identity
+
+
+def test_heiferI_to_heiferII(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _heiferI_to_heiferII in file life_cycle.py"""
+    sim_day = 100
+    mock_heiferI_second_stage = mocker.MagicMock(autospec=HeiferI)
+    mock_heiferI_second_stage.update.return_value = True
+    mock_move_heiferI_to_second_stage = mocker.patch.object(life_cycle_manager,
+                                                            '_move_heiferI_to_second_stage')
+
+    mock_matured_heiferI = mocker.MagicMock(autospec=HeiferI)
+    mock_matured_heiferI.update.return_value = False
+    mock_matured_heiferI.mature_body_weight = mature_body_weight = 400.0
+
+    mock_heiferIs: List[HeiferI] = [mock_heiferI_second_stage, mock_matured_heiferI]
+    mock_heiferIIs: List[HeiferII] = []
+    life_cycle_manager.heiferI_num = 0
+    total_animal_num = 0
+    life_cycle_manager.avg_mature_body_weight = 0.0
+
+    new_total_animal_num = life_cycle_manager._heiferI_to_heiferII(sim_day, mock_heiferIs,
+                                                                   mock_heiferIIs,
+                                                                   total_animal_num)
+
+    mock_heiferI_second_stage.update.assert_called_once_with(sim_day)
+    mock_move_heiferI_to_second_stage.assert_called_once_with(mock_heiferI_second_stage, mock_heiferIIs)
+
+    mock_matured_heiferI.update.assert_called_once_with(sim_day)
+    assert life_cycle_manager.heiferI_num == 1
+
+    assert len(mock_heiferIs) == 1
+    assert mock_heiferIs[0] == mock_matured_heiferI
+    assert new_total_animal_num == 1
+    assert life_cycle_manager.avg_mature_body_weight == approx(mature_body_weight)
+
+
+def test_move_heiferII_to_third_stage(mocker: MockerFixture) -> None:
+    """Unit test for function _move_heiferII_to_third_stage in file life_cycle.py"""
+    heiferII_body_weight_history = [50.0, 60.0]
+    heiferII_pen_history = [mocker.MagicMock(autospec=Pen) for _ in range(2)]
+    heiferII_conceptus_weight = 10.0
+    heiferII_calf_birth_weight = 20.0
+
+    mock_heiferII = mocker.MagicMock(autospec=HeiferII)
+    mock_heiferII.body_weight_history = heiferII_body_weight_history
+    mock_heiferII.pen_history = heiferII_pen_history
+    mock_heiferII.conceptus_weight = heiferII_conceptus_weight
+    mock_heiferII.calf_birth_weight = heiferII_calf_birth_weight
+
+    mock_heiferII_vals = mocker.MagicMock(autospec=Dict)
+    mock_heiferII.get_heiferII_values.return_value = mock_heiferII_vals
+
+    heiferIIIs: List[HeiferIII] = []
+    mock_new_heiferIII = mocker.MagicMock(autospec=HeiferIII)
+    mocker.patch('RUFAS.routines.animal.life_cycle.life_cycle.HeiferIII',
+                 return_value=mock_new_heiferIII)
+    LifeCycleManager._move_heiferII_to_third_stage(mock_heiferII, heiferIIIs)
+
+    mock_heiferII_vals.update.assert_called_once_with({
+        'body_weight_history': heiferII_body_weight_history,
+        'pen_history': heiferII_pen_history,
+        'conceptus_weight': heiferII_conceptus_weight,
+        'calf_birth_weight': heiferII_calf_birth_weight
+    })
+    assert len(heiferIIIs) == 1
+    assert heiferIIIs[0] == mock_new_heiferIII  # check identity
+
+
+def test_extract_repro_stats_from_heiferII(mocker: MockerFixture,
+                                           life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _extract_repro_stats_from_heiferII in file life_cycle.py"""
+    mock_data = {
+        'CIDR_count': 10,
+        'GnRH_injections': 20,
+        'PGF_injections': 30,
+        'preg_diagnoses': 40,
+        'semen_num': 50,
+        'AI_times': 60,
+        'ED_days': 70
+    }
+    mock_heiferII = mocker.MagicMock(autospec=HeiferII)
+    mock_heiferII.CIDR_count = mock_data['CIDR_count']
+    mock_heiferII.GnRH_injections = mock_data['GnRH_injections']
+    mock_heiferII.PGF_injections = mock_data['PGF_injections']
+    mock_heiferII.preg_diagnoses = mock_data['preg_diagnoses']
+    mock_heiferII.semen_num = mock_data['semen_num']
+    mock_heiferII.AI_times = mock_data['AI_times']
+    mock_heiferII.ED_days = mock_data['ED_days']
+
+    spy_extract_repro_stats = mocker.spy(life_cycle_manager, '_extract_repro_stats_from_heiferII')
+
+    # Before
+    assert life_cycle_manager.CIDR_count == 0
+    assert life_cycle_manager.GnRH_injection_num_h == 0
+    assert life_cycle_manager.PGF_injection_num_h == 0
+    assert life_cycle_manager.preg_check_num_h == 0
+    assert life_cycle_manager.semen_num_h == 0
+    assert life_cycle_manager.ai_num_h == 0
+    assert life_cycle_manager.ed_period_h == 0
+
+    life_cycle_manager._extract_repro_stats_from_heiferII(mock_heiferII)
+
+    # After
+    spy_extract_repro_stats.assert_called_once_with(mock_heiferII)
+    assert life_cycle_manager.CIDR_count == mock_data['CIDR_count']
+    assert life_cycle_manager.GnRH_injection_num_h == mock_data['GnRH_injections']
+    assert life_cycle_manager.PGF_injection_num_h == mock_data['PGF_injections']
+    assert life_cycle_manager.preg_check_num_h == mock_data['preg_diagnoses']
+    assert life_cycle_manager.semen_num_h == mock_data['semen_num']
+    assert life_cycle_manager.ai_num_h == mock_data['AI_times']
+    assert life_cycle_manager.ed_period_h == mock_data['ED_days']
+
+
+def test_keep_heiferII_as_pregnant(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _keep_heiferII_as_pregnant in file life_cycle.py"""
+    # Set up
+    mock_heiferII = mocker.MagicMock(autospec=HeiferII)
+    spy_extract_repro_stats = mocker.spy(life_cycle_manager, '_extract_repro_stats_from_heiferII')
+
+    total_animal_num = 10
+    life_cycle_manager.avg_mature_body_weight = 20.0
+    mock_heiferII.mature_body_weight = 42.0
+
+    preg_heifer_num = 10
+    life_cycle_manager.avg_breeding_to_preg_time = 20.0
+    mock_heiferII.breeding_to_preg_time = 42.0
+
+    # Before
+    assert life_cycle_manager.heiferII_num == 0
+    assert life_cycle_manager.avg_mature_body_weight == approx(20.0)
+    assert life_cycle_manager.avg_breeding_to_preg_time == approx(20.0)
+
+    # Act
+    result = life_cycle_manager._keep_heiferII_as_pregnant(mock_heiferII, total_animal_num, preg_heifer_num)
+    new_total_animal_num, new_preg_heifer_num = result
+
+    # After
+    assert life_cycle_manager.heiferII_num == 1
+    assert new_total_animal_num == 11
+    assert life_cycle_manager.avg_mature_body_weight == approx(22.0)
+    assert new_preg_heifer_num == 11
+    assert life_cycle_manager.avg_breeding_to_preg_time == approx(22.0)
+    spy_extract_repro_stats.assert_called_once()
+
+
+def test_heiferII_to_heiferIII(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _heiferII_to_heiferIII in file life_cycle.py"""
+    # Set up
+    sim_day = 300
+    mock_heiferII_cull_stage = mocker.MagicMock(autospec=HeiferII)
+    mock_heiferII_cull_stage.update.return_value = [True, False]  # cull_stage = True, third_stage = False
+    mock_heiferII_cull_stage.days_born = 100
+    life_cycle_manager.culled_heifer_num = 0
+    life_cycle_manager.avg_heifer_culling_age = 0.0
+    life_cycle_manager.culled_heifers = []
+
+    mock_heiferII_third_stage = mocker.MagicMock(autospec=HeiferII)
+    mock_heiferII_third_stage.update.return_value = [False, True]  # cull_stage = False, third_stage = True
+    mock_move_heiferII_to_third_stage = mocker.patch.object(life_cycle_manager,
+                                                            '_move_heiferII_to_third_stage')
+
+    mock_heiferII_pregnant_stage = mocker.MagicMock(autospec=HeiferII)
+    mock_heiferII_pregnant_stage.update.return_value = [False, False]  # cull_stage = False, third_stage = False
+    mock_keep_heiferII_as_pregnant = mocker.patch.object(life_cycle_manager,
+                                                         '_keep_heiferII_as_pregnant')
+    mock_keep_heiferII_as_pregnant.return_value = (1, 1)  # new_total_animal_num = 1, new_preg_heifer_num = 1
+    total_animal_num = 0
+    preg_heifer_num = 0
+
+    mock_heiferIIs: List[HeiferIII] = [mock_heiferII_cull_stage,
+                                       mock_heiferII_third_stage,
+                                       mock_heiferII_pregnant_stage]
+    mock_heiferIIIs: List[HeiferIII] = []
+
+    # Before
+    assert life_cycle_manager.culled_heifer_num == 0
+    assert life_cycle_manager.avg_heifer_culling_age == approx(0.0)
+    assert len(life_cycle_manager.culled_heifers) == 0
+
+    # Act
+    result = life_cycle_manager._heiferII_to_heiferIII(sim_day, mock_heiferIIs,
+                                                       mock_heiferIIIs, preg_heifer_num,
+                                                       total_animal_num)
+    new_total_animal_num, new_preg_heifer_num = result
+
+    # After
+    assert life_cycle_manager.culled_heifer_num == 1
+    assert life_cycle_manager.avg_heifer_culling_age == approx(100.0)
+    assert len(life_cycle_manager.culled_heifers) == 1
+    assert life_cycle_manager.culled_heifers[0] == mock_heiferII_cull_stage
+    mock_heiferII_cull_stage.update.assert_called_once_with(sim_day)
+
+    mock_move_heiferII_to_third_stage.assert_called_once_with(mock_heiferII_third_stage, mock_heiferIIIs)
+
+    mock_keep_heiferII_as_pregnant.assert_called_once_with(mock_heiferII_pregnant_stage,
+                                                           total_animal_num, preg_heifer_num)
+    assert new_total_animal_num == 1
+    assert new_preg_heifer_num == 1
+    assert len(mock_heiferIIs) == 1
+    assert mock_heiferIIs[0] == mock_heiferII_pregnant_stage
+
+
+def test_move_heiferIII_to_cow_stage(mocker: MockerFixture) -> None:
+    """Unit test for function _move_heiferIII_to_cow_stage in file life_cycle.py"""
+    # Arrange
+    heiferIII_body_weight_history = [30.0, 40.0]
+    heiferIII_pen_history = [mocker.MagicMock(autospec=Pen) for _ in range(2)]
+    heiferIII_conceptus_weight = 10.0
+    heiferIII_calf_birth_weight = 20.0
+
+    mock_heiferIII = mocker.MagicMock(autospec=HeiferIII)
+    mock_heiferIII.body_weight_history = heiferIII_body_weight_history
+    mock_heiferIII.pen_history = heiferIII_pen_history
+    mock_heiferIII.conceptus_weight = heiferIII_conceptus_weight
+    mock_heiferIII.calf_birth_weight = heiferIII_calf_birth_weight
+
+    mock_heiferIII_vals = mocker.MagicMock(autospec=Dict)
+    mock_heiferIII.get_heiferIII_values.return_value = mock_heiferIII_vals
+
+    cows: List[Cow] = []
+    mock_new_cow = mocker.MagicMock(autospec=Cow)
+    mocker.patch('RUFAS.routines.animal.life_cycle.life_cycle.Cow',
+                 return_value=mock_new_cow)
+
+    cow_repro_method = 'TAI'
+    cow_presynch_protocol = 'Double OvSynch'
+    cow_TAI_protocol = 'OvSynch 56'
+    cow_resynch_protocol = 'TAIafterPD'
+    animal_base_config = {
+        "cow_repro_method": cow_repro_method,
+        "cow_presynch_protocol": cow_presynch_protocol,
+        "cow_TAI_protocol": cow_TAI_protocol,
+        "cow_resynch_protocol": cow_resynch_protocol
+    }
+    mocker.patch('RUFAS.routines.animal.life_cycle.life_cycle.AnimalBase.config', animal_base_config)
+
+    # Act
+    LifeCycleManager._move_heiferIII_to_cow_stage(mock_heiferIII, cows)
+
+    # Assert
+    assert mock_heiferIII_vals.update.mock_calls == [
+        mocker.call({
+            'body_weight_history': heiferIII_body_weight_history,
+            'pen_history': heiferIII_pen_history,
+            'conceptus_weight': heiferIII_conceptus_weight,
+            'calf_birth_weight': heiferIII_calf_birth_weight
+        }),
+        mocker.call(repro_program=cow_repro_method),
+        mocker.call(presynch_method=cow_presynch_protocol),
+        mocker.call(tai_method_c=cow_TAI_protocol),
+        mocker.call(resynch_method=cow_resynch_protocol)
+    ]
+
+    assert len(cows) == 1
+    assert cows[0] == mock_new_cow  # check identity
+
+
+def test_heiferIII_to_cow(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _heiferIII_to_cow in file life_cycle.py"""
+    sim_day = 400
+    mock_heiferIII_cow_stage = mocker.MagicMock(autospec=HeiferIII)
+    mock_heiferIII_cow_stage.update.return_value = True
+    mock_move_heiferIII_to_cow_stage = mocker.patch.object(life_cycle_manager,
+                                                           '_move_heiferIII_to_cow_stage')
+
+    mock_matured_heiferIII = mocker.MagicMock(autospec=HeiferIII)
+    mock_matured_heiferIII.update.return_value = False
+    mock_matured_heiferIII.mature_body_weight = mature_body_weight = 600.0
+
+    mock_heiferIIIs: List[HeiferIII] = [mock_heiferIII_cow_stage, mock_matured_heiferIII]
+    mock_cows: List[Cow] = []
+    life_cycle_manager.heiferIII_num = 0
+    total_animal_num = 0
+    life_cycle_manager.avg_mature_body_weight = 0.0
+
+    # Assert before
+    assert life_cycle_manager.heiferIII_num == 0
+    assert total_animal_num == 0
+    assert life_cycle_manager.avg_mature_body_weight == approx(0.0)
+
+    # Act
+    new_total_animal_num = life_cycle_manager._heiferIII_to_cow(sim_day, mock_heiferIIIs,
+                                                                mock_cows,
+                                                                total_animal_num)
+
+    # Assert after
+    mock_heiferIII_cow_stage.update.assert_called_once_with(sim_day)
+    mock_move_heiferIII_to_cow_stage.assert_called_once_with(mock_heiferIII_cow_stage, mock_cows)
+
+    mock_matured_heiferIII.update.assert_called_once_with(sim_day)
+    assert life_cycle_manager.heiferIII_num == 1
+
+    assert len(mock_heiferIIIs) == 1
+    assert mock_heiferIIIs[0] == mock_matured_heiferIII
+    assert new_total_animal_num == 1
+    assert life_cycle_manager.avg_mature_body_weight == approx(mature_body_weight)
+
+
+def test_check_if_heifers_need_to_be_sold(mocker: MockerFixture,
+                                          life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _check_if_heifers_need_to_be_sold in file life_cycle.py"""
+
+    # Case 1: len(heiferIIIs) + len(cows) > herd_num * 1.03 AND len(heiferIIIs) > 0
+    # Arrange
+    life_cycle_manager.herd_num = 100
+    mock_heiferIIIs: List[HeiferIII] = []
+    for i in range(55):
+        mock_heiferIII = mocker.MagicMock(autospec=HeiferIII)
+        mock_heiferIII.id = i
+        mock_heiferIIIs.append(mock_heiferIII)
+    mock_cows: List[Cow] = [mocker.MagicMock(autospec=Cow)] * 50
+    ids_removed = []
+    life_cycle_manager.sold_heifers = []
+    life_cycle_manager.sold_heifer_num = 0
+
+    # Assert before
+    assert len(life_cycle_manager.sold_heifers) == 0
+    assert life_cycle_manager.sold_heifer_num == 0
+
+    # Act
+    life_cycle_manager._check_if_heifers_need_to_be_sold(mock_heiferIIIs, mock_cows, ids_removed)
+
+    # Assert after
+    assert len(mock_heiferIIIs) == 53
+    assert len(mock_cows) == 50
+    assert len(life_cycle_manager.sold_heifers) == 2
+    assert life_cycle_manager.sold_heifer_num == 2
+    assert ids_removed == [54, 53]
+    # ---------------------------------------------------------------
+
+    # Case 2: len(heiferIIIs) + len(cows) <= herd_num * 1.03
+    # Arrange
+    life_cycle_manager.herd_num = 100
+    mock_heiferIIIs: List[HeiferIII] = []
+    for i in range(53):
+        mock_heiferIII = mocker.MagicMock(autospec=HeiferIII)
+        mock_heiferIII.id = i
+        mock_heiferIIIs.append(mock_heiferIII)
+    mock_cows: List[Cow] = [mocker.MagicMock(autospec=Cow)] * 50
+    ids_removed = []
+    life_cycle_manager.sold_heifers = []
+    life_cycle_manager.sold_heifer_num = 0
+
+    # Assert before
+    assert len(life_cycle_manager.sold_heifers) == 0
+    assert life_cycle_manager.sold_heifer_num == 0
+
+    # Act
+    life_cycle_manager._check_if_heifers_need_to_be_sold(mock_heiferIIIs, mock_cows, ids_removed)
+
+    # Assert after
+    assert len(mock_heiferIIIs) == 53
+    assert len(mock_cows) == 50
+    assert len(life_cycle_manager.sold_heifers) == 0
+    assert life_cycle_manager.sold_heifer_num == 0
+    assert len(ids_removed) == 0
+    # ---------------------------------------------------------------
+
+    # Case 3: len(heiferIIIs) == 0
+    # Arrange
+    life_cycle_manager.herd_num = 100
+    mock_heiferIIIs: List[HeiferIII] = []
+    mock_cows: List[Cow] = [mocker.MagicMock(autospec=Cow)] * 104
+    ids_removed = []
+    life_cycle_manager.sold_heifers = []
+    life_cycle_manager.sold_heifer_num = 0
+
+    # Assert before
+    assert len(life_cycle_manager.sold_heifers) == 0
+    assert life_cycle_manager.sold_heifer_num == 0
+
+    # Act
+    life_cycle_manager._check_if_heifers_need_to_be_sold(mock_heiferIIIs, mock_cows, ids_removed)
+
+    # Assert after
+    assert len(mock_heiferIIIs) == 0
+    assert len(mock_cows) == 104
+    assert len(life_cycle_manager.sold_heifers) == 0
+    assert life_cycle_manager.sold_heifer_num == 0
+    assert len(ids_removed) == 0
+
+
+def test_check_if_replacement_heifers_needed(mocker: MockerFixture,
+                                             life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _check_if_replacement_heifers_needed in file life_cycle.py"""
+
+    # Case 1: len(cows) + len(heiferIIIs) + bought_heifer_num < herd_num * 1.01 AND sim_day > 1
+    # Arrange
+    sim_day = 100
+    days_born = 30
+    mock_heiferIIIs: List[HeiferIII] = [mocker.MagicMock(autospec=HeiferIII)] * 50
+    mock_cows: List[Cow] = [mocker.MagicMock(autospec=Cow)] * 50
+    animals_added = []
+    life_cycle_manager.bought_heifer_num = 0
+    life_cycle_manager.herd_num = 100
+
+    life_cycle_manager.replacement_market = []
+    for i in range(10):
+        mock_replacement = mocker.MagicMock(autospec=Cow)
+        mock_replacement.id = i
+        mock_replacement.days_born = days_born
+        life_cycle_manager.replacement_market.append(mock_replacement)
+
+    # Assert before
+    assert life_cycle_manager.bought_heifer_num == 0
+
+    # Act
+    life_cycle_manager._check_if_replacement_heifers_needed(sim_day, mock_heiferIIIs,
+                                                            mock_cows, animals_added)
+
+    # Assert after
+    assert life_cycle_manager.bought_heifer_num == 1
+    assert len(animals_added) == 1
+    assert animals_added[0].id == 0
+    animals_added[0].events.add_event.assert_called_once_with(days_born, sim_day, ENTER_HERD)
+    animals_added[0].set_p_purchased.assert_called_once()
+    # ---------------------------------------------------------------
+
+    # Case 2: len(cows) + len(heiferIIIs) + bought_heifer_num >= herd_num * 1.01
+    # Arrange
+    sim_day = 100
+    days_born = 30
+    mock_heiferIIIs: List[HeiferIII] = [mocker.MagicMock(autospec=HeiferIII)] * 51
+    mock_cows: List[Cow] = [mocker.MagicMock(autospec=Cow)] * 50
+    animals_added = []
+    life_cycle_manager.bought_heifer_num = 0
+    life_cycle_manager.herd_num = 100
+
+    life_cycle_manager.replacement_market = []
+    for i in range(10):
+        mock_replacement = mocker.MagicMock(autospec=Cow)
+        mock_replacement.id = i
+        mock_replacement.days_born = days_born
+        life_cycle_manager.replacement_market.append(mock_replacement)
+
+    # Assert before
+    assert life_cycle_manager.bought_heifer_num == 0
+
+    # Act
+    life_cycle_manager._check_if_replacement_heifers_needed(sim_day, mock_heiferIIIs,
+                                                            mock_cows, animals_added)
+
+    # Assert after
+    assert life_cycle_manager.bought_heifer_num == 0
+    assert len(mock_heiferIIIs) == 51
+    assert len(mock_cows) == 50
+    assert len(animals_added) == 0
+    # ---------------------------------------------------------------
+
+    # Case 3: sim_day == 1
+    # Arrange
+    sim_day = 1
+    days_born = 30
+    mock_heiferIIIs: List[HeiferIII] = [mocker.MagicMock(autospec=HeiferIII)] * 50
+    mock_cows: List[Cow] = [mocker.MagicMock(autospec=Cow)] * 50
+    animals_added = []
+    life_cycle_manager.bought_heifer_num = 0
+    life_cycle_manager.herd_num = 100
+
+    life_cycle_manager.replacement_market = []
+    for i in range(10):
+        mock_replacement = mocker.MagicMock(autospec=Cow)
+        mock_replacement.id = i
+        mock_replacement.days_born = days_born
+        life_cycle_manager.replacement_market.append(mock_replacement)
+
+    # Assert before
+    assert life_cycle_manager.bought_heifer_num == 0
+
+    # Act
+    life_cycle_manager._check_if_replacement_heifers_needed(sim_day, mock_heiferIIIs,
+                                                            mock_cows, animals_added)
+
+    # Assert after
+    assert life_cycle_manager.bought_heifer_num == 0
+    assert len(mock_heiferIIIs) == 50
+    assert len(mock_cows) == 50
+    assert len(animals_added) == 0
+
+
+def test_cull_cow(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
+    """Unit test for function _cull_cow in file life_cycle.py"""
+
+    # Arrange
+    mock_cow: Cow = mocker.MagicMock(autospec=Cow)
+    mock_cow.cull_reason = LOW_PROD_CULL
+    life_cycle_manager.culled_cows = []
+    life_cycle_manager.cull_reason_stats_range = collections.defaultdict(int)
+    life_cycle_manager._reset_cull_reason_stats()
+
+    parity = 3
+    mock_cow.calves = parity
+    life_cycle_manager.parity_culling_stats_range = collections.defaultdict(int)
+
+    mock_cow.days_born = 100
+    life_cycle_manager.culled_cow_num = 0
+    life_cycle_manager.avg_cow_culling_age = 0
+
+    # Assert before
+    assert len(life_cycle_manager.culled_cows) == 0
+    assert len(life_cycle_manager.cull_reason_stats_range) == 0
+    assert LifeCycleManager.cull_reason_stats[LOW_PROD_CULL] == 0
+    assert len(life_cycle_manager.parity_culling_stats_range) == 0
+
+    # Act
+    life_cycle_manager._cull_cow(mock_cow)
+
+    # Assert
+    assert len(life_cycle_manager.culled_cows) == 1
+    assert len(life_cycle_manager.cull_reason_stats_range) == 1
+    assert LOW_PROD_CULL in life_cycle_manager.cull_reason_stats_range
+    assert life_cycle_manager.cull_reason_stats_range[LOW_PROD_CULL] == 1
+    assert LifeCycleManager.cull_reason_stats[LOW_PROD_CULL] == 1
+
+    assert len(life_cycle_manager.parity_culling_stats_range) == 1
+    assert parity in life_cycle_manager.parity_culling_stats_range
+    assert life_cycle_manager.parity_culling_stats_range[parity] == 1
+
+    assert life_cycle_manager.culled_cow_num == 1
+    assert life_cycle_manager.avg_cow_culling_age == approx(100.0)
+
+
+def test_handle_cow_body_weight():
+    pass
+
+
+def test_handle_cow_milking():
+    pass
+
+
+def test__handle_cow_days_in_milk():
+    pass
+
+
+def test_handle_cow_days_in_preg():
+    pass
+
+
+def test_handle_cow_calves():
+    pass
+
+
+def test_handle_cow_ci():
+    pass
+
+
+def test_extract_repro_stats_from_cow():
+    pass
+
+
+def test_handle_new_born():
+    pass
+
+
+def test__cull_cows_and_record_stats(mocker: MockerFixture, life_cycle_manager: LifeCycleManager) -> None:
+    pass


### PR DESCRIPTION
Some notes about the main changes in this PR:
- `life_cycle.py`: This refactoring focuses on breaking up the two main functions `initialize_herd` and `daily_update` into smaller, more manageable, and testable private functions. 
- `animal_typed_dicts.py`: list of dictionaries that mirror what we have in the animal config json. The main purpose is to enable type-checking and make sure we don't use an undeclared key.
- `clustering_pen_grouping`: there seems to be an occasional numerical error when comparing percentages. For example, 1.00000000000002 is supposed to be equal to 1.0, but due to rounding errors or inherent imperfect representation of floating point numbers, they are unequal. So one way to fix that is to check the absolute difference between the two numbers and compare it to a tolerance level. There is a helper function for this: `math.isclose(x, y, rel_tol=1e-09)`