### PR TITLE
Feed quality PR2

### DIFF
--- a/RUFAS/output_handler/reports/pen_report.py
+++ b/RUFAS/output_handler/reports/pen_report.py
@@ -5,22 +5,24 @@ Description:
 Author(s): William Donovan, wmdonovan@wisc.edu
 """
 
+# from RUFAS.routines.feed.feed import Feed
 from .base_report_driver import BaseReportDriver
 from .base_report import BaseReport
 from .. import graphics
+from typing import Any, Dict
 
 
 class PensReport(BaseReportDriver):
-    def __init__(self, data, state):
+    def __init__(self, data: Dict[Any, Any], state) -> None:
         super().__init__(data)
         for pen in state.animal_management.all_pens:
-            self.reports[f'pen_{pen.id}'] = PenReport(data, state.feed, pen, pen.id)
+            self.reports[f'pen_{pen.id}'] = PenReport(data, state.feed, pen.id)
 
         self.reports['pens_summary'] = PensSummary(data['pens_summary'])
 
 
 class PensSummary(BaseReport):
-    def __init__(self, data):
+    def __init__(self, data: Dict[Any, Any]) -> None:
         super().__init__(data)
 
         self.daily_variables = {
@@ -34,7 +36,7 @@ class PensSummary(BaseReport):
 
 
 class PenReport(BaseReportDriver):
-    def __init__(self, data, feed, individual_pen, pen_id):
+    def __init__(self, data: Dict[Any, Any], feed, pen_id: int) -> None:
         super().__init__(data)
         self.pen_id = pen_id
         self.report_name = 'pen_' + str(pen_id)
@@ -45,11 +47,11 @@ class PenReport(BaseReportDriver):
         }
 
     class BasePenReport(BaseReport):
-        def __init__(self, data, pen_id):
+        def __init__(self, data: Dict[Any, Any], pen_id: int) -> None:
             super().__init__(data)
             self.pen_id = pen_id
 
-        def daily_update(self, state, weather, time):
+        def daily_update(self, state, weather, time) -> None:
             animal_management = state.animal_management
             feed = state.feed
             pen = state.animal_management.all_pens[self.pen_id]
@@ -60,7 +62,7 @@ class PenReport(BaseReportDriver):
                 self.daily_variables[variable][2].append(
                     eval(self.daily_variables[variable][0], globals(), locals()))
 
-        def annual_update(self, state, weather, time):
+        def annual_update(self, state, weather, time) -> None:
             animal_management = state.animal_management
             feed = state.feed
             pen = state.animal_management.all_pens[self.pen_id]
@@ -73,7 +75,7 @@ class PenReport(BaseReportDriver):
                          [0], globals(), locals())
 
     class GrowthReport(BasePenReport):
-        def __init__(self, data, pen_id):
+        def __init__(self, data: Dict[Any, Any], pen_id: int) -> None:
             super().__init__(data, pen_id)
 
             self.daily_variables = {'year': ['time.calendar_year', '', []],
@@ -89,7 +91,7 @@ class PenReport(BaseReportDriver):
                                      }
 
     class ManureReport(BasePenReport):
-        def __init__(self, data, pen_id):
+        def __init__(self, data: Dict[Any, Any], pen_id: int) -> None:
             super().__init__(data, pen_id)
 
             self.daily_variables = {'year': ['time.calendar_year', '', []],
@@ -115,7 +117,7 @@ class PenReport(BaseReportDriver):
             self.manure_info = {}
 
     class RationReport(BasePenReport):
-        def __init__(self, data, feed, pen_id):
+        def __init__(self, data: Dict[Any, Any], feed, pen_id: int) -> None:
             super().__init__(data, pen_id)
             self.ration_interval = data['ration_interval']
 

--- a/RUFAS/output_handler/reports/pen_report.py
+++ b/RUFAS/output_handler/reports/pen_report.py
@@ -115,7 +115,7 @@ class PenReport(BaseReportDriver):
             self.manure_info = {}
 
     class RationReport(BasePenReport):
-        def __init__(self, data, feed, individual_pen, pen_id):
+        def __init__(self, data, feed, pen_id):
             super().__init__(data, pen_id)
             self.ration_interval = data['ration_interval']
 

--- a/RUFAS/output_handler/reports/pen_report.py
+++ b/RUFAS/output_handler/reports/pen_report.py
@@ -14,7 +14,7 @@ class PensReport(BaseReportDriver):
     def __init__(self, data, state):
         super().__init__(data)
         for pen in state.animal_management.all_pens:
-            self.reports['pen_' + str(pen.id)] = PenReport(data, state.feed, pen, pen.id)
+            self.reports[f'pen_{pen.id}'] = PenReport(data, state.feed, pen, pen.id)
 
         self.reports['pens_summary'] = PensSummary(data['pens_summary'])
 
@@ -39,7 +39,7 @@ class PenReport(BaseReportDriver):
         self.pen_id = pen_id
         self.report_name = 'pen_' + str(pen_id)
         self.reports = {
-            'ration_report': self.RationReport(data['ration_report'], feed, individual_pen, self.pen_id),
+            'ration_report': self.RationReport(data['ration_report'], feed, self.pen_id),
             'growth_report': self.GrowthReport(data['growth_report'], self.pen_id),
             'manure_report': self.ManureReport(data['manure_report'], self.pen_id)
         }
@@ -123,30 +123,19 @@ class PenReport(BaseReportDriver):
                                     'j_day': ['time.day', '', []],
                                     'num_animals': ['len(pen.animals_in_pen)', '', []]
                                     }
-            # this subsets the pen's allotted feed given the animals type(s)
-            # that are present within the pen that is currently being
-            # simulated
-            individual_pen.subset_class_feeds(feed)
 
             # dictionary with all feed ids and keys and their pertaining information as values
             all_feeds = feed.all_feed_ids
 
-            # subsets the entirety of the feed ids for the individual pen's needs
-            pen_specific_feeds = {str(x): all_feeds[str(x)] for x in individual_pen.allocated_feeds}
-
-            for feed_id in individual_pen.allocated_feeds:
-                feed_name = pen_specific_feeds[str(feed_id)]['feed_name']
-                units = pen_specific_feeds[str(feed_id)]['units']
+            for feed_id in all_feeds:
+                feed_name = all_feeds[str(feed_id)]['feed_name']
+                units = all_feeds[str(feed_id)]['units']
 
                 self.daily_variables[str(feed_id) + "(" + feed_name + ")"] = \
                     [
                         'pen.ration[\'%s\'] if pen.pen_populated and \'%s\' in pen.ration.keys() else 0' % (
                             feed_id, feed_id), units,
                         []]
-                # [
-                #     'pen.ration[\'%s\'] if pen.pen_populated and int(\'%s\') in pen.allocated_feeds else 0' % (
-                #         feed_id, feed_id), units,
-                #     []]
 
             self.annual_variables = {
                 'year': ['time.calendar_year', '', 0]

--- a/RUFAS/routines/animal/animal_management.py
+++ b/RUFAS/routines/animal/animal_management.py
@@ -434,21 +434,24 @@ class AnimalManagement:
             self.all_pens[pen.id].set_up_new_animal(animal, animal_p_conc,
                                                     feed, temp, pen_population_before_additions[pen.id])
 
-        for pen in range(len(self.all_pens)):
-            if len(self.all_pens[pen].animals_in_pen) > 0 and 'Cow' in self.all_pens[pen].classes_in_pen and \
-                    self.all_pens[pen].ration == {}:
-                available_feeds = ration_driver.AvailableFeeds()
-                available_feeds.feed_nutrients(feed)
-                self.all_pens[pen].ration = self.all_pens[pen].calc_ration(feed, available_feeds)
+        for i in range(len(self.all_pens)):
+            if len(self.all_pens[i].animals_in_pen) > 0:
+                if self.all_pens[i].ration == {}:
+                    available_feeds = ration_driver.AvailableFeeds()
+                    available_feeds.feed_nutrients(feed)
+                    self.all_pens[i].allocated_feeds = feed.input_feed_combinations[self.all_pens[i].animal_combination]
+                    pen_specific_feed_data = available_feeds.get_feed_data_from_feed_ids(self.all_pens[i].allocated_feeds)
+                    self.all_pens[i].ration = self.all_pens[i].calc_ration(feed, pen_specific_feed_data)
             else:
-                # Need to adjust the ration totals for the pen attributes now
-                # that all new animals have been added
-                for key in self.all_pens[pen].ration:
-                    if key != 'status' and key != 'objective':
-                        self.all_pens[pen].ration[key] = \
-                            (self.all_pens[pen].ration[key] /
-                             pen_population_before_additions[pen]) * len(
-                                self.all_pens[pen].animals_in_pen)
+                if len(self.all_pens[i].animals_in_pen) > 0:
+                    # Need to adjust the ration totals for the pen attributes now
+                    # that all new animals have been added
+                    for key in self.all_pens[i].ration:
+                        if key != 'status' and key != 'objective' and pen_population_before_additions[i] > 0:
+                            self.all_pens[i].ration[key] = \
+                                (self.all_pens[i].ration[key] /
+                                    pen_population_before_additions[i]) * len(
+                                    self.all_pens[i].animals_in_pen)
 
         for calf in calves_born:
             # getting valid pen to place calves in
@@ -697,7 +700,9 @@ class AnimalManagement:
         available_feeds.feed_nutrients(feed)
         for i, pen in enumerate(self.all_pens):
             if pen.pen_populated:
-                self.all_pens[i].ration = self.all_pens[i].calc_ration(feed, available_feeds)
+                pen.subset_class_feeds(feed)
+                pen_specific_feed_data = available_feeds.get_feed_data_from_feed_ids(pen.allocated_feeds)
+                self.all_pens[i].ration = self.all_pens[i].calc_ration(feed, pen_specific_feed_data)
 
     def calc_manure_excretion(self, feed, methane_model):
         """

