### PR TITLE
Output manager parameters

### DIFF
--- a/RUFAS/classes.py
+++ b/RUFAS/classes.py
@@ -86,10 +86,10 @@ class Config:
             weather_file: path to the weather file specified in the json file
         """
 
-        info_map = {'caller_class': self.__class__.__name__, 
-                    'caller_function': self.__init__.__name__,
-                    'data': data,
-                    'weather_file': weather_file,}
+        info_map = {"class": self.__class__.__name__, 
+                    "function": self.__init__.__name__,
+                    "data": data,
+                    "weather_file": weather_file,}
         
         # gets a start/end date in the format year:julian-day. That way the program
         # can start in the middle of the year
@@ -174,18 +174,18 @@ class Config:
                   + str(w_start_year) + ":" + str(w_start_day))
             self.start_day = w_start_day
 
-            om.add_variable('start_day', self.start_day, info_map)
+            om.add_variable("start_day", self.start_day, info_map)
             self.start_year = w_start_year
-            om.add_variable('start_year', self.start_year, info_map)
+            om.add_variable("start_year", self.start_year, info_map)
 
         if self.end_year == w_end_year and self.end_day > w_end_day \
                 or self.end_year > w_end_year:
             print("End date invalid. Ending simulation on "
                   + str(w_end_year) + ":" + str(w_end_day))
             self.end_day = w_end_day
-            om.add_variable('end_day', self.end_day, info_map)
+            om.add_variable("end_day", self.end_day, info_map)
             self.end_year = w_end_year
-            om.add_variable('end_year', self.end_year, info_map)
+            om.add_variable("end_year", self.end_year, info_map)
 
         # start date errors if the simulation starts before day 1 or after
         # the last possible day of the year
@@ -193,19 +193,19 @@ class Config:
             print("Start date invalid. Starting simulation on "
                   + str(self.start_year) + ":" + str(1))
             self.start_day = 1
-            om.add_variable('start_day', self.start_day, info_map)
+            om.add_variable("start_day", self.start_day, info_map)
         if not is_leap_year(self.start_year):
             if self.start_day > year_length:
                 print("Start date invalid. Starting simulation on "
                       + str(self.start_year) + ":" + str(year_length))
                 self.start_day = year_length
-                om.add_variable('start_day', self.start_day, info_map)
+                om.add_variable("start_day", self.start_day, info_map)
         else:
             if self.start_day > leap_year_length:
                 print("Start date invalid. Starting simulation on "
                       + str(self.start_year) + ":" + str(leap_year_length))
                 self.start_day = leap_year_length
-                om.add_variable('start_day', self.start_day, info_map)
+                om.add_variable("start_day", self.start_day, info_map)
 
         # end date errors if the simulation ends before day 1 or after
         # the last possible day of the year
@@ -213,19 +213,19 @@ class Config:
             print("End date invalid. Ending simulation on "
                   + str(self.end_year) + ":" + str(1))
             self.end_day = 1
-            om.add_variable('end_day', self.end_day, info_map)
+            om.add_variable("end_day", self.end_day, info_map)
         if not is_leap_year(self.end_year):
             if self.end_day > year_length:
                 print("End date invalid. Ending simulation on "
                       + str(self.end_year) + ":" + str(year_length))
                 self.end_day = year_length
-                om.add_variable('end_day', self.end_day, info_map)
+                om.add_variable("end_day", self.end_day, info_map)
         else:
             if self.end_day > leap_year_length:
                 print("End date invalid. Ending simulation on "
                       + str(self.end_year) + ":" + str(leap_year_length))
                 self.end_day = leap_year_length
-                om.add_variable('end_day', self.end_day, info_map)
+                om.add_variable("end_day", self.end_day, info_map)
 
         # checks that start date is not after end date
         if self.start_year > self.end_year \

--- a/RUFAS/output_handler/output_handler.py
+++ b/RUFAS/output_handler/output_handler.py
@@ -91,7 +91,7 @@ class OutputHandler:
         for report_name in self.reports:
             report = self.reports[report_name]
             if not report.produce_csv and report.produce_graphics:
-                info_map['report'] = report
+                info_map["report"] = report
                 om.add_warning("inactive_report_warning", 
                                 "Warning: Cannot produce graphics for" 
                                 + f" inactive report: {report.report_name}."

--- a/RUFAS/output_handler/output_handler.py
+++ b/RUFAS/output_handler/output_handler.py
@@ -85,17 +85,17 @@ class OutputHandler:
     def initialize_reports(self):
         """Transfer needed (initial) data from state to report handlers."""
 
-        info_map = {'caller_class': self.__class__.__name__, 
-                    'caller_function': self.initialize_reports.__name__,}
+        info_map = {"class": self.__class__.__name__, 
+                    "function": self.initialize_reports.__name__,}
 
         for report_name in self.reports:
             report = self.reports[report_name]
             if not report.produce_csv and report.produce_graphics:
                 info_map['report'] = report
-                om.add_warning('inactive_report_warning', 
-                                'Warning: Cannot produce graphics for' 
-                                + f' inactive report: {report.report_name}.'
-                                + ' Setting produce_graphics to False', 
+                om.add_warning("inactive_report_warning", 
+                                "Warning: Cannot produce graphics for" 
+                                + f" inactive report: {report.report_name}."
+                                + " Setting produce_graphics to False", 
                                 info_map)
                 report.produce_graphics = False
             if report.produce_csv:

--- a/RUFAS/output_handler/reports/base_report_driver.py
+++ b/RUFAS/output_handler/reports/base_report_driver.py
@@ -14,8 +14,8 @@ class BaseReportDriver:
         self.reports = {}
 
     def initialize(self):
-        info_map = {'caller_class': self.__class__.__name__, 
-                    'caller_function': self.initialize.__name__,}
+        info_map = {"class": self.__class__.__name__, 
+                    "function": self.initialize.__name__,}
         if self.produce_csv:
             for report in self.reports.values():
                 if not report.produce_csv and report.produce_graphics:

--- a/RUFAS/output_handler/reports/base_report_driver.py
+++ b/RUFAS/output_handler/reports/base_report_driver.py
@@ -19,11 +19,11 @@ class BaseReportDriver:
         if self.produce_csv:
             for report in self.reports.values():
                 if not report.produce_csv and report.produce_graphics:
-                    info_map['report'] = report
-                    om.add_warning('inactive_report_warning', 
-                                    'Warning: Cannot produce graphics for'
-                                    + f' inactive report: {report.report_name}.'
-                                    + ' Setting produce_graphics to False', 
+                    info_map["report"] = report
+                    om.add_warning("inactive_report_warning", 
+                                    "Warning: Cannot produce graphics for"
+                                    + f" inactive report: {report.report_name}."
+                                    + " Setting produce_graphics to False", 
                                     info_map)
                     report.produce_graphics = False
                 if report.produce_csv:

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -210,7 +210,7 @@ class OutputManager (object):
 
         return f"{prefix}{name}{suffix}"
 
-    def _get_prefix(self, class: str, function: str) -> str:
+    def _get_prefix(self, class_: str, function: str) -> str:
         """
         Returns the prefix for a key in the pool.
 
