### PR TITLE
command line functionality with option to suppress graphics production

### DIFF
--- a/RUFAS/__init__.py
+++ b/RUFAS/__init__.py
@@ -1,2 +1,2 @@
-from .user_prompt import input_prompt
+from .user_prompt import user_prompt
 from .simulation_engine import SimulationEngine

--- a/RUFAS/__init__.py
+++ b/RUFAS/__init__.py
@@ -1,2 +1,1 @@
-from .user_prompt import user_prompt
 from .simulation_engine import SimulationEngine

--- a/RUFAS/output_handler/reports/base_report.py
+++ b/RUFAS/output_handler/reports/base_report.py
@@ -8,6 +8,7 @@ Author(s): William Donovan wmdonovan@wisc.edu
 import csv
 from pathlib import Path
 
+import config.global_variables
 from .. import graphics
 
 
@@ -22,8 +23,10 @@ class BaseReport:
         the data passed to it and assigns the properties below.
         """
 
+        _suppress_graphics = config.global_variables.SUPPRESS_GRAPHICS
+
         self.produce_csv = data['produce_csv']
-        self.produce_graphics = data['produce_graphics']
+        self.produce_graphics = data['produce_graphics'] if not _suppress_graphics else False
         self.report_name = data['report_name']
         self.file_name = self.report_name + '.csv'
         self.annual_file_name = self.report_name + '_annual.csv'

--- a/RUFAS/output_handler/reports/base_report.py
+++ b/RUFAS/output_handler/reports/base_report.py
@@ -23,10 +23,8 @@ class BaseReport:
         the data passed to it and assigns the properties below.
         """
 
-        _suppress_graphics = config.global_variables.SUPPRESS_GRAPHICS
-
         self.produce_csv = data['produce_csv']
-        self.produce_graphics = data['produce_graphics'] if not _suppress_graphics else False
+        self.produce_graphics = data['produce_graphics'] if config.global_variables.PRODUCE_GRAPHICS else False
         self.report_name = data['report_name']
         self.file_name = self.report_name + '.csv'
         self.annual_file_name = self.report_name + '_annual.csv'

--- a/RUFAS/simulation_engine.py
+++ b/RUFAS/simulation_engine.py
@@ -37,7 +37,7 @@ class SimulationEngine:
         print("Simulation Successful")
         print(f"Total Simulation Time: {t_end_sim - t_start_sim} seconds")
 
-        if not config.global_variables.SUPPRESS_GRAPHICS:
+        if config.global_variables.PRODUCE_GRAPHICS:
             sys.stdout.write('Producing Graphics\n')
             t_start_graphics = timer.time()
             self.output.produce_graphics()
@@ -61,7 +61,7 @@ class SimulationEngine:
         """
         Shows the messages of the end of the simulation
         """
-        if not config.global_variables.SUPPRESS_GRAPHICS:
+        if config.global_variables.PRODUCE_GRAPHICS:
             sys.stdout.write(f"Time to produce graphics: {graphics_prod_time}\n")
             sys.stdout.write(f"Output Successful.\nGraphics stored in: {self.config.graphic_dir}\n")
             sys.stdout.write(f"Total Run Time: {total_runtime} seconds\n")

--- a/RUFAS/simulation_engine.py
+++ b/RUFAS/simulation_engine.py
@@ -3,6 +3,8 @@
 import sys
 import time as timer
 from pathlib import Path
+
+import config.global_variables
 from RUFAS import routines, errors
 from RUFAS.classes import Config, State, Weather, Time
 from RUFAS.output_handler import OutputHandler
@@ -35,14 +37,16 @@ class SimulationEngine:
         print("Simulation Successful")
         print(f"Total Simulation Time: {t_end_sim - t_start_sim} seconds")
 
-        t_start_graphics = timer.time()
-        sys.stdout.write('Producing Graphics\n')
-        self.output.produce_graphics()
-        t_end_graphics = timer.time()
+        if not config.global_variables.SUPPRESS_GRAPHICS:
+            sys.stdout.write('Producing Graphics\n')
+            t_start_graphics = timer.time()
+            self.output.produce_graphics()
+            t_end_graphics = timer.time()
+            graphics_prod_time = t_end_graphics - t_start_graphics
+        else:
+            graphics_prod_time = 0
 
-        graphics_prod_time = t_end_graphics - t_start_graphics
-        total_runtime = (t_end_sim-t_start_sim) + \
-            (t_end_graphics-t_start_graphics)
+        total_runtime = (t_end_sim - t_start_sim) + graphics_prod_time
         self._show_final_messages(graphics_prod_time, total_runtime)
 
     def _run_simulation_main_loop(self) -> None:
@@ -57,10 +61,10 @@ class SimulationEngine:
         """
         Shows the messages of the end of the simulation
         """
-        sys.stdout.write(
-            f"Output Successful.\nGraphics stored in: {self.config.graphic_dir}\n")
-        sys.stdout.write(f"Time to produce graphics: {graphics_prod_time}\n")
-        sys.stdout.write(f"Total Run Time: {total_runtime} seconds\n")
+        if not config.global_variables.SUPPRESS_GRAPHICS:
+            sys.stdout.write(f"Time to produce graphics: {graphics_prod_time}\n")
+            sys.stdout.write(f"Output Successful.\nGraphics stored in: {self.config.graphic_dir}\n")
+            sys.stdout.write(f"Total Run Time: {total_runtime} seconds\n")
 
     def _daily_simulation(self) -> None:
         """Executes the daily simulation routines."""

--- a/RUFAS/user_prompt.py
+++ b/RUFAS/user_prompt.py
@@ -100,7 +100,7 @@ def get_json_list_from_dir(dir_path: Path, verbose: bool) -> list[Path]:
         raise FileExistsError("Directory contains no json files")
     else:
         if verbose:
-            print(str(len(json_paths)) + "json files detected...\n")
+            print(str(len(json_paths)) + " json files detected...\n")
         return json_paths
 
 

--- a/RUFAS/user_prompt.py
+++ b/RUFAS/user_prompt.py
@@ -7,9 +7,17 @@ Author(s): Kass Chupongstimun, kass_c@hotmail.com
 
 import sys
 from pathlib import Path
-
 from RUFAS import util, errors
 import fileReader
+import config.global_variables
+
+
+def get_files_from_input(path=None, verbose=True):
+    if path is None:
+        out = input_prompt()
+    else:
+        out = handle_input_file(path, verbose)
+    return out
 
 
 def input_prompt():
