### PR TITLE
Output handler 1/3

### DIFF
--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -1,8 +1,7 @@
 # !/usr/bin/env python3
 
-
-from typing import Any, Dict
-
+from typing import Any, Dict, Optional
+import time
 
 class OutputManager (object):
     """
@@ -10,28 +9,126 @@ class OutputManager (object):
     the pool, and populates requested output channels from the pool once the simulation
     is done. 
 
-    Attributes:
+    Attributes
+    ----------
         pool (Dict[str, Any]): Contains variables reported from simulation engine
     """
 
     def __init__(self) -> None:
         self.pool: Dict[str, Any] = {}
 
-    def collect(self, name: str, value: Any, caller: Any) -> None:
-        key = f"{self.__get_prefix(caller)}_{name}_{self.__get_suffix(name,caller)}"
-        self.__add_to_pool(key, value)
+    def add_to_pool(self, name: str, value: Any, **kwargs: Dict[Any, Any]) -> None:
+        """
+        Adds a variable to the output pool.
 
-    def __add_to_pool(self, key: str, value: Any) -> None:
+        Parameters
+        ----------
+        name : str
+            The name of the variable
+        value : Any
+            The value of the variable
+        kwargs : Dict[Any, Any]
+            Additional args, some are non-optional
+        kwargs['caller_class'] : str
+            The name of the class which called this function
+        kwargs['caller_function'] : str
+            The name of the function which called this function 
+        kwargs['prefix'] : str, optional
+            If present, overrides the automated prefix
+        kwargs['suffix'] : str, optional
+            If present, overrides the automated suffix
+        kwargs['suppress_prefix'] : bool, optional
+            If present and True, suppresses the automated prefix generation.
+            Has no effect on manual prefixes.
+        kwargs['suppress_suffix'] : bool, optional
+            If present and True, suppresses the automated suffix generation.
+            Has no effect on manual suffix.
+        kwargs['enforce_override'] : bool, optional
+            If present and True, overrides the existing value in the pool if a
+            name collision happens.
+        kwargs['fail_silently'] : bool, optional
+            If present and True, suppresses raising error if a name collision
+            happens.
+
+        Raises
+        ------
+        ValueError
+            If a name collision happens in the pool and either
+            **kwargs['fail_silently'] or **kwargs['enforce_override'] 
+            are not set to True.
+        """
+        key = self.__generate_key(name, kwargs)
+        key_not_exists = self.pool.get(key) is None
+        if key_not_exists:
+            self.pool[key] = value
+            return
+        if kwargs.get('enforce_override', False):
+            self.pool[key] = value
+            return
+        if not kwargs.get('fail_silently', False):
+            raise ValueError(f"Key {key} already exists in the pool." +
+                             "Consider using different name, prefix/suffix;" +
+                             "or turn the automated prefix/suffix generation on"
+                             )
+
+    def __generate_key(self, name: str, **kwargs: Dict[Any, Any]) -> str:
+        """
+        Generates key for the pool.
+        See 'add_to_pool' docs for detailed arg description.
+
+        Raises
+        ------
+        KeyError
+            If either kwargs['caller_class'] or kwargs['caller_function'] are 
+            not present.
+        """
+        if kwargs.get('caller_class') is None:
+            raise KeyError("'caller_class' were not found in kwargs")
+        if kwargs.get('caller_function') is None:
+            raise KeyError("'caller_function' were not found in kwargs")
+
+        prefix = ""
+        if kwargs.get('prefix') is not None:
+            prefix = kwargs.get('prefix') + "."
+        elif not kwargs.get('suppress_prefix', False):
+            prefix = self.__get_prefix(kwargs.get(
+                'caller_class'), kwargs.get('caller_function')) + "."
+
+        suffix = ""
+        if kwargs.get('suffix') is not None:
+            suffix = "." + kwargs.get('suffix')
+        elif not kwargs.get('suppress_suffix', False):
+            suffix = "." + self.__get_suffix()
+
+        return f"{prefix}{name}{suffix}"
+
+    def __get_prefix(self, caller_class: str, caller_function: str) -> str:
+        """
+        Returns the prefix for a key in the pool.
+
+        Parameters
+        ----------
+        caller_class : str
+            The name of the class in which this key-value pair is originated
+        caller_function : str
+            The name of the function in which this key-value pair is originated
+
+        Returns
+        -------
+        str
+            {caller_class}.{caller_function}
+        """
+        return f"{caller_class}.{caller_function}"
+
+    def __get_suffix(self) -> str:
+        """
+        Returns a suffix for a key in the pool by usin timestamp in ns.
+        This gurrantees that no name collision will happen.
+        """
+        return str(time.time())
+
+    def __read_json_configs(self) -> None:
         pass
 
-    def __get_prefix(self, caller: Any) -> str:
-        pass
-
-    def __get_suffix(self, name: str, caller: Any) -> str:
-        pass
-
-    def __read_json_configs(self)->None:
-        pass
-
-    def save_to_file(self)->None:
+    def save_to_file(self) -> None:
         pass

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -1,0 +1,37 @@
+# !/usr/bin/env python3
+
+
+from typing import Any, Dict
+
+
+class OutputManager (object):
+    """
+    Output manager for Rufas simulation results. Works by collecting variables into
+    the pool, and populates requested output channels from the pool once the simulation
+    is done. 
+
+    Attributes:
+        pool (Dict[str, Any]): Contains variables reported from simulation engine
+    """
+
+    def __init__(self) -> None:
+        self.pool: Dict[str, Any] = {}
+
+    def collect(self, name: str, value: Any, caller: Any) -> None:
+        key = f"{self.__get_prefix(caller)}_{name}_{self.__get_suffix(name,caller)}"
+        self.__add_to_pool(key, value)
+
+    def __add_to_pool(self, key: str, value: Any) -> None:
+        pass
+
+    def __get_prefix(self, caller: Any) -> str:
+        pass
+
+    def __get_suffix(self, name: str, caller: Any) -> str:
+        pass
+
+    def __read_json_configs(self)->None:
+        pass
+
+    def save_to_file(self)->None:
+        pass

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -6,7 +6,7 @@ import time
 
 class OutputManager (object):
     """
-    Output manager for Rufas simulation results. Works by collecting variables
+    Output manager for RufaS simulation results. Works by collecting variables
     into the pool, and populates requested output channels from the pool once
     the simulation is done. Warnings and errors are added to their own pools.
 
@@ -18,17 +18,23 @@ class OutputManager (object):
         Contains warnings reported from simulation engine
     errors_pool : Dict[str, Any]
         Contains errors reported from simulation engine
+    logs_pool : Dict[str, Any]
+        Contains logs reported from simulation engine
     """
 
     def __init__(self) -> None:
         self.pool: Dict[str, Any] = {}
         self.warnings_pool: Dict[str, Any] = {}
         self.errors_pool: Dict[str, Any] = {}