--- a/RUFAS/routines/animal/clustering_pen_grouping.py
+++ b/RUFAS/routines/animal/clustering_pen_grouping.py
@@ -13,6 +13,7 @@ Author(s): Chris VanKerkhove, cjv47@cornell.edu
 ################################################################################
 import pandas as pd
 import numpy as np
+import math
 from scipy.stats import percentileofscore
 
 
@@ -140,7 +141,8 @@ def grouping(cow_list, pens, stocking_density):
     # Adding pen_assignment number to list based on percentile
     for i in range(len(percentile)):
         key = 0
-        while percentile[i] <= index[key-1] or percentile[i] > index[key]:
+        while percentile[i] <= index[key - 1] or (
+                percentile[i] > index[key] and not math.isclose(percentile[i], index[key], rel_tol=1e-09)):
             key += 1
         pen_assignment.append(key)
 

--- a/RUFAS/routines/animal/life_cycle/heiferII.py
+++ b/RUFAS/routines/animal/life_cycle/heiferII.py
@@ -452,7 +452,7 @@ class HeiferII(HeiferI):
             self.PGF_injections = self.PGF_injections + 1
         elif self.days_born == self.tai_program_start_day_h + 8:
             self.ai_day = self.days_born
-            self.conception_rate = AnimalBase.config['m5dCGP_conception_rate']
+            self.conception_rate = AnimalBase.config['m5dCG2P_conception_rate']
             self.events.add_event(self.days_born, sim_day, const.INJECT_GNRH)
             self.GnRH_injections = self.GnRH_injections + 1
 