@@ -32,6 +40,59 @@ def input_prompt():
             The list could contain only 1 or multiple paths.
     """
 
+    user_input = accept_path_from_prompt()
+    formatted_input = handle_input_file(path=user_input)
+    return formatted_input
+
+
+def handle_input_file(path="input/ARL.json", verbose=True):
+    """ Converts a file path string into usable file path objects (from pathlib package)
+
+    Args:
+        path: The path to an input file (.json or .txt) or a directory containing .json files
+        verbose: bool indicating whether to print progress messages
+
+    Returns: a list of OS-specific files
+
+    """
+
+    # check for global message flag
+    be_verbose = False if not config.global_variables.PRINT_STATUS_MESSAGES else verbose
+
+    input_path = Path(str(path).strip())
+
+    if input_path.suffix == '.txt':
+        if not input_path.is_file():
+            raise errors.UserInput("Specified file does not exist")
+        elif be_verbose:
+            print("commented json file detected, stripping comments...\n")
+        json_filename = fileReader.convert_to_json(str(input_path))
+        json_path = Path(json_filename.strip())
+        return [json_path]
+
+    if input_path.suffix == '.json':
+        if not input_path.is_file():
+            raise errors.UserInput("Specified file does not exist")
+        elif be_verbose:
+            print("json file detected...\n")
+        return [input_path]
+
+    elif input_path.is_dir():
+        # Grab all json files in dir
+        path_list = list(input_path.glob('*.json'))
+        # Handle no json files in dir
+        if len(path_list) < 1:
+            raise errors.UserInput("Directory contains no json files")
+        else:
+            print(str(len(path_list)) + " json files detected...\n")
+            return path_list
+
+    else:
+        raise errors.UserInput("Invalid Input")
+
+
+def accept_path_from_prompt():
+
     print("\nSingle Simulation:\n\t" +
           "Enter a json file name\n" +
           "Batch Simulation:\n\t" +
@@ -45,65 +106,23 @@ def input_prompt():
 
         try:
             user_input = 'input/' + input("\nEnter RUFAS Input: ")
-            #
-            # Handle user exiting program
-            #
+
             if user_input.upper() == 'Q':
                 print("Exiting RUFAS...")
                 sys.exit()
 
-            #
-            # Handle print base directory
-            #
             elif user_input.lower() == 'dir':
                 print(str(util.get_base_dir()))
                 continue
 
-            input_path = Path(user_input.strip())
-
-            #
-            # Handle commented json text file input
-            #
-            if input_path.suffix == '.txt':
-                if not input_path.is_file():
-                    raise errors.UserInput("Specified file does not exist")
-                else:
-                    print("commented json file detected, stripping comments...\n")
-                json_filename = fileReader.convert_to_json(str(input_path))
-                json_path = Path(json_filename.strip())
-                return [json_path]
-
-            #
-            # Handle single json file input
-            #
-            if input_path.suffix == '.json':
-                if not input_path.is_file():
-                    raise errors.UserInput("Specified file does not exist")
-                else:
-                    print("json file detected...\n")
-                return [input_path]
-
-            #
-            # Handle directory of json files input
-            #
-            elif input_path.is_dir():
-                # Grab all json files in dir
-                path_list = list(input_path.glob('*.json'))
-                # Handle no json files in dir
-                if len(path_list) < 1:
-                    raise errors.UserInput("Directory contains no json files")
-                else:
-                    print(str(len(path_list)) + " json files detected...\n")
-                    return path_list
-
-            #
-            # Handle bad input
-            #
-            else:
-                raise errors.UserInput("Invalid Input")
-
-        #
-        # Handles bad user input, prints out error messages
-        #
+            return user_input
         except errors.UserInput as e:
             print(e.msg)
+
+
+# ToDo make tests. The following should work (from RUFAS/ dir)
+# handle_input_file("../input/ARL.json")
+# handle_input_file("../input/ARL.json", verbose=False)
+# handle_input_file("../input/")
+# handle_input_file(path=accept_path_from_prompt())
+# input_prompt()

--- a/RUFAS/user_prompt.py
+++ b/RUFAS/user_prompt.py
@@ -64,7 +64,10 @@ def convert_path_string_to_list(path: str, verbose: bool = True):
     """
     input_path = Path(str(path).strip())
 
-    if input_path.suffix == '.txt':  # TODO: Deprecated - GitHub Issue #210
+    if input_path.is_dir():
+        return get_json_list_from_dir(input_path, verbose)
+
+    elif input_path.suffix == '.txt':  # TODO: Deprecated - GitHub Issue #210
         Warning("ability to use .txt files is deprecated. Please use .json input files in the future")
         if not input_path.is_file():
             raise errors.UserInput("Specified file does not exist")
@@ -74,11 +77,8 @@ def convert_path_string_to_list(path: str, verbose: bool = True):
         json_path = Path(json_filename.strip())
         return [json_path]
 
-    if input_path.suffix == '.json':
+    elif input_path.suffix == '.json':
         return convert_json_path_to_list(input_path, verbose)
-
-    elif input_path.is_dir():
-        return get_json_list_from_dir(input_path, verbose)
 
     else:
         raise ValueError("Invalid input path")

--- a/RUFAS/user_prompt.py
+++ b/RUFAS/user_prompt.py
@@ -9,7 +9,6 @@ import sys
 from pathlib import Path
 from RUFAS import util, errors
 import fileReader
-import config.global_variables
 
 
 def obtain_file_list(path=None, verbose: bool = True) -> list[Path]:
@@ -66,11 +65,11 @@ def convert_path_string_to_list(path: str, verbose: bool = True):
         Warning("ability to use .txt files is deprecated. Please use .json input files in the future")
         if not input_path.is_file():
             raise errors.UserInput("Specified file does not exist")
-        if verbose: print("commented json file detected, stripping comments...\n")
+        if verbose:
+            print("commented json file detected, stripping comments...\n")
         json_filename = fileReader.convert_to_json(str(input_path))
         json_path = Path(json_filename.strip())
         return [json_path]
-
 
     if input_path.suffix == '.json':
         return convert_json_path_to_list(input_path, verbose)
@@ -113,7 +112,8 @@ def convert_json_path_to_list(json_path: Path, verbose: bool) -> list[Path]:
     if not json_path.is_file():
         raise errors.UserInput("Specified file does not exist")
 
-    if verbose: print("json file detected... \n")
+    if verbose:
+        print("json file detected... \n")
 
     return [json_path]
 

--- a/RUFAS/user_prompt.py
+++ b/RUFAS/user_prompt.py
@@ -12,92 +12,124 @@ import fileReader
 import config.global_variables
 
 
-def get_files_from_input(path=None, verbose=True):
-    if path is None:
-        out = input_prompt()
-    else:
-        out = handle_input_file(path, verbose)
-    return out
+def obtain_file_list(path=None, verbose: bool = True) -> list[Path]:
+    """
+    Description: obtains a json file list, usable by RuFaS, from the user. The location of the files is given
+    directly as a path string, or as a response to an input prompt.
 
-
-def input_prompt():
-    """Prompts the user for an input to RUFAS.
-
-    Prompts the user for an input path that could either be a path to a json
-    file (for a single simulation mode) or a path to a directory containing one
-    or more json files (for a batch simulation).
-    Loops back to the prompt until the user either chooses to quit or enters a
-    valid input.
-    Valid input are:
-        Valid path to a json file: single simulation mode
-        Valid path to directory of json files: batch simulation mode
-        'Q' or 'q': quit the program
-        'dir': prints the program's current working directory
+    Args:
+         path: a path (absolute or relative) to the file or directory to be used.
+         verbose: should messages containing details be printed?
 
     Returns:
-        list[Path]: A list of Path objects containing the Paths to the json
-            files from which the program will draw data for the simulation.
-            The list could contain only 1 or multiple paths.
-    """
+          a list of file Paths
 
-    user_input = accept_path_from_prompt()
-    formatted_input = handle_input_file(path=user_input)
+    Details: If path=None, the user will be prompted to provide a path with user_prompt()
+    """
+    if path is None:
+        path_list = user_prompt()
+    else:
+        path_list = convert_path_string_to_list(path, verbose)
+    return path_list
+
+
+def user_prompt() -> list[Path]:
+    """
+    Description: prompts the user for an input path to RuFaS data.
+
+    Details: User input is passed to convert_path_string_to_list
+
+    Returns: A list of paths to json input files
+    """
+    user_input = prompt_user_for_input()
+    formatted_input = convert_path_string_to_list(path=user_input)
     return formatted_input
 
 
-def handle_input_file(path="input/ARL.json", verbose=True):
-    """ Converts a file path string into usable file path objects (from pathlib package)
+def convert_path_string_to_list(path: str, verbose: bool = True):
+    """
+    Description: converts a file path string into list of file paths
 
     Args:
-        path: The path to an input file (.json or .txt) or a directory containing .json files
-        verbose: bool indicating whether to print progress messages
+        path: The path (relative or absolute) to an input json file or a directory containing .json files
+        verbose: should progress messages be printed?
 
     Returns: a list of OS-specific files
 