+        self.logs_pool: Dict[str, Any] = {}
+        self.add_log("Output Manager instantiated.",
+                     caller_class=self.__class__.__name__,
+                     caller_function=self.__init__.__name__)
 
-    def add_to_pool(self, name: str, value: Any,
+    def add_variable(self, name: str, value: Any,
                     **kwargs: Dict[str, Union[str, bool]]) -> None:
         """
-        Adds a variable to the output pool.
+        Adds a variable to the pool.
 
         Parameters
         ----------
@@ -54,15 +60,15 @@ class OutputManager (object):
             Has no effect on manual suffix overrides.
         kwargs['enforce_override'] : bool, optional
             If present and True, overrides the existing value in the pool if a
-            name collision happens.
+            key collision happens.
         kwargs['fail_silently'] : bool, optional
-            If present and True, suppresses raising error if a name collision
+            If present and True, suppresses raising error if a key collision
             happens.
 
         Raises
         ------
         ValueError
-            If a name collision happens in the pool and either
+            If a key collision happens in the pool and either
             **kwargs['fail_silently'] or **kwargs['enforce_override'] 
             are not set to True.
         """
@@ -80,7 +86,7 @@ class OutputManager (object):
             return
         if kwargs.get('fail_silently', False):
             self.add_warning(
-                "Key collision happened; the value was overriden per given flag.",
+                "Key collision happened; the event was ignored per given flag.",
                 self.__class__.__name__, function_name, [key], kwargs)
             return
         raise ValueError(f"Key {key} already exists in the pool." +
@@ -88,8 +94,29 @@ class OutputManager (object):
                          "or turn the automated prefix/suffix generation on"
                          )
 
-    def add_warning(self, msg: str, caller_class: str, caller_function: str,
-                    *args: List[Any], **kwargs: Dict[Any, Any]) -> None:
+    def add_log(
+            self, msg: str, *args: List[Any], **kwargs: Dict[Any, Any]) -> None:
+        """
+        Adds a log message to the pool of logs.
+
+        Parameters
+        ----------
+        msg : str
+            The log message to be added to the pool
+        *args: List[Any]
+            Contains any additional information to be added to the message  
+        **kwargs: Dict[Any, Any]
+            Additional args, some are non-optional
+        kwargs['caller_class'] : str
+            The name of the class which called this function
+        kwargs['caller_function'] : str
+            The name of the function which called this function 
+        """
+        key = self.__generate_key('log_entry', kwargs)
+        self.logs_pool[key] = {'msg': msg, 'args': args, 'kwargs': kwargs}
+
+    def add_warning(
+            self, msg: str, *args: List[Any], **kwargs: Dict[Any, Any]) -> None:
         """
         Adds a warning message to the pool of warnings.
 
@@ -97,16 +124,17 @@ class OutputManager (object):
         ----------
         msg : str
             The warning message to be added to the pool
-        caller_class : str
-            The name of the class which called this function
-        caller_function : str
-            The name of the function which called this function    
         *args: List[Any]
             Contains any additional information to be added to the message  
         **kwargs: Dict[Any, Any]
-            Contains any additional information to be added to the message
+            Additional args, some are non-optional
+        kwargs['caller_class'] : str
+            The name of the class which called this function
+        kwargs['caller_function'] : str
+            The name of the function which called this function 
         """
-        pass
+        key = self.__generate_key('warning_entry', kwargs)
+        self.warnings_pool[key] = {'msg': msg, 'args': args, 'kwargs': kwargs}
 
     def add_error(self, msg: str, caller_class: str, caller_function: str,
                   *args: List[Any], **kwargs: Dict[Any, Any]) -> None:
@@ -117,16 +145,17 @@ class OutputManager (object):
         ----------
         msg : str
             The error message to be added to the pool
-        caller_class : str
-            The name of the class which called this function
-        caller_function : str
-            The name of the function which called this function    
         *args: List[Any]
             Contains any additional information to be added to the message  
         **kwargs: Dict[Any, Any]
-            Contains any additional information to be added to the message
+            Additional args, some are non-optional
+        kwargs['caller_class'] : str
+            The name of the class which called this function
+        kwargs['caller_function'] : str
+            The name of the function which called this function 
         """
-        pass
+        key = self.__generate_key('error_entry', kwargs)
+        self.errors_pool[key] = {'msg': msg, 'args': args, 'kwargs': kwargs}
 
     def __generate_key(self, name: str,
                        **kwargs: Dict[str, Union[str, bool]]) -> str:

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -13,13 +13,13 @@ class OutputManager (object):
     Attributes
     ----------
     pool : Dict[str, Any]
-        Contains variables reported from simulation engine
+        Contains variables reported to the output manager
     warnings_pool : Dict[str, Any]
-        Contains warnings reported from simulation engine
+        Contains warnings reported to the output manager
     errors_pool : Dict[str, Any]
-        Contains errors reported from simulation engine
+        Contains errors reported to the output manager
     logs_pool : Dict[str, Any]
-        Contains logs reported from simulation engine
+        Contains logs reported to the output manager 
     """
 
     def __init__(self) -> None:

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -6,9 +6,9 @@ import time
 
 class OutputManager (object):
     """
-    Output manager for RufaS simulation results. Works by collecting variables,
-    logs, warnings, and errors into the pools, and populates requested output
-    channels from the pool once the simulation is done. 
+    Output manager for RuFaS simulation results. Works by collecting variables,
+    logs, warnings, and errors into separate pools, and populates requested
+    output channels from the pools once the simulation is done. 
 
     OutputManager is singleton, i.e., only one instance of it can exist. After
     the first instance is created, future calls to the constructor method 
@@ -16,7 +16,7 @@ class OutputManager (object):
 
     Attributes
     ----------
-    pool : Dict[str, Any]
+    variables_pool : Dict[str, Any]
         Contains variables reported to the output manager
     warnings_pool : Dict[str, Any]
         Contains warnings reported to the output manager
@@ -35,7 +35,7 @@ class OutputManager (object):
     def __init__(self) -> None:
         if OutputManager.__instance is None:
             OutputManager.__instance = self
-            self.pool: Dict[str, Any] = {}
+            self.variables_pool: Dict[str, Any] = {}
             self.warnings_pool: Dict[str, Any] = {}
             self.errors_pool: Dict[str, Any] = {}
             self.logs_pool: Dict[str, Any] = {}
@@ -85,15 +85,15 @@ class OutputManager (object):
             are not set to True.
         """
         key = self._generate_key(name, info_map)
-        key_not_exists = self.pool.get(key) is None
+        key_not_exists = self.variables_pool.get(key) is None
         if key_not_exists:
-            self.pool[key] = value
+            self.variables_pool[key] = value
             return
         info_map['key'] = key
         info_map['caller_function'] = self.add_variable.__name__
         info_map['caller_class'] = self.__class__.__name__
         if info_map.get('enforce_override', False):
-            self.pool[key] = value
+            self.variables_pool[key] = value
             self.add_warning('key_collision',
                              "Key collision happened; the value was overriden per given flag.",
                              info_map)
@@ -103,7 +103,7 @@ class OutputManager (object):
                            "Key collision happened; the event was ignored per given flag.",
                            info_map)
             return