--- a/RUFAS/routines/animal/life_cycle/heiferII.py
+++ b/RUFAS/routines/animal/life_cycle/heiferII.py
@@ -452,7 +452,7 @@ class HeiferII(HeiferI):
             self.PGF_injections = self.PGF_injections + 1
         elif self.days_born == self.tai_program_start_day_h + 8:
             self.ai_day = self.days_born
-            self.conception_rate = AnimalBase.config['m5dCG2P_conception_rate']
+            self.conception_rate = AnimalBase.config['md5CGP_conception_rate']
             self.events.add_event(self.days_born, sim_day, const.INJECT_GNRH)
             self.GnRH_injections = self.GnRH_injections + 1
 
@@ -473,9 +473,9 @@ class HeiferII(HeiferI):
             self.determine_tai_program_day(
                 AnimalBase.config['breeding_start_day_h'])
 
-        if self.tai_method_h == '5dCG2P':
+        if self.tai_method_h == 'd5CG2P':
             self.d5CG2P_update(sim_day)
-        elif self.tai_method_h == '5dCGP':
+        elif self.tai_method_h == 'd5CGP':
             self.d5CGP_update(sim_day)
         elif self.tai_method_h == 'user_defined':
             self.user_defined_update()

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -301,7 +301,7 @@ class Pen:
             new_animals: list of new animals in the pen
             animal_combination: an AnimalCombination Enum representating the type of the new animals
         """
-        # self.animals_in_pen = new_animals
+
         for animal in new_animals:
             self.animals_in_pen.append(animal)
         self.pen_populated = not (len(self.animals_in_pen) == 0)
@@ -341,17 +341,17 @@ class Pen:
                     'HeiferII' in self.classes_in_pen or \
                     'HeiferIII' in self.classes_in_pen:
                 ration_per_animal, ration_vals = \
-                    ration_driver.ration_formulation(self, feed, available_feeds, 'heifer', False)
+                    ration_driver.ration_formulation(self, available_feeds, 'heifer', False)
 
             elif 'Cow' in self.classes_in_pen and \
                     self.animals_in_pen[0].milking:  # lactating cow
                 ration_per_animal, ration_vals = \
-                    ration_driver.ration_formulation(self, feed, available_feeds, 'cow', True)
+                    ration_driver.ration_formulation(self, available_feeds, 'cow', True)
 
             elif 'Cow' in self.classes_in_pen and \
                     not self.animals_in_pen[0].milking:  # dry cow
                 ration_per_animal, ration_vals = \
-                    ration_driver.ration_formulation(self, feed, available_feeds, 'cow', False)
+                    ration_driver.ration_formulation(self, available_feeds, 'cow', False)
 
             else:  # this should never occur
                 print('error in pen ration calculation')
@@ -556,10 +556,6 @@ class Pen:
                 'NEl']) / animal.DMIest
             animal.DMPD_req = (requirements['MP_req']) / animal.DMIest
 
-        # set animal's ration to be the intake of all other animals in pen
-        # if self.ration == {}:
-        #     self.ration = self.calc_ration(feed, temp)
-
         animal.dry_matter_intake = self.dry_matter_intake
 
         for key in self.ration:
@@ -572,7 +568,8 @@ class Pen:
         # set animal's manure to be the average manure of all other
         # animals in pen
         for key in self.manure.keys():
-            animal.manure_excretion[key] = self.manure[key] / len(self.animals_in_pen)
+            if len(self.animals_in_pen) > 0:
+                animal.manure_excretion[key] = self.manure[key] / (len(self.animals_in_pen))
 
         # since the manure attribute is a total from all animals in the pen,
         # we need to add the current animal's values to the total values for
@@ -617,7 +614,6 @@ class Pen:
         # that are non-zero.
         self.animals_in_pen = []
         self.pen_populated = False
-        # self.classes_in_pen = set()
         self.avg_p_animal = 0
 
     def subset_class_feeds(self, feed):

--- a/RUFAS/routines/animal/ration/ration_driver.py
+++ b/RUFAS/routines/animal/ration/ration_driver.py
@@ -10,9 +10,10 @@ Author(s): Chris VanKerkhove, cjv47@cornell.edu
 """
 from RUFAS.routines.animal.ration import animal_requirements
 from RUFAS.routines.animal.ration import ration_NLP as NLP