@@ -226,7 +226,7 @@ class OutputManager (object):
         str
             {class}.{function}
         """
-        return f"{class}.{function}"
+        return f"{class_}.{function}"
 
     def _get_time_based_suffix(self) -> str:
         """

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -210,13 +210,13 @@ class OutputManager (object):
 
         return f"{prefix}{name}{suffix}"
 
-    def _get_prefix(self, class_: str, function: str) -> str:
+    def _get_prefix(self, caller_class: str, function: str) -> str:
         """
         Returns the prefix for a key in the pool.
 
         Parameters
         ----------
-        class : str
+        caller_class : str
             The name of the class in which this key-value pair is originated
         function : str
             The name of the function in which this key-value pair is originated
@@ -226,7 +226,7 @@ class OutputManager (object):
         str
             {class}.{function}
         """
-        return f"{class_}.{function}"
+        return f"{caller_class}.{function}"
 
     def _get_time_based_suffix(self) -> str:
         """

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -40,8 +40,8 @@ class OutputManager (object):
             self.errors_pool: Dict[str, Any] = {}
             self.logs_pool: Dict[str, Any] = {}
             self.add_log("init_log", "Output Manager instantiated.",
-                         info_map={'caller_class': self.__class__.__name__,
-                                   'caller_function': self.__init__.__name__})
+                         info_map={"class": self.__class__.__name__,
+                                   "function": self.__init__.__name__})
 
     def add_variable(self, name: str, value: Any,
                      info_map: Dict[str, Union[str, bool]]) -> None:
@@ -56,24 +56,24 @@ class OutputManager (object):
             The value of the variable
         info_map : Dict[str, Union[str,bool]]
             Additional args, some are non-optional
-        info_map['caller_class'] : str
+        info_map["class"] : str
             The name of the class which called this function
-        info_map['caller_function'] : str
+        info_map["function"] : str
             The name of the function which called this function 
-        info_map['prefix'] : str, optional
+        info_map["prefix"] : str, optional
             If present, overrides the automated prefix
-        info_map['suffix'] : str, optional
+        info_map["suffix"] : str, optional
             If present, overrides the automated suffix
-        info_map['suppress_prefix'] : bool, optional
+        info_map["suppress_prefix"] : bool, optional
             If present and True, suppresses the automated prefix generation.
             Has no effect on manual prefix overrides.
-        info_map['suppress_suffix'] : bool, optional
+        info_map["suppress_suffix"] : bool, optional
             If present and True, suppresses the automated suffix generation.
             Has no effect on manual suffix overrides.
-        info_map['enforce_override'] : bool, optional
+        info_map["enforce_override"] : bool, optional
             If present and True, overrides the existing value in the pool if a
             key collision happens.
-        info_map['fail_silently'] : bool, optional
+        info_map["fail_silently"] : bool, optional
             If present and True, suppresses raising error if a key collision
             happens.
 
@@ -81,7 +81,7 @@ class OutputManager (object):
         ------
         ValueError
             If a key collision happens in the pool and either
-            info_map['fail_silently'] or info_map['enforce_override'] 
+            info_map["fail_silently"] or info_map["enforce_override"] 
             are not set to True.
         """
         key = self._generate_key(name, info_map)