-        raise ValueError(f"Key {key} already exists in the pool." +
+        raise ValueError(f"Key {key} already exists in the variables_pool." +
                          "Consider using different name, prefix/suffix;" +
                          "or turn the automated prefix/suffix generation on"
                          )
@@ -205,7 +205,7 @@ class OutputManager (object):
         if info_map.get('suffix') is not None:
             suffix = "." + info_map.get('suffix')
         elif not info_map.get('suppress_suffix', False):
-            suffix = "." + self._get_suffix()
+            suffix = "." + self._get_time_based_suffix()
 
         return f"{prefix}{name}{suffix}"
 
@@ -227,7 +227,7 @@ class OutputManager (object):
         """
         return f"{caller_class}.{caller_function}"
 
-    def _get_suffix(self) -> str:
+    def _get_time_based_suffix(self) -> str:
         """
         Returns a suffix for a key in the pool by using timestamp in ns.
         This gurrantees that no name collision will happen.

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -32,15 +32,14 @@ class OutputManager (object):
             cls.instance = super(OutputManager, cls).__new__(cls)
         return cls.instance
 
-    def __init__(self, cls) -> None:
+    def __init__(self) -> None:
         if OutputManager.__instance is None:
             OutputManager.__instance = self
-            self.x = 0
             self.pool: Dict[str, Any] = {}
             self.warnings_pool: Dict[str, Any] = {}
             self.errors_pool: Dict[str, Any] = {}
             self.logs_pool: Dict[str, Any] = {}
-            self.add_log("Output Manager instantiated.",
+            self.add_log("init_log", "Output Manager instantiated.",
                          info_map={'caller_class': self.__class__.__name__,
                                    'caller_function': self.__init__.__name__})
 
@@ -85,87 +84,104 @@ class OutputManager (object):
             info_map['fail_silently'] or info_map['enforce_override'] 
             are not set to True.
         """
-        key = self.__generate_key(name, info_map)
+        key = self._generate_key(name, info_map)
         key_not_exists = self.pool.get(key) is None
         if key_not_exists:
             self.pool[key] = value
             return
         info_map['key'] = key
-        info_map['caller_function'] = self.add_to_pool.__name__
+        info_map['caller_function'] = self.add_variable.__name__
         info_map['caller_class'] = self.__class__.__name__
         if info_map.get('enforce_override', False):
             self.pool[key] = value
-            self.add_warning(
-                "Key collision happened; the value was overriden per given flag.", info_map)
+            self.add_warning('key_collision',
+                             "Key collision happened; the value was overriden per given flag.",
+                             info_map)
             return
         if info_map.get('fail_silently', False):
-            self.add_error(
-                "Key collision happened; the event was ignored per given flag.", info_map)
+            self.add_error('key_collision',
+                           "Key collision happened; the event was ignored per given flag.",
+                           info_map)
             return
         raise ValueError(f"Key {key} already exists in the pool." +
                          "Consider using different name, prefix/suffix;" +
                          "or turn the automated prefix/suffix generation on"
                          )
 
-    def add_log(self, msg: str, info_map: Dict[str, Any]) -> None:
+    def add_log(self, name: str, msg: str, info_map: Dict[str, Any]) -> None:
         """
         Adds a log message to the pool of logs.
 
         Parameters
         ----------
+        name : str
+            The name of the log
         msg : str
             The log message to be added to the pool
-        info_map: Dict[Any, Any]
-            Additional args, some are non-optional
+        info_map: Dict[str, Any]
+            Additional args to be logged, some are non-optional
         info_map['caller_class'] : str
             The name of the class which called this function
         info_map['caller_function'] : str
             The name of the function which called this function 
         """
-        key = self.__generate_key('log_entry', info_map)
+        key = self._generate_key(name,
+                                 {
+                                     'caller_class': info_map['caller_class'],
+                                     'caller_function': info_map['caller_function']})
         self.logs_pool[key] = {'msg': msg, 'info_map': info_map}
 
-    def add_warning(self, msg: str, info_map: Dict[str, Any]) -> None:
+    def add_warning(self, name: str, msg: str, info_map: Dict[str, Any]) -> None:
         """
         Adds a warning message to the pool of warnings.
 
         Parameters
         ----------
+        name : str
+            The name of the warning
         msg : str
             The warning message to be added to the pool
-        info_map: Dict[Any, Any]
-            Additional args, some are non-optional
+        info_map: Dict[str, Any]
+            Additional args to be logged, some are non-optional
         info_map['caller_class'] : str
             The name of the class which called this function
         info_map['caller_function'] : str
             The name of the function which called this function 
         """
-        key = self.__generate_key('warning_entry', info_map)
+        key = self._generate_key(name,
+                                 {
+                                     'caller_class': info_map['caller_class'],
+                                     'caller_function': info_map['caller_function']})
         self.warnings_pool[key] = {'msg': msg, 'info_map': info_map}
 
-    def add_error(self, msg: str, info_map: Dict[str, Any]) -> None:
+    def add_error(self, name: str, msg: str, info_map: Dict[str, Any]) -> None:
         """
         Adds an error message to the pool of errors.
 
         Parameters
         ----------
+        name : str
+            The name of the error
         msg : str
             The error message to be added to the pool
         info_map: Dict[str, Any]
-            Additional args, some are non-optional
+            Additional args to be logged, some are non-optional
         info_map['caller_class'] : str
             The name of the class which called this function
         info_map['caller_function'] : str
             The name of the function which called this function 
         """
-        key = self.__generate_key('error_entry', info_map)
+        key = self._generate_key(name,
+                                 {
+                                     'caller_class': info_map['caller_class'],
+                                     'caller_function': info_map['caller_function']})
         self.errors_pool[key] = {'msg': msg, 'info_map': info_map}
 
-    def __generate_key(self, name: str,
-                       info_map: Dict[str, Union[str, bool]]) -> str:
+    def _generate_key(self, name: str,
+                      info_map: Dict[str, Union[str, bool]]) -> str:
         """
         Generates key for the pool.
-        See 'add_to_pool' docs for detailed arg description.
+        See 'add_variable' docs for detailed arg description.
 
         Raises
         ------
@@ -182,18 +198,18 @@ class OutputManager (object):
         if info_map.get('prefix') is not None:
             prefix = info_map.get('prefix') + "."
         elif not info_map.get('suppress_prefix', False):
-            prefix = self.__get_prefix(info_map.get(
+            prefix = self._get_prefix(info_map.get(
                 'caller_class'), info_map.get('caller_function')) + "."
 
         suffix = ""
         if info_map.get('suffix') is not None:
             suffix = "." + info_map.get('suffix')
         elif not info_map.get('suppress_suffix', False):
-            suffix = "." + self.__get_suffix()
+            suffix = "." + self._get_suffix()
 
         return f"{prefix}{name}{suffix}"
 
-    def __get_prefix(self, caller_class: str, caller_function: str) -> str:
+    def _get_prefix(self, caller_class: str, caller_function: str) -> str:
         """
         Returns the prefix for a key in the pool.
 
@@ -211,7 +227,7 @@ class OutputManager (object):
         """
         return f"{caller_class}.{caller_function}"
 
-    def __get_suffix(self) -> str:
+    def _get_suffix(self) -> str:
         """
         Returns a suffix for a key in the pool by using timestamp in ns.
         This gurrantees that no name collision will happen.

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -32,7 +32,7 @@ class OutputManager (object):
             cls.instance = super(OutputManager, cls).__new__(cls)
         return cls.instance
 
-    def __init__(self,cls) -> None:
+    def __init__(self, cls) -> None:
         if OutputManager.__instance is None:
             OutputManager.__instance = self
             self.x = 0
@@ -41,11 +41,11 @@ class OutputManager (object):
             self.errors_pool: Dict[str, Any] = {}
             self.logs_pool: Dict[str, Any] = {}
             self.add_log("Output Manager instantiated.",
-                         caller_class=self.__class__.__name__,
-                         caller_function=self.__init__.__name__)
+                         info_map={'caller_class': self.__class__.__name__,
+                                   'caller_function': self.__init__.__name__})
 
     def add_variable(self, name: str, value: Any,
-                     **kwargs: Dict[str, Union[str, bool]]) -> None:
+                     info_map: Dict[str, Union[str, bool]]) -> None:
         """
         Adds a variable to the pool.
 
@@ -55,26 +55,26 @@ class OutputManager (object):
             The name of the variable
         value : Any
             The value of the variable
-        kwargs : Dict[str, Union[str,bool]]
+        info_map : Dict[str, Union[str,bool]]
             Additional args, some are non-optional
-        kwargs['caller_class'] : str
+        info_map['caller_class'] : str
             The name of the class which called this function
-        kwargs['caller_function'] : str
+        info_map['caller_function'] : str
             The name of the function which called this function 
-        kwargs['prefix'] : str, optional
+        info_map['prefix'] : str, optional
             If present, overrides the automated prefix
-        kwargs['suffix'] : str, optional
+        info_map['suffix'] : str, optional
             If present, overrides the automated suffix
-        kwargs['suppress_prefix'] : bool, optional
+        info_map['suppress_prefix'] : bool, optional
             If present and True, suppresses the automated prefix generation.
             Has no effect on manual prefix overrides.
-        kwargs['suppress_suffix'] : bool, optional
+        info_map['suppress_suffix'] : bool, optional
             If present and True, suppresses the automated suffix generation.
             Has no effect on manual suffix overrides.
-        kwargs['enforce_override'] : bool, optional
+        info_map['enforce_override'] : bool, optional
             If present and True, overrides the existing value in the pool if a
             key collision happens.
-        kwargs['fail_silently'] : bool, optional
+        info_map['fail_silently'] : bool, optional
             If present and True, suppresses raising error if a key collision
             happens.
 
@@ -82,33 +82,32 @@ class OutputManager (object):
         ------
         ValueError
             If a key collision happens in the pool and either
-            **kwargs['fail_silently'] or **kwargs['enforce_override'] 
+            info_map['fail_silently'] or info_map['enforce_override'] 
             are not set to True.
         """
-        function_name = self.add_to_pool.__name__
-        key = self.__generate_key(name, kwargs)
+        key = self.__generate_key(name, info_map)
         key_not_exists = self.pool.get(key) is None
         if key_not_exists:
             self.pool[key] = value
             return
-        if kwargs.get('enforce_override', False):
+        info_map['key'] = key
+        info_map['caller_function'] = self.add_to_pool.__name__
+        info_map['caller_class'] = self.__class__.__name__
+        if info_map.get('enforce_override', False):
             self.pool[key] = value
             self.add_warning(
-                "Key collision happened; the value was overriden per given flag.",
-                self.__class__.__name__, function_name, [key], kwargs)
+                "Key collision happened; the value was overriden per given flag.", info_map)
             return
-        if kwargs.get('fail_silently', False):
-            self.add_warning(
-                "Key collision happened; the event was ignored per given flag.",
-                self.__class__.__name__, function_name, [key], kwargs)
+        if info_map.get('fail_silently', False):
+            self.add_error(
+                "Key collision happened; the event was ignored per given flag.", info_map)
             return
         raise ValueError(f"Key {key} already exists in the pool." +
                          "Consider using different name, prefix/suffix;" +
                          "or turn the automated prefix/suffix generation on"
                          )
 
-    def add_log(
-            self, msg: str, *args: List[Any], **kwargs: Dict[Any, Any]) -> None:
+    def add_log(self, msg: str, info_map: Dict[str, Any]) -> None:
         """
         Adds a log message to the pool of logs.
 
@@ -116,20 +115,17 @@ class OutputManager (object):
         ----------
         msg : str
             The log message to be added to the pool
-        *args: List[Any]
-            Contains any additional information to be added to the message  
-        **kwargs: Dict[Any, Any]
+        info_map: Dict[Any, Any]
             Additional args, some are non-optional
-        kwargs['caller_class'] : str
+        info_map['caller_class'] : str
             The name of the class which called this function
-        kwargs['caller_function'] : str
+        info_map['caller_function'] : str
             The name of the function which called this function 
         """
-        key = self.__generate_key('log_entry', **kwargs)
-        self.logs_pool[key] = {'msg': msg, 'args': args, 'kwargs': kwargs}
+        key = self.__generate_key('log_entry', info_map)
+        self.logs_pool[key] = {'msg': msg, 'info_map': info_map}
 
-    def add_warning(
-            self, msg: str, *args: List[Any], **kwargs: Dict[Any, Any]) -> None:
+    def add_warning(self, msg: str, info_map: Dict[str, Any]) -> None:
         """
         Adds a warning message to the pool of warnings.
 
@@ -137,20 +133,17 @@ class OutputManager (object):
         ----------
         msg : str
             The warning message to be added to the pool
-        *args: List[Any]
-            Contains any additional information to be added to the message  
-        **kwargs: Dict[Any, Any]
+        info_map: Dict[Any, Any]
             Additional args, some are non-optional
-        kwargs['caller_class'] : str
+        info_map['caller_class'] : str
             The name of the class which called this function
-        kwargs['caller_function'] : str
+        info_map['caller_function'] : str
             The name of the function which called this function 
         """
-        key = self.__generate_key('warning_entry', kwargs)
-        self.warnings_pool[key] = {'msg': msg, 'args': args, 'kwargs': kwargs}
+        key = self.__generate_key('warning_entry', info_map)
+        self.warnings_pool[key] = {'msg': msg, 'info_map': info_map}
 
-    def add_error(self, msg: str, caller_class: str, caller_function: str,
-                  *args: List[Any], **kwargs: Dict[Any, Any]) -> None:
+    def add_error(self, msg: str, info_map: Dict[str, Any]) -> None:
         """
         Adds an error message to the pool of errors.
 
@@ -158,20 +151,18 @@ class OutputManager (object):
         ----------
         msg : str
             The error message to be added to the pool
-        *args: List[Any]
-            Contains any additional information to be added to the message  
-        **kwargs: Dict[Any, Any]
+        info_map: Dict[str, Any]
             Additional args, some are non-optional
-        kwargs['caller_class'] : str
+        info_map['caller_class'] : str
             The name of the class which called this function
-        kwargs['caller_function'] : str
+        info_map['caller_function'] : str
             The name of the function which called this function 
         """
-        key = self.__generate_key('error_entry', kwargs)
-        self.errors_pool[key] = {'msg': msg, 'args': args, 'kwargs': kwargs}
+        key = self.__generate_key('error_entry', info_map)
+        self.errors_pool[key] = {'msg': msg, 'info_map': info_map}
 
     def __generate_key(self, name: str,
-                       **kwargs: Dict[str, Union[str, bool]]) -> str:
+                       info_map: Dict[str, Union[str, bool]]) -> str:
         """
         Generates key for the pool.
         See 'add_to_pool' docs for detailed arg description.
@@ -179,25 +170,25 @@ class OutputManager (object):
         Raises
         ------
         KeyError
-            If either kwargs['caller_class'] or kwargs['caller_function'] are 
+            If either info_map['caller_class'] or info_map['caller_function'] are 
             not present.
         """
-        if kwargs.get('caller_class') is None:
-            raise KeyError("'caller_class' were not found in kwargs")
-        if kwargs.get('caller_function') is None:
-            raise KeyError("'caller_function' were not found in kwargs")
+        if info_map.get('caller_class') is None:
+            raise KeyError("'caller_class' were not found in info_map")
+        if info_map.get('caller_function') is None:
+            raise KeyError("'caller_function' were not found in info_map")
 
         prefix = ""
-        if kwargs.get('prefix') is not None:
-            prefix = kwargs.get('prefix') + "."
-        elif not kwargs.get('suppress_prefix', False):
-            prefix = self.__get_prefix(kwargs.get(
-                'caller_class'), kwargs.get('caller_function')) + "."
+        if info_map.get('prefix') is not None:
+            prefix = info_map.get('prefix') + "."
+        elif not info_map.get('suppress_prefix', False):
+            prefix = self.__get_prefix(info_map.get(
+                'caller_class'), info_map.get('caller_function')) + "."
 
         suffix = ""
-        if kwargs.get('suffix') is not None:
-            suffix = "." + kwargs.get('suffix')
-        elif not kwargs.get('suppress_suffix', False):
+        if info_map.get('suffix') is not None:
+            suffix = "." + info_map.get('suffix')
+        elif not info_map.get('suppress_suffix', False):
             suffix = "." + self.__get_suffix()
 
         return f"{prefix}{name}{suffix}"

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -12,7 +12,7 @@ class OutputManager (object):
 
     OutputManager is singleton, i.e., only one instance of it can exist. After
     the first instance is created, future calls to the constructor method 
-    returns the first instance. Also, the initilizer method only works once.
+    returns the first instance. Also, the initializer method only works once.
 
     Attributes
     ----------
@@ -103,9 +103,10 @@ class OutputManager (object):
                            "Key collision happened; the event was ignored per given flag.",
                            info_map)
             return
-        raise ValueError(f"Key {key} already exists in the variables_pool." +
-                         "Consider using different name, prefix/suffix;" +
-                         "or turn the automated prefix/suffix generation on"
+        raise ValueError(f"Key {key} already exists in the variables_pool."
+                         + "Consider using different name, prefix/suffix;"
+                         + "or turn the automated prefix/suffix generation on."
+                         + f"info_map is: {info_map}"
                          )
 
     def add_log(self, name: str, msg: str, info_map: Dict[str, Any]) -> None:
@@ -230,6 +231,6 @@ class OutputManager (object):
     def _get_time_based_suffix(self) -> str:
         """
         Returns a suffix for a key in the pool by using timestamp in ns.
-        This gurrantees that no name collision will happen.
+        This guarantees that no name collision will happen.
         """
         return str(time.time())

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -6,9 +6,13 @@ import time
 
 class OutputManager (object):
     """
-    Output manager for RufaS simulation results. Works by collecting variables
-    into the pool, and populates requested output channels from the pool once
-    the simulation is done. Warnings and errors are added to their own pools.
+    Output manager for RufaS simulation results. Works by collecting variables,
+    logs, warnings, and errors into the pools, and populates requested output
+    channels from the pool once the simulation is done. 
+
+    OutputManager is singleton, i.e., only one instance of it can exist. After
+    the first instance is created, future calls to the constructor method 
+    returns the first instance. Also, the initilizer method only works once.
 
     Attributes
     ----------
@@ -21,18 +25,27 @@ class OutputManager (object):
     logs_pool : Dict[str, Any]
         Contains logs reported to the output manager 
     """
+    __instance = None
 
-    def __init__(self) -> None:
-        self.pool: Dict[str, Any] = {}
-        self.warnings_pool: Dict[str, Any] = {}
-        self.errors_pool: Dict[str, Any] = {}
-        self.logs_pool: Dict[str, Any] = {}
-        self.add_log("Output Manager instantiated.",
-                     caller_class=self.__class__.__name__,
-                     caller_function=self.__init__.__name__)
+    def __new__(cls):
+        if not hasattr(cls, 'instance'):
+            cls.instance = super(OutputManager, cls).__new__(cls)
+        return cls.instance
+
+    def __init__(self,cls) -> None:
+        if OutputManager.__instance is None:
+            OutputManager.__instance = self
+            self.x = 0
+            self.pool: Dict[str, Any] = {}
+            self.warnings_pool: Dict[str, Any] = {}
+            self.errors_pool: Dict[str, Any] = {}
+            self.logs_pool: Dict[str, Any] = {}
+            self.add_log("Output Manager instantiated.",
+                         caller_class=self.__class__.__name__,
+                         caller_function=self.__init__.__name__)
 
     def add_variable(self, name: str, value: Any,
-                    **kwargs: Dict[str, Union[str, bool]]) -> None:
+                     **kwargs: Dict[str, Union[str, bool]]) -> None:
         """
         Adds a variable to the pool.
 
@@ -112,7 +125,7 @@ class OutputManager (object):
         kwargs['caller_function'] : str
             The name of the function which called this function 
         """
-        key = self.__generate_key('log_entry', kwargs)
+        key = self.__generate_key('log_entry', **kwargs)
         self.logs_pool[key] = {'msg': msg, 'args': args, 'kwargs': kwargs}
 
     def add_warning(

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -1,23 +1,32 @@
 # !/usr/bin/env python3
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Union
 import time
+
 
 class OutputManager (object):
     """
-    Output manager for Rufas simulation results. Works by collecting variables into
-    the pool, and populates requested output channels from the pool once the simulation
-    is done. 
+    Output manager for Rufas simulation results. Works by collecting variables
+    into the pool, and populates requested output channels from the pool once
+    the simulation is done. Warnings and errors are added to their own pools.
 
     Attributes
     ----------
-        pool (Dict[str, Any]): Contains variables reported from simulation engine
+    pool : Dict[str, Any]
+        Contains variables reported from simulation engine
+    warnings_pool : Dict[str, Any]
+        Contains warnings reported from simulation engine
+    errors_pool : Dict[str, Any]
+        Contains errors reported from simulation engine
     """
 
     def __init__(self) -> None:
         self.pool: Dict[str, Any] = {}
+        self.warnings_pool: Dict[str, Any] = {}
+        self.errors_pool: Dict[str, Any] = {}
 
-    def add_to_pool(self, name: str, value: Any, **kwargs: Dict[Any, Any]) -> None:
+    def add_to_pool(self, name: str, value: Any,
+                    **kwargs: Dict[str, Union[str, bool]]) -> None:
         """
         Adds a variable to the output pool.
 
@@ -27,7 +36,7 @@ class OutputManager (object):
             The name of the variable
         value : Any
             The value of the variable
-        kwargs : Dict[Any, Any]
+        kwargs : Dict[str, Union[str,bool]]
             Additional args, some are non-optional
         kwargs['caller_class'] : str
             The name of the class which called this function
@@ -39,10 +48,10 @@ class OutputManager (object):
             If present, overrides the automated suffix
         kwargs['suppress_prefix'] : bool, optional
             If present and True, suppresses the automated prefix generation.
-            Has no effect on manual prefixes.
+            Has no effect on manual prefix overrides.
         kwargs['suppress_suffix'] : bool, optional
             If present and True, suppresses the automated suffix generation.
-            Has no effect on manual suffix.
+            Has no effect on manual suffix overrides.
         kwargs['enforce_override'] : bool, optional
             If present and True, overrides the existing value in the pool if a
             name collision happens.
@@ -57,6 +66,7 @@ class OutputManager (object):
             **kwargs['fail_silently'] or **kwargs['enforce_override'] 
             are not set to True.
         """
+        function_name = self.add_to_pool.__name__
         key = self.__generate_key(name, kwargs)
         key_not_exists = self.pool.get(key) is None
         if key_not_exists:
@@ -64,14 +74,62 @@ class OutputManager (object):
             return
         if kwargs.get('enforce_override', False):
             self.pool[key] = value
+            self.add_warning(
+                "Key collision happened; the value was overriden per given flag.",
+                self.__class__.__name__, function_name, [key], kwargs)
             return
-        if not kwargs.get('fail_silently', False):
-            raise ValueError(f"Key {key} already exists in the pool." +
-                             "Consider using different name, prefix/suffix;" +
-                             "or turn the automated prefix/suffix generation on"
-                             )
+        if kwargs.get('fail_silently', False):
+            self.add_warning(
+                "Key collision happened; the value was overriden per given flag.",
+                self.__class__.__name__, function_name, [key], kwargs)
+            return
+        raise ValueError(f"Key {key} already exists in the pool." +
+                         "Consider using different name, prefix/suffix;" +
+                         "or turn the automated prefix/suffix generation on"
+                         )
 
-    def __generate_key(self, name: str, **kwargs: Dict[Any, Any]) -> str:
+    def add_warning(self, msg: str, caller_class: str, caller_function: str,
+                    *args: List[Any], **kwargs: Dict[Any, Any]) -> None:
+        """
+        Adds a warning message to the pool of warnings.
+
+        Parameters
+        ----------
+        msg : str
+            The warning message to be added to the pool
+        caller_class : str
+            The name of the class which called this function
+        caller_function : str
+            The name of the function which called this function    
+        *args: List[Any]
+            Contains any additional information to be added to the message  
+        **kwargs: Dict[Any, Any]
+            Contains any additional information to be added to the message
+        """
+        pass
+
+    def add_error(self, msg: str, caller_class: str, caller_function: str,
+                  *args: List[Any], **kwargs: Dict[Any, Any]) -> None:
+        """
+        Adds an error message to the pool of errors.
+
+        Parameters
+        ----------
+        msg : str
+            The error message to be added to the pool
+        caller_class : str
+            The name of the class which called this function
+        caller_function : str
+            The name of the function which called this function    
+        *args: List[Any]
+            Contains any additional information to be added to the message  
+        **kwargs: Dict[Any, Any]
+            Contains any additional information to be added to the message
+        """
+        pass
+
+    def __generate_key(self, name: str,
+                       **kwargs: Dict[str, Union[str, bool]]) -> str:
         """
         Generates key for the pool.
         See 'add_to_pool' docs for detailed arg description.
@@ -122,13 +180,7 @@ class OutputManager (object):
 
     def __get_suffix(self) -> str:
         """
-        Returns a suffix for a key in the pool by usin timestamp in ns.
+        Returns a suffix for a key in the pool by using timestamp in ns.
         This gurrantees that no name collision will happen.
         """
         return str(time.time())
-
-    def __read_json_configs(self) -> None:
-        pass
-
-    def save_to_file(self) -> None:
-        pass

--- a/RUFAS/routines/animal/animal_management.py
+++ b/RUFAS/routines/animal/animal_management.py
@@ -24,7 +24,6 @@ import random
 from typing import Tuple
 from statistics import mean
 
-
 def daily_animal_routine(animal_management, feed, weather, time):
     """
     Executes daily routines relating to Animals. This method is called every day
@@ -38,7 +37,6 @@ def daily_animal_routine(animal_management, feed, weather, time):
         weather: instance of the Weather class as defined in classes.py
         time: instance of the Time class as defined in classes.py
     """
-
     animal_management.daily_updates(feed, weather, time)
 
 

--- a/RUFAS/routines/field/field.py
+++ b/RUFAS/routines/field/field.py
@@ -11,7 +11,6 @@ from .soil.soil import *
 from .field_management.field_management import *
 from ...util import Utility
 
-
 def daily_fields_routine(fields, manure_storage, weather, time):
     for field in fields.fields.values():
         soil = field.soil

--- a/RUFAS/routines/manure/manure_management.py
+++ b/RUFAS/routines/manure/manure_management.py
@@ -15,7 +15,6 @@ from typing import Dict, List, Tuple
 from RUFAS.routines.animal.animal_management import AnimalManagement
 from RUFAS.routines.manure.ManureManagementPen.manure_management_pen import ManureManagementPen
 
-
 class ManureManagement:
     """
     A class that sets up and manages different manure management components including manure handlers,

--- a/RUFAS/simulation_engine.py
+++ b/RUFAS/simulation_engine.py
@@ -69,7 +69,8 @@ class SimulationEngine:
             self.state.animal_management, self.state.feed, self.weather, self.time)
         routines.daily_manure_storage_routine(
             self.state.manure_storage, self.state.animal_management)
-        simulate_daily_manure_management(self.state.manure_management, self.state.animal_management)
+        simulate_daily_manure_management(
+            self.state.manure_management, self.state.animal_management)
         routines.daily_fields_routine(
             self.state.fields, self.state.manure_storage, self.weather, self.time)
         routines.daily_feed_routine(self.state.feed, self.state.fields, self.state.animal_management,

--- a/RUFAS/simulation_engine.py
+++ b/RUFAS/simulation_engine.py
@@ -26,7 +26,6 @@ class SimulationEngine:
 
     def simulate(self) -> None:
         """Executes the simulation"""
-
         t_start_sim = timer.time()
         self._run_simulation_main_loop()
         self.output.finalize(self.state, self.weather, self.time)

--- a/main.py
+++ b/main.py
@@ -15,7 +15,6 @@ def main():
     print("RUFAS: Ruminant Farm Systems Model 2022")
 
     input_file_list = input_prompt()
-
     for input_file_path in input_file_list:
         simulator = SimulationEngine(input_file_path)
         simulator.simulate()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -10,6 +10,7 @@ from mock.mock import MagicMock
 from pytest import approx, raises
 from pytest_mock.plugin import MockerFixture
 
+from RUFAS.output_manager import OutputManager
 from RUFAS.simulation_engine import SimulationEngine
 from RUFAS.util import Utility
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -287,12 +287,12 @@ def test_percent_calculator() -> None:
         pc(1.0)
 
 
-def test_get_suffix(mocker: MockerFixture) -> None:
+def test_get_time_based_suffix(mocker: MockerFixture) -> None:
     """Unit test for function _get_suffix in file output_manager.py"""
     auto_suffix = '1669002803.9697945'
     mocker.patch('time.time', return_value=auto_suffix)
     om = OutputManager()
-    assert om._get_suffix() == auto_suffix
+    assert om._get_time_based_suffix() == auto_suffix
 
 
 def test_get_prefix() -> None:
@@ -393,7 +393,7 @@ def test_add_variable(mocker: MockerFixture) -> None:
     om = OutputManager()
     info_map = {'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}
     om.add_variable('dummy_name', 'dummy_value', info_map)
-    assert om.pool[key] == 'dummy_value'
+    assert om.variables_pool[key] == 'dummy_value'
 
     with raises(ValueError):
         om.add_variable('dummy_name', 'dummy_value', info_map)
@@ -402,12 +402,11 @@ def test_add_variable(mocker: MockerFixture) -> None:
 
 def test_output_manager_singleton(mocker: MockerFixture) -> None:
     """Test case to ensure output_manager is singleton"""
-    key = 'key'
+    key = 'key1'
     mocker.patch('RUFAS.output_manager.OutputManager._generate_key',
                  return_value=key)
     om1 = OutputManager()
     om2 = OutputManager()
     info_map = {'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}
-    om1.add_log('dummy_name', 'dummy_msg', info_map)
-    assert om2.logs_pool[key] == {'info_map': {
-        'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}, 'msg': 'dummy_msg'}
+    om1.add_variable('dummy_name', 'dummy_value', info_map)    
+    assert om2.variables_pool[key] == 'dummy_value'

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -59,7 +59,7 @@ def test_is_leap_year():
 def patch_simulation_engine(mocker: MockerFixture) -> SimulationEngine:
     """Returns a mocked SimulationEngine"""
     mocker.patch(
-            'RUFAS.simulation_engine.SimulationEngine._initialize_simulation')
+        'RUFAS.simulation_engine.SimulationEngine._initialize_simulation')
 
     sim_eng = SimulationEngine('dummy_path')
     sim_eng.config = MagicMock()
@@ -74,20 +74,20 @@ def patch_simulation_engine(mocker: MockerFixture) -> SimulationEngine:
 def test_init_simulation_engine(patch_simulation_engine: SimulationEngine) -> None:
     """Unit test for function __init__ in file RUFAS/simulation_engine.py"""
     patch_simulation_engine._initialize_simulation.assert_called_once_with(
-            'dummy_path')
+        'dummy_path')
 
 
 def test_simulate(patch_simulation_engine: SimulationEngine, mocker: MockerFixture) -> None:
     """Unit test for function simulate in file RUFAS/simulation_engine.py"""
     mocker.patch(
-            'RUFAS.simulation_engine.SimulationEngine._run_simulation_main_loop')
+        'RUFAS.simulation_engine.SimulationEngine._run_simulation_main_loop')
     mocker.patch(
-            'RUFAS.simulation_engine.SimulationEngine._show_final_messages')
+        'RUFAS.simulation_engine.SimulationEngine._show_final_messages')
     sim_eng = patch_simulation_engine
     sim_eng.simulate()
     sim_eng._run_simulation_main_loop.assert_called_once()
     sim_eng.output.finalize.assert_called_once_with(
-            sim_eng.state, sim_eng.weather, sim_eng.time)
+        sim_eng.state, sim_eng.weather, sim_eng.time)
     sim_eng._show_final_messages.assert_called_once()
 
 
@@ -285,3 +285,129 @@ def test_percent_calculator() -> None:
     pc = Utility.percent_calculator(denominator=0)
     with raises(ZeroDivisionError):
         pc(1.0)
+
+
+def test_get_suffix(mocker: MockerFixture) -> None:
+    """Unit test for function _get_suffix in file output_manager.py"""
+    auto_suffix = '1669002803.9697945'
+    mocker.patch('time.time', return_value=auto_suffix)
+    om = OutputManager()
+    assert om._get_suffix() == auto_suffix
+
+
+def test_get_prefix() -> None:
+    """Unit test for function _get_prefix in file output_manager.py"""
+    om = OutputManager()
+    assert om._get_prefix('class', 'func') == 'class.func'
+
+
+def test_generate_key(mocker: MockerFixture) -> None:
+    """Unit test for function _generate_key in file output_manager.py"""
+    om = OutputManager()
+    with raises(KeyError):
+        om._generate_key('name', {})
+
+    auto_suffix = '1669002803.9697945'
+    mocker.patch('time.time', return_value=auto_suffix)
+
+    info_map = {'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}
+    key = om._generate_key('key_name', info_map)
+    assert key == f'dummy_class.dummy_func.key_name.{auto_suffix}'
+
+    info_map['suppress_prefix'] = True
+    key = om._generate_key('key_name', info_map)
+    assert key == f'key_name.{auto_suffix}'
+
+    info_map['suppress_prefix'] = False
+    key = om._generate_key('key_name', info_map)
+    assert key == f'dummy_class.dummy_func.key_name.{auto_suffix}'
+
+    info_map['suppress_suffix'] = True
+    key = om._generate_key('key_name', info_map)
+    assert key == 'dummy_class.dummy_func.key_name'
+
+    info_map['suppress_suffix'] = False
+    key = om._generate_key('key_name', info_map)
+    assert key == f'dummy_class.dummy_func.key_name.{auto_suffix}'
+
+    info_map['suppress_prefix'] = True
+    info_map['suppress_suffix'] = True
+    key = om._generate_key('key_name', info_map)
+    assert key == 'key_name'
+
+    info_map['prefix'] = 'dummy_prefix'
+    info_map['suppress_suffix'] = False
+    key = om._generate_key('key_name', info_map)
+    assert key == f'dummy_prefix.key_name.{auto_suffix}'
+
+    info_map['suffix'] = 'dummy_suffix'
+    key = om._generate_key('key_name', info_map)
+    assert key == 'dummy_prefix.key_name.dummy_suffix'
+
+
+def test_add_error(mocker: MockerFixture) -> None:
+    """Unit test for function add_error in file output_manager.py"""
+
+    key = 'key'
+    mocker.patch('RUFAS.output_manager.OutputManager._generate_key',
+                 return_value=key)
+    om = OutputManager()
+    info_map = {'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}
+    om.add_error('dummy_name', 'dummy_msg', info_map)
+    assert om.errors_pool[key] == {'info_map': {
+        'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}, 'msg': 'dummy_msg'}
+
+
+def test_add_warning(mocker: MockerFixture) -> None:
+    """Unit test for function add_warning in file output_manager.py"""
+
+    key = 'key'
+    mocker.patch('RUFAS.output_manager.OutputManager._generate_key',
+                 return_value=key)
+    om = OutputManager()
+    info_map = {'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}
+    om.add_warning('dummy_name', 'dummy_msg', info_map)
+    assert om.warnings_pool[key] == {'info_map': {
+        'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}, 'msg': 'dummy_msg'}
+
+
+def test_add_log(mocker: MockerFixture) -> None:
+    """Unit test for function add_log in file output_manager.py"""
+
+    key = 'key'
+    mocker.patch('RUFAS.output_manager.OutputManager._generate_key',
+                 return_value=key)
+    om = OutputManager()
+    info_map = {'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}
+    om.add_log('dummy_name', 'dummy_msg', info_map)
+    assert om.logs_pool[key] == {'info_map': {
+        'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}, 'msg': 'dummy_msg'}
+
+
+def test_add_variable(mocker: MockerFixture) -> None:
+    """Unit test for function add_variable in file output_manager.py"""
+
+    key = 'key'
+    mocker.patch('RUFAS.output_manager.OutputManager._generate_key',
+                 return_value=key)
+    om = OutputManager()
+    info_map = {'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}
+    om.add_variable('dummy_name', 'dummy_value', info_map)
+    assert om.pool[key] == 'dummy_value'
+
+    with raises(ValueError):
+        om.add_variable('dummy_name', 'dummy_value', info_map)
+    # TODO issue 214
+
+
+def test_output_manager_singleton(mocker: MockerFixture) -> None:
+    """Test case to ensure output_manager is singleton"""
+    key = 'key'
+    mocker.patch('RUFAS.output_manager.OutputManager._generate_key',
+                 return_value=key)
+    om1 = OutputManager()
+    om2 = OutputManager()
+    info_map = {'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}
+    om1.add_log('dummy_name', 'dummy_msg', info_map)
+    assert om2.logs_pool[key] == {'info_map': {
+        'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}, 'msg': 'dummy_msg'}


### PR DESCRIPTION
This PR is the first out of 3 PRs for the output manager. The output manager is going to replace the output handler and be RuFaS's sole _output manager_.

The class OutputManager is developed based on **singleton pattern**, meaning that it can only have one instance. After the first instance is made, all subsequent instances will point to the first one. This pattern was chosen to ensure the whole model is reporting to the same output manager. 

This class has a pool that contains all reported variables, and 3 other pools that contain logs, warnings, and errors.

This PR implements the input side of the output manager. There will be two more PRs; the first one will implement basic functionality to save pools' content to files, and the second one will extend this functionality.

Note: some files changed due to autoformat, there is no code change in them, just formatting.
 