### PR TITLE
Temp fix heifer repro

### DIFF
--- a/RUFAS/routines/animal/life_cycle/heiferII.py
+++ b/RUFAS/routines/animal/life_cycle/heiferII.py
@@ -473,9 +473,9 @@ class HeiferII(HeiferI):
             self.determine_tai_program_day(
                 AnimalBase.config['breeding_start_day_h'])
 
-        if self.tai_method_h == '5dCG2P':
+        if self.tai_method_h == 'd5CG2P':
             self.d5CG2P_update(sim_day)
-        elif self.tai_method_h == '5dCGP':
+        elif self.tai_method_h == 'd5CGP':
             self.d5CGP_update(sim_day)
         elif self.tai_method_h == 'user_defined':
             self.user_defined_update()

--- a/RUFAS/routines/animal/life_cycle/heiferII.py
+++ b/RUFAS/routines/animal/life_cycle/heiferII.py
@@ -452,7 +452,7 @@ class HeiferII(HeiferI):
             self.PGF_injections = self.PGF_injections + 1
         elif self.days_born == self.tai_program_start_day_h + 8:
             self.ai_day = self.days_born
-            self.conception_rate = AnimalBase.config['m5dCGP_conception_rate']
+            self.conception_rate = AnimalBase.config['md5CGP_conception_rate']
             self.events.add_event(self.days_born, sim_day, const.INJECT_GNRH)
             self.GnRH_injections = self.GnRH_injections + 1
 

--- a/input/animal/animal_management_animal.json
+++ b/input/animal/animal_management_animal.json
@@ -42,8 +42,8 @@
 				},
 				"TAI_related":{
 					"heifer_TAI_protocol": "d5CG2P",
-					"m5dCG2P_conception_rate": 0.6,
-					"m5dCGP_conception_rate": 0.48,
+					"md5CG2P_conception_rate": 0.6,
+					"md5CGP_conception_rate": 0.48,
 					"heifer_user_defined_tai_cr": 0.0,
 					"cow_presynch_protocol": "Double OvSynch",
 					"user_defined_presynch_length": 0,


### PR DESCRIPTION
What: This pull request is to temporarily fix that heifer reproductive inputs are not assigned correctly. 

Why: Because the whole reproductive branch has not been merged into the master branch yet. This pull request is to make the master branch heifer reproduction work correctly so that further development can be based on the master. 

How: The input name in heiferII.py and animal_management_animal.json are changed to be consistent now. 

Test way: I tested it by running Rufas (python3 main.py) and inputted animal_management.json (where I changed the "end_date" to "2013:264" to make it run longer). Then I checked the 'MASM/output/graphics/life_cycle_report/herd_report/heiferiii_percent.png' to see if heiferIII percent increased. 
Note: You can test for both heifer TAI protocols: "5dCG2P" and "5dCGP".
Note: those renamings are contained in Loi's refactoring. So no unit test is included in this PR. 