+    Details: If a path to a json file is given, it is converted to a Path list with convert_json_path_to_list(). If a
+    path to a directory is given, a Path list pointing to json files within the directory is retrieved with
+    get_json_list_from_dir().
     """
-
-    # check for global message flag
-    be_verbose = False if not config.global_variables.PRINT_STATUS_MESSAGES else verbose
-
     input_path = Path(str(path).strip())
 
-    if input_path.suffix == '.txt':
+    if input_path.suffix == '.txt':  # TODO: Deprecated - GitHub Issue #210
+        Warning("ability to use .txt files is deprecated. Please use .json input files in the future")
         if not input_path.is_file():
             raise errors.UserInput("Specified file does not exist")
-        elif be_verbose:
-            print("commented json file detected, stripping comments...\n")
+        if verbose: print("commented json file detected, stripping comments...\n")
         json_filename = fileReader.convert_to_json(str(input_path))
         json_path = Path(json_filename.strip())
         return [json_path]
 
+
     if input_path.suffix == '.json':
-        if not input_path.is_file():
-            raise errors.UserInput("Specified file does not exist")
-        elif be_verbose:
-            print("json file detected...\n")
-        return [input_path]
+        return convert_json_path_to_list(input_path, verbose)
 
     elif input_path.is_dir():
-        # Grab all json files in dir
-        path_list = list(input_path.glob('*.json'))
-        # Handle no json files in dir
-        if len(path_list) < 1:
-            raise errors.UserInput("Directory contains no json files")
-        else:
-            print(str(len(path_list)) + " json files detected...\n")
-            return path_list
+        return get_json_list_from_dir(input_path, verbose)
 
     else:
-        raise errors.UserInput("Invalid Input")
+        raise ValueError("Invalid input path")
 
 
-def accept_path_from_prompt():
+def get_json_list_from_dir(dir_path: Path, verbose: bool) -> list[Path]:
+    """gets a list of all json files contained in a directory.
 
+    Details: throws an error if the directory does not exist or if not json files are found.
+
+    Args:
+         dir_path: path to search for json files
+         verbose: should status messages be printed?
+
+    Returns: a list of json files (as libpath.Path objects)
+    """
+    if not dir_path.is_dir():
+        raise IsADirectoryError("specified path is not a directory")
+
+    json_paths = list(dir_path.glob("*.json"))
+    if len(json_paths) < 1:
+        raise FileExistsError("Directory contains no json files")
+    else:
+        if verbose:
+            print(str(len(json_paths)) + "json files detected...\n")
+        return json_paths
+
+
+def convert_json_path_to_list(json_path: Path, verbose: bool) -> list[Path]:
+    """converts a path to a json file into a list of libpath.Path objects
+
+    Details: throws an error if the file is not found.
+    """
+    if not json_path.is_file():
+        raise errors.UserInput("Specified file does not exist")
+
+    if verbose: print("json file detected... \n")
+
+    return [json_path]
+
+
+def prompt_user_for_input() -> str:
+    """prompts a user for RuFaS input
+
+    Details: the user is prompted with a message giving them options for input. Input can be a path string,
+    the letter 'Q' to quit by calling sys.exit(), or 'dir' to print the directory with util.get_base_dir()
+
+    Returns: the user input, as a string"""
     print("\nSingle Simulation:\n\t" +
           "Enter a json file name\n" +
           "Batch Simulation:\n\t" +
           "Enter a directory containing json files\n" +
-          "Print Base Directory:\n\t" +
+          "Print Base Directory:\n\t" +  # TODO: neither "dir" nor "Q/q" work at all - GitHub Issue #208
           "Enter \'dir\'\n" +
           "Exit RUFAS:\n\t" +
           "Enter \'Q\' or \'q\'")
@@ -112,17 +144,16 @@ def accept_path_from_prompt():
                 sys.exit()
 
             elif user_input.lower() == 'dir':
-                print(str(util.get_base_dir()))
+                print(str(util.get_base_dir()))  # TODO: No such function, likely cause of GitHub Issue #208
                 continue
 
             return user_input
         except errors.UserInput as e:
             print(e.msg)
 
-
-# ToDo make tests. The following should work (from RUFAS/ dir)
-# handle_input_file("../input/ARL.json")
-# handle_input_file("../input/ARL.json", verbose=False)
-# handle_input_file("../input/")
-# handle_input_file(path=accept_path_from_prompt())
+# TODO make tests. The following should work (from RUFAS/ dir) - GitHub Issue #209
+# convert_path_string_to_list("../input/ARL.json")
+# convert_path_string_to_list("../input/ARL.json", verbose=False)
+# convert_path_string_to_list("../input/")
+# convert_path_string_to_list(path=prompt_user_for_input())
 # input_prompt()

--- a/RUFAS/user_prompt.py
+++ b/RUFAS/user_prompt.py
@@ -7,11 +7,14 @@ Author(s): Kass Chupongstimun, kass_c@hotmail.com
 
 import sys
 from pathlib import Path
-from RUFAS import util, errors
+from typing import List
+
 import fileReader
+from RUFAS import errors
+from RUFAS.util import Utility
 
 
-def obtain_file_list(path=None, verbose: bool = True) -> list[Path]:
+def obtain_file_list(path=None, verbose: bool = True) -> List[Path]:
     """
     Description: obtains a json file list, usable by RuFaS, from the user. The location of the files is given
     directly as a path string, or as a response to an input prompt.
@@ -32,7 +35,7 @@ def obtain_file_list(path=None, verbose: bool = True) -> list[Path]:
     return path_list
 
 
-def user_prompt() -> list[Path]:
+def user_prompt() -> List[Path]:
     """
     Description: prompts the user for an input path to RuFaS data.
 
@@ -81,7 +84,7 @@ def convert_path_string_to_list(path: str, verbose: bool = True):
         raise ValueError("Invalid input path")
 
 
-def get_json_list_from_dir(dir_path: Path, verbose: bool) -> list[Path]:
+def get_json_list_from_dir(dir_path: Path, verbose: bool) -> List[Path]:
     """gets a list of all json files contained in a directory.
 
     Details: throws an error if the directory does not exist or if not json files are found.
@@ -104,7 +107,7 @@ def get_json_list_from_dir(dir_path: Path, verbose: bool) -> list[Path]:
         return json_paths
 
 
-def convert_json_path_to_list(json_path: Path, verbose: bool) -> list[Path]:
+def convert_json_path_to_list(json_path: Path, verbose: bool) -> List[Path]:
     """converts a path to a json file into a list of libpath.Path objects
 
     Details: throws an error if the file is not found.
@@ -134,22 +137,23 @@ def prompt_user_for_input() -> str:
           "Exit RUFAS:\n\t" +
           "Enter \'Q\' or \'q\'")
 
-    while True:
+    try:
+        rel_root = 'input/'
 
-        try:
-            user_input = 'input/' + input("\nEnter RUFAS Input: ")
+        user_input = input("\nEnter RUFAS Input: ")
 
-            if user_input.upper() == 'Q':
-                print("Exiting RUFAS...")
-                sys.exit()
+        while user_input == 'dir':
+            print(str(Utility.get_base_dir()))
+            user_input = input("\nEnter RUFAS Input: ")
 
-            elif user_input.lower() == 'dir':
-                print(str(util.get_base_dir()))  # TODO: No such function, likely cause of GitHub Issue #208
-                continue
+        if user_input.upper() == 'Q':
+            print("Exiting RUFAS...")
+            sys.exit()
 
-            return user_input
-        except errors.UserInput as e:
-            print(e.msg)
+        return rel_root + user_input
+
+    except errors.UserInput as e:
+        print(e.msg)
 
 # TODO make tests. The following should work (from RUFAS/ dir) - GitHub Issue #209
 # convert_path_string_to_list("../input/ARL.json")

--- a/config/global_variables.py
+++ b/config/global_variables.py
@@ -1,9 +1,9 @@
 import os
 ROOT_DIR = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))
 
-SUPPRESS_GRAPHICS = False  # optional global flag to suppress graphics
-# TODO: "producing graphics" message and directory structure still generated when SUPPRESS_GRAPHICS = True
+PRODUCE_GRAPHICS = True  # optional global flag to suppress graphics
+# TODO: "producing graphics" message and directory structure still generated when PRODUCE_GRAPHICS = True - GitHub Issue # 211
 
-PRINT_STATUS_MESSAGES = True  # optional flag to print status messages - TODO: unimplemented
+PRINT_STATUS_MESSAGES = True  # optional flag to print status messages - TODO: unimplemented - GitHub Issue #211
 
-OUT_DIR = os.path.join(ROOT_DIR, "output")  # where should output files go? - TODO: unimplemented
+OUT_DIR = os.path.join(ROOT_DIR, "output")  # where should output files go? - TODO: unimplemented - GitHub Issue #211

--- a/config/global_variables.py
+++ b/config/global_variables.py
@@ -1,0 +1,9 @@
+import os
+ROOT_DIR = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))
+
+SUPPRESS_GRAPHICS = False  # optional global flag to suppress graphics
+# TODO: "producing graphics" message and directory structure still generated when SUPPRESS_GRAPHICS = True
+
+PRINT_STATUS_MESSAGES = True  # optional flag to print status messages - TODO: unimplemented
+
+OUT_DIR = os.path.join(ROOT_DIR, "output")  # where should output files go? - TODO: unimplemented

--- a/main.py
+++ b/main.py
@@ -1,25 +1,62 @@
-# !/usr/bin/env python3
+# !/usr/bin/env python
 
+"""
+This file serves as a main entry point to RuFaS.
+
+The main function run_rufas() will execute the model simulation(s). It accepts a path to the location of the input
+file(s) or, if this input is not given, it will run in interactive mode and accept input from the user.
+"""
+
+import config.global_variables
+import argparse
 from RUFAS.simulation_engine import SimulationEngine
-from RUFAS import input_prompt
+from RUFAS.user_prompt import get_files_from_input
 
-def main():
+
+def run_rufas(in_path=None, make_graphs=True, verbose=True):
+    """ main function to run RuFaS, with options. If in_file is not provided, the interactive user prompt is triggered
     """
-    Main function of RUFAS, executes simulations for all files specified.
+    set_global_variables(make_graphs, verbose)
+    if verbose:
+        print_rufas_intro()
+    file_list = get_files_from_input(in_path, verbose)
+    simulate_from_files(file_list)
 
-    Prompts the user to enter an input path to a json file or a directory of
-    json files. The path(s) are returned in a list, which the program loops
-    through and executes the simulation for each of the files in the list.
-    """
 