-from RUFAS.routines.animal.ration import pyomo_solver as pslv
-import statistics as stat
+from typing import Dict, List, Set
+import collections
 import math
+import statistics as stat
 
 
 def optimization(requirements, available_feeds, animal_type, cow_type):
@@ -26,25 +27,25 @@ def optimization(requirements, available_feeds, animal_type, cow_type):
         animal_type: string representation of the animal
         cow_type: Boolean which is True if cow is lactating, False otherwise
     """
-    price = NLP.list_reconfig(available_feeds.price)
-    TDN = NLP.list_reconfig(available_feeds.TDN)
-    DE = NLP.list_reconfig(available_feeds.DE)
-    EE = NLP.list_reconfig(available_feeds.EE)
-    is_fat = NLP.list_reconfig(available_feeds.is_fat)
-    calcium = NLP.list_reconfig(available_feeds.calcium)
-    phosphorus = NLP.list_reconfig(available_feeds.phosphorus)
-    NDF = NLP.list_reconfig(available_feeds.NDF)
-    feed_type = NLP.list_reconfig(available_feeds.type)
-    is_wetforage = NLP.list_reconfig(available_feeds.is_wetforage)
-    Kd = NLP.list_reconfig(available_feeds.Kd)
-    N_A = NLP.list_reconfig(available_feeds.N_A)
-    N_B = NLP.list_reconfig(available_feeds.N_B)
-    CP = NLP.list_reconfig(available_feeds.CP)
-    dRUP = NLP.list_reconfig(available_feeds.dRUP)
+    price = NLP.list_reconfig(available_feeds['price'])
+    TDN = NLP.list_reconfig(available_feeds['TDN'])
+    DE = NLP.list_reconfig(available_feeds['DE'])
+    EE = NLP.list_reconfig(available_feeds['EE'])
+    is_fat = NLP.list_reconfig(available_feeds['is_fat'])
+    calcium = NLP.list_reconfig(available_feeds['calcium'])
+    phosphorus = NLP.list_reconfig(available_feeds['phosphorus'])
+    NDF = NLP.list_reconfig(available_feeds['NDF'])
+    feed_type = NLP.list_reconfig(available_feeds['type'])
+    is_wetforage = NLP.list_reconfig(available_feeds['is_wetforage'])
+    Kd = NLP.list_reconfig(available_feeds['Kd'])
+    N_A = NLP.list_reconfig(available_feeds['N_A'])
+    N_B = NLP.list_reconfig(available_feeds['N_B'])
+    CP = NLP.list_reconfig(available_feeds['CP'])
+    dRUP = NLP.list_reconfig(available_feeds['dRUP'])
     if cow_type:
-        limit = NLP.list_reconfig(available_feeds.lactating_cow_limit)
+        limit = NLP.list_reconfig(available_feeds['lactating_cow_limit'])
     else:
-        limit = NLP.list_reconfig(available_feeds.dry_cow_limit)
+        limit = NLP.list_reconfig(available_feeds['dry_cow_limit'])
     NLP.set_globals(price, requirements.NEmaint, requirements.NEa, requirements.NEpreg,
                     requirements.NEl, requirements.NEg, requirements.MP_req,
                     requirements.Ca_req, requirements.P_req,
@@ -77,7 +78,7 @@ def optimization(requirements, available_feeds, animal_type, cow_type):
     return solution, ration_vals
 
 
-def ration_formulation(pen, feed, available_feeds, animal_type, cow_type):
+def ration_formulation(pen, available_feeds, animal_type, cow_type):
     """
     Function that links the ration_driver file with the calc_ration function in
     pen.py. Returns a dictionary of the rations by feed and status of the NLP
