### PR TITLE
Phosphorus Concentration Naming Convention rework

### DIFF
--- a/RUFAS/routines/animal/animal_management.py
+++ b/RUFAS/routines/animal/animal_management.py
@@ -119,12 +119,12 @@ class AnimalManagement:
                                            Pen.AnimalCombination.GROWING_AND_CLOSE_UP: [],
                                            Pen.AnimalCombination.LAC_COW: []}
 
-        # these variables are the P compositions of each class of animal. They
+        # these variables are the P concentrations of each class of animal. They
         # are calculated daily and are used when an animal is added to the
         # herd, whether by birth or replacement herd purchase. They are calculated
-        # in calc_all_p_comp() and are the total body weight of the animals in the
-        # respective class divided by the total P in the animals of the class
-        self.p_comp = {
+        # in calc_all_p_conc() and are calculated by dividing the total P in the animals
+        # of the class by the total body weight of the animals, on a per-animal basis
+        self.p_conc = {
             'calf': 0,
             'heiferI': 0,
             'heiferII': 0,
@@ -383,27 +383,27 @@ class AnimalManagement:
 
         for animal in animals_added:
             if type(animal).__name__ == 'Calf':
-                animal_p_conc = self.p_comp['calf']
+                animal_p_conc = self.p_conc['calf']
                 self.calves.append(animal)
                 group = Pen.AnimalCombination.CALF
             elif type(animal).__name__ == 'HeiferI':
-                animal_p_conc = self.p_comp['heiferI']
+                animal_p_conc = self.p_conc['heiferI']
                 self.heiferIs.append(animal)
                 group = Pen.AnimalCombination.GROWING
             elif type(animal).__name__ == 'HeiferII':
-                animal_p_conc = self.p_comp['heiferII']
+                animal_p_conc = self.p_conc['heiferII']
                 self.heiferIIs.append(animal)
                 group = Pen.AnimalCombination.GROWING
             elif type(animal).__name__ == 'HeiferIII':
-                animal_p_conc = self.p_comp['heiferIII']
+                animal_p_conc = self.p_conc['heiferIII']
                 self.heiferIIIs.append(animal)
                 group = Pen.AnimalCombination.CLOSE_UP
             elif not animal.milking:
-                animal_p_conc = self.p_comp['cow']
+                animal_p_conc = self.p_conc['cow']
                 self.cows.append(animal)
                 group = Pen.AnimalCombination.CLOSE_UP
             else:  # animal is of class Cow
-                animal_p_conc = self.p_comp['cow']
+                animal_p_conc = self.p_conc['cow']
                 # self.all_pens[pen].animals_in_pen.append(animal)
                 self.cows.append(animal)
                 group = Pen.AnimalCombination.LAC_COW
@@ -751,13 +751,13 @@ class AnimalManagement:
         self.gather_cow_class_history(self.cows)
 
     @staticmethod
-    def _calc_p_comp(animals):
+    def _calc_p_conc(animals):
         """
         Args:
-            animals: the list of animals for which the P composition should be
+            animals: the list of animals for which the P concentration should be
                 calculated
         Returns:
-            p_comp: the P composition of @animals
+            p_conc: the P concentration of @animals
         """
 
         if len(animals) == 0:
@@ -765,15 +765,15 @@ class AnimalManagement:
         else:
             return sum(a.p_animal for a in animals) / sum(a.body_weight for a in animals)
 
-    def calc_all_p_comp(self):
+    def calc_all_p_conc(self):
         """
         Calculates each animal class's P concentration.
         """
         # TODO: see if there is a better way to do this using dictionary comprehension
-        self.p_comp['calf'] = self._calc_p_comp(self.calves)
-        self.p_comp['heiferI'] = self._calc_p_comp(self.heiferIs)
-        self.p_comp['heiferII'] = self._calc_p_comp(self.heiferIIs)
-        self.p_comp['cow'] = self._calc_p_comp(self.heiferIIIs)
+        self.p_conc['calf'] = self._calc_p_conc(self.calves)
+        self.p_conc['heiferI'] = self._calc_p_conc(self.heiferIs)
+        self.p_conc['heiferII'] = self._calc_p_conc(self.heiferIIs)
+        self.p_conc['cow'] = self._calc_p_conc(self.heiferIIIs)
 
     def calc_p_rqmts(self):
         """
@@ -839,7 +839,7 @@ class AnimalManagement:
 
             # phosphorus updates
             self.daily_p_update()  # per animal
-            self.calc_all_p_comp()  # per animal
+            self.calc_all_p_conc()  # per animal
 
             self.record_pen_history()
 

--- a/RUFAS/routines/animal/animal_management.py
+++ b/RUFAS/routines/animal/animal_management.py
@@ -763,7 +763,7 @@ class AnimalManagement:
         if len(animals) == 0:
             return 0
         else:
-            return sum(a.p_animal for a in animals) / sum(a.body_weight for a in animals)
+            return (sum(a.p_animal for a in animals) / 1000 )/ sum(a.body_weight for a in animals)
 
     def calc_all_p_conc(self):
         """

--- a/RUFAS/routines/animal/life_cycle/animal_base.py
+++ b/RUFAS/routines/animal/life_cycle/animal_base.py
@@ -75,7 +75,7 @@ class AnimalBase(object):
         #self.DBW = 0
         self.p_animal = 0
         self.p_intake = 0
-        self.p_conc = 0
+        self.p_conc_ration = 0
         self.p_excrt = 0
         self.birth_weight = 0
         self.body_weight = 0
@@ -116,16 +116,16 @@ class AnimalBase(object):
         self.ration_formulation = ration
         self.dry_matter_intake = DMI
 
-    def set_p_intake(self, p_intake, p_conc):
+    def set_p_intake(self, p_intake, p_conc_ration):
         """
         Sets this animal's phosphorus intake.
 
         Args:
             p_intake: the phosphorus intake
-            p_conc: the concentration of P in the ration
+            p_conc_ration: the concentration of P in the ration
         """
         self.p_intake = p_intake
-        self.p_conc = p_conc
+        self.p_conc_ration = p_conc_ration
 
     def daily_p_update(self):
         """

--- a/RUFAS/routines/animal/life_cycle/cow.py
+++ b/RUFAS/routines/animal/life_cycle/cow.py
@@ -334,8 +334,8 @@ class Cow(HeiferIII):
         # requirement of P from the ration (g) (A.1EF.E.7)
         if self.milking:
             self.p_req = p_absorb / \
-                         (1.86696 - 5.01238 * self.p_conc + 5.12286 *
-                          self.p_conc ** 2)
+                         (1.86696 - 5.01238 * self.p_conc_ration + 5.12286 *
+                          self.p_conc_ration ** 2)
         else:
             self.p_req = p_absorb / 0.664
 

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -497,7 +497,7 @@ class Pen:
                 total_p_animal += animal.p_animal
             self.avg_p_animal = total_p_animal / len(self.animals_in_pen)
 
-    def set_up_new_animal(self, animal, p_comp, feed, temp, num_animals_before_additions):
+    def set_up_new_animal(self, animal, p_conc, feed, temp, num_animals_before_additions):
         """
         Sets the necessary attributes for @animal to be a replacement in this
         pen.
@@ -505,7 +505,7 @@ class Pen:
         Args:
             animal: the replacement animal which needs to have necessary values
                 for later computations
-            p_comp: P composition of @animal's class, used to calculate the
+            p_conc: P concentration of @animal's class, used to calculate the
                 P in @animal. -1 for this value indicates that @animal is a
                 calf and that its p_animal attribute has already been calculated
             feed: instance of the Feed class defined in feed.py
@@ -585,8 +585,8 @@ class Pen:
 
         # set this animal's p_animal to be the average P concentration of other
         # animals in its class times its body weight
-        if not p_comp == -1:
-            animal.p_animal = animal.body_weight * p_comp
+        if not p_conc == -1:
+            animal.p_animal = animal.body_weight * p_conc
 
         animal.p_intake = self.avg_p_intake
 

--- a/tests/test_animal_management.py
+++ b/tests/test_animal_management.py
@@ -376,20 +376,20 @@ def mock_animals() -> List[MagicMock]:
     return create_mock_object_list(animal_attribute_dicts)
 
 
-def test_calc_p_comp(mock_animals: List[MagicMock]) -> None:
-    """Unit test for function _calc_p_comp in file routines/animal/animal_management.py"""
+def test_calc_p_conc(mock_animals: List[MagicMock]) -> None:
+    """Unit test for function _calc_p_conc in file routines/animal/animal_management.py"""
     expected = 0
-    actual = AnimalManagement._calc_p_comp([])
+    actual = AnimalManagement._calc_p_conc([])
     assert actual == expected
 
-    actual = AnimalManagement._calc_p_comp(mock_animals)
+    actual = AnimalManagement._calc_p_conc(mock_animals)
     expected = (16.0 / 8.0)
 
     assert actual == pytest.approx(expected)
 
 
-def test_calc_all_p_comp():
-    """Unit test for function calc_all_p_comp in file routines/animal/animal_management.py"""
+def test_calc_all_p_conc():
+    """Unit test for function calc_all_p_conc in file routines/animal/animal_management.py"""
     pass
 
 


### PR DESCRIPTION
This PR is dedicated to ensuring that the variable names regarding an animal's phosphorus percentage are accurate and consistent throughout the entirety of the model. As seen in https://github.com/RuminantFarmSystems/MASM/commit/aadb6e55da402950184aecdec26f2a7f4d03c6b4 , some inconsistencies in the model's Phosphorus naming conventions were introduced. These inconsistencies have grown since then, leading to a pull request to address them. While most of this pull request involves changes from "p_comp" to "p_conc," to more accurately describe that we are referring to an animal's Phosphorus concentration, the introduction of a new ration-specific Phosphorus concentration class variable is seen in animal_base.py.