-    print("RUFAS: Ruminant Farm Systems Model 2022")
+def set_global_variables(make_graphs: bool, verbose: bool) -> None:
+    """set values of global variables in config/global_variables.py"""
+    config.global_variables.SUPPRESS_GRAPHICS = not make_graphs
+    config.global_variables.PRINT_STATUS_MESSAGES = verbose  # TODO: this is currently unimplemented
 
-    input_file_list = input_prompt()
 
-    for input_file_path in input_file_list:
-        simulator = SimulationEngine(input_file_path)
+def print_rufas_intro() -> None:
+    """print introduction message"""
+    print("RuFaS: Ruminant Farm Systems Model 2022")
+
+
+def simulate_from_files(files) -> None:
+    """execute simulations for each file"""
+    for f in files:
+        simulator = SimulationEngine(f)
         simulator.simulate()
 
 
+def parse_gnu_args():
+    """parse command line options, if applicable"""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("in_path", type=str, metavar="path", nargs="?",
+                        help="path to input .json file or directory of .json files")
+    # TODO: rather than a string, this should probably be a file handle as in the link below, but that would affect
+    #   the current input handler, file reader, etc.
+    #   https://stackoverflow.com/questions/11540854/file-as-command-line-argument-for-argparse-error-message-if-argument-is-not-va
+
+    parser.add_argument("--no-graphics", help="prevent graphics from generating", action="store_true")
+    parser.add_argument("-v", "--verbose", help="print progress messages", action="store_true")
+    # parser.add_argument("-i", "--interactive", help="run in interactive mode", action="store_true")
+
+    return parser.parse_args()
+
+
 if __name__ == '__main__':
-    main()
+    cmd_arguments = parse_gnu_args()
+    run_rufas(in_path=cmd_arguments.in_path, make_graphs=not cmd_arguments.no_graphics, verbose=cmd_arguments.verbose)

--- a/main.py
+++ b/main.py
@@ -6,13 +6,13 @@ This file serves as a main entry point to RuFaS.
 The main function run_rufas() will execute the model simulation(s). It accepts a path to the location of the input
 file(s) or, if this input is not given, it will run in interactive mode and accept input from the user.
 """
+import argparse
+from pathlib import Path
 from typing import List
 
 import config.global_variables
-import argparse
 from RUFAS.simulation_engine import SimulationEngine
 from RUFAS.user_prompt import obtain_file_list
-from pathlib import Path
 
 
 def run_rufas(input_path=None, make_graphs=True, verbose=True):

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python
+# !/usr/bin/env python3
 
 """
 This file serves as a main entry point to RuFaS.
@@ -10,31 +10,28 @@ file(s) or, if this input is not given, it will run in interactive mode and acce
 import config.global_variables
 import argparse
 from RUFAS.simulation_engine import SimulationEngine
-from RUFAS.user_prompt import get_files_from_input
+from RUFAS.user_prompt import obtain_file_list
+from pathlib import Path
 
 
-def run_rufas(in_path=None, make_graphs=True, verbose=True):
-    """ main function to run RuFaS, with options. If in_file is not provided, the interactive user prompt is triggered
+def run_rufas(input_path=None, make_graphs=True, verbose=True):
+    """ main function to run RuFaS, with options. If input_path is not provided, the interactive user prompt is
+    triggered.
     """
     set_global_variables(make_graphs, verbose)
     if verbose:
-        print_rufas_intro()
-    file_list = get_files_from_input(in_path, verbose)
-    simulate_from_files(file_list)
+        print("RuFaS: Ruminant Farm Systems Model 2022")
+    file_list = obtain_file_list(input_path, verbose)
+    execute_simulations_from_files(file_list)
 
 
 def set_global_variables(make_graphs: bool, verbose: bool) -> None:
-    """set values of global variables in config/global_variables.py"""
-    config.global_variables.SUPPRESS_GRAPHICS = not make_graphs
-    config.global_variables.PRINT_STATUS_MESSAGES = verbose  # TODO: this is currently unimplemented
+    """sets values of global variables in config/global_variables.py"""
+    config.global_variables.PRODUCE_GRAPHICS = make_graphs
+    config.global_variables.PRINT_STATUS_MESSAGES = verbose  # TODO: this is currently unimplemented - GitHub Issue #211
 
 
-def print_rufas_intro() -> None:
-    """print introduction message"""
-    print("RuFaS: Ruminant Farm Systems Model 2022")
-
-
-def simulate_from_files(files) -> None:
+def execute_simulations_from_files(files: list[Path]) -> None:
     """execute simulations for each file"""
     for f in files:
         simulator = SimulationEngine(f)
@@ -44,13 +41,13 @@ def simulate_from_files(files) -> None:
 def parse_gnu_args():
     """parse command line options, if applicable"""
     parser = argparse.ArgumentParser()
-    parser.add_argument("in_path", type=str, metavar="path", nargs="?",
+    parser.add_argument("input_path", type=str, metavar="path", nargs="?",
                         help="path to input .json file or directory of .json files")
     # TODO: rather than a string, this should probably be a file handle as in the link below, but that would affect
     #   the current input handler, file reader, etc.
     #   https://stackoverflow.com/questions/11540854/file-as-command-line-argument-for-argparse-error-message-if-argument-is-not-va
 
-    parser.add_argument("--no-graphics", help="prevent graphics from generating", action="store_true")
+    parser.add_argument("-ng", "--no-graphics", help="prevent graphics from generating", action="store_true")
     parser.add_argument("-v", "--verbose", help="print progress messages", action="store_true")
     # parser.add_argument("-i", "--interactive", help="run in interactive mode", action="store_true")
 
@@ -59,4 +56,4 @@ def parse_gnu_args():
 
 if __name__ == '__main__':
     cmd_arguments = parse_gnu_args()
-    run_rufas(in_path=cmd_arguments.in_path, make_graphs=not cmd_arguments.no_graphics, verbose=cmd_arguments.verbose)
+    run_rufas(input_path=cmd_arguments.input_path, make_graphs=not cmd_arguments.no_graphics, verbose=cmd_arguments.verbose)

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ This file serves as a main entry point to RuFaS.
 The main function run_rufas() will execute the model simulation(s). It accepts a path to the location of the input
 file(s) or, if this input is not given, it will run in interactive mode and accept input from the user.
 """
+from typing import List
 
 import config.global_variables
 import argparse
@@ -31,7 +32,7 @@ def set_global_variables(make_graphs: bool, verbose: bool) -> None:
     config.global_variables.PRINT_STATUS_MESSAGES = verbose  # TODO: this is currently unimplemented - GitHub Issue #211
 
 