@@ -123,12 +124,12 @@ def ration_formulation(pen, feed, available_feeds, animal_type, cow_type):
 
     if solution != None:
         ration = {}
-        for feed_id in range(len(available_feeds.feed_id)):
+        for feed_id in range(len(available_feeds['feed_id'])):
             i = feed_id * 3
             num = solution.x[i]
             num += solution.x[i + 1]
             num += solution.x[i + 2]
-            ration[available_feeds.feed_key[feed_id]] = round(num, 6)
+            ration[available_feeds['feed_key'][feed_id]] = round(num, 6)
         ration['status'] = 'Optimal'
         ration['objective'] = NLP.objective(solution.x)
         return ration, ration_vals
@@ -433,10 +434,10 @@ class AvailableFeeds:
         self.heiferI_limit = []
         # calf limit
         self.calf_limit = []
-        # pyomo dictionary structure
-        self.pyomo_data = {}
-        # list of the feeds used in this ration
-        self.feeds = []
+        # key = feed_id, val = index of that feed_id in self.feed_id list
+        self._feed_id_to_list_idx_dict = {}
+        # key = feed_id, val = index of that feed_id in self.feed_id list
+        self._feed_id_to_list_idx_dict = {}
 
     def feed_nutrients(self, feed):
         """
@@ -478,60 +479,36 @@ class AvailableFeeds:
                 self.lactating_cow_limit.append(feed['limit'])
                 self.dry_cow_limit.append(feed['limit'])
 
-    def pyomo_nutrients_data(self, feed, animal_type, cow_type):
+    def get_feed_data_from_feed_ids(self, feed_ids: Set[int]):
         """
-        Class function that manipulates the available feeds nutrient information
-        into a valid data input for the pyomo structured solver.
+        Returns a subset of data from all the available feeds based on the
+        given set of feed ids.
 