@@ -89,17 +89,17 @@ class OutputManager (object):
         if key_not_exists:
             self.variables_pool[key] = value
             return
-        info_map['key'] = key
-        info_map['caller_function'] = self.add_variable.__name__
-        info_map['caller_class'] = self.__class__.__name__
-        if info_map.get('enforce_override', False):
+        info_map["key"] = key
+        info_map["function"] = self.add_variable.__name__
+        info_map["class"] = self.__class__.__name__
+        if info_map.get("enforce_override", False):
             self.variables_pool[key] = value
-            self.add_warning('key_collision',
+            self.add_warning("key_collision",
                              "Key collision happened; the value was overriden per given flag.",
                              info_map)
             return
-        if info_map.get('fail_silently', False):
-            self.add_error('key_collision',
+        if info_map.get("fail_silently", False):
+            self.add_error("key_collision",
                            "Key collision happened; the event was ignored per given flag.",
                            info_map)
             return
@@ -121,16 +121,16 @@ class OutputManager (object):
             The log message to be added to the pool
         info_map: Dict[str, Any]
             Additional args to be logged, some are non-optional
-        info_map['caller_class'] : str
+        info_map["class"] : str
             The name of the class which called this function
-        info_map['caller_function'] : str
+        info_map["function"] : str
             The name of the function which called this function 
         """
         key = self._generate_key(name,
                                  {
-                                     'caller_class': info_map['caller_class'],
-                                     'caller_function': info_map['caller_function']})
-        self.logs_pool[key] = {'msg': msg, 'info_map': info_map}
+                                     "class": info_map["class"],
+                                     "function": info_map["function"]})
+        self.logs_pool[key] = {"msg": msg, "info_map": info_map}
 
     def add_warning(self, name: str, msg: str, info_map: Dict[str, Any]) -> None:
         """
@@ -144,16 +144,16 @@ class OutputManager (object):
             The warning message to be added to the pool
         info_map: Dict[str, Any]
             Additional args to be logged, some are non-optional
-        info_map['caller_class'] : str
+        info_map["class"] : str
             The name of the class which called this function
-        info_map['caller_function'] : str
+        info_map["function"] : str
             The name of the function which called this function 
         """
         key = self._generate_key(name,
                                  {
-                                     'caller_class': info_map['caller_class'],
-                                     'caller_function': info_map['caller_function']})
-        self.warnings_pool[key] = {'msg': msg, 'info_map': info_map}
+                                     "class": info_map["class"],
+                                     "function": info_map["function"]})
+        self.warnings_pool[key] = {"msg": msg, "info_map": info_map}
 
     def add_error(self, name: str, msg: str, info_map: Dict[str, Any]) -> None:
         """
@@ -167,66 +167,66 @@ class OutputManager (object):
             The error message to be added to the pool
         info_map: Dict[str, Any]
             Additional args to be logged, some are non-optional
-        info_map['caller_class'] : str
+        info_map["class"] : str
             The name of the class which called this function
-        info_map['caller_function'] : str
+        info_map["function"] : str
             The name of the function which called this function 
         """
         key = self._generate_key(name,
                                  {
-                                     'caller_class': info_map['caller_class'],
-                                     'caller_function': info_map['caller_function']})
-        self.errors_pool[key] = {'msg': msg, 'info_map': info_map}
+                                     "class": info_map["class"],
+                                     "function": info_map["function"]})
+        self.errors_pool[key] = {"msg": msg, "info_map": info_map}
 
     def _generate_key(self, name: str,
                       info_map: Dict[str, Union[str, bool]]) -> str:
         """
         Generates key for the pool.
-        See 'add_variable' docs for detailed arg description.
+        See "add_variable" docs for detailed arg description.
 
         Raises
         ------
         KeyError
-            If either info_map['caller_class'] or info_map['caller_function'] are 
+            If either info_map["class"] or info_map["function"] are 
             not present.
         """
-        if info_map.get('caller_class') is None:
-            raise KeyError("'caller_class' were not found in info_map")
-        if info_map.get('caller_function') is None:
-            raise KeyError("'caller_function' were not found in info_map")
+        if info_map.get("class") is None:
+            raise KeyError("'class' were not found in info_map")
+        if info_map.get("function") is None:
+            raise KeyError("'function' were not found in info_map")
 
         prefix = ""
-        if info_map.get('prefix') is not None:
-            prefix = info_map.get('prefix') + "."
-        elif not info_map.get('suppress_prefix', False):
+        if info_map.get("prefix") is not None:
+            prefix = info_map.get("prefix") + "."
+        elif not info_map.get("suppress_prefix", False):
             prefix = self._get_prefix(info_map.get(
-                'caller_class'), info_map.get('caller_function')) + "."
+                "class"), info_map.get("function")) + "."
 
         suffix = ""
-        if info_map.get('suffix') is not None:
-            suffix = "." + info_map.get('suffix')
-        elif not info_map.get('suppress_suffix', False):
+        if info_map.get("suffix") is not None:
+            suffix = "." + info_map.get("suffix")
+        elif not info_map.get("suppress_suffix", False):
             suffix = "." + self._get_time_based_suffix()
 
         return f"{prefix}{name}{suffix}"
 
-    def _get_prefix(self, caller_class: str, caller_function: str) -> str:
+    def _get_prefix(self, class: str, function: str) -> str:
         """
         Returns the prefix for a key in the pool.
 
         Parameters
         ----------
-        caller_class : str
+        class : str
             The name of the class in which this key-value pair is originated
-        caller_function : str
+        function : str
             The name of the function in which this key-value pair is originated
 
         Returns
         -------
         str
-            {caller_class}.{caller_function}
+            {class}.{function}
         """
-        return f"{caller_class}.{caller_function}"
+        return f"{class}.{function}"
 
     def _get_time_based_suffix(self) -> str:
         """

--- a/RUFAS/routines/animal/animal_management.py
+++ b/RUFAS/routines/animal/animal_management.py
@@ -163,8 +163,8 @@ class AnimalManagement:
             herd_data: dictionary containing information about the herd
         """
 
-        info_map = {'caller_class': self.__class__.__name__, 
-                    'caller_function': self.init_pens.__name__,
+        info_map = {"class": self.__class__.__name__, 
+                    "function": self.init_pens.__name__,
                     'all_pens_data': all_pens_data,
                     'herd_data': herd_data,}
 
@@ -260,8 +260,8 @@ class AnimalManagement:
             weather: instance of the Weather class defined in classes.py
             time: instance of the Time class defined in classes.py
         """
-        info_map = {'caller_class': self.__class__.__name__, 
-                    'caller_function': self.__init__.__name__,
+        info_map = {"class": self.__class__.__name__, 
+                    "function": self.__init__.__name__,
                     'herd_data': herd_data,
                     'pen_data': pen_data,
                     'weather': weather,
@@ -606,9 +606,9 @@ class AnimalManagement:
                 else:
                     mixed_types[pen.id] = pen.animal_combination
         # organzing pens by class and ensuring sufficeint storage
-        info_map = {'caller_class': self.__class__.__name__, 
-                    'caller_function': self.pen_allocation.__name__,
-                    'all_pens': self.all_pens,}
+        info_map = {"class": self.__class__.__name__, 
+                    "function": self.pen_allocation.__name__,
+                    "all_pens": self.all_pens,}
         while True:
             max_value = max(stall_shortage.values())
             if max_value > 0:
@@ -1010,8 +1010,8 @@ class AnimalManagement:
                           len(self.life_cycle_manager.sold_heifers),
                           len(self.life_cycle_manager.culled_cows))
 
-        info_map = {'caller_class': self.__class__.__name__, 
-                    'caller_function': self.get_life_cycle_output.__name__,
+        info_map = {"class": self.__class__.__name__, 
+                    "function": self.get_life_cycle_output.__name__,
                     'num_animals': num_animals,
                     'minimum_num': minimum_num,}
 

--- a/RUFAS/routines/animal/animal_management.py
+++ b/RUFAS/routines/animal/animal_management.py
@@ -165,8 +165,8 @@ class AnimalManagement:
 
         info_map = {"class": self.__class__.__name__, 
                     "function": self.init_pens.__name__,
-                    'all_pens_data': all_pens_data,
-                    'herd_data': herd_data,}
+                    "all_pens_data": all_pens_data,
+                    "herd_data": herd_data,}
 
         for pen_name in all_pens_data:
             pen_data = all_pens_data[pen_name]
@@ -201,11 +201,11 @@ class AnimalManagement:
         manure_separator = "sedimentation"
         manure_storage = "storage_pit"
         animal_combination = None
-        info_map['all_pens'] = self.all_pens
+        info_map["all_pens"] = self.all_pens
         if (len(self.all_pens) == 0) and (herd_num > 0):
-            om.add_warning('invalid_pen_num_warning', 
-                            'Warning: herd_num > 0, but pen_num = 0.'
-                            + ' Initilizing 3 default pens.',
+            om.add_warning("invalid_pen_num_warning", 
+                            "Warning: herd_num > 0, but pen_num = 0."
+                            + " Initilizing 3 default pens.",
                              info_map)
             pen_1 = Pen(0, 0.1, 1.6, 100, 'open air barn', 'sand', 'freestall',
                         manure_handling, manure_separator, manure_storage,
@@ -220,9 +220,9 @@ class AnimalManagement:
             self.all_pens.append(pen_2)
             self.all_pens.append(pen_3)
         elif (len(self.all_pens) == 1) and (herd_num > 0):
-            om.add_warning('invalid_pen_num_warning', 
-                            'Warning: herd_num > 0, but pen_num = 1.'
-                            + ' Initilizing 2 default pens.',
+            om.add_warning("invalid_pen_num_warning", 
+                            "Warning: herd_num > 0, but pen_num = 1."
+                            + " Initilizing 2 default pens.",
                              info_map)
             pen_2 = Pen(1, 0.1, 1.6, 300, 'open air barn', 'sawdust', 'freestall',
                         manure_handling, manure_separator, manure_storage,
@@ -233,9 +233,9 @@ class AnimalManagement:
             self.all_pens.append(pen_2)
             self.all_pens.append(pen_3)
         elif (len(self.all_pens) == 2) and (herd_num > 0):
-            om.add_warning('invalid_pen_num_warning', 
-                            'Warning: herd_num > 0, but pen_num = 2.' 
-                            + ' Initilizing 1 default pen.',
+            om.add_warning("invalid_pen_num_warning", 
+                            "Warning: herd_num > 0, but pen_num = 2." 
+                            + " Initilizing 1 default pen.",
                              info_map)
             pen_3 = Pen(2, 0.1, 1.6, 300, 'open air barn', 'straw', 'tiestall',
                         manure_handling, manure_separator, manure_storage,
@@ -262,12 +262,12 @@ class AnimalManagement:
         """
         info_map = {"class": self.__class__.__name__, 
                     "function": self.__init__.__name__,
-                    'herd_data': herd_data,
-                    'pen_data': pen_data,
-                    'weather': weather,
-                    'time': time,
-                    'config': config,
-                    'feed': feed,}
+                    "herd_data": herd_data,
+                    "pen_data": pen_data,
+                    "weather": weather,
+                    "time": time,
+                    "config": config,
+                    "feed": feed,}
         calf_num = herd_data['calf_num']
         heiferI_num = herd_data['heiferI_num']
         heiferII_num = herd_data['heiferII_num']
@@ -280,34 +280,34 @@ class AnimalManagement:
         if herd_num == 0:
             self.simulate_animals = False
             if not calf_num == 0:
-                om.add_warning('invalid_calf_num_warning', 
-                                'Warning: herd_num is 0, but calf_num is not.'
-                                + ' Setting calf_num = 0.', 
+                om.add_warning("invalid_calf_num_warning", 
+                                "Warning: herd_num is 0, but calf_num is not."
+                                + " Setting calf_num = 0.", 
                                 info_map)
                 calf_num = 0
             if not heiferI_num == 0:
-                om.add_warning('invalid_heiferI_num_warning', 
-                                'Warning: herd_num is 0, but heiferI_num is not.'
-                                + ' Setting heiferI_num = 0.', 
+                om.add_warning("invalid_heiferI_num_warning", 
+                                "Warning: herd_num is 0, but heiferI_num is not."
+                                + " Setting heiferI_num = 0.", 
                                 info_map)
                 heiferI_num = 0
             if not heiferII_num == 0:
-                om.add_warning('invalid_heiferII_num_warning', 
-                                'Warning: herd_num is 0, but heiferII_num is not.'
-                                + ' Setting heiferII_num = 0.', 
+                om.add_warning("invalid_heiferII_num_warning", 
+                                "Warning: herd_num is 0, but heiferII_num is not."
+                                + " Setting heiferII_num = 0.", 
                                 info_map)
                 heiferII_num = 0
             if not heiferIII_num == 0:
-                om.add_warning('invalid_heiferIII_num_warning', 
-                                'Warning: herd_num is 0, but heiferIII_num is not.'
-                                + ' Setting heiferII_num = 0.', 
+                om.add_warning("invalid_heiferIII_num_warning", 
+                                "Warning: herd_num is 0, but heiferIII_num is not."
+                                + " Setting heiferII_num = 0.", 
                                 info_map)
                 heiferIII_num = 0
             if not cow_num == 0:
 
-                om.add_warning('invalid_cow_num_warning', 
-                                'Warning: herd_num is 0, but cow_num is not.'
-                                + ' Setting cow_num = 0.', 
+                om.add_warning("invalid_cow_num_warning", 
+                                "Warning: herd_num is 0, but cow_num is not."
+                                + " Setting cow_num = 0.", 
                                 info_map)
                 cow_num = 0
         else:
@@ -623,9 +623,9 @@ class AnimalManagement:
                         stalls = pen.num_stalls
                 # if no available pens for this group in mixed types
                 if pen is None:
-                    om.add_warning('pen_shortage_warning', 
-                                    f'Warning: shortage of {max_key[0].name} pens,' 
-                                    + ' initializing new pen,', 
+                    om.add_warning("pen_shortage_warning", 
+                                    f"Warning: shortage of {max_key[0].name} pens," 
+                                    + " initializing new pen,", 
                                     info_map)
                     # initalizing a default pen to be used for any class
                     pen = Pen(len(self.all_pens), 0.1, 1.6, max_value,
@@ -1012,15 +1012,15 @@ class AnimalManagement:
 
         info_map = {"class": self.__class__.__name__, 
                     "function": self.get_life_cycle_output.__name__,
-                    'num_animals': num_animals,
-                    'minimum_num': minimum_num,}
+                    "num_animals": num_animals,
+                    "minimum_num": minimum_num,}
 
         if num_animals > minimum_num:
-            om.add_warning('invalid_animal_list_size', 
-                            f'The smallest animal list is of size {minimum_num}'
-                            + f' so {num_animals} of each animal class cannot be' 
-                            + f' in the life cycle output. Only {minimum_num} of' 
-                            + ' each animal type will be in the life cycle output.',
+            om.add_warning("invalid_animal_list_size", 
+                            f"The smallest animal list is of size {minimum_num}"
+                            + f" so {num_animals} of each animal class cannot be" 
+                            + f" in the life cycle output. Only {minimum_num} of" 
+                            + " each animal type will be in the life cycle output.",
                             info_map)
             num_animals = minimum_num
 

--- a/RUFAS/simulation_engine.py
+++ b/RUFAS/simulation_engine.py
@@ -39,7 +39,7 @@ class SimulationEngine:
 
         print("Simulation Successful")
         total_simulation_time = t_end_sim - t_start_sim
-        om.add_log("total_simulation_time", total_simulation_time, info_map)
+        om.add_log("total_simulation_time", f"Total simulation time is: {total_simulation_time}", info_map)
 
 
         t_start_graphics = timer.time()
@@ -48,10 +48,10 @@ class SimulationEngine:
         t_end_graphics = timer.time()
 
         graphics_prod_time = t_end_graphics - t_start_graphics
-        om.add_log('graphics_prod_time', graphics_prod_time, info_map)
+        om.add_log("graphics_prod_time", f"Graphics production time is: {graphics_prod_time}", info_map)
         total_runtime = (t_end_sim-t_start_sim) + \
             (t_end_graphics-t_start_graphics)
-        om.add_log('total_runtime', total_runtime, info_map)
+        om.add_log("total_runtime", f"Total runtime is: {total_runtime}", info_map)
         self._show_final_messages(graphics_prod_time, total_runtime)
 
     def _run_simulation_main_loop(self) -> None:

--- a/RUFAS/simulation_engine.py
+++ b/RUFAS/simulation_engine.py
@@ -29,8 +29,8 @@ class SimulationEngine:
 
     def simulate(self) -> None:
         """Executes the simulation"""
-        info_map = {'caller_class': self.__class__.__name__, 
-                    'caller_function': self.simulate.__name__,}
+        info_map = {"class": self.__class__.__name__, 
+                    "function": self.simulate.__name__,}
         t_start_sim = timer.time()
         
         self._run_simulation_main_loop()
@@ -39,7 +39,7 @@ class SimulationEngine:
 
         print("Simulation Successful")
         total_simulation_time = t_end_sim - t_start_sim
-        om.add_log('total_simulation_time', total_simulation_time, info_map)
+        om.add_log("total_simulation_time", total_simulation_time, info_map)
 
 
         t_start_graphics = timer.time()
@@ -151,11 +151,11 @@ class SimulationEngine:
             InvalidJSONFile: If the json file at the given path does not conform 
             with the format required
         """
-        info_map = {'caller_class': self.__class__.__name__, 
-                    'caller_function': self._initialize_simulation.__name__,
-                    'file_path': file_path,}
+        info_map = {"class": self.__class__.__name__, 
+                    "function": self._initialize_simulation.__name__,
+                    "file_path": file_path,}
         print(f"Initializing simulation environment from {file_path}")
-        om.add_variable('simulation_initialization_file_path', file_path, info_map)
+        om.add_variable("simulation_initialization_file_path", file_path, info_map)
 
         try:
             data = Utility.read_json_file(file_path)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -289,8 +289,8 @@ def test_percent_calculator() -> None:
 
 def test_get_time_based_suffix(mocker: MockerFixture) -> None:
     """Unit test for function _get_suffix in file output_manager.py"""
-    auto_suffix = '1669002803.9697945'
-    mocker.patch('time.time', return_value=auto_suffix)
+    auto_suffix = "1669002803.9697945"
+    mocker.patch("time.time", return_value=auto_suffix)
     om = OutputManager()
     assert om._get_time_based_suffix() == auto_suffix
 
@@ -298,58 +298,58 @@ def test_get_time_based_suffix(mocker: MockerFixture) -> None:
 def test_get_prefix() -> None:
     """Unit test for function _get_prefix in file output_manager.py"""
     om = OutputManager()
-    assert om._get_prefix('class', 'func') == 'class.func'
+    assert om._get_prefix("class", "func") == "class.func"
 
 
 def test_generate_key(mocker: MockerFixture) -> None:
     """Unit test for function _generate_key in file output_manager.py"""
     om = OutputManager()
     with raises(KeyError):
-        om._generate_key('name', {})
+        om._generate_key("name", {})
 
-    auto_suffix = '1669002803.9697945'
-    mocker.patch('time.time', return_value=auto_suffix)
+    auto_suffix = "1669002803.9697945"
+    mocker.patch("time.time", return_value=auto_suffix)
 
     info_map = {"class": "dummy_class", "function": "dummy_func"}
-    key = om._generate_key('key_name', info_map)
-    assert key == f'dummy_class.dummy_func.key_name.{auto_suffix}'
+    key = om._generate_key("key_name", info_map)
+    assert key == f"dummy_class.dummy_func.key_name.{auto_suffix}"
 
-    info_map['suppress_prefix'] = True
-    key = om._generate_key('key_name', info_map)
-    assert key == f'key_name.{auto_suffix}'
+    info_map["suppress_prefix"] = True
+    key = om._generate_key("key_name", info_map)
+    assert key == f"key_name.{auto_suffix}"
 
-    info_map['suppress_prefix'] = False
-    key = om._generate_key('key_name', info_map)
-    assert key == f'dummy_class.dummy_func.key_name.{auto_suffix}'
+    info_map["suppress_prefix"] = False
+    key = om._generate_key("key_name", info_map)
+    assert key == f"dummy_class.dummy_func.key_name.{auto_suffix}"
 
-    info_map['suppress_suffix'] = True
-    key = om._generate_key('key_name', info_map)
-    assert key == 'dummy_class.dummy_func.key_name'
+    info_map["suppress_suffix"] = True
+    key = om._generate_key("key_name", info_map)
+    assert key == "dummy_class.dummy_func.key_name"
 
-    info_map['suppress_suffix'] = False
-    key = om._generate_key('key_name', info_map)
-    assert key == f'dummy_class.dummy_func.key_name.{auto_suffix}'
+    info_map["suppress_suffix"] = False
+    key = om._generate_key("key_name", info_map)
+    assert key == f"dummy_class.dummy_func.key_name.{auto_suffix}"
 
-    info_map['suppress_prefix'] = True
-    info_map['suppress_suffix'] = True
-    key = om._generate_key('key_name', info_map)
-    assert key == 'key_name'
+    info_map["suppress_prefix"] = True
+    info_map["suppress_suffix"] = True
+    key = om._generate_key("key_name", info_map)
+    assert key == "key_name"
 
-    info_map['prefix'] = 'dummy_prefix'
-    info_map['suppress_suffix'] = False
-    key = om._generate_key('key_name', info_map)
-    assert key == f'dummy_prefix.key_name.{auto_suffix}'
+    info_map["prefix"] = "dummy_prefix"
+    info_map["suppress_suffix"] = False
+    key = om._generate_key("key_name", info_map)
+    assert key == f"dummy_prefix.key_name.{auto_suffix}"
 
-    info_map['suffix'] = 'dummy_suffix'
-    key = om._generate_key('key_name', info_map)
-    assert key == 'dummy_prefix.key_name.dummy_suffix'
+    info_map["suffix"] = "dummy_suffix"
+    key = om._generate_key("key_name", info_map)
+    assert key == "dummy_prefix.key_name.dummy_suffix"
 
 
 def test_add_error(mocker: MockerFixture) -> None:
     """Unit test for function add_error in file output_manager.py"""
 
-    key = 'key'
-    mocker.patch('RUFAS.output_manager.OutputManager._generate_key',
+    key = "key"
+    mocker.patch("RUFAS.output_manager.OutputManager._generate_key",
                  return_value=key)
     om = OutputManager()
     info_map = {"class": "dummy_class", "function": "dummy_func"}
@@ -361,8 +361,8 @@ def test_add_error(mocker: MockerFixture) -> None:
 def test_add_warning(mocker: MockerFixture) -> None:
     """Unit test for function add_warning in file output_manager.py"""
 
-    key = 'key'
-    mocker.patch('RUFAS.output_manager.OutputManager._generate_key',
+    key = "key"
+    mocker.patch("RUFAS.output_manager.OutputManager._generate_key",
                  return_value=key)
     om = OutputManager()
     info_map = {"class": "dummy_class", "function": "dummy_func"}
@@ -374,8 +374,8 @@ def test_add_warning(mocker: MockerFixture) -> None:
 def test_add_log(mocker: MockerFixture) -> None:
     """Unit test for function add_log in file output_manager.py"""
 
-    key = 'key'
-    mocker.patch('RUFAS.output_manager.OutputManager._generate_key',
+    key = "key"
+    mocker.patch("RUFAS.output_manager.OutputManager._generate_key",
                  return_value=key)
     om = OutputManager()
     info_map = {"class": "dummy_class", "function": "dummy_func"}
@@ -387,26 +387,26 @@ def test_add_log(mocker: MockerFixture) -> None:
 def test_add_variable(mocker: MockerFixture) -> None:
     """Unit test for function add_variable in file output_manager.py"""
 
-    key = 'key'
-    mocker.patch('RUFAS.output_manager.OutputManager._generate_key',
+    key = "key"
+    mocker.patch("RUFAS.output_manager.OutputManager._generate_key",
                  return_value=key)
     om = OutputManager()
     info_map = {"class": "dummy_class", "function": "dummy_func"}
-    om.add_variable("dummy_name", 'dummy_value', info_map)
-    assert om.variables_pool[key] == 'dummy_value'
+    om.add_variable("dummy_name", "dummy_value", info_map)
+    assert om.variables_pool[key] == "dummy_value"
 
     with raises(ValueError):
-        om.add_variable("dummy_name", 'dummy_value', info_map)
+        om.add_variable("dummy_name", "dummy_value", info_map)
     # TODO issue 214
 
 
 def test_output_manager_singleton(mocker: MockerFixture) -> None:
     """Test case to ensure output_manager is singleton"""
-    key = 'key1'
-    mocker.patch('RUFAS.output_manager.OutputManager._generate_key',
+    key = "key1"
+    mocker.patch("RUFAS.output_manager.OutputManager._generate_key",
                  return_value=key)
     om1 = OutputManager()
     om2 = OutputManager()
     info_map = {"class": "dummy_class", "function": "dummy_func"}
-    om1.add_variable("dummy_name", 'dummy_value', info_map)    
-    assert om2.variables_pool[key] == 'dummy_value'
+    om1.add_variable("dummy_name", "dummy_value", info_map)    
+    assert om2.variables_pool[key] == "dummy_value"

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -310,7 +310,7 @@ def test_generate_key(mocker: MockerFixture) -> None:
     auto_suffix = '1669002803.9697945'
     mocker.patch('time.time', return_value=auto_suffix)
 
-    info_map = {'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}
+    info_map = {"class": "dummy_class", "function": "dummy_func"}
     key = om._generate_key('key_name', info_map)
     assert key == f'dummy_class.dummy_func.key_name.{auto_suffix}'
 
@@ -352,10 +352,10 @@ def test_add_error(mocker: MockerFixture) -> None:
     mocker.patch('RUFAS.output_manager.OutputManager._generate_key',
                  return_value=key)
     om = OutputManager()
-    info_map = {'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}
-    om.add_error('dummy_name', 'dummy_msg', info_map)
-    assert om.errors_pool[key] == {'info_map': {
-        'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}, 'msg': 'dummy_msg'}
+    info_map = {"class": "dummy_class", "function": "dummy_func"}
+    om.add_error("dummy_name", "dummy_msg", info_map)
+    assert om.errors_pool[key] == {"info_map": {
+        "class": "dummy_class", "function": "dummy_func"}, "msg": "dummy_msg"}
 
 
 def test_add_warning(mocker: MockerFixture) -> None:
@@ -365,10 +365,10 @@ def test_add_warning(mocker: MockerFixture) -> None:
     mocker.patch('RUFAS.output_manager.OutputManager._generate_key',
                  return_value=key)
     om = OutputManager()
-    info_map = {'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}
-    om.add_warning('dummy_name', 'dummy_msg', info_map)
-    assert om.warnings_pool[key] == {'info_map': {
-        'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}, 'msg': 'dummy_msg'}
+    info_map = {"class": "dummy_class", "function": "dummy_func"}
+    om.add_warning("dummy_name", "dummy_msg", info_map)
+    assert om.warnings_pool[key] == {"info_map": {
+        "class": "dummy_class", "function": "dummy_func"}, "msg": "dummy_msg"}
 
 
 def test_add_log(mocker: MockerFixture) -> None:
@@ -378,10 +378,10 @@ def test_add_log(mocker: MockerFixture) -> None:
     mocker.patch('RUFAS.output_manager.OutputManager._generate_key',
                  return_value=key)
     om = OutputManager()
-    info_map = {'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}
-    om.add_log('dummy_name', 'dummy_msg', info_map)
-    assert om.logs_pool[key] == {'info_map': {
-        'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}, 'msg': 'dummy_msg'}
+    info_map = {"class": "dummy_class", "function": "dummy_func"}
+    om.add_log("dummy_name", "dummy_msg", info_map)
+    assert om.logs_pool[key] == {"info_map": {
+        "class": "dummy_class", "function": "dummy_func"}, "msg": "dummy_msg"}
 
 
 def test_add_variable(mocker: MockerFixture) -> None:
@@ -391,12 +391,12 @@ def test_add_variable(mocker: MockerFixture) -> None:
     mocker.patch('RUFAS.output_manager.OutputManager._generate_key',
                  return_value=key)
     om = OutputManager()
-    info_map = {'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}
-    om.add_variable('dummy_name', 'dummy_value', info_map)
+    info_map = {"class": "dummy_class", "function": "dummy_func"}
+    om.add_variable("dummy_name", 'dummy_value', info_map)
     assert om.variables_pool[key] == 'dummy_value'
 
     with raises(ValueError):
-        om.add_variable('dummy_name', 'dummy_value', info_map)
+        om.add_variable("dummy_name", 'dummy_value', info_map)
     # TODO issue 214
 
 
@@ -407,6 +407,6 @@ def test_output_manager_singleton(mocker: MockerFixture) -> None:
                  return_value=key)
     om1 = OutputManager()
     om2 = OutputManager()
-    info_map = {'caller_class': 'dummy_class', 'caller_function': 'dummy_func'}
-    om1.add_variable('dummy_name', 'dummy_value', info_map)    
+    info_map = {"class": "dummy_class", "function": "dummy_func"}
+    om1.add_variable("dummy_name", 'dummy_value', info_map)    
     assert om2.variables_pool[key] == 'dummy_value'


### PR DESCRIPTION
**What:** 
This PR makes some name-adjustments to OutputManager params ("caller_function" to "function" and "caller_class" to "class") as well as addressing some issues with proper json syntax (single quotes to double quotes).

**Why**
The renaming of the OutputManager params is meant to make them easier to enter while not losing the intent or understanding behind them. The json syntax adjustments are due to json only accepting double quotes around strings and parameter names.

**How**
Through search and replace of the params for all the instances of the OM in the model so far including in the class constructor for OutputManager. Additionally doing search and replace for single quotes when used in context of OM instantiation and usage to ensure json data is entered with double quotes.