-def execute_simulations_from_files(files: list[Path]) -> None:
+def execute_simulations_from_files(files: List[Path]) -> None:
     """execute simulations for each file"""
     for f in files:
         simulator = SimulationEngine(f)

--- a/tests/test_user_prompt.py
+++ b/tests/test_user_prompt.py
@@ -1,0 +1,44 @@
+import os.path
+
+import pytest
+import unittest.mock
+
+from RUFAS.user_prompt import *
+
+dir_path = os.path.join(config.global_variables.ROOT_DIR, "input")
+file_path = os.path.join(dir_path, "input/ARL.json")
+
+# TODO: Tests remain unimplemented - GitHub Issue #209
+
+@pytest.mark.parametrize("path", [file_path, None])
+def test_obtain_file_list(path):
+    """check that obtain_file_list correctly calls input_prompt or convert_path_string_to_list"""
+    pass
+
+@pytest.mark.parametrize("path", [file_path, dir_path])
+def test_convert_path_string_to_list(path):
+    """check that convert_path_string_to_list provides correct file lists"""
+    pass
+
+@pytest.mark.parametrize("user_input", [file_path, dir_path])
+def test_user_prompt(user_input):
+    """check that user_prompt() correctly accepts user input and returns a Path list"""
+    pass
+
+@pytest.mark.parametrize("path", [file_path, dir_path])
+def test_convert_path_string_to_list(path):
+    """check that convert_path_string_to_list() properly returns a Path list"""
+    pass
+
+def test_get_json_list_from_dir(path):
+    """check that get_json_list_from_dir() properly detects all json files in a directory"""
+    pass
+
+def test_convert_json_path_to_list(path):
+    """check that convert_json_path_to_list() properly returns a Path list from a json path string"""
+    pass
+
+@pytest.mark.parametrize("input", ["Q", "q", "dir", file_path, dir_path])
+def test_prompt_user_for_input(input):
+    """check that prompt_user_for_input correctly returns the users input and that other options work as expected"""
+    pass

--- a/tests/test_user_prompt.py
+++ b/tests/test_user_prompt.py
@@ -1,47 +1,68 @@
 import os.path
 
 import pytest
+from pytest_mock import MockerFixture
+
 from config import global_variables
-import unittest.mock
-from RUFAS.user_prompt import *
+from RUFAS.user_prompt import obtain_file_list
 
 dir_path = os.path.join(global_variables.ROOT_DIR, "input")
 file_path = os.path.join(dir_path, "input/ARL.json")
 
+
 # TODO: Tests remain unimplemented - GitHub Issue #209
 
 @pytest.mark.parametrize("path", [file_path, None])
-def test_obtain_file_list(path):
+def test_obtain_file_list(mocker: MockerFixture, path):
     """check that obtain_file_list correctly calls input_prompt or convert_path_string_to_list"""
-    pass
+    # Arrange
+    verbose = True
+    patch_for_user_prompt = mocker.patch("RUFAS.user_prompt.user_prompt")
+    patch_for_convert_path_string_to_list = mocker.patch("RUFAS.user_prompt.convert_path_string_to_list", return_value=[path])
+
+    # Act
+    obtain_file_list(path, verbose)
+
+    # Assert
+    if path is None:
+        patch_for_user_prompt.assert_called_once()
+        patch_for_convert_path_string_to_list.assert_not_called()
+    else:
+        patch_for_convert_path_string_to_list.assert_called_once()
+        patch_for_user_prompt.assert_not_called()
+
 
 @pytest.mark.parametrize("path", [file_path, dir_path])
 def test_convert_path_string_to_list(path):
     """check that convert_path_string_to_list provides correct file lists"""
     pass
 
+
 @pytest.mark.parametrize("user_input", [file_path, dir_path])
 def test_user_prompt(user_input):
     """check that user_prompt() correctly accepts user input and returns a Path list"""
     pass
+
 
 @pytest.mark.parametrize("path", [file_path, dir_path])
 def test_convert_path_string_to_list(path):
     """check that convert_path_string_to_list() properly returns a Path list"""
     pass
 
+
 @pytest.mark.parametrize("path", [dir_path])
 def test_get_json_list_from_dir(path):
     """check that get_json_list_from_dir() properly detects all json files in a directory"""
     pass
+
 
 @pytest.mark.parametrize("path", [file_path])
 def test_convert_json_path_to_list(path):
     """check that convert_json_path_to_list() properly returns a Path list from a json path string"""
     pass
 
+
 @pytest.mark.parametrize("input", ["Q", "q", "dir", file_path, dir_path])
 def test_prompt_user_for_input(input):
     """check that prompt_user_for_input correctly returns the users input and that other options work as expected"""
     pass
-

--- a/tests/test_user_prompt.py
+++ b/tests/test_user_prompt.py
@@ -1,14 +1,17 @@
+import argparse
 import os.path
 from pathlib import Path
 
 import pytest
 from pytest_mock import MockerFixture
 
-from config import global_variables
-from RUFAS import errors
-from RUFAS.user_prompt import get_json_list_from_dir
+import config.global_variables
+from RUFAS import errors, SimulationEngine
+from RUFAS.user_prompt import get_json_list_from_dir, user_prompt, convert_path_string_to_list
 from RUFAS.user_prompt import obtain_file_list
 from RUFAS.user_prompt import prompt_user_for_input
+from config import global_variables
+from main import parse_gnu_args, run_rufas, set_global_variables, execute_simulations_from_files
 
 dir_path = os.path.join(global_variables.ROOT_DIR, "input")
 file_path = os.path.join(dir_path, "input/ARL.json")
@@ -37,22 +40,83 @@ def test_obtain_file_list(mocker: MockerFixture, path):
         patch_for_user_prompt.assert_not_called()
 
 
-@pytest.mark.parametrize("path", [file_path, dir_path])
-def test_convert_path_string_to_list(path):
+@pytest.mark.parametrize("path, is_file, is_dir", [
+    ("dummy_json.json", True, False),
+    ("dummy_dir", False, True),
+    ("valid_dummy_txt_file.txt", True, False),
+    ("invalid_dummy_txt_file.txt", False, False),
+    ("invalid_file_path", False, False)
+])
+def test_convert_path_string_to_list(path: str,
+                                     is_file: bool,
+                                     is_dir: bool,
+                                     mocker: MockerFixture,
+                                     capsys: pytest.CaptureFixture):
     """check that convert_path_string_to_list provides correct file lists"""
-    pass
+    # Arrange
+    input_path = mocker.MagicMock(auto_spec=Path)
+    input_path.__str__.return_value = path
+    input_path.is_dir.return_value = is_dir
+    input_path.is_file.return_value = is_file
+    input_path.suffix = '.' + path.split(".")[-1]
+    verbose = True
+    json_filename = "dummy.json"
+    patch_for_path_init = mocker.patch("RUFAS.user_prompt.Path", side_effect=[input_path, input_path])
+    patch_for_convert_to_json = mocker.patch("RUFAS.user_prompt.fileReader.convert_to_json",
+                                             return_value=json_filename)
+    patch_for_convert_json_path_to_list = mocker.patch("RUFAS.user_prompt.convert_json_path_to_list",
+                                                       return_value=[input_path])
+    patch_for_get_json_list_from_dir = mocker.patch("RUFAS.user_prompt.get_json_list_from_dir",
+                                                    return_value=[json_filename])
+    patch_for_builtin_warning = mocker.patch("builtins.Warning")
+
+    # Act
+    if not is_file and not is_dir:
+        if input_path.suffix == ".txt":
+            with pytest.raises(errors.UserInput) as e:
+                convert_path_string_to_list(path, verbose)
+        else:
+            with pytest.raises(ValueError) as e:
+                convert_path_string_to_list(path, verbose)
+                assert "Invalid input path" in str(e.value)
+        return
+
+    actual_file_list = convert_path_string_to_list(path, verbose)
+
+    # Assert
+    if is_dir:
+        patch_for_path_init.assert_called_once_with(path)
+        input_path.is_dir.assert_called_once()
+        patch_for_get_json_list_from_dir.assert_called_once_with(input_path, verbose)
+    elif input_path.suffix == ".txt":
+        patch_for_builtin_warning.assert_called_once()
+        input_path.is_file.assert_called_once()
+        patch_for_convert_to_json.assert_called_once_with(str(input_path))
+        assert actual_file_list == [input_path]
+        if verbose:
+            captured = capsys.readouterr()
+            assert "commented json file detected, stripping comments" in captured.out
+    elif input_path.suffix == ".json":
+        patch_for_path_init.assert_called_once_with(path)
+        patch_for_convert_json_path_to_list.assert_called_once_with(input_path, verbose)
 
 
 @pytest.mark.parametrize("user_input", [file_path, dir_path])