-        Arg(s):
-            feed: an instance of the Feed class object
-            animal_type: string representation  of the animal type
-            cow_type: boolean, True if cow is lactating
+        Args
+        ----
+        feed_ids: a set of feed ids
+
+        Returns
+        -------
+        A dictionary that contains a subset of data from all the available feeds based on the
+        given set of feed ids
         """
-        # available feeds dictionary from the feed module
-        available_feeds = feed.available_feeds
-        # dictionary of feed costs
-        feed_costs = feed.feed_costs
-        # list of parameters for non-LP
-        params = ['TDN', 'DE', 'EE', 'is_fat', 'calcium',
-                  'phosphorus', 'NDF', 'is_wetforage', 'Kd', 'N_A', 'N_B',
-                  'CP', 'dRUP']
-        # list of different energy types feed decision variable are split across
-        enrg = ['mact', 'lact', 'growth']
-        # structuring empty data container
-        for p in params:
-            self.pyomo_data[p] = {}
-        self.pyomo_data['price'] = {}
-        self.pyomo_data['ftype'] = {}
-        self.pyomo_data['limit'] = {}
-        feeds = []
-        # iterating through each feed available in formulation
-        for key, feed in available_feeds.items():
-            feeds.append(key)
-            # price and type data
-            for s in enrg:
-                self.pyomo_data['price'][key, s] = feed_costs[key]
-                self.pyomo_data['ftype'][key, s] = feed['type']
-            # iterating through all param values for non-LP
-            for p in params:
-                self.pyomo_data[p][key, 'mact'] = feed[p]
-                self.pyomo_data[p][key, 'lact'] = feed[p]
-                self.pyomo_data[p][key, 'growth'] = feed[p]
-            # checking if grown feed available and pop
-            if isinstance(feed['limit'], dict):
-                if cow_type:
-                    for s in enrg:
-                        self.pyomo_data['limit'][key, s] = \
-                            feed['limit']['lactating_cows']
-                elif animal_type == 'cow':
-                    for s in enrg:
-                        self.pyomo_data['limit'][key, s] = feed['limit']['dry_cows']
-                else:
-                    for s in enrg:
-                        self.pyomo_data['limit'][key, s] = feed['limit']['heiferIIIs']
-            # if there are not farm grown feeds in diet
-            else:
-                for s in enrg:
-                    self.pyomo_data['limit'][key, s] = feed['limit']
-        # populating feeds list class variable
-        self.feeds = feeds
+        # An explanation of code seen below can be found in Basecamp with the following path:
+        # RuFaS > Docs & Files > Animal Module > Ration Driver Logic
+
+        if not self._feed_id_to_list_idx_dict:
+            self._feed_id_to_list_idx_dict = {fid: i for i, fid in enumerate(self.feed_id)}
+
+        excluded_keys = ['_feed_id_to_list_idx_dict']
+        result = collections.defaultdict(list)
+        for key, vals in self.__dict__.items():
+            if key in excluded_keys:
+                continue
+            if not vals:
+                result[key] = []
+                continue
+            for feed_id in sorted(list(feed_ids)):
+                # Get the list index of the feed_id in self.feed_id list.
+                idx = self._feed_id_to_list_idx_dict[int(feed_id)]
+                result[key].append(vals[idx])
+        return result

--- a/input/animal/animal_feed_management.json
+++ b/input/animal/animal_feed_management.json
@@ -42,8 +42,8 @@
 				},
 				"TAI_related":{
 					"heifer_TAI_protocol": "d5CG2P",
-					"m5dCG2P_conception_rate": 0.6,
-					"m5dCGP_conception_rate": 0.48,
+					"md5CG2P_conception_rate": 0.6,
+					"md5CGP_conception_rate": 0.48,
 					"heifer_user_defined_tai_cr": 0.0,
 					"cow_presynch_protocol": "Double OvSynch",
 					"user_defined_presynch_length": 0,

--- a/input/animal/animal_management_animal.json
+++ b/input/animal/animal_management_animal.json
@@ -42,8 +42,8 @@
 				},
 				"TAI_related":{
 					"heifer_TAI_protocol": "d5CG2P",
-					"m5dCG2P_conception_rate": 0.6,
-					"m5dCGP_conception_rate": 0.48,
+					"md5CG2P_conception_rate": 0.6,
+					"md5CGP_conception_rate": 0.48,
 					"heifer_user_defined_tai_cr": 0.0,
 					"cow_presynch_protocol": "Double OvSynch",
 					"user_defined_presynch_length": 0,

--- a/input/animal/barnyard_animal.json
+++ b/input/animal/barnyard_animal.json
@@ -42,8 +42,8 @@
 				},
 				"TAI_related":{
 					"heifer_TAI_protocol": "5dCG2P",
-					"m5dCG2P_conception_rate": 0.6,
-					"m5dCGP_conception_rate": 0.48,
+					"md5CG2P_conception_rate": 0.6,
+					"md5CGP_conception_rate": 0.48,
 					"heifer_user_defined_tai_cr": 0.0,
 					"cow_presynch_protocol": "Double OvSynch",
 					"user_defined_presynch_length": 0,

--- a/input/output/field_report.json
+++ b/input/output/field_report.json
@@ -107,7 +107,7 @@
         "feed_storage_report": {
             "produce_csv": true,
             "produce_graphics": false,
-            "report_name": "feed_storage_report"
+            "report_name": "storage_report"
         },
         "feed_storage_summary": {
             "produce_csv": true,
@@ -132,7 +132,7 @@
         "storage_report": {
             "produce_csv": true,
             "produce_graphics": false,
-            "report_name": "storage_report"
+            "report_name": "feed_storage_report"
         },
         "manure_storage_summary": {
             "produce_csv": true,

--- a/input/output/mass_balance.json
+++ b/input/output/mass_balance.json
@@ -107,7 +107,7 @@
         "feed_storage_report": {
             "produce_csv": true,
             "produce_graphics": false,
-            "report_name": "feed_storage_report"
+            "report_name": "storage_report"
         },
         "feed_storage_summary": {
             "produce_csv": true,

--- a/input/output/pen_report.json
+++ b/input/output/pen_report.json
@@ -49,8 +49,8 @@
                 "report_name": "soil_nitrogen_report"
             },
             "soil_phosphorus_report": {
-                "produce_csv": false,
-                "produce_graphics": false,
+                "produce_csv": true,
+                "produce_graphics": true,
                 "report_name": "soil_phosphorus_report"
             },
             "soil_carbon_report": {
@@ -59,27 +59,27 @@
                 "report_name": "soil_carbon_report"
             },
             "soil_summary": {
-                "produce_csv": true,
-                "produce_graphics": true,
+                "produce_csv": false,
+                "produce_graphics": false,
                 "report_name": "soil_summary"
             }
         },
         "field_management_report": {
-            "produce_csv": false,
-            "produce_graphics": false,
+            "produce_csv": true,
+            "produce_graphics": true,
             "report_name": "field_management_report"
         },
-        "phosphorus_balance_report": {
+        "phosphorus_balance": {
             "produce_csv": false,
             "produce_graphics": false,
             "report_name": "phosphorus_balance_report"
         },
-        "nitrogen_balance_report": {
+        "nitrogen_balance": {
             "produce_csv": false,
             "produce_graphics": false,
             "report_name": "nitrogen_balance_report"
         },
-        "water_balance_report": {
+        "water_balance": {
             "produce_csv": false,
             "produce_graphics": false,
             "report_name": "water_balance_report"

--- a/input/output/standard_output.json
+++ b/input/output/standard_output.json
@@ -107,7 +107,7 @@
         "feed_storage_report": {
             "produce_csv": true,
             "produce_graphics": false,
-            "report_name": "feed_storage_report"
+            "report_name": "storage_report"
         },
         "feed_storage_summary": {
             "produce_csv": true,

--- a/tests/test_animal.py
+++ b/tests/test_animal.py
@@ -5,6 +5,7 @@ Description: Implements test cases
 Author(s): Pooya Hekmati, sh2235@cornell.edu
 """
 
