### PR TITLE
added testing workflow to SC_redesign branch

### DIFF
--- a/.github/workflows/Test-SCredesign-branch_TEMPORARY.yml
+++ b/.github/workflows/Test-SCredesign-branch_TEMPORARY.yml
@@ -1,0 +1,32 @@
+# This workflow will install Python dependencies, run tests with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+# TODO: This file should be deleted as soon as the SC_redesign branch is merged into master (if branch deleted)
+#  Method copied from testing_pytest.yml, with test directory changed
+
+name: Testing_SC_Redesign
+
+on:
+  push:
+    branches: [ SC_redesign ]
+  pull_request:
+    branches: [ SC_redesign ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Test with pytest
+      run: |
+        pytest SC_redesign/Crop_and_Soil/tests_SC/

--- a/.github/workflows/lint_flake8.yml
+++ b/.github/workflows/lint_flake8.yml
@@ -5,9 +5,9 @@ name: Linting
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, SC_redesign ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, SC_redesign ]
 
 jobs:
   build:


### PR DESCRIPTION
This PR simply adds a github workflow to ensure that pushes and pull-requests to the SC_redesign branch are tested. 

The new workflow calls `pytest SC_redesign/Crop_and_Soil/tests_SC/` every time there is a push to SC_redesign, or when a pull request uses SC_redesign as its base. It also adds SC_redesign to the linting checks.