-def test_user_prompt(user_input):
+def test_user_prompt(user_input: str, mocker: MockerFixture):
     """check that user_prompt() correctly accepts user input and returns a Path list"""
-    pass
+    # Arrange
+    patch_for_prompt_user_for_input = mocker.patch("RUFAS.user_prompt.prompt_user_for_input",
+                                                   return_value=user_input)
+    patch_for_convert_path_string_to_list = mocker.patch("RUFAS.user_prompt.convert_path_string_to_list",
+                                                         return_value=[user_input])
 
+    # Act
+    actual = user_prompt()
 
-@pytest.mark.parametrize("path", [file_path, dir_path])
-def test_convert_path_string_to_list(path):
-    """check that convert_path_string_to_list() properly returns a Path list"""
-    pass
+    # Assert
+    patch_for_prompt_user_for_input.assert_called_once()
+    patch_for_convert_path_string_to_list.assert_called_once_with(path=user_input)
+    assert actual == [user_input]
 
 
 def test_get_json_list_from_dir(mocker: MockerFixture,
@@ -116,7 +180,6 @@ def test_get_json_list_from_dir(mocker: MockerFixture,
 @pytest.mark.parametrize("path", [file_path])
 def test_convert_json_path_to_list(path):
     """check that convert_json_path_to_list() properly returns a Path list from a json path string"""
-    pass
 
 
 @pytest.mark.parametrize("user_input", ['Q', 'q', file_path, dir_path, 'dir', 'error'])
@@ -159,3 +222,98 @@ def test_prompt_user_for_input(mocker: MockerFixture, capsys: pytest.CaptureFixt
     else:
         patch_for_input.assert_called_once_with("\nEnter RUFAS Input: ")
         assert actual_user_input == 'input/' + user_input
+
+
+@pytest.mark.parametrize("input_path, make_graphs, verbose", [
+    ("dummy_path", True, True),
+    ("dummy_path", False, True),
+    ("dummy_path", True, False),
+    ("dummy_path", False, False)
+])
+def test_run_rufas(input_path: str,
+                   make_graphs: bool,
+                   verbose: bool,
+                   mocker: MockerFixture) -> None:
+    """Checks that run_rufas() calls the correct functions in the correct order"""
+    # Arrange
+    patch_for_set_global_variables = mocker.patch("main.set_global_variables")
+    file_list = ['file1.json', 'file2.json']
+    patch_for_obtain_file_list = mocker.patch("main.obtain_file_list", return_value=file_list)
+    patch_for_execute_simulations_from_files = mocker.patch("main.execute_simulations_from_files")
+
+    # Act
+    run_rufas(input_path, make_graphs, verbose)
+
+    # Assert
+    patch_for_set_global_variables.assert_called_once_with(make_graphs, verbose)
+    patch_for_obtain_file_list.assert_called_once_with(input_path, verbose)
+    patch_for_execute_simulations_from_files.assert_called_once_with(file_list)
+
+
+@pytest.mark.parametrize("make_graphs, verbose", [
+    (True, True),
+    (False, True),
+    (True, False),
+    (False, False)
+])
+def test_set_global_variables(make_graphs: bool,
+                              verbose: bool,
+                              mocker: MockerFixture) -> None:
+    """Checks that set_global_variables() sets the global variables correctly"""
+    # Arrange
+    old_make_graphs = config.global_variables.PRODUCE_GRAPHICS
+    old_verbose = config.global_variables.PRINT_STATUS_MESSAGES
+
+    # Act
+    set_global_variables(make_graphs, verbose)
+
+    # Assert
+    assert config.global_variables.PRODUCE_GRAPHICS == make_graphs
+    assert config.global_variables.PRINT_STATUS_MESSAGES == verbose
+
+    # Cleanup
+    config.global_variables.PRODUCE_GRAPHICS = old_make_graphs
+    config.global_variables.PRINT_STATUS_MESSAGES = old_verbose
+
+
+def test_execute_simulations_from_files(mocker: MockerFixture) -> None:
+    """Checks that execute_simulations_from_files() calls the correct functions in the correct order"""
+    # Arrange
+    file_path1 = Path('file1.json')
+    file_path2 = Path('file2.json')
+    file_list = [file_path1, file_path2]
+    mock_simulator = mocker.MagicMock(auto_spec=SimulationEngine)
+    mock_simulator.simulate.return_value = None
+    patch_for_simulation_engine_init = mocker.patch("main.SimulationEngine", return_value=mock_simulator)
+
+    # Act
+    execute_simulations_from_files(file_list)
+
+    # Assert
+    assert patch_for_simulation_engine_init.call_count == 2
+    assert patch_for_simulation_engine_init.call_args_list == [mocker.call(file_path1), mocker.call(file_path2)]
+    assert mock_simulator.simulate.call_count == 2
+
+
+def test_parse_gnu_args(mocker: MockerFixture) -> None:
+    """Checks that parse_gnu_args() correctly parses the user's input."""
+    # Arrange
+    mock_parser = mocker.MagicMock(auto_spec=argparse.ArgumentParser)
+    mock_add_argument = mocker.patch.object(mock_parser, "add_argument")
+    mock_parse_args = mocker.patch.object(mock_parser, "parse_args", return_value="test_args")
+    mocker.patch("main.argparse.ArgumentParser",
+                 return_value=mock_parser)
+
+    # Act
+    actual_args = parse_gnu_args()
+
+    # Assert
+    assert mock_add_argument.call_count == 3
+    assert mock_add_argument.call_args_list == [
+        mocker.call("input_path", type=str, metavar="path", nargs="?",
+                    help="path to input .json file or directory of .json files"),
+        mocker.call("-ng", "--no-graphics", help="prevent graphics from generating", action="store_true"),
+        mocker.call("-v", "--verbose", help="print progress messages", action="store_true")
+    ]
+    mock_parse_args.assert_called_once()
+    assert actual_args == "test_args"

--- a/tests/test_user_prompt.py
+++ b/tests/test_user_prompt.py
@@ -1,11 +1,11 @@
 import os.path
 
 import pytest
+from config import global_variables
 import unittest.mock
-
 from RUFAS.user_prompt import *
 
-dir_path = os.path.join(config.global_variables.ROOT_DIR, "input")
+dir_path = os.path.join(global_variables.ROOT_DIR, "input")
 file_path = os.path.join(dir_path, "input/ARL.json")
 
 # TODO: Tests remain unimplemented - GitHub Issue #209

--- a/tests/test_user_prompt.py
+++ b/tests/test_user_prompt.py
@@ -7,6 +7,7 @@ from pytest_mock import MockerFixture
 
 import config.global_variables
 from RUFAS import errors, SimulationEngine
+from RUFAS.output_manager import OutputManager
 from RUFAS.user_prompt import get_json_list_from_dir, user_prompt, convert_path_string_to_list
 from RUFAS.user_prompt import obtain_file_list
 from RUFAS.user_prompt import prompt_user_for_input
@@ -279,6 +280,10 @@ def test_set_global_variables(make_graphs: bool,
 def test_execute_simulations_from_files(mocker: MockerFixture) -> None:
     """Checks that execute_simulations_from_files() calls the correct functions in the correct order"""
     # Arrange
+    mock_output_manager = mocker.MagicMock(auto_spec=OutputManager)
+    mock_output_manager.flush_pools.return_value = None
+    mock_output_manager.save_all_pools.return_value = None
+    mocker.patch("main.OutputManager", return_value=mock_output_manager)
     file_path1 = Path('file1.json')
     file_path2 = Path('file2.json')
     file_list = [file_path1, file_path2]
@@ -290,9 +295,12 @@ def test_execute_simulations_from_files(mocker: MockerFixture) -> None:
     execute_simulations_from_files(file_list)
 
     # Assert
-    assert patch_for_simulation_engine_init.call_count == 2
+    assert patch_for_simulation_engine_init.call_count == len(file_list)
     assert patch_for_simulation_engine_init.call_args_list == [mocker.call(file_path1), mocker.call(file_path2)]
-    assert mock_simulator.simulate.call_count == 2
+    assert mock_simulator.simulate.call_count == len(file_list)
+    assert mock_output_manager.flush_pools.call_count == len(file_list)
+    assert mock_output_manager.save_all_pools.call_count == len(file_list)
+    assert mock_output_manager.save_all_pools.call_args_list == [mocker.call('output')] * len(file_list)
 
 
 def test_parse_gnu_args(mocker: MockerFixture) -> None:

--- a/tests/test_user_prompt.py
+++ b/tests/test_user_prompt.py
@@ -1,9 +1,11 @@
 import os.path
+from pathlib import Path
 
 import pytest
 from pytest_mock import MockerFixture
 
 from config import global_variables
+from RUFAS.user_prompt import get_json_list_from_dir
 from RUFAS.user_prompt import obtain_file_list
 
 dir_path = os.path.join(global_variables.ROOT_DIR, "input")
@@ -18,7 +20,8 @@ def test_obtain_file_list(mocker: MockerFixture, path):
     # Arrange
     verbose = True
     patch_for_user_prompt = mocker.patch("RUFAS.user_prompt.user_prompt")
-    patch_for_convert_path_string_to_list = mocker.patch("RUFAS.user_prompt.convert_path_string_to_list", return_value=[path])
+    patch_for_convert_path_string_to_list = mocker.patch("RUFAS.user_prompt.convert_path_string_to_list",
+                                                         return_value=[path])
 
     # Act
     obtain_file_list(path, verbose)
@@ -50,10 +53,62 @@ def test_convert_path_string_to_list(path):
     pass
 
 
-@pytest.mark.parametrize("path", [dir_path])
-def test_get_json_list_from_dir(path):
+def test_get_json_list_from_dir(mocker: MockerFixture,
+                                capsys: pytest.CaptureFixture):
     """check that get_json_list_from_dir() properly detects all json files in a directory"""
-    pass
+    verbose = True
+
+    # Case 1: Input path is not a directory
+    # Arrange
+    dummy_path = Path('dummy_path')
+
+    # Act
+    # check an error is raised
+    with pytest.raises(IsADirectoryError) as e:
+        get_json_list_from_dir(dummy_path, verbose)
+        assert "specified path is not a directory" in str(e.value)
+
+    # ------------------------------
+
+    # Case 2: Input path is a directory, but contains no json files
+    # Arrange
+    # Print current directory
+    dummy_dir = Path('dummy_dir')
+    dummy_dir.mkdir()
+    empty_json_paths = []
+    patch_for_glob = mocker.patch("RUFAS.user_prompt.Path.glob", return_value=empty_json_paths)
+
+    # Act
+    with pytest.raises(FileExistsError) as e:
+        get_json_list_from_dir(dummy_dir, verbose)
+        assert "Directory contains no json files" in str(e.value)
+
+    # Assert
+    patch_for_glob.assert_called_once_with('*.json')
+
+    # Cleanup
+    dummy_dir.rmdir()
+
+    # ------------------------------
+
+    # Case 3: Input path is a directory, and contains json files
+    # Arrange
+    dummy_dir = Path('dummy_dir')
+    dummy_dir.mkdir()
+    expected_json_paths = ['dummy.json', 'dummy2.json']
+    patch_for_glob = mocker.patch("RUFAS.user_prompt.Path.glob", return_value=expected_json_paths)
+
+    # Act
+    actual_json_paths = get_json_list_from_dir(dummy_dir, verbose)
+
+    # Assert
+    patch_for_glob.assert_called_once_with('*.json')
+    captured = capsys.readouterr()
+    assert f'{len(expected_json_paths)} json files detected...' in captured.out
+    assert actual_json_paths == expected_json_paths
+
+    # Cleanup
+    dummy_dir.rmdir()
 
 
 @pytest.mark.parametrize("path", [file_path])

--- a/tests/test_user_prompt.py
+++ b/tests/test_user_prompt.py
@@ -5,8 +5,10 @@ import pytest
 from pytest_mock import MockerFixture
 
 from config import global_variables
+from RUFAS import errors
 from RUFAS.user_prompt import get_json_list_from_dir
 from RUFAS.user_prompt import obtain_file_list
+from RUFAS.user_prompt import prompt_user_for_input
 
 dir_path = os.path.join(global_variables.ROOT_DIR, "input")
 file_path = os.path.join(dir_path, "input/ARL.json")
@@ -117,7 +119,43 @@ def test_convert_json_path_to_list(path):
     pass
 
 
-@pytest.mark.parametrize("input", ["Q", "q", "dir", file_path, dir_path])
-def test_prompt_user_for_input(input):
+@pytest.mark.parametrize("user_input", ['Q', 'q', file_path, dir_path, 'dir', 'error'])
+def test_prompt_user_for_input(mocker: MockerFixture, capsys: pytest.CaptureFixture, user_input: str) -> None:
     """check that prompt_user_for_input correctly returns the users input and that other options work as expected"""
-    pass
+
+    # Arrange
+    def mock_user_input_error_side_effect(*args, **kwargs):
+        raise errors.UserInput("test error")
+
+    side_effect_by_user_input = {
+        'dir': ['dir', 'Q'],
+        'error': mock_user_input_error_side_effect
+    }
+    patch_for_input = mocker.patch("builtins.input",
+                                   side_effect=side_effect_by_user_input.get(user_input, [user_input]))
+
+    patch_for_exit = mocker.patch("sys.exit")
+    current_dir_path = Path.cwd()
+    patch_for_get_base_dir = mocker.patch("RUFAS.user_prompt.Utility.get_base_dir", return_value=current_dir_path)
+
+    # Act
+    actual_user_input = prompt_user_for_input()
+
+    # Assert
+    captured = capsys.readouterr().out.split('\n')
+
+    if user_input in ["Q", "q"]:
+        patch_for_input.assert_called_once_with("\nEnter RUFAS Input: ")
+        patch_for_exit.assert_called_once()
+        assert "Exiting RUFAS..." in captured
+    elif user_input == "dir":
+        assert patch_for_input.call_count == 2
+        patch_for_get_base_dir.assert_called_once()
+        patch_for_exit.assert_called_once()
+        assert "Exiting RUFAS..." in captured
+        assert str(current_dir_path) in captured
+    elif user_input == "error":
+        assert 'USER INPUT ERROR: test error' in captured
+    else:
+        patch_for_input.assert_called_once_with("\nEnter RUFAS Input: ")
+        assert actual_user_input == 'input/' + user_input

--- a/tests/test_user_prompt.py
+++ b/tests/test_user_prompt.py
@@ -6,13 +6,20 @@ import pytest
 from pytest_mock import MockerFixture
 
 import config.global_variables
-from RUFAS import errors, SimulationEngine
+from config import global_variables
+from main import execute_simulations_from_files
+from main import parse_gnu_args
+from main import run_rufas
+from main import set_global_variables
+from RUFAS import errors
+from RUFAS import SimulationEngine
 from RUFAS.output_manager import OutputManager
-from RUFAS.user_prompt import get_json_list_from_dir, user_prompt, convert_path_string_to_list
+from RUFAS.user_prompt import convert_json_path_to_list
+from RUFAS.user_prompt import convert_path_string_to_list
+from RUFAS.user_prompt import get_json_list_from_dir
 from RUFAS.user_prompt import obtain_file_list
 from RUFAS.user_prompt import prompt_user_for_input
-from config import global_variables
-from main import parse_gnu_args, run_rufas, set_global_variables, execute_simulations_from_files
+from RUFAS.user_prompt import user_prompt
 
 dir_path = os.path.join(global_variables.ROOT_DIR, "input")
 file_path = os.path.join(dir_path, "input/ARL.json")
@@ -126,60 +133,81 @@ def test_get_json_list_from_dir(mocker: MockerFixture,
 
     # Case 1: Input path is not a directory
     # Arrange
-    dummy_path = Path('dummy_path')
+    mock_dir_path = mocker.MagicMock(auto_spec=Path)
+    mock_dir_path.is_dir.return_value = False
 
     # Act
     # check an error is raised
     with pytest.raises(IsADirectoryError) as e:
-        get_json_list_from_dir(dummy_path, verbose)
+        get_json_list_from_dir(mock_dir_path, verbose)
         assert "specified path is not a directory" in str(e.value)
 
     # ------------------------------
 
     # Case 2: Input path is a directory, but contains no json files
     # Arrange
-    # Print current directory
-    dummy_dir = Path('dummy_dir')
-    dummy_dir.mkdir()
-    empty_json_paths = []
-    patch_for_glob = mocker.patch("RUFAS.user_prompt.Path.glob", return_value=empty_json_paths)
+    mock_dir_path = mocker.MagicMock(auto_spec=Path)
+    mock_dir_path.is_dir.return_value = True
+    mock_dir_path.glob.return_value = []
 
     # Act
     with pytest.raises(FileExistsError) as e:
-        get_json_list_from_dir(dummy_dir, verbose)
+        get_json_list_from_dir(mock_dir_path, verbose)
         assert "Directory contains no json files" in str(e.value)
 
     # Assert
-    patch_for_glob.assert_called_once_with('*.json')
-
-    # Cleanup
-    dummy_dir.rmdir()
+    mock_dir_path.is_dir.assert_called_once()
+    mock_dir_path.glob.assert_called_once_with('*.json')
 
     # ------------------------------
 
     # Case 3: Input path is a directory, and contains json files
     # Arrange
-    dummy_dir = Path('dummy_dir')
-    dummy_dir.mkdir()
+    mock_dir_path = mocker.MagicMock(auto_spec=Path)
+    mock_dir_path.is_dir.return_value = True
     expected_json_paths = ['dummy.json', 'dummy2.json']
-    patch_for_glob = mocker.patch("RUFAS.user_prompt.Path.glob", return_value=expected_json_paths)
+    mock_dir_path.glob.return_value = expected_json_paths
 
     # Act
-    actual_json_paths = get_json_list_from_dir(dummy_dir, verbose)
+    actual_json_paths = get_json_list_from_dir(mock_dir_path, verbose)
 
     # Assert
-    patch_for_glob.assert_called_once_with('*.json')
+    mock_dir_path.glob.assert_called_once_with('*.json')
     captured = capsys.readouterr()
     assert f'{len(expected_json_paths)} json files detected...' in captured.out
     assert actual_json_paths == expected_json_paths
 
-    # Cleanup
-    dummy_dir.rmdir()
 
-
-@pytest.mark.parametrize("path", [file_path])
-def test_convert_json_path_to_list(path):
+def test_convert_json_path_to_list(mocker: MockerFixture,
+                                   capsys: pytest.CaptureFixture):
     """check that convert_json_path_to_list() properly returns a Path list from a json path string"""
+    # Case 1: Input path is not a json file
+    # Arrange
+    mock_json_path = mocker.MagicMock(auto_spec=Path)
+    mock_json_path.is_file.return_value = False
+    verbose = True
+
+    # Act
+    with pytest.raises(errors.UserInput) as e:
+        convert_json_path_to_list(mock_json_path, verbose)
+        assert "Specified file does not exist" in str(e.value)
+
+    # ------------------------------
+
+    # Case 2: Input path is a json file
+    # Arrange
+    mock_json_path = mocker.MagicMock(auto_spec=Path)
+    mock_json_path.is_file.return_value = True
+    verbose = True
+
+    # Act
+    actual = convert_json_path_to_list(mock_json_path, verbose)
+
+    # Assert
+    mock_json_path.is_file.assert_called_once()
+    captured = capsys.readouterr()
+    assert "json file detected" in captured.out
+    assert actual == [mock_json_path]
 
 
 @pytest.mark.parametrize("user_input", ['Q', 'q', file_path, dir_path, 'dir', 'error'])
@@ -257,8 +285,7 @@ def test_run_rufas(input_path: str,
     (False, False)
 ])
 def test_set_global_variables(make_graphs: bool,
-                              verbose: bool,
-                              mocker: MockerFixture) -> None:
+                              verbose: bool) -> None:
     """Checks that set_global_variables() sets the global variables correctly"""
     # Arrange
     old_make_graphs = config.global_variables.PRODUCE_GRAPHICS

--- a/tests/test_user_prompt.py
+++ b/tests/test_user_prompt.py
@@ -18,8 +18,6 @@ dir_path = os.path.join(global_variables.ROOT_DIR, "input")
 file_path = os.path.join(dir_path, "input/ARL.json")
 
 
-# TODO: Tests remain unimplemented - GitHub Issue #209
-
 @pytest.mark.parametrize("path", [file_path, None])
 def test_obtain_file_list(mocker: MockerFixture, path):
     """check that obtain_file_list correctly calls input_prompt or convert_path_string_to_list"""
@@ -76,6 +74,7 @@ def test_convert_path_string_to_list(path: str,
         if input_path.suffix == ".txt":
             with pytest.raises(errors.UserInput) as e:
                 convert_path_string_to_list(path, verbose)
+                assert "does not exist" in str(e.value)
         else:
             with pytest.raises(ValueError) as e:
                 convert_path_string_to_list(path, verbose)

--- a/tests/test_user_prompt.py
+++ b/tests/test_user_prompt.py
@@ -30,10 +30,12 @@ def test_convert_path_string_to_list(path):
     """check that convert_path_string_to_list() properly returns a Path list"""
     pass
 
+@pytest.mark.parametrize("path", [dir_path])
 def test_get_json_list_from_dir(path):
     """check that get_json_list_from_dir() properly detects all json files in a directory"""
     pass
 
+@pytest.mark.parametrize("path", [file_path])
 def test_convert_json_path_to_list(path):
     """check that convert_json_path_to_list() properly returns a Path list from a json path string"""
     pass
@@ -42,3 +44,4 @@ def test_convert_json_path_to_list(path):
 def test_prompt_user_for_input(input):
     """check that prompt_user_for_input correctly returns the users input and that other options work as expected"""
     pass
+


### PR DESCRIPTION
# Purpose
This small pull request adds functionality to allow RuFaS to run from the command line without being prompted for input.
It also adds the option to prevent graphics from being produced - which cuts the runtime in half. This functionality
is needed for circumstances in which RuFaS needs to be run many times in an automated way (i.e., batch mode). It will
be especially useful for model validation and optimization.

The model can be run exactly as it was previously, prompting users for direct input:

```commandline
python main.py
```

Or the input file (or dir) can be specified directly from the command line, skipping the need for interactive input:

```commandline
python main.py "input/ARL.json"
```

And you can prevent graphics from being created by passing the GNU-style flag `--no-graphics`:

```commandline
python main.py "input/ARL.json" --no-graphics
```

The same can be achieved from within python as well:
```python
from main import run_rufas

run_rufas(in_path="input/ARL.json", make_graphs=False)
```

# Changes

The primary changes were made in `main.py`. The main function has been renamed from `main()` to `run_rufas()`, which 
accepts an optional file path, an argument specifying if graphics should be produced, and an argument specifying if
messages should be printed (not fully implemented). In order to suppress graphics across all modules, a global variable 
`SUPPRESS_GRAPHICS` was created (`config/global_variables.py`) and is updated by this function. Command line arguments 
are parsed with the `argparse` python package when applicable. 

`user_prompt.py` was also slightly refactored to implement these changes. The main function in this file is now 
`get_files_from_input()`, which returns a formatted file path based on its `path` initiating a prompt for the user to 
give input if `path=None`. 

`simulation_engine.py` has been slightly altered to suppress graphics production if the `SUPPRESS_GRAPHICS=True` 

Finally, `base_report.py` assigns its `produce_graphics` attribute to `False` if `SUPPRESS_GRAPHICS=True`.

No unit tests have yet been added for these changes mostly because I am unsure how to formally test them. 