+from RUFAS.routines.animal.ration.ration_driver import AvailableFeeds
 import pytest
 
 from RUFAS.routines.animal.life_cycle.animal_events import AnimalEvents
@@ -815,3 +816,71 @@ def test_set_requirements():
 def test_feed_nutrients():
     """Unit test for function feed_nutrients in file routines/animal/ration/ration_driver.py"""
     pass
+
+def test_get_feed_data_from_feed_ids() -> None:
+    """Unit test for function get_feed_data_from_feed_ids in file routines/animal/ration/ration_driver.py"""
+
+    # Arrange
+    feed_ids = {155, 157}
+    available_feeds = AvailableFeeds()
+    available_feeds.feed_id = [136, 139, 155, 157]
+    available_feeds.CP = [0, 0, 25.4, 18]
+    available_feeds.DE = [0, 0, 5.59, 3.69]
+    available_feeds.EE = [0, 0, 30.8, 3]
+    available_feeds.Kd = [0, 0, 0, 0]
+    available_feeds.NDF = [0, 0, 0, 0]
+    available_feeds.N_A = [0, 0, 0, 0]
+    available_feeds.N_B = [0, 0, 0, 0]
+    available_feeds.TDN = [0, 0, 0, 0]
+    available_feeds.calcium = [22, 34, 1, 0.7]
+    available_feeds.dRUP = [0, 0, 0, 0]
+    available_feeds.dry_cow_limit = [100, 100, 100, 100]
+    available_feeds.feed_key = ['136', '139', '155', '157']
+    available_feeds.is_fat = [0, 0, 0, None]
+    available_feeds.is_wetforage = [0, 0, 0, None]
+    available_feeds.lactating_cow_limit = [100, 100, 100, 100]
+    available_feeds.phosphorus = [19.3, 0, 0.75, 0.45]
+    available_feeds.price = [0.1, 0.05, 0.82, 0.44]
+    available_feeds.type = ['Mineral', 'Mineral', 'Milk', 'Starter']
+
+    # Assert before
+    assert len(available_feeds._feed_id_to_list_idx_dict) == 0
+
+    # Act
+    pen_specific_feed_data = available_feeds.get_feed_data_from_feed_ids(feed_ids)
+
+    # Assert after
+    expected_feed_id_to_list_idx_dict = {
+        136: 0,
+        139: 1,
+        155: 2,
+        157: 3
+    }
+    assert available_feeds._feed_id_to_list_idx_dict == expected_feed_id_to_list_idx_dict
+
+    expected_pen_specific_feed_data = {
+        'feed_id': [155, 157],
+        'heiferIII_limit': [],
+        'heiferII_limit': [],
+        'heiferI_limit': [],
+        'calf_limit': [],
+        'CP': [25.4, 18],
+        'DE': [5.59, 3.69],
+        'EE': [30.8, 3],
+        'Kd': [0, 0],
+        'NDF': [0, 0],
+        'N_A': [0, 0],
+        'N_B': [0, 0],
+        'TDN': [0, 0],
+        'calcium': [1, 0.7],
+        'dRUP': [0, 0],
+        'dry_cow_limit': [100, 100],
+        'feed_key': ['155', '157'],
+        'is_fat': [0, None],
+        'is_wetforage': [0, None],
+        'lactating_cow_limit': [100, 100],
+        'phosphorus': [0.75, 0.45],
+        'price': [0.82, 0.44],
+        'type': ['Milk', 'Starter']
+    }
+    assert pen_specific_feed_data == expected_pen_specific_feed_data


### PR DESCRIPTION
What:
This PR is 2/2 in the process of breaking up https://github.com/RuminantFarmSystems/MASM/pull/187 into smaller and more focused pieces.

This one is focused on issue [#112](https://github.com/RuminantFarmSystems/MASM/issues/112) - "Feed stored as "available" for ration formulation not restricted by user input."

This PR also addresses some of the corresponding conversational feedback provided in PR 187 specific to the sections that are altered in this PR.

Why:
While most of the work was approved in terms of functionality in PR 187, there were too many separate issues it addressed so it seemed to stray too far from single-responsibility principles to be merged all at once. 

How:
This issue was primarily addressed by updating the quality specific feed ids in the available_feeds dictionary and the input_feed_combinations dictionary which gives the abilty to feed quality specific feed to individual animal classes if it is purchased.

This branch was tested with master and pytest and ran well with these changes.

1/11/23: We are experiencing errors running the simulation with the feed_update.json file. If you are reviewing this please try that file as well as the animal_management.json file

1/11/23: Fix applied to deal with above error due to rounding. feed_update.json file should work as simulation input file.