### PR TITLE
Canopy growth/LAI refactor

### DIFF
--- a/RUFAS/routines/field/crop/crop_types/crop_config.py
+++ b/RUFAS/routines/field/crop/crop_types/crop_config.py
@@ -21,8 +21,7 @@ Description:
     or any variables that do not correspond to crop-specific parameters.
 """
 
-# TODO: SWAT distributes with a database of plant-growth parameters by species. This file needs to be cross-referenced
-#       with that database. source: https://swat.tamu.edu/media/69341/ch14_input_plantdb.pdf
+# TODO: Validate species-specific growth parameters - GitHub Issue #231
 
 ALFALFA = {
         # alfalfa ID variables

--- a/RUFAS/routines/field/crop/crop_types/crop_config.py
+++ b/RUFAS/routines/field/crop/crop_types/crop_config.py
@@ -21,6 +21,9 @@ Description:
     or any variables that do not correspond to crop-specific parameters.
 """
 
+# TODO: SWAT distributes with a database of plant-growth parameters by species. This file needs to be cross-referenced
+#       with that database. source: https://swat.tamu.edu/media/69341/ch14_input_plantdb.pdf
+
 ALFALFA = {
         # alfalfa ID variables
         "harvest_type": 'optimal',  # TODO: is this always the type for alfalfa? Corn reads this from data

--- a/SC_redesign/Crop_and_Soil/crop/crop.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop.py
@@ -3,10 +3,11 @@ from SC_redesign.Crop_and_Soil.crop.biomass_allocation import BiomassAllocation
 from SC_redesign.Crop_and_Soil.crop.nitrogen_incorporation import NitrogenIncorporation
 from SC_redesign.Crop_and_Soil.crop.water_dynamics import WaterDynamics
 from SC_redesign.Crop_and_Soil.crop.heat_units import HeatUnits
+from SC_redesign.Crop_and_Soil.crop.leaf_area_index import LeafAreaIndex
 from SC_redesign.Crop_and_Soil.soil.soil import Soil
 
 
-class Crop(GrowthConstraints, BiomassAllocation, WaterDynamics, NitrogenIncorporation, HeatUnits):
+class Crop(GrowthConstraints, BiomassAllocation, WaterDynamics, NitrogenIncorporation, HeatUnits, LeafAreaIndex):
     def __init__(self):
         GrowthConstraints.__init__(self)
         BiomassAllocation.__init__(self)

--- a/SC_redesign/Crop_and_Soil/crop/crop.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop.py
@@ -52,9 +52,7 @@ class Crop(GrowthConstraints, BiomassAllocation, WaterDynamics, NitrogenIncorpor
         # phosphorus_uptake.update_all()
         #
         self.constrain_growth(max_transpiration, air_temperature)
-        #
-        # leaf_area_index.update_all()
-        #
+        self.grow_canopy()
         self.allocate_biomass(incoming_light)
         self.cycle_water(evaporation, transpiration, max_evapotranspiration)
 

--- a/SC_redesign/Crop_and_Soil/crop/leaf_area_index.py
+++ b/SC_redesign/Crop_and_Soil/crop/leaf_area_index.py
@@ -4,11 +4,185 @@ from math import exp, log, sqrt
 This module is based off of the 'Canopy Cover and Height' section of SWAT
 """
 
+class LeafAreaIndex:
+    def __init__(self):
+        # fixed attributes (unchanged during simulations)
+        self.first_heat_fraction_point = 0.15
+        self.second_heat_fraction_point = 0.50
+        self.first_leaf_fraction_point = 0.01
+        self.second_leaf_fraction_point = 0.95
+        self.max_canopy_height = 2.5  # m
+        self.growth_factor = 1.0
+        self.max_leaf_area_index = 3.0
+        self.senescent_heat_fraction = 0.9
+        # variable attributes (change throughout simulations)
+        self.leaf_area_index = 0
+        self.heat_fraction = 0.73
+        self.is_in_senescence = False
+        # empty variables
+        self._lai_shapes = None
+        self.optimal_leaf_area_fraction = None
+        self.canopy_height = None
+        self.leaf_area_added = None
+        self.max_leaf_area_change = None
+        self.previous_leaf_area_index = None
+        self.previous_optimal_leaf_area_fraction = None
+
+    def grow_canopy(self):
+        """main leaf area index function"""
+        self.determine_optimal_leaf_area_fraction()
+        self.determine_canopy_height()
+        self.check_for_senescence()
+        if self.is_in_senescence:  # senescence
+            self.senesce_leaf_area()
+        else:  # normal growth
+            self.check_previous_leaf_area_values()
+            self.determine_max_leaf_area_change()
+            self.determine_leaf_area_added()
+            self.add_leaf_area()
+        self.shift_leaf_area_time()
+
+    def _determine_lai_shapes(self):
+        """sets lai shape parameters for optimal leaf area fraction calculations"""
+        self._lai_shapes = calc_shape_parameters(self.first_heat_fraction_point, self.second_heat_fraction_point,
+                                                 self.first_leaf_fraction_point, self.second_leaf_fraction_point)
+
+    def determine_optimal_leaf_area_fraction(self):
+        """sets optimal leaf area fraction
+        SWAT Reference: 5:2.1.10"""
+        self._determine_lai_shapes()
+        self.optimal_leaf_area_fraction = calc_optimal_leaf_area_fraction(self.heat_fraction,
+                                                                          self._lai_shapes[0],
+                                                                          self._lai_shapes[1])
+
+    def shift_leaf_area_time(self):
+        """shifts the time window by one step for leaf area attributes"""
+        self.previous_leaf_area_index = self.leaf_area_index
+        self.previous_optimal_leaf_area_fraction = self.optimal_leaf_area_fraction
+
+    def determine_canopy_height(self):
+        """sets the current height of the canopy, in meters
+        SWAT Reference: 5:2.1.14"""
+        self.canopy_height = min(self.max_canopy_height,
+                                 self.max_canopy_height * sqrt(self.optimal_leaf_area_fraction))
+
+    def check_previous_leaf_area_values(self):
+        """check for previous LAI values and set them to 0 if none are present. This function handles the
+        initial time point in the simulation"""
+        if self.previous_optimal_leaf_area_fraction is None:
+            self.previous_optimal_leaf_area_fraction = 0
+        if self.previous_leaf_area_index is None:
+            self.previous_leaf_area_index = 0
+
+    def determine_max_leaf_area_change(self):
+        """sets the maximum amount that leaf area can change under ideal circumstances
+        SWAT Reference: 5:2.1.16"""
+        self.max_leaf_area_change = calc_max_leaf_area_change(self.optimal_leaf_area_fraction,
+                                                              self.previous_optimal_leaf_area_fraction,
+                                                              self.max_leaf_area_index,
+                                                              self.previous_leaf_area_index)
+
+    def determine_leaf_area_added(self):
+        """sets actual leaf area added, by adjusting for the plant growth factor
+        SWAT Reference: 5:3.2.2
+        """
+        self.leaf_area_added = min(self.max_leaf_area_change * sqrt(self.growth_factor), self.max_leaf_area_change)
+
+    def add_leaf_area(self):
+        """add new leaf area to the plant
+        SWAT Reference: 5:2.1.18"""
+        self.leaf_area_index = max(0, self.previous_leaf_area_index + self.leaf_area_added)
+
+    def check_for_senescence(self):
+        """check if the plant is in senescence"""
+        self.is_in_senescence = self.heat_fraction > self.senescent_heat_fraction
+
+    def senesce_leaf_area(self):
+        """determines the leaf area index during senescence
+        SWAT Reference: 5:2.1.19
+        """
+        self.leaf_area_index = calc_senescent_leaf_area_index(self.heat_fraction, self.senescent_heat_fraction,
+                                                              self.optimal_leaf_area_fraction)
 
 
+def calc_senescent_leaf_area_index(heat_fraction, senescent_heat_fraction, optimal_leaf_area_fraction):
+    """calculates a plant's leaf area index during senescence
+
+    Args:
+        heat_fraction: the current fraction of potential heat units
+        senescent_heat_fraction: the fraction of potential heat units at which senescence begins
+        optimal_leaf_area_fraction: the optimal leaf area fraction for the plant
+
+    Returns: the plant's leaf area index
+    """
+    if senescent_heat_fraction == 1:
+        prop = 1 - heat_fraction
+    else:
+        prop = (1 - heat_fraction) / (1 - senescent_heat_fraction)
+
+    return max(prop * optimal_leaf_area_fraction, 0)
+
+# ---- helper functions ----
+
+def calc_shape_log(heat_fraction: float, leaf_area_fraction: float) -> float:
+    """calculates the log term of LAI shape parameter function
+
+    Args:
+        heat_fraction: fraction of heat units accumulated; must be greater than zero
+        leaf_area_fraction: fraction of max leaf area; must be greater than zero, less than one, and not
+            equal to heat_fraction
+
+    Details: used by calc_shape_parameters, where errors are handled
+    """
+    return log((heat_fraction/leaf_area_fraction) - heat_fraction)
+
+def calc_shape_parameters(first_heat_fraction: float, second_heat_fraction: float,
+                          first_leaf_fraction: float, second_leaf_fraction: float) -> list[float]:
+    """calculates the shape coefficients for optimal LAI formula"""
+    if not 0 < first_heat_fraction:
+        raise ValueError("first_heat_fraction must be greater than 0")
+    if not 0 < second_heat_fraction:
+        raise ValueError("second_heat_fraction must be greater than 0")
+    if not 0 < first_leaf_fraction < 1:
+        raise ValueError("first_leaf_fraction must not be greater than 0 or less than 1")
+    if not 0 < second_leaf_fraction < 1:
+        raise ValueError("second_leaf_fraction must not be greater than 0 or less than 1")
+    if first_heat_fraction == second_heat_fraction:
+        # TODO: perhaps a way to handle this instead of throwing an error would be better
+        #   something like: second_heat_fraction += 1e-9
+        raise ValueError("first_heat_fraction cannot be exactly equal to second_heat_fractions")
 
 
+    # TODO: add error handling (see test_error_calc_shape_log() for conditions that fail)
 
+    first_log = calc_shape_log(first_heat_fraction, first_leaf_fraction)
+    second_log = calc_shape_log(second_heat_fraction, second_leaf_fraction)
+
+    second_shape = (first_log - second_log) / (second_heat_fraction - first_heat_fraction)
+    first_shape = first_log + (second_shape * first_heat_fraction)
+
+    return [first_shape, second_shape]
+
+def calc_max_leaf_area_change(leaf_area_fraction, previous_leaf_area_fraction,
+                              max_leaf_area_index, previous_leaf_area_index):
+    """
+    calculates the maximum leaf area added during the day
+
+    Args:
+        leaf_area_fraction: optimal leaf area fraction for the day
+        previous_leaf_area_fraction: previous day's optimal leaf area fraction
+        max_leaf_area_index: the maximum leaf area index achievable by the plant
+        previous_leaf_area_index: the previous day's leaf area index
+
+    Returns:
+        the maximum leaf area added during the day
+
+    Details: because actual leaf area index (LAI) is corrected for growth constraints, the previous
+    day's optimal leaf area fraction may not be the same as the previous day's LAI divided by the
+    max LAI.
+    """
+    return (leaf_area_fraction - previous_leaf_area_fraction) * max_leaf_area_index * \
+           (1 - exp(5 * previous_leaf_area_index - max_leaf_area_index))
 
 def calc_optimal_leaf_area_fraction(heat_fraction: float, shape1: float, shape2: float) -> float:
     """calculates leaf area index fraction, from the optimal leaf area development curve, for the initial period of
@@ -21,126 +195,10 @@ def calc_optimal_leaf_area_fraction(heat_fraction: float, shape1: float, shape2:
 
     Returns:
         fraction of the plant's maximum leaf area index
+
+    Details: specifically, the calculated value is the 'fraction of the plant's maximum leaf area index corresponding
+    to a given fraction of potential heat units for the plant' (heat_fraction), constrained to be bounded at zero.
+
+    SWAT Reference: 5:2.1.10
     """
-    return heat_fraction / (heat_fraction + exp(shape1 - (shape2 * heat_fraction)))
-
-
-def calc_shape_log(heat_fraction: float, leaf_area_fraction: float) -> float:
-    """calculates the log term of LAI shape parameter function"""
-    return log(heat_fraction/leaf_area_fraction - heat_fraction)
-
-def calc_shape_parameters(first_heat_fraction: float, second_heat_fraction: float,
-                          first_leaf_fraction: float, second_leaf_fraction: float) -> list[float]:
-    """calculates the shape coefficients for """
-
-    first_log = calc_shape_log(first_heat_fraction, first_leaf_fraction)
-    second_log = calc_shape_log(second_heat_fraction, second_leaf_fraction)
-
-    second_shape = (first_log - second_log) / (first_heat_fraction - second_heat_fraction)
-    first_shape = first_log + (second_shape * first_heat_fraction)
-
-    return [first_shape, second_shape]
-
-
-
-def update_all(crop_type):
-    """
-    Description:
-        Calls all the necessary functions to update information
-        related to the leaf area index for the given crop_type.
-
-    Args:
-        crop_type: an instance of a crop
-    """
-    L1, L2 = calculate_shape_coefficients(crop_type)
-    calc_fr_LAI_max(crop_type, L1, L2)
-    calculate_LAI_actual(crop_type)
-
-
-def calculate_shape_coefficients(crop_type):
-    """
-    Description:
-        Calculate shape coefficients for LAI accumulation.
-        "pseudocode_crop" section C.8.A.1/2
-
-    Args:
-        crop_type
-    Returns:
-        int: shape coefficients
-    """
-    # 8.A.1
-    L2_part1 = (crop_type.fr_PHU_1 / crop_type.fr_LAI_1) - crop_type.fr_PHU_1
-    L2_part2 = (crop_type.fr_PHU_2 / crop_type.fr_LAI_2) - crop_type.fr_PHU_2
-
-    L2 = ((log(L2_part1) - log(L2_part2))
-          / (crop_type.fr_PHU_2 - crop_type.fr_PHU_1))
-
-    # C.8.A.2
-    L1_part1 = (crop_type.fr_PHU_1 / crop_type.fr_LAI_1) - crop_type.fr_PHU_1
-
-    L1 = log(L1_part1) + (L2 * crop_type.fr_PHU_1)
-
-    return L1, L2
-
-
-
-def calc_fr_LAI_max(crop_type, L1, L2):
-    """
-    Description:
-        Calculates the accumulated fraction of LAI maximum
-        accumulated including today for the given crop type.
-        "pseudocode_crop" section C.8.A.3
-
-    Args:
-        crop_type
-        L1: first shape coefficient
-        L2: second shape coefficient
-    """
-
-    crop_type.prev_fr_LAI_max = crop_type.fr_LAI_max
-
-    exp_part = exp(L1 - (L2 * crop_type.fr_PHU))
-    crop_type.fr_LAI_max = crop_type.fr_PHU / (crop_type.fr_PHU + exp_part)
-
-
-def calculate_LAI_actual(crop_type):
-    """
-    Description:
-        This calculates LAI_actual for the given crop_type.
-        "pseudocode_crop" section C.8.A.4/6
-
-    Args:
-        crop_type
-    """
-
-    # C.8.A.4
-    exp_part = exp(5 * (crop_type.LAI_actual - crop_type.LAI_max))
-    d_fr_LAI_max = (crop_type.fr_LAI_max - crop_type.prev_fr_LAI_max)
-    d_LAI_max = d_fr_LAI_max * crop_type.LAI_max * (1 - exp_part)
-    d_LAI_actual = calculate_d_LAI_actual(crop_type, d_LAI_max)
-
-    if crop_type.fr_PHU <= crop_type.fr_PHU_sen:
-        # C.8.A.6
-        crop_type.LAI_actual = crop_type.LAI_actual + d_LAI_actual
-        crop_type.LAI_actual = max(crop_type.LAI_actual, 0)
-    else:
-        # C.8.A.6
-        crop_type.LAI_actual = crop_type.LAI_actual * (1 - crop_type.fr_PHU) / (1 - crop_type.fr_PHU_sen)
-        crop_type.LAI_actual = max(crop_type.LAI_actual, 0)
-
-
-def calculate_d_LAI_actual(crop_type, d_LAI_max):
-    """
-    Description:
-        Calculates d_LAI_actual for use in calculating d_LAI_max and
-        LAI_actual on a given day for the given crop.
-        "pseudocode_crop" C.8.A.5
-
-    Args:
-        crop_type
-        d_LAI_max: change in LAI maximum
-    Returns:
-        float: change in LAI actual
-    """
-
-    return d_LAI_max * sqrt(crop_type.gamma_reg)
+    return max(heat_fraction / (heat_fraction + exp(shape1 - (shape2 * heat_fraction))), 0)

--- a/SC_redesign/Crop_and_Soil/crop/leaf_area_index.py
+++ b/SC_redesign/Crop_and_Soil/crop/leaf_area_index.py
@@ -1,4 +1,5 @@
 from math import exp, log, sqrt
+from typing import List
 
 """
 This module is based off of the 'Canopy Cover and Height' section of SWAT
@@ -137,7 +138,7 @@ def calc_shape_log(heat_fraction: float, leaf_area_fraction: float) -> float:
     return log((heat_fraction/leaf_area_fraction) - heat_fraction)
 
 def calc_shape_parameters(first_heat_fraction: float, second_heat_fraction: float,
-                          first_leaf_fraction: float, second_leaf_fraction: float) -> list[float]:
+                          first_leaf_fraction: float, second_leaf_fraction: float) -> List[float]:
     """calculates the shape coefficients for optimal LAI formula"""
     if first_heat_fraction <= 0:
         raise ValueError("first_heat_fraction must be greater than 0")

--- a/SC_redesign/Crop_and_Soil/crop/leaf_area_index.py
+++ b/SC_redesign/Crop_and_Soil/crop/leaf_area_index.py
@@ -139,11 +139,11 @@ def calc_shape_log(heat_fraction: float, leaf_area_fraction: float) -> float:
 def calc_shape_parameters(first_heat_fraction: float, second_heat_fraction: float,
                           first_leaf_fraction: float, second_leaf_fraction: float) -> list[float]:
     """calculates the shape coefficients for optimal LAI formula"""
-    if not 0 < first_heat_fraction:
+    if first_heat_fraction <= 0:
         raise ValueError("first_heat_fraction must be greater than 0")
-    if not 0 < second_heat_fraction:
+    if second_heat_fraction <= 0:
         raise ValueError("second_heat_fraction must be greater than 0")
-    if not 0 < first_leaf_fraction < 1:
+    if first_leaf_fraction <= 0:
         raise ValueError("first_leaf_fraction must not be greater than 0 or less than 1")
     if not 0 < second_leaf_fraction < 1:
         raise ValueError("second_leaf_fraction must not be greater than 0 or less than 1")

--- a/SC_redesign/Crop_and_Soil/crop/leaf_area_index.py
+++ b/SC_redesign/Crop_and_Soil/crop/leaf_area_index.py
@@ -1,0 +1,146 @@
+from math import exp, log, sqrt
+
+"""
+This module is based off of the 'Canopy Cover and Height' section of SWAT
+"""
+
+
+
+
+
+
+
+def calc_optimal_leaf_area_fraction(heat_fraction: float, shape1: float, shape2: float) -> float:
+    """calculates leaf area index fraction, from the optimal leaf area development curve, for the initial period of
+    plant growth
+
+    Args:
+        heat_fraction: fraction of potential heat units
+        shape1: first shape coefficient
+        shape2: second shape coefficient
+
+    Returns:
+        fraction of the plant's maximum leaf area index
+    """
+    return heat_fraction / (heat_fraction + exp(shape1 - (shape2 * heat_fraction)))
+
+
+def calc_shape_log(heat_fraction: float, leaf_area_fraction: float) -> float:
+    """calculates the log term of LAI shape parameter function"""
+    return log(heat_fraction/leaf_area_fraction - heat_fraction)
+
+def calc_shape_parameters(first_heat_fraction: float, second_heat_fraction: float,
+                          first_leaf_fraction: float, second_leaf_fraction: float) -> list[float]:
+    """calculates the shape coefficients for """
+
+    first_log = calc_shape_log(first_heat_fraction, first_leaf_fraction)
+    second_log = calc_shape_log(second_heat_fraction, second_leaf_fraction)
+
+    second_shape = (first_log - second_log) / (first_heat_fraction - second_heat_fraction)
+    first_shape = first_log + (second_shape * first_heat_fraction)
+
+    return [first_shape, second_shape]
+
+
+
+def update_all(crop_type):
+    """
+    Description:
+        Calls all the necessary functions to update information
+        related to the leaf area index for the given crop_type.
+
+    Args:
+        crop_type: an instance of a crop
+    """
+    L1, L2 = calculate_shape_coefficients(crop_type)
+    calc_fr_LAI_max(crop_type, L1, L2)
+    calculate_LAI_actual(crop_type)
+
+
+def calculate_shape_coefficients(crop_type):
+    """
+    Description:
+        Calculate shape coefficients for LAI accumulation.
+        "pseudocode_crop" section C.8.A.1/2
+
+    Args:
+        crop_type
+    Returns:
+        int: shape coefficients
+    """
+    # 8.A.1
+    L2_part1 = (crop_type.fr_PHU_1 / crop_type.fr_LAI_1) - crop_type.fr_PHU_1
+    L2_part2 = (crop_type.fr_PHU_2 / crop_type.fr_LAI_2) - crop_type.fr_PHU_2
+
+    L2 = ((log(L2_part1) - log(L2_part2))
+          / (crop_type.fr_PHU_2 - crop_type.fr_PHU_1))
+
+    # C.8.A.2
+    L1_part1 = (crop_type.fr_PHU_1 / crop_type.fr_LAI_1) - crop_type.fr_PHU_1
+
+    L1 = log(L1_part1) + (L2 * crop_type.fr_PHU_1)
+
+    return L1, L2
+
+
+
+def calc_fr_LAI_max(crop_type, L1, L2):
+    """
+    Description:
+        Calculates the accumulated fraction of LAI maximum
+        accumulated including today for the given crop type.
+        "pseudocode_crop" section C.8.A.3
+
+    Args:
+        crop_type
+        L1: first shape coefficient
+        L2: second shape coefficient
+    """
+
+    crop_type.prev_fr_LAI_max = crop_type.fr_LAI_max
+
+    exp_part = exp(L1 - (L2 * crop_type.fr_PHU))
+    crop_type.fr_LAI_max = crop_type.fr_PHU / (crop_type.fr_PHU + exp_part)
+
+
+def calculate_LAI_actual(crop_type):
+    """
+    Description:
+        This calculates LAI_actual for the given crop_type.
+        "pseudocode_crop" section C.8.A.4/6
+
+    Args:
+        crop_type
+    """
+
+    # C.8.A.4
+    exp_part = exp(5 * (crop_type.LAI_actual - crop_type.LAI_max))
+    d_fr_LAI_max = (crop_type.fr_LAI_max - crop_type.prev_fr_LAI_max)
+    d_LAI_max = d_fr_LAI_max * crop_type.LAI_max * (1 - exp_part)
+    d_LAI_actual = calculate_d_LAI_actual(crop_type, d_LAI_max)
+
+    if crop_type.fr_PHU <= crop_type.fr_PHU_sen:
+        # C.8.A.6
+        crop_type.LAI_actual = crop_type.LAI_actual + d_LAI_actual
+        crop_type.LAI_actual = max(crop_type.LAI_actual, 0)
+    else:
+        # C.8.A.6
+        crop_type.LAI_actual = crop_type.LAI_actual * (1 - crop_type.fr_PHU) / (1 - crop_type.fr_PHU_sen)
+        crop_type.LAI_actual = max(crop_type.LAI_actual, 0)
+
+
+def calculate_d_LAI_actual(crop_type, d_LAI_max):
+    """
+    Description:
+        Calculates d_LAI_actual for use in calculating d_LAI_max and
+        LAI_actual on a given day for the given crop.
+        "pseudocode_crop" C.8.A.5
+
+    Args:
+        crop_type
+        d_LAI_max: change in LAI maximum
+    Returns:
+        float: change in LAI actual
+    """
+
+    return d_LAI_max * sqrt(crop_type.gamma_reg)

--- a/SC_redesign/Crop_and_Soil/crop/leaf_area_index.py
+++ b/SC_redesign/Crop_and_Soil/crop/leaf_area_index.py
@@ -143,7 +143,7 @@ def calc_shape_parameters(first_heat_fraction: float, second_heat_fraction: floa
         raise ValueError("first_heat_fraction must be greater than 0")
     if second_heat_fraction <= 0:
         raise ValueError("second_heat_fraction must be greater than 0")
-    if first_leaf_fraction <= 0:
+    if no 0 < first_leaf_fraction < 1:
         raise ValueError("first_leaf_fraction must not be greater than 0 or less than 1")
     if not 0 < second_leaf_fraction < 1:
         raise ValueError("second_leaf_fraction must not be greater than 0 or less than 1")

--- a/SC_redesign/Crop_and_Soil/crop/leaf_area_index.py
+++ b/SC_redesign/Crop_and_Soil/crop/leaf_area_index.py
@@ -143,7 +143,7 @@ def calc_shape_parameters(first_heat_fraction: float, second_heat_fraction: floa
         raise ValueError("first_heat_fraction must be greater than 0")
     if second_heat_fraction <= 0:
         raise ValueError("second_heat_fraction must be greater than 0")
-    if no 0 < first_leaf_fraction < 1:
+    if not 0 < first_leaf_fraction < 1:
         raise ValueError("first_leaf_fraction must not be greater than 0 or less than 1")
     if not 0 < second_leaf_fraction < 1:
         raise ValueError("second_leaf_fraction must not be greater than 0 or less than 1")

--- a/SC_redesign/Crop_and_Soil/crop/nitrogen_incorporation.py
+++ b/SC_redesign/Crop_and_Soil/crop/nitrogen_incorporation.py
@@ -1,5 +1,6 @@
 from math import log, exp
 from bisect import bisect
+from typing import List
 
 """
 This module is based upon the 'Nitrogen Uptake" section of of the SWAT model documentation 
@@ -42,7 +43,7 @@ class NitrogenIncorporation:
         self.fixation_stage_factor = None
 
     # ---- wrapper functions (main routines) ----
-    def incorporate_nitrogen(self, layer_nitrates: list[float], layer_depths: list[float],
+    def incorporate_nitrogen(self, layer_nitrates: List[float], layer_depths: List[float],
                              soil_water_factor: float) -> None:
         """main nitrogen incorporation function - runs all nitrogen processes and stores nitrogen as biomass
 
@@ -65,7 +66,7 @@ class NitrogenIncorporation:
         self.try_fixation(total_accessible_nitrates, soil_water_factor)
         self.store_obtained_nitrogen()
 
-    def uptake_nitrogen(self, layer_nitrates: list[float], layer_depths: list[float]) -> None:
+    def uptake_nitrogen(self, layer_nitrates: List[float], layer_depths: List[float]) -> None:
         """conducts steps necessary to uptake nitrogen from soil
 
         Args:
@@ -122,7 +123,7 @@ class NitrogenIncorporation:
                                                                             self.mature_nitrogen_fraction,
                                                                             self.biomass_growth_max)
 
-    def determine_deepest_accessible_soil_layer(self, depths: list[float]) -> None:
+    def determine_deepest_accessible_soil_layer(self, depths: List[float]) -> None:
         """evaluates the accessibility of layers in the soil profile by plant roots
 
         Args:
@@ -145,7 +146,7 @@ class NitrogenIncorporation:
         """
         return layer_list[0:self.accessible_soil_layers]
 
-    def stratify_potential_nitrogen_uptake(self, accessible_depths: list[float]) -> None:
+    def stratify_potential_nitrogen_uptake(self, accessible_depths: List[float]) -> None:
         """stratifies potential nitrogen uptake by the accessible soil layers.
 
         Args:
@@ -161,7 +162,7 @@ class NitrogenIncorporation:
                                                                               self.root_depth,
                                                                               self.nitrogen_distro_param)
 
-    def stratify_unmet_nitrogen_demand(self, accessible_nitrates: list[float]) -> None:
+    def stratify_unmet_nitrogen_demand(self, accessible_nitrates: List[float]) -> None:
         """determines the nitrogen demand at each accessible soil layer that remains unmet by the above layers
 
         Args:
@@ -169,7 +170,7 @@ class NitrogenIncorporation:
         """
         self.unmet_nitrogen_demands = calc_layer_nitrogen_demands(self.layer_nitrogen_potentials, accessible_nitrates)
 
-    def stratify_nitrogen_uptake_requests(self, accessible_nitrates: list[float]) -> None:
+    def stratify_nitrogen_uptake_requests(self, accessible_nitrates: List[float]) -> None:
         """determines the amount of nitrogen the plant would like to request from each soil layer
 
         Args:
@@ -200,7 +201,7 @@ class NitrogenIncorporation:
         if self.inaccessible_soil_layers > 0:
             self.actual_nitrogen_uptakes += [0] * self.inaccessible_soil_layers
 
-    def extract_nitrogen_from_soil_layers(self, layer_nitrates: list[float]) -> None:
+    def extract_nitrogen_from_soil_layers(self, layer_nitrates: List[float]) -> None:
         """extracts nitrogen from the soil profile by layer.
 
         Args:
@@ -269,7 +270,7 @@ class NitrogenIncorporation:
 # TODO: these should maybe be static methods instead?
 def calc_shape_parameters(half_mature_heat_fraction: float, mature_heat_fraction: float,
                           emergence_nitrogen_fraction: float, half_mature_nitrogen_fraction: float,
-                          near_mature_nitrogen_fraction: float, mature_nitrogen_fraction: float) -> list[float]:  # pseudocode: C.5.A.1, C.5.A.2
+                          near_mature_nitrogen_fraction: float, mature_nitrogen_fraction: float) -> List[float]:  # pseudocode: C.5.A.1, C.5.A.2
     """
     Description: calculates the shape coefficients for the nitrogen fraction equation
 
@@ -399,8 +400,8 @@ def calc_potential_nitrogen_uptake(demand: float, nitrogen_start: float, mature_
     return min(demand - nitrogen_start, 4 * mature_nitrogen_fraction * max_growth)
 
 
-def calc_layer_nitrogen_uptake(layer_demands: list[float], layer_uptake_potentials: list[float],
-                               layer_nitrates: list[float]) -> list[float]:  # pseudocode: C.5.C.4
+def calc_layer_nitrogen_uptake(layer_demands: List[float], layer_uptake_potentials: List[float],
+                               layer_nitrates: List[float]) -> List[float]:  # pseudocode: C.5.C.4
     """
     Description: calculates nitrogen uptake from each soil layer
 
@@ -419,7 +420,7 @@ def calc_layer_nitrogen_uptake(layer_demands: list[float], layer_uptake_potentia
     return [min(desired, nitrate) for desired, nitrate in zip(layer_desired, layer_nitrates)]
 
 
-def calc_layer_nitrogen_demands(uptake_potentials: list[float], nitrate_availabilities: list[float]) -> list[float]:  # pseudocode: C.5.C.5
+def calc_layer_nitrogen_demands(uptake_potentials: List[float], nitrate_availabilities: List[float]) -> List[float]:  # pseudocode: C.5.C.5
     """
     Description: calculates nitrogen demand of the plant from each soil layer
 
@@ -459,8 +460,8 @@ def calc_nitrogen_uptake_to_depth(demand: float, depth: float, root_depth: float
         return first_term * second_term
 
 
-def calc_layer_nitrogen_uptake_potential(layer_bounds: list[float], total_demand: float, root_depth: float,
-                                         nitrogen_distribution_parameter: float) -> list[float]:  # pseudocode: C.5.C.2, C.5.C.3
+def calc_layer_nitrogen_uptake_potential(layer_bounds: List[float], total_demand: float, root_depth: float,
+                                         nitrogen_distribution_parameter: float) -> List[float]:  # pseudocode: C.5.C.2, C.5.C.3
     """
     Description: calculates potential nitrogen uptake from each soil layer
 
@@ -502,7 +503,7 @@ def calc_extracted_resource(request: float, source: float) -> float:
     return min(request, max(0.0, source))
 
 
-def calc_layer_extracted_resource(requests: list[float], sources: list[float]) -> list[float]:
+def calc_layer_extracted_resource(requests: List[float], sources: List[float]) -> List[float]:
     if len(requests) != len(sources):
         raise ValueError("requests and sources should be the same length")
 
@@ -591,7 +592,7 @@ def calc_nitrate_factor(total_accessible_nitrates):
     else:
         return 0
 
-def calc_deepest_accessible_layer(root_depth: float, layer_bounds: list[float]) -> int:
+def calc_deepest_accessible_layer(root_depth: float, layer_bounds: List[float]) -> int:
     """
     Description:
         Determines the deepest soil layer that is accessible to roots.

--- a/SC_redesign/Crop_and_Soil/tests_SC/test_leaf_area_index.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/test_leaf_area_index.py
@@ -227,7 +227,11 @@ def test_senesce_leaf_area(opt_lai_frac, heatfrac, cutoff):
     lai.senesce_leaf_area()
     assert lai.leaf_area_index == calc_senescent_leaf_area_index(heatfrac, cutoff, opt_lai_frac)
 
-@pytest.mark.parametrize("opt_lai_frac,heatfrac,cutoff", [])
+@pytest.mark.parametrize("opt_lai_frac,heatfrac,cutoff", [
+    (1, 1.2, 1 - 1e-9),  # cutoff approx 1
+    (0.9, 0.87, 0.8),
+    (0.5, 0.43, 0.44)
+])
 def test_calc_senescent_leaf_area_index(opt_lai_frac, heatfrac, cutoff):
     """check that LAI is calculated correctly during senescence with calc_senescent_leaf_area_index()"""
     if cutoff == 1:

--- a/SC_redesign/Crop_and_Soil/tests_SC/test_leaf_area_index.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/test_leaf_area_index.py
@@ -1,0 +1,272 @@
+import pytest
+from SC_redesign.Crop_and_Soil.crop.leaf_area_index import *
+
+@pytest.mark.parametrize("heatfrac,s1,s2", [
+    (0.5, 1, 1),  # starting point
+    (0.0, 1, 1),  # no heatfrac
+    (1.0, 1, 1),  # full heatfrac
+    (0.5, 0.33, 1),  # reduced s1
+    (0.5, 1, 0.33),  # reduced s2
+    (0.5, 0.33, 0.33),  # reduced s1 and s2
+    (0.239, 1.2, -2.33),  # arbitrary
+    (-1, 1, 1)
+])
+def test_calc_optimal_leaf_area_fraction(heatfrac, s1, s2):
+    """ensure that optimal leaf area fraction is properly calculated by calc_optimal_leaf_area_fraction()"""
+    x = heatfrac + exp(s1 - s2*heatfrac)
+    if heatfrac/x < 0:
+        expect = 0
+    else:
+        expect = heatfrac/x
+    assert calc_optimal_leaf_area_fraction(heatfrac, s1, s2) == expect
+
+@pytest.mark.parametrize("heatfrac,areafrac", [
+    (0.5, 0.5),  # heatfrac = areafrac
+    (0.3, 0.5),  # heatfrac < areafrac
+    (0.4, 0.2),  # heatfrac > areafrac
+    (1, 0.5),  # heatfrac = 1
+    (1.3, 0.5),  # heatfrac > 1
+    (0.5, 1-1e-9),  # areafrac approx 1
+    (0.5, 1e-9),  # areafrac approx 0
+    (1e-9, 0.5),  # heatfrac approx 0
+    (-2, -1),  # both negative
+    (-1, -2),  # both negative
+    (0.439, 0.611),  # arbitrary
+])
+def test_calc_shape_log(heatfrac, areafrac):
+    """ensure that log terms are calculated correctly"""
+    observe = calc_shape_log(heatfrac, areafrac)
+    x = (heatfrac/areafrac) - heatfrac
+    assert log(x) == observe
+
+
+@pytest.mark.parametrize("heatfrac,areafrac", [
+    (0, 1),  # heatfrac = 0 -- math domain
+    (0, 0.5),  # heatfrac = 0 -- math domain
+    (1, 0),  # areafrac = 0 -- division by zero
+    (0.5, 0),  # areafrac = 0 -- division by zero
+    (0.5, 1),  # areafrac = 1 -- math domain
+    (-1, 0.5),  # negative heatfrac -- math domain
+    (0.5, -1),  # negative areafrac -- math domain
+])
+def test_error_calc_shape_log(heatfrac, areafrac):
+    """ensure that the errors are thrown for inappropriate input to calc_shape_log()"""
+    with pytest.raises(Exception):
+        calc_shape_log(heatfrac, areafrac)
+
+
+@pytest.mark.parametrize("heatfrac1,heatfrac2,areafrac1,areafrac2", [
+    (0.3, 0.6, 0.2, 0.4),  # start
+    (0.6, 0.3, 0.2, 0.4),  # heatfrac1 > heatfrac2
+    (0.3, 0.6, 0.4, 0.2),  # areafrac1 > areafrac2
+    (0.3, 0.6, 0.2, 0.2),  # areafrac1 = areafrac2
+    (1, 0.6, 0.2, 0.4),  # heatfrac1 = 1
+    (0.3, 1, 0.2, 0.4),  # heatfrac2 = 1
+    (1.3, 0.6, 0.2, 0.4),  # heatfrac1 > 1
+    (1, 1-1e-9, 0.2, 0.4),  # heatfrac1 approx heatfrac2
+    (0.135, 0.842, 0.09, 0.321),  # arbitrary
+])
+def test_calc_shape_parameters(heatfrac1, heatfrac2, areafrac1, areafrac2):
+    x = calc_shape_log(heatfrac1, areafrac1)
+    y = calc_shape_log(heatfrac2, areafrac2)
+    s2 = (x - y) / (heatfrac2 - heatfrac1)
+    s1 = x + s2*heatfrac1
+    assert calc_shape_parameters(heatfrac1, heatfrac2, areafrac1, areafrac2) == [s1, s2]
+
+# TODO: implement test cases for test_error_calc_shape_parameters()
+@pytest.mark.parametrize("heatfrac1,heatfrac2,areafrac1,areafrac2", [
+    # shape log errors
+    (0, 0.3, 0.2, 0.4),  # heatfrac1 = 0 -- math domain
+    (0.5, 0, 0.2, 0.4),  # heatfrac2 = 0 -- math domain
+    (0.5, 0.3, 0, 0.4),  # areafrac1 = 0 -- division by zero
+    (0.5, 0.3, 0.2, 0),  # areafrac2 = 0 -- division by zero
+    (0.5, 0.3, 1, 0.4),  # areafrac1 = 0 -- math domain
+    (0.5, 0.3, 0.2, 1),  # areafrac2 = 0 -- math domain
+    (-1, 0.3, 0.2, 0.4),  # heatfrac1 < 0 -- math domain
+    (0.5, -1, 0.2, 0.4),  # heatfrac2 < 0 -- math domain
+    (0.5, 0.3, -1, 0.4),  # areafrac1 < 0 -- math domain
+    (0.5, 0.3, 0.2, -1),  # areafrac2 < 0 -- math domain
+    (0.3, 0.3, 0.2, 0.4),  # heatfrac1 = heatfrac2 -- division by zero
+])
+def test_error_calc_shape_parameters(heatfrac1, heatfrac2, areafrac1, areafrac2):
+    """check that invalid input to test_error_calc_shape_parameters throws errors"""
+    with pytest.raises(ValueError):
+        calc_shape_parameters(heatfrac1, heatfrac2, areafrac1, areafrac2)
+
+@pytest.mark.parametrize("frac,prev_frac,max_lai,prev_lai", [
+    (1, 1/3, 3, 1),  # start (prevfrac = prev_lai/max_lai)
+    (1, 1/3, 3, 2.5),  # increased prev_lai, same prev_frac
+    (0.5, 1/3, 3, 1),  # reduced frac
+    (0, 1/3, 3, 1),  # frac = 0
+    (1, 1/3, 3, 3),  # prev_lai = lai
+    (1, 1, 3, 3),  # prev_lai = lai, pref_frac = current frac
+    (1.2, 0.657, 3, 2.5),  # arbitrary
+])
+def test_calc_max_leaf_area_change(frac, prev_frac, max_lai, prev_lai):
+    scaled_diff = (frac - prev_frac) * max_lai
+    expo = 1 - exp(5 * prev_lai - max_lai)
+    assert calc_max_leaf_area_change(frac, prev_frac, max_lai, prev_lai) == scaled_diff * expo
+
+# ---- Initializer functions
+def init_lai(**kwargs):
+    """helper function to create GrowthConstraint instance, with specified attributes"""
+    lai = LeafAreaIndex()
+    for key, val in kwargs.items():
+        setattr(lai, key, val)
+    return lai
+
+# ---- Member functions
+
+@pytest.mark.parametrize("heatfrac", [-1, 0, 0.11, 0.25, 0.5, 0.8, 1])
+def test_determine_optimal_leaf_area_fraction(heatfrac):
+    """ensure that the optimal leaf area fraction is properly set by determine_optimal_leaf_area_fraction"""
+    lai = init_lai(heat_fraction=heatfrac, first_heat_fraction_point=0.15, second_heat_fraction_point=0.50,
+                   first_leaf_fraction_point=0.01, second_leaf_fraction_point=0.95)
+    lai.determine_optimal_leaf_area_fraction()
+    assert [lai._lai_shapes[0], lai._lai_shapes[1]] == calc_shape_parameters(0.15, 0.50, 0.01, 0.95)
+    assert lai.optimal_leaf_area_fraction == calc_optimal_leaf_area_fraction(heatfrac, lai._lai_shapes[0],
+                                                                             lai._lai_shapes[1])
+
+@pytest.mark.parametrize("leaf_area,optimal_fraction", [
+    (1, 1),
+    (2, 1/3),
+    (2.44, 0.359)
+])
+def test_shift_leaf_area_time(leaf_area, optimal_fraction):
+    """ensure that the time window is properly shifted for LAI traits with shift_leaf_area_time()"""
+    lai = init_lai(leaf_area_index=leaf_area, optimal_leaf_area_fraction=optimal_fraction)
+    lai.shift_leaf_area_time()
+    assert lai.previous_leaf_area_index == leaf_area
+    assert lai.previous_optimal_leaf_area_fraction == optimal_fraction
+
+@pytest.mark.parametrize("max_h,opt_lai_frac,expect", [
+    (1, 1, 1),
+    (20, 1, 20),
+    (20, 0.5, 20*sqrt(0.5)),
+    (20, 1.5, 20),
+    (232.765, 0.83, 232.765*sqrt(0.83))
+])
+def test_determine_canopy_height(max_h, opt_lai_frac, expect):
+    """ensure that canopy height is calculated as expected by determine_canopy_height()"""
+    lai = init_lai(max_canopy_height=max_h, optimal_leaf_area_fraction=opt_lai_frac)
+    lai.determine_canopy_height()
+    assert lai.canopy_height == expect
+
+@pytest.mark.parametrize("frac,lai,expect", [
+    (None, None, (0, 0)),
+    (None, 1.3, (0, 1.3)),
+    (0.33, None, (0.33, 0)),
+    (0.33, 1.3, (0.33, 1.3)),
+])
+def test_check_for_previous_leaf_area_values(frac, lai, expect):
+    """ensure that previous LAI values are properly set with check_previous_leaf_area_values()"""
+    obj = init_lai(previous_optimal_leaf_area_fraction=frac, previous_leaf_area_index=lai)
+    obj.check_previous_leaf_area_values()
+    assert (obj.previous_optimal_leaf_area_fraction, obj.previous_leaf_area_index) == expect
+
+@pytest.mark.parametrize("frac,prev_frac,max_lai,prev_lai", [
+    (0.5, 0.3, 3, 1),
+    (0.5, 0.5, 3, 1),
+    (0.5, 0.6, 3, 1),
+    (0.5, 0, 3, 1),
+    (0.5, 0, 3, 0),
+    (0.79, 0.62, 2.8, 1.75)
+])
+def test_determine_max_leaf_area_change(frac, prev_frac, max_lai, prev_lai):
+    lai = init_lai(optimal_leaf_area_fraction=frac, previous_optimal_leaf_area_fraction=prev_frac,
+                   max_leaf_area_index=max_lai, previous_leaf_area_index=prev_lai)
+    lai.determine_max_leaf_area_change()
+    assert lai.max_leaf_area_change == calc_max_leaf_area_change(frac, prev_frac, max_lai, prev_lai)
+
+@pytest.mark.parametrize("max_change,growth,expect", [
+    (1, 1, 1),
+    (100, 1, 100),
+    (100, 1.3, 100),
+    (100, 0.8, 100*sqrt(0.8)),
+    (12.359, 0.633, 12.359*sqrt(0.633))
+])
+def test_determine_leaf_area_added(max_change, growth, expect):
+    """ensure that added leaf area is calculated correctly by determine_leaf_area_added()"""
+    lai = init_lai(max_leaf_area_change=max_change, growth_factor=growth)
+    lai.determine_leaf_area_added()
+    assert lai.leaf_area_added == expect
+
+@pytest.mark.parametrize("previous,added,expect", [
+    (0, 1, 1),  # start = 0
+    (1, 1, 2),  # start = 1
+    (0, -1, 0),  # loss < 0
+    (10, -15, 0),  # lose more than possible
+    (122.374, 15.99, 122.374 + 15.99)  # arbitrary
+])
+def test_add_leaf_area(previous, added, expect):
+    """ensure that leaf area index is properly updated by add_leaf_area()"""
+    lai = init_lai(previous_leaf_area_index=previous, leaf_area_added=added)
+    lai.add_leaf_area()
+    assert lai.leaf_area_index == expect
+
+@pytest.mark.parametrize("current,cutoff,expect", [
+    (0.5, 0.9, False),
+    (0.9, 0.9, False),
+    (0.95, 0.9, True),
+    (1.3, 1, True)
+])
+def test_check_for_senescence(current, cutoff, expect):
+    """check that senescence is properly triggered by check_for_senescence()"""
+    lai = init_lai(heat_fraction=current, senescent_heat_fraction=cutoff)
+    lai.check_for_senescence()
+    assert lai.is_in_senescence == expect
+
+@pytest.mark.parametrize("opt_lai_frac,heatfrac,cutoff", [
+    (1, 1.2, 1-1e-9),  # cutoff approx 1
+    (0.9, 0.87, 0.8),
+    (0.5, 0.43, 0.44)
+])
+def test_senesce_leaf_area(opt_lai_frac, heatfrac, cutoff):
+    """check that leaf area is correctly set with senesce_leaf_area()"""
+    lai = init_lai(optimal_leaf_area_fraction=opt_lai_frac, heat_fraction=heatfrac, senescent_heat_fraction=cutoff)
+    lai.senesce_leaf_area()
+    assert lai.leaf_area_index == calc_senescent_leaf_area_index(heatfrac, cutoff, opt_lai_frac)
+
+@pytest.mark.parametrize("opt_lai_frac,heatfrac,cutoff", [])
+def test_calc_senescent_leaf_area_index(opt_lai_frac, heatfrac, cutoff):
+    """check that LAI is calculated correctly during senescence with calc_senescent_leaf_area_index()"""
+    if cutoff == 1:
+        x = 1 - heatfrac
+    else:
+        x = (1 - heatfrac) / (1 - cutoff)
+    y = x * opt_lai_frac
+    if y > 0:
+        expect = y
+    else:
+        expect = 0
+    assert calc_senescent_leaf_area_index(heatfrac, cutoff, opt_lai_frac) == expect
+
+@pytest.mark.parametrize("heatfrac", [0, 0.2, 0.5, 0.75, 0.9, 0.95, 1, 1.2, -1])
+def test_determine_leaf_area(heatfrac):
+    """integration test for leaf area processes via grow_canopy()"""
+    # observe
+    lai = init_lai(heat_fraction=heatfrac, leaf_area_index=0.7,
+                   first_heat_fraction_point=0.2, second_heat_fraction_point=0.33, first_leaf_fraction_point=0.05,
+                   second_leaf_fraction_point=0.95, max_canopy_height=2.5, growth_factor=0.95, max_leaf_area_index=3.0,
+                   senescent_heat_fraction=0.9, previous_leaf_area_index=0.1, previous_optimal_leaf_area_fraction=0.01)
+    lai.grow_canopy()
+    # expect
+    shapes = calc_shape_parameters(0.2, 0.33, 0.05, 0.95)
+    assert lai._lai_shapes == shapes
+    optimal_lai = calc_optimal_leaf_area_fraction(heatfrac, shapes[0], shapes[1])
+    assert lai.optimal_leaf_area_fraction == optimal_lai
+    assert lai.canopy_height == 2.5*sqrt(optimal_lai)
+    if heatfrac <= 0.9:  # normal growth
+        assert lai.is_in_senescence is False
+        max_change = calc_max_leaf_area_change(optimal_lai, 0.01, 3.0, 0.1)
+        assert lai.max_leaf_area_change == max_change
+        added = max_change*sqrt(0.95)
+        if max_change < added:  # when heatfrac = 0, no growth occurs
+            added = max_change
+        assert lai.leaf_area_added == added
+        assert lai.leaf_area_index == 0.1 + added
+        assert lai.previous_leaf_area_index == lai.leaf_area_index
+        assert lai.previous_optimal_leaf_area_fraction == optimal_lai
+    else:  # senescence
+        assert lai.is_in_senescence is True
+        assert lai.leaf_area_index == calc_senescent_leaf_area_index(heatfrac, 0.9, optimal_lai)

--- a/SC_redesign/Crop_and_Soil/tests_SC/test_nitrogen_incorporation.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/test_nitrogen_incorporation.py
@@ -648,6 +648,7 @@ def test_store_obtained_nitrogen(up, nitro, fix):
     crop.store_obtained_nitrogen()
     assert crop.nitrogen == calc_stored_nitrogen(up, nitro, fix)
 
+# TODO: Integration tests needed
 # def test_uptake_nitrogen():
 #     """integration test for uptake_nitrogen()"""
 #     raise Exception("need to write an integration test for uptake_nitrogen")


### PR DESCRIPTION
This PR, is a part of the Soil and Crop redesign. It is the first sub-PR of a series that aims to make PR #223 more manageable to review. Each sub-PR will make small changes to the `SC_redesign` branch to allow reviewers an easier time to understand, comment, and make suggestions on each change. 

This PR focuses specifically on the restructuring of the leaf area crop processes, contained in [leaf_area_index.py](SC_redesign/Crop_and_Soil/crop/leaf_area_index.py). The test suite for these processes is implemented in [test_leaf_area_index.py](SC_redesign/Crop_and_Soil/tests_SC/test_leaf_area_index.py)

`grow_canopy()` is the primary process function that will be called externally. This function updates leaf attributes (primarily `leaf_area_index`). The function follows one set of methods during a plant's normal growth and a different set for a plant that is undergoing senescence.