### PR TITLE
Restructure LAI and HeatUnits

### DIFF
--- a/SC_redesign/Crop_and_Soil/crop/biomass_allocation.py
+++ b/SC_redesign/Crop_and_Soil/crop/biomass_allocation.py
@@ -5,22 +5,7 @@ from SC_redesign.Crop_and_Soil.crop.crop_data import CropData
 # TODO - Refactor this class to match others - GitHub Issue #257
 class BiomassAllocation:
     def __init__(self, crop_data: Optional[CropData] = None):
-        data = crop_data or CropData()  # initialize with defaults, if not given
-        # TODO replace attributes with reference to data - GitHub Issue #255
-        #  in various methods
-        self.light_extinction = 0.65
-        self.leaf_area_index = 1.2
-        self.light_conversion = 20
-        self.biomass = 0
-        self.growth_factor = 1.0
-        self.root_fraction = 1 / 3
-
-        self.usable_light = None
-        self.biomass_growth_max = None
-        self.biomass_growth = None
-        self.previous_biomass = None
-        self.green_biomass = None
-        self.root_biomass = None
+        self.data = crop_data or CropData()  # initialize with defaults, if not given
 
     def allocate_biomass(self, light):
         """allocate a plant's accumulated biomass during the day's growth"""
@@ -35,93 +20,96 @@ class BiomassAllocation:
 
     def intercept_radiation(self, light):
         """capture usable energy from the day's incoming solar radiation (light)"""
-        self.usable_light = calc_intercepted_radiation(light, self.light_extinction, self.leaf_area_index)
+        self.data.usable_light = self.calc_intercepted_radiation(light, self.data.light_extinction,
+                                                                 self.data.leaf_area_index)
 
     def determine_max_growth(self):
         """determine how much the plant can grow_crop under ideal circumstance, from the light captured"""
-        self.biomass_growth_max = calc_max_accumulation(self.usable_light, self.light_conversion)
+        self.data.biomass_growth_max = self.calc_max_accumulation(self.data.usable_light, self.data.light_conversion)
 
     def accumulate_biomass(self):
         """accumulate plant biomass during the day's growth"""
-        self.previous_biomass = self.biomass
-        self.biomass_growth = calc_biomass_accumulation(self.growth_factor, self.biomass_growth_max)
-        self.biomass += self.biomass_growth
+        self.data.previous_biomass = self.data.biomass
+        self.data.biomass_growth = self.calc_biomass_accumulation(self.data.growth_factor,
+                                                                  self.data.biomass_growth_max)
+        self.data.biomass += self.data.biomass_growth
 
     def partition_biomass(self):
         """partition the accumulated biomass into above ground and below grown portions"""
-        self.green_biomass = calc_above_ground_biomass(self.root_fraction, self.biomass)
-        self.root_biomass = calc_below_ground_biomass(self.root_fraction, self.biomass)
+        self.data.above_ground_biomass = self.calc_above_ground_biomass(self.data.root_fraction, self.data.biomass)
+        self.data.root_biomass = self.calc_below_ground_biomass(self.data.root_fraction, self.data.biomass)
+
+    @staticmethod
+    def calc_intercepted_radiation(radiation: float, extinction: float, lai: float) -> float:  # pseudocode: C.9.A.1
+        """
+        Description:
+            calculates amount of solar radiation intercepted for photosynthesis during the day
+
+        Args:
+            radiation: total solar radiation available for the day (MJ m^-2)
+            extinction: the light extinction coefficient
+            lai: current leaf area index of the crop
+
+        Returns:
+            intercepted radiation energy (MJ m^-2)
+        """
+        intercepted_radiation = 0.5 * radiation * (1 - exp(-1 * extinction * lai))
+        return intercepted_radiation
+
+    @staticmethod
+    def calc_max_accumulation(energy: float, efficiency: float) -> float:  # pseudocode: C.9.A.2
+        """
+        Description: calculates the upper-limit to biomass accumulation during a day
+
+        Args:
+            efficiency: crop-specific radiation use efficiency (dg/MJ)
+            energy: intercepted energy from solar radiation for the day (MJ m^-2)
+
+        Returns: the maximum biomass that can be accumulated in a day
+        """
+        return energy * efficiency
+
+    @staticmethod
+    def calc_biomass_accumulation(growth_factor: float, max_growth: float) -> float:  # pseudocode: C.9.A.3
+        """
+        Description:
+            Calculates the biomass accumulated during the day
+
+        Args:
+            growth_factor: the growth factor for the plant, which is a value from 0 to 1.
+            max_growth: the maximum amount of biomass the plant can accumulate in a day
+
+        Returns:
+            a dictionary containing the starting biomass of the plant ("start"), the biomass of the plant at the end of the
+            day ("end"), and the total biomass accumulated ("accumulated biomass")
+        """
+        growth = max_growth * growth_factor
+        return growth
+
+    @staticmethod
+    def calc_above_ground_biomass(root_frac: float, biomass: float) -> float:  # pseudocode: C.9.B.1
+        """
+        Description: calculates above ground plant biomass.
+
+        SWAT Reference: 5:2.4.4
+
+        Args:
+            root_frac: fraction of biomass stored in roots
+            biomass: the current total biomass of the plant
+
+        Returns: above ground biomass
+        """
+        return (1 - root_frac) * biomass
 
 
-def calc_intercepted_radiation(radiation: float, extinction: float, lai: float) -> float:  # pseudocode: C.9.A.1
-    """
-    Description:
-        calculates amount of solar radiation intercepted for photosynthesis during the day
+    @staticmethod
+    def calc_below_ground_biomass(root_frac: float, biomass: float) -> float:
+        """Description: calculates below ground plant biomass
 
-    Args:
-        radiation: total solar radiation available for the day (MJ m^-2)
-        extinction: the light extinction coefficient
-        lai: current leaf area index of the crop
+        Args:
+            root_frac: fraction of biomass stored in roots
+            biomass: the current total biomass of the plant
 
-    Returns:
-        intercepted radiation energy (MJ m^-2)
-    """
-    intercepted_radiation = 0.5 * radiation * (1 - exp(-1 * extinction * lai))
-    return intercepted_radiation
-
-
-def calc_max_accumulation(energy: float, efficiency: float) -> float:  # pseudocode: C.9.A.2
-    """
-    Description: calculates the upper-limit to biomass accumulation during a day
-
-    Args:
-        efficiency: crop-specific radiation use efficiency (dg/MJ)
-        energy: intercepted energy from solar radiation for the day (MJ m^-2)
-
-    Returns: the maximum biomass that can be accumulated in a day
-    """
-    return energy * efficiency
-
-
-def calc_biomass_accumulation(growth_factor: float, max_growth: float) -> float:  # pseudocode: C.9.A.3
-    """
-    Description:
-        Calculates the biomass accumulated during the day
-
-    Args:
-        growth_factor: the growth factor for the plant, which is a value from 0 to 1.
-        max_growth: the maximum amount of biomass the plant can accumulate in a day
-
-    Returns:
-        a dictionary containing the starting biomass of the plant ("start"), the biomass of the plant at the end of the
-        day ("end"), and the total biomass accumulated ("accumulated biomass")
-    """
-    growth = max_growth * growth_factor
-    return growth
-
-
-def calc_above_ground_biomass(root_frac: float, biomass: float) -> float:  # pseudocode: C.9.B.1
-    """
-    Description: calculates above ground plant biomass.
-
-    SWAT Reference: 5:2.4.4
-
-    Args:
-        root_frac: fraction of biomass stored in roots
-        biomass: the current total biomass of the plant
-
-    Returns: above ground biomass
-    """
-    return (1 - root_frac) * biomass
-
-
-def calc_below_ground_biomass(root_frac: float, biomass: float) -> float:
-    """Description: calculates below ground plant biomass
-
-    Args:
-        root_frac: fraction of biomass stored in roots
-        biomass: the current total biomass of the plant
-
-    Returns: below ground biomass
-    """
-    return root_frac * biomass
+        Returns: below ground biomass
+        """
+        return root_frac * biomass

--- a/SC_redesign/Crop_and_Soil/crop/biomass_allocation.py
+++ b/SC_redesign/Crop_and_Soil/crop/biomass_allocation.py
@@ -13,34 +13,29 @@ class BiomassAllocation:
         self.partition_biomass()
 
     def photosynthesize(self, light):
-        """convert the day's incoming light energy into plant biomass"""
-        self.intercept_radiation(light)
-        self.determine_max_growth()
-        self.accumulate_biomass()
+        """convert the day's incoming light energy into plant biomass
 
-    def intercept_radiation(self, light):
-        """capture usable energy from the day's incoming solar radiation (light)"""
-        self.data.usable_light = self.calc_intercepted_radiation(light, self.data.light_extinction,
-                                                                 self.data.leaf_area_index)
+        Args: total available solar radiation for the day (MJ/m^2)
+        """
 
-    def determine_max_growth(self):
-        """determine how much the plant can grow_crop under ideal circumstance, from the light captured"""
-        self.data.biomass_growth_max = self.calc_max_accumulation(self.data.usable_light, self.data.light_conversion)
-
-    def accumulate_biomass(self):
-        """accumulate plant biomass during the day's growth"""
+        # intercept light
+        self.data.usable_light = self._intercept_radiation(light, self.data.light_extinction, self.data.leaf_area_index)
+        # accumulate biomass
+        self.data.biomass_growth_max = self._determine_max_accumulation(self.data.usable_light,
+                                                                        self.data.light_conversion)
         self.data.previous_biomass = self.data.biomass
-        self.data.biomass_growth = self.calc_biomass_accumulation(self.data.growth_factor,
-                                                                  self.data.biomass_growth_max)
+        self.data.biomass_growth = self._determine_accumulated_biomass(self.data.growth_factor,
+                                                                       self.data.biomass_growth_max)
         self.data.biomass += self.data.biomass_growth
 
     def partition_biomass(self):
         """partition the accumulated biomass into above ground and below grown portions"""
-        self.data.above_ground_biomass = self.calc_above_ground_biomass(self.data.root_fraction, self.data.biomass)
-        self.data.root_biomass = self.calc_below_ground_biomass(self.data.root_fraction, self.data.biomass)
+        self.data.above_ground_biomass = self._determine_above_ground_biomass(self.data.root_fraction,
+                                                                              self.data.biomass)
+        self.data.root_biomass = self._determine_below_ground_biomass(self.data.root_fraction, self.data.biomass)
 
     @staticmethod
-    def calc_intercepted_radiation(radiation: float, extinction: float, lai: float) -> float:  # pseudocode: C.9.A.1
+    def _intercept_radiation(radiation: float, extinction: float, lai: float) -> float:  # pseudocode: C.9.A.1
         """
         Description:
             calculates amount of solar radiation intercepted for photosynthesis during the day
@@ -57,7 +52,7 @@ class BiomassAllocation:
         return intercepted_radiation
 
     @staticmethod
-    def calc_max_accumulation(energy: float, efficiency: float) -> float:  # pseudocode: C.9.A.2
+    def _determine_max_accumulation(energy: float, efficiency: float) -> float:  # pseudocode: C.9.A.2
         """
         Description: calculates the upper-limit to biomass accumulation during a day
 
@@ -70,7 +65,7 @@ class BiomassAllocation:
         return energy * efficiency
 
     @staticmethod
-    def calc_biomass_accumulation(growth_factor: float, max_growth: float) -> float:  # pseudocode: C.9.A.3
+    def _determine_accumulated_biomass(growth_factor: float, max_growth: float) -> float:  # pseudocode: C.9.A.3
         """
         Description:
             Calculates the biomass accumulated during the day
@@ -87,7 +82,7 @@ class BiomassAllocation:
         return growth
 
     @staticmethod
-    def calc_above_ground_biomass(root_frac: float, biomass: float) -> float:  # pseudocode: C.9.B.1
+    def _determine_above_ground_biomass(root_frac: float, biomass: float) -> float:  # pseudocode: C.9.B.1
         """
         Description: calculates above ground plant biomass.
 
@@ -103,7 +98,7 @@ class BiomassAllocation:
 
 
     @staticmethod
-    def calc_below_ground_biomass(root_frac: float, biomass: float) -> float:
+    def _determine_below_ground_biomass(root_frac: float, biomass: float) -> float:
         """Description: calculates below ground plant biomass
 
         Args:

--- a/SC_redesign/Crop_and_Soil/crop/crop.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop.py
@@ -39,8 +39,7 @@ class Crop(NitrogenIncorporation, LeafAreaIndex):
         """Process component controlling plant nitrogen incorporation, including uptake and fixation"""
         self.heat_units = HeatUnits(data)  # TODO: rename module and component (e.g., "HeatAccumulation")?
         """Process component controlling plant heat accumulation"""
-        LeafAreaIndex.__init__(self)  # TODO: rename module and component (e.g., "CanopyGrowth")?
-        # self.leaf_area_index = LeafAreaIndex(data)
+        self.leaf_area_index = LeafAreaIndex(data)  # TODO: rename module and component (e.g., "CanopyGrowth")?
         """Process component controlling canopy growth, including leaf area index"""
         self.root_development = RootDevelopment(data)
         """Process component controlling plant root development"""
@@ -100,7 +99,7 @@ class Crop(NitrogenIncorporation, LeafAreaIndex):
         # phosphorus_uptake.update_all()
         #
         self.growth_constraints.constrain_growth(max_transpiration, air_temperature)
-        self.grow_canopy()
+        self.leaf_area_index.grow_canopy()
         self.biomass_allocation.allocate_biomass(incoming_light)
         self.water_dynamics.cycle_water(evaporation, transpiration, max_evapotranspiration)
 

--- a/SC_redesign/Crop_and_Soil/crop/crop.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop.py
@@ -13,7 +13,7 @@ from typing import List, Optional
 
 # TODO: Should use an ENUM class to represent the supported species??
 
-class Crop(NitrogenIncorporation, HeatUnits, LeafAreaIndex):
+class Crop(NitrogenIncorporation, LeafAreaIndex):
     def __init__(self, crop_data: Optional[CropData] = None):
         """Creates a crop object, from a crop data specification object.
 
@@ -35,13 +35,12 @@ class Crop(NitrogenIncorporation, HeatUnits, LeafAreaIndex):
         self.water_dynamics = WaterDynamics(data)
         """Process component controlling plant water dynamics"""
         NitrogenIncorporation.__init__(self)
-        # nitrogen_incorporation = NitrogenIncorporation(data)
+        # self.nitrogen_incorporation = NitrogenIncorporation(data)
         """Process component controlling plant nitrogen incorporation, including uptake and fixation"""
-        HeatUnits.__init__(self)
-        # heat_units = HeatUnits(data)  # TODO: rename module and component (e.g., "HeatAccumulation")?
+        self.heat_units = HeatUnits(data)  # TODO: rename module and component (e.g., "HeatAccumulation")?
         """Process component controlling plant heat accumulation"""
         LeafAreaIndex.__init__(self)  # TODO: rename module and component (e.g., "CanopyGrowth")?
-        # leaf_area_index = LeafAreaIndex(data)
+        # self.leaf_area_index = LeafAreaIndex(data)
         """Process component controlling canopy growth, including leaf area index"""
         self.root_development = RootDevelopment(data)
         """Process component controlling plant root development"""
@@ -94,11 +93,9 @@ class Crop(NitrogenIncorporation, HeatUnits, LeafAreaIndex):
             process sub-routines. It should be called every day that the crop
             is alive and growing in the simulation
         """
-        self.absorb_heat_units(mean_air_temperature, min_air_temperature,
-                               max_air_temperature)
+        self.heat_units.absorb_heat_units(mean_air_temperature, min_air_temperature, max_air_temperature)
         self.root_development.develop_roots()
-        self.incorporate_nitrogen(layer_nitrates, layer_depths,
-                                  soil_water_factor)
+        self.incorporate_nitrogen(layer_nitrates, layer_depths, soil_water_factor)
         #
         # phosphorus_uptake.update_all()
         #

--- a/SC_redesign/Crop_and_Soil/crop/crop.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop.py
@@ -13,21 +13,40 @@ from typing import List, Optional
 
 # TODO: Should use an ENUM class to represent the supported species??
 
-class Crop(GrowthConstraints, BiomassAllocation,
-           NitrogenIncorporation, HeatUnits, LeafAreaIndex):
+class Crop(NitrogenIncorporation, HeatUnits, LeafAreaIndex):
     def __init__(self, crop_data: Optional[CropData] = None):
-        data = crop_data or CropData() # defaults if not given
+        """Creates a crop object, from a crop data specification object.
 
+        Args:
+            crop_data: a CropData object containing the attributes tracked throughout the simulation
 
-        # Initialize inherited classes
-        GrowthConstraints.__init__(self)
-        BiomassAllocation.__init__(self)
+        Details:
+            If crop_data is not given, the default specifications are used.
+        """
+        # Common data object that is updated throughout routines
+        data = crop_data or CropData()  # defaults if not given
+        """reference to the crop data; tracks all crop variables through the simulation"""
+
+        # growth process components
+        self.growth_constraints = GrowthConstraints(data)
+        """Process component controlling growth constraints, limits plant growth as a function of stressors"""
+        self.biomass_allocation = BiomassAllocation(data)
+        """Process component controlling allocation of plant biomass as a function of growth and photosynthesis"""
         self.water_dynamics = WaterDynamics(data)
+        """Process component controlling plant water dynamics"""
         NitrogenIncorporation.__init__(self)
+        # nitrogen_incorporation = NitrogenIncorporation(data)
+        """Process component controlling plant nitrogen incorporation, including uptake and fixation"""
         HeatUnits.__init__(self)
-        LeafAreaIndex.__init__(self)
+        # heat_units = HeatUnits(data)  # TODO: rename module and component (e.g., "HeatAccumulation")?
+        """Process component controlling plant heat accumulation"""
+        LeafAreaIndex.__init__(self)  # TODO: rename module and component (e.g., "CanopyGrowth")?
+        # leaf_area_index = LeafAreaIndex(data)
+        """Process component controlling canopy growth, including leaf area index"""
         self.root_development = RootDevelopment(data)
+        """Process component controlling plant root development"""
         self.crop_yields = Yields(data)
+        """Process component controlling calculation of end-of-season production"""
         # TODO: Loi recommended that a composition pattern might fit better
         #  than multiple inheritance: A crop "has" a Growth constraint (system)
         #  but is not itself a growth constraint. This pattern might be worth
@@ -83,9 +102,9 @@ class Crop(GrowthConstraints, BiomassAllocation,
         #
         # phosphorus_uptake.update_all()
         #
-        self.constrain_growth(max_transpiration, air_temperature)
+        self.growth_constraints.constrain_growth(max_transpiration, air_temperature)
         self.grow_canopy()
-        self.allocate_biomass(incoming_light)
+        self.biomass_allocation.allocate_biomass(incoming_light)
         self.water_dynamics.cycle_water(evaporation, transpiration, max_evapotranspiration)
 
     @classmethod

--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -42,7 +42,7 @@ class CropData:
     optimal_phosphorus: float = 80
     """optimal amount of phosphorus stored in the plant for the curent growth stage (kg/ha)"""
     minimum_temperature: float = 15
-    """minumum temperature below which plant growth cannot occur (Celsius)"""
+    """minimum temperature below which plant growth cannot occur (Celsius)"""
     optimal_temperature: float = 22
     """ideal temperature for maximum plant growth (Celsius)"""
     ##growth_factor: float = 1.0  # duplicate
@@ -58,18 +58,29 @@ class CropData:
     # ---- heat_units
     ##minimum_temperature: float = 20 # duplicate
     maximum_temperature: float = 38
+    """maximum temperature above which plant growth cannot occur (Celsius)"""
     potential_heat_units: float = 800
+    """total heat units required for the plant to reach maturity (unitless)
+    """
     accumulated_heat_units: float = 0  # accumulator
+    """total heat units accumulated to date (unitless)"""
     is_growing: bool = True  # TODO: not currently using; SWAT 5:2.1.4
+    """is the crop currently growing?"""
     use_heat_unit_temperature: bool = False
-    """determines if heat unit temperature will be used for heat unit 
-    accumulation."""
+    """should the alternative heat unit method be used? 
+    Determines if heat unit temperature will be used for heat unit  accumulation."""
     new_heat_units: Optional[float] = None
+    """heat units accumulated on the current day; degrees C above minimum growth temperature (Celsius*)"""
     heat_fraction: Optional[float] = None
+    """fraction of potential heat units accumulated to date (unitless)"""
     minimum_heat_unit_temperature: Optional[float] = None
+    """minimum temperature used for heat unit calculations during the alternative heat unit method (Celsius)"""
     maximum_heat_unit_temperature: Optional[float] = None
+    """maximum temperature used for heat unit calculations during the alternative heat unit method (Celsius)"""
     heat_unit_temperature: Optional[float] = None
+    """heat unit temperature used by alternative heat unit method (Celsius)"""
     previous_heat_fraction: Optional[float] = None
+    """fraction of potential heat units on the previous day (unitless)"""
     
     # ---- leaf area index
     # fixed attributes (unchanged during simulations)

--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -221,3 +221,8 @@ class CropData:
     def has_given_harvest_index(self) -> bool:
         """was a user-defined harvest index is given? This triggers a harvest index override"""
         return self.user_harvest_index is not None
+
+    @property
+    def is_in_senescence(self) -> bool:
+        """check if the plant is in senescence"""
+        return self.heat_fraction > self.senescent_heat_fraction

--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -85,24 +85,42 @@ class CropData:
     # ---- leaf area index
     # fixed attributes (unchanged during simulations)
     first_heat_fraction_point: float = 0.15
+    """fraction of the growing season corresponding to the first point on the optimal leaf development 
+    curve (unitless)"""
     second_heat_fraction_point: float = 0.50
+    """fraction of the growing season corresponding to the second point on the optimal leaf development 
+    curve (unitless)"""
     first_leaf_fraction_point: float = 0.01
+    """fraction of max leaf area index corresponding to the first point on the optimal leaf development 
+    curve (unitless)"""
     second_leaf_fraction_point: float = 0.95
+    """fraction of max leaf area index corresponding to the second point on the optimal leaf development 
+        curve (unitless)"""
     max_canopy_height: float = 2.5  # m
+    """maximum canopy height for the plant (m)"""
     ##growth_factor = 1.0  #duplicate
     max_leaf_area_index: float = 3.0
+    """maximum leaf area index for the plant (unitless)"""
     senescent_heat_fraction: float = 0.9
+    """the fraction of potential heat units above which the plant goes enters senescence (unitless)"""
     # variable attributes (change throughout simulations)
     ##leaf_area_index = 0 # duplicate
     ##heat_fraction = 0.73 # duplicate
     # empty variables
     _lai_shapes: Optional[float] = None
+    """shape coefficients used to calculate fraction of max leaf area index (unitless)."""
     optimal_leaf_area_fraction: Optional[float] = None
+    """fraction of the plant's maximum leaf area index corresponding to the current heat fraction (unitless)"""
     canopy_height: Optional[float] = None
+    """current height of the plant (m)"""
     leaf_area_added: Optional[float] = None
-    max_leaf_area_change: Optional[float] = None
+    """leaf area index change during the day; corrected for growth constraints (unitless)"""
+    optimal_leaf_area_change: Optional[float] = None
+    """leaf area index added under ideal conditions for the day; not corrected for growth constraints (unitless)"""
     previous_leaf_area_index: Optional[float] = None
+    """leaf area index on the previous day"""
     previous_optimal_leaf_area_fraction: Optional[float] = None
+    """optimal leaf area fraction on the previous day"""
     
     # ---- nitrogen incorporation
     # constant declarations with defaults (unchanged during simulations)

--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -6,19 +6,29 @@ from typing import Optional
 class CropData:
     # ---- biomass allocation
     light_extinction: float = 0.65
+    """the light extinction coefficient (unitless)"""
     leaf_area_index: float = 1.2
+    """leaf area index of the plant (unitless)"""
     light_conversion: float = 20
+    """light use efficiency of the plant (dg/MJ)"""
     biomass: float = 0
     """total plant biomass (kg/ha)"""
     growth_factor: float = 1.0
+    """growth factor multiplier for the plant (unitless; [0, 1])"""
     root_fraction: float = 1 / 3
     """proportion of plant biomass that is stored below ground in roots (unitless)"""
     usable_light: Optional[float] = None
+    """solar radiation captured for photosynthesis during the day (MJ/m^2)"""
     biomass_growth_max: Optional[float] = None
+    """upper-limit of biomass accumulation for the day (kg/ha)"""
     biomass_growth: Optional[float] = None
+    """biomass accumulated by the plant during the day (kg/ha)"""
     previous_biomass: Optional[float] = None
-    green_biomass: Optional[float] = None
+    """biomass accumulated by the plant on the previous day (kg/ha)"""
+    above_ground_biomass: Optional[float] = None
+    """biomass stored in the above ground portion of the plant; plant biomass excluding roots (kg/ha)"""
     root_biomass: Optional[float] = None
+    """biomass stored in roots (kg/ha)"""
     
     # ---- growth constraints
     water_uptake: float = 18
@@ -162,8 +172,7 @@ class CropData:
     # temporally variable attributes
     ##heat_fraction = 0.6  # duplicate
     ##water_deficiency = 0.2  # duplicate
-    above_ground_biomass: float = 15  # kg
-    """biomass stored in the above ground portion of the plant; plant biomass excluding roots (kg/ha)"""
+    ##above_ground_biomass: float = 15  # kg
     ##biomass = 25  # duplicate
     dry_down_fraction: float = 0.2
     """proportion of plant biomass that is lost to dry-down (unitless; [0, 1])"""

--- a/SC_redesign/Crop_and_Soil/crop/heat_units.py
+++ b/SC_redesign/Crop_and_Soil/crop/heat_units.py
@@ -15,6 +15,8 @@ class HeatUnits:
             min_air_temperature: minimum air temperature for the day (C)
             max_air_temperature: maximum air temperature for the day (C)
 
+        SWAT References: 5:1.1, 5:2.1.2,
+
         Details: if the attribute use_heat_unit_temperature is false, both min_air_temperature and max_air_temperature
         are optional. Otherwise, they are used to determine heat unit accumulation rather than average air temperature.
         """
@@ -97,6 +99,8 @@ class HeatUnits:
         Args:
             temperature: the temperature to be compared to min_temp for accumulating heat units (C)
             min_temperature: the minimum temperature below which a crop cannot grow (C)
+
+        SWAT Reference: 5:1.1
         """
         return max(temperature - min_temperature, 0)  # from SWAT:
 

--- a/SC_redesign/Crop_and_Soil/crop/heat_units.py
+++ b/SC_redesign/Crop_and_Soil/crop/heat_units.py
@@ -4,24 +4,7 @@ from SC_redesign.Crop_and_Soil.crop.crop_data import CropData
 class HeatUnits:
     def __init__(self, crop_data: Optional[CropData] = None,
                  use_heat_unit_temperature: bool = False):
-        data = crop_data or CropData()  # initialize with defaults, if not given
-        # TODO replace attributes with reference to data - GitHub Issue #255
-        #  in various methods
-        self.minimum_temperature = 20
-        self.maximum_temperature = 38
-        self.potential_heat_units = 800
-        self.accumulated_heat_units = 0  # accumulator
-        self.is_growing = True  # TODO: not currently using; SWAT 5:2.1.4
-        self.use_heat_unit_temperature: bool = use_heat_unit_temperature
-        """determines if heat unit temperature will be used for heat unit accumulation."""
-        # self.heat_unit_scheduling = True
-
-        self.new_heat_units = None
-        self.heat_fraction = None
-        self.minimum_heat_unit_temperature = None
-        self.maximum_heat_unit_temperature = None
-        self.heat_unit_temperature = None
-        self.previous_heat_fraction = None
+        self.data = crop_data or CropData()  # initialize with defaults, if not given
 
     def absorb_heat_units(self, mean_air_temperature: float = None,
                           min_air_temperature: float = None, max_air_temperature: float = None) -> None:
@@ -37,34 +20,22 @@ class HeatUnits:
         """
         self._check_absorb_heat_for_input_errors(mean_air_temperature, min_air_temperature, max_air_temperature)
 
-        if self.use_heat_unit_temperature:
-            self.maximum_heat_unit_temperature = \
-                HeatUnits._determine_maximum_heat_unit_temperature(max_air_temperature, self.maximum_temperature)
-            self.minimum_heat_unit_temperature = \
-                HeatUnits._determine_minimum_heat_unit_temperature(min_air_temperature, self.minimum_temperature)
-            self.heat_unit_temperature = \
-                (self.minimum_heat_unit_temperature + self.maximum_heat_unit_temperature) / 2
+        if self.data.use_heat_unit_temperature:
+            self.data.maximum_heat_unit_temperature = \
+                HeatUnits._determine_maximum_heat_unit_temperature(max_air_temperature, self.data.maximum_temperature)
+            self.data.minimum_heat_unit_temperature = \
+                HeatUnits._determine_minimum_heat_unit_temperature(min_air_temperature, self.data.minimum_temperature)
+            self.data.heat_unit_temperature = \
+                (self.data.minimum_heat_unit_temperature + self.data.maximum_heat_unit_temperature) / 2
 
-        if self.use_heat_unit_temperature or mean_air_temperature is None:
-            use_temp = self.heat_unit_temperature
+        if self.data.use_heat_unit_temperature or mean_air_temperature is None:
+            use_temp = self.data.heat_unit_temperature
         else:
             use_temp = mean_air_temperature
-        self.is_growing = self.minimum_temperature <= use_temp <= self.maximum_temperature
+        self.data.is_growing = self.data.minimum_temperature <= use_temp <= self.data.maximum_temperature
         self.accumulate_heat_units(mean_air_temperature)
-        self.previous_heat_fraction = self.heat_fraction
-        self.heat_fraction = self.accumulated_heat_units / self.potential_heat_units
-
-    # TODO: add these warnings to output manager at a later date.
-    def _check_absorb_heat_for_input_errors(self, mean_air_temperature: float = None,
-                                            min_air_temperature: float = None,
-                                            max_air_temperature: float = None):
-        """raises errors if inputs given for absorb_heat_units don't make sense with the value of the
-        use_heat_unit_temperature attribute"""
-        if self.use_heat_unit_temperature and (min_air_temperature is None or max_air_temperature is None):
-            raise ValueError("min_air_temperature and max_air_temperature must be provided" +
-                             " when use_heat_unit_temperature is True")
-        if not self.use_heat_unit_temperature and mean_air_temperature is None:
-            raise ValueError("mean_air_temperature must be provided when use_heat_temperature is False")
+        self.data.previous_heat_fraction = self.data.heat_fraction
+        self.data.heat_fraction = self.data.accumulated_heat_units / self.data.potential_heat_units
 
     def accumulate_heat_units(self, air_temperature: float = None) -> None:
         """accumulates heat units during a day
@@ -97,14 +68,27 @@ class HeatUnits:
 
     def assign_new_heat_units(self, air_temperature: float = None) -> None:
         """assign new heat units based on if the alternative accumulation method is to be used"""
-        if self.use_heat_unit_temperature or (air_temperature is None):  # alternative method
-            self.new_heat_units = self._determine_new_heat_units(self.heat_unit_temperature, self.minimum_temperature)
+        if self.data.use_heat_unit_temperature or (air_temperature is None):  # alternative method
+            self.data.new_heat_units = self._determine_new_heat_units(self.data.heat_unit_temperature,
+                                                                      self.data.minimum_temperature)
         else:  # main method
-            self.new_heat_units = self._determine_new_heat_units(air_temperature, self.minimum_temperature)
+            self.data.new_heat_units = self._determine_new_heat_units(air_temperature, self.data.minimum_temperature)
 
     def add_heat_units(self) -> None:
         """add newly acquired heat units to accumulated heat units"""
-        self.accumulated_heat_units += self.new_heat_units
+        self.data.accumulated_heat_units += self.data.new_heat_units
+
+    # TODO: add these warnings to output manager at a later date.
+    def _check_absorb_heat_for_input_errors(self, mean_air_temperature: float = None,
+                                            min_air_temperature: float = None,
+                                            max_air_temperature: float = None):
+        """raises errors if inputs given for absorb_heat_units don't make sense with the value of the
+        use_heat_unit_temperature attribute"""
+        if self.data.use_heat_unit_temperature and (min_air_temperature is None or max_air_temperature is None):
+            raise ValueError("min_air_temperature and max_air_temperature must be provided" +
+                             " when use_heat_unit_temperature is True")
+        if not self.data.use_heat_unit_temperature and mean_air_temperature is None:
+            raise ValueError("mean_air_temperature must be provided when use_heat_temperature is False")
 
     @staticmethod
     def _determine_new_heat_units(temperature: float, min_temperature: float) -> float:

--- a/SC_redesign/Crop_and_Soil/crop/leaf_area_index.py
+++ b/SC_redesign/Crop_and_Soil/crop/leaf_area_index.py
@@ -4,7 +4,7 @@ from SC_redesign.Crop_and_Soil.crop.crop_data import CropData
 
 
 """
-This module is based off of the 'Canopy Cover and Height' section of SWAT
+This module is based off of the 'Canopy Cover and Height' section of SWAT (5:2.1.2)
 """
 
 
@@ -31,7 +31,7 @@ class LeafAreaIndex:
                                                                                   self.data.optimal_leaf_area_fraction)
         else:  # normal growth
             self.check_previous_leaf_area_values()
-            self.data.max_leaf_area_change = self._determine_max_leaf_area_change(
+            self.data.optimal_leaf_area_change = self._determine_max_leaf_area_change(
                 self.data.optimal_leaf_area_fraction,
                 self.data.previous_optimal_leaf_area_fraction,
                 self.data.max_leaf_area_index,
@@ -58,8 +58,8 @@ class LeafAreaIndex:
         """sets actual leaf area added, by adjusting for the plant growth factor
         SWAT Reference: 5:3.2.2
         """
-        self.data.leaf_area_added = min(self.data.max_leaf_area_change * sqrt(self.data.growth_factor),
-                                        self.data.max_leaf_area_change)
+        self.data.leaf_area_added = min(self.data.optimal_leaf_area_change * sqrt(self.data.growth_factor),
+                                        self.data.optimal_leaf_area_change)
 
     def add_leaf_area(self) -> None:
         """add new leaf area to the plant

--- a/SC_redesign/Crop_and_Soil/crop/leaf_area_index.py
+++ b/SC_redesign/Crop_and_Soil/crop/leaf_area_index.py
@@ -10,82 +10,63 @@ This module is based off of the 'Canopy Cover and Height' section of SWAT
 
 class LeafAreaIndex:
     def __init__(self, crop_data: Optional[CropData] = None):
-        data = crop_data or CropData()  # initialize with defaults, if not given
-        # TODO replace attributes with reference to data - GitHub Issue #255
-        #  in various methods
-        # fixed attributes (unchanged during simulations)
-        self.first_heat_fraction_point = 0.15
-        self.second_heat_fraction_point = 0.50
-        self.first_leaf_fraction_point = 0.01
-        self.second_leaf_fraction_point = 0.95
-        self.max_canopy_height = 2.5  # m
-        self.growth_factor = 1.0
-        self.max_leaf_area_index = 3.0
-        self.senescent_heat_fraction = 0.9
-        # variable attributes (change throughout simulations)
-        self.leaf_area_index = 0
-        self.heat_fraction = 0.73
-        # empty variables
-        self._lai_shapes = None
-        self.optimal_leaf_area_fraction = None
-        self.canopy_height = None
-        self.leaf_area_added = None
-        self.max_leaf_area_change = None
-        self.previous_leaf_area_index = None
-        self.previous_optimal_leaf_area_fraction = None
+        self.data = crop_data or CropData()  # initialize with defaults, if not given
 
     def grow_canopy(self) -> None:
         """main leaf area index function"""
-        self._lai_shapes = self._determine_lai_shapes(self.first_heat_fraction_point, self.second_heat_fraction_point,
-                                                      self.first_leaf_fraction_point, self.second_leaf_fraction_point)
+        self.data._lai_shapes = self._determine_lai_shapes(self.data.first_heat_fraction_point,
+                                                           self.data.second_heat_fraction_point,
+                                                           self.data.first_leaf_fraction_point,
+                                                           self.data.second_leaf_fraction_point)
 
-        self.optimal_leaf_area_fraction = self._determine_optimal_leaf_area_fraction(self.heat_fraction,
-                                                                                     self._lai_shapes[0],
-                                                                                     self._lai_shapes[1])
+        self.data.optimal_leaf_area_fraction = self._determine_optimal_leaf_area_fraction(self.data.heat_fraction,
+                                                                                          self.data._lai_shapes[0],
+                                                                                          self.data._lai_shapes[1])
 
-        self.canopy_height = self.determine_canopy_height(self.max_canopy_height, self.optimal_leaf_area_fraction)
-        if self.is_in_senescence:  # senescence
-            self.leaf_area_index = self._determine_senescent_leaf_area_index(self.heat_fraction,
-                                                                             self.senescent_heat_fraction,
-                                                                             self.optimal_leaf_area_fraction)
+        self.data.canopy_height = self.determine_canopy_height(self.data.max_canopy_height,
+                                                               self.data.optimal_leaf_area_fraction)
+        if self.data.is_in_senescence:  # senescence
+            self.data.leaf_area_index = self._determine_senescent_leaf_area_index(self.data.heat_fraction,
+                                                                                  self.data.senescent_heat_fraction,
+                                                                                  self.data.optimal_leaf_area_fraction)
         else:  # normal growth
             self.check_previous_leaf_area_values()
-            self.max_leaf_area_change = self._determine_max_leaf_area_change(self.optimal_leaf_area_fraction,
-                                                                             self.previous_optimal_leaf_area_fraction,
-                                                                             self.max_leaf_area_index,
-                                                                             self.previous_leaf_area_index)
+            self.data.max_leaf_area_change = self._determine_max_leaf_area_change(
+                self.data.optimal_leaf_area_fraction,
+                self.data.previous_optimal_leaf_area_fraction,
+                self.data.max_leaf_area_index,
+                self.data.previous_leaf_area_index
+            )
             self.determine_leaf_area_added()
             self.add_leaf_area()
         self.shift_leaf_area_time()
 
     def shift_leaf_area_time(self) -> None:
         """shifts the time window by one step for leaf area attributes"""
-        self.previous_leaf_area_index = self.leaf_area_index
-        self.previous_optimal_leaf_area_fraction = self.optimal_leaf_area_fraction
+        self.data.previous_leaf_area_index = self.data.leaf_area_index
+        self.data.previous_optimal_leaf_area_fraction = self.data.optimal_leaf_area_fraction
 
     def check_previous_leaf_area_values(self) -> None:
         """check for previous LAI values and set them to 0 if none are present. This function handles the
         initial time point in the simulation"""
-        if self.previous_optimal_leaf_area_fraction is None:
-            self.previous_optimal_leaf_area_fraction = 0
-        if self.previous_leaf_area_index is None:
-            self.previous_leaf_area_index = 0
+        if self.data.previous_optimal_leaf_area_fraction is None:
+            self.data.previous_optimal_leaf_area_fraction = 0
+        if self.data.previous_leaf_area_index is None:
+            self.data.previous_leaf_area_index = 0
 
     def determine_leaf_area_added(self) -> None:
         """sets actual leaf area added, by adjusting for the plant growth factor
         SWAT Reference: 5:3.2.2
         """
-        self.leaf_area_added = min(self.max_leaf_area_change * sqrt(self.growth_factor), self.max_leaf_area_change)
+        self.data.leaf_area_added = min(self.data.max_leaf_area_change * sqrt(self.data.growth_factor),
+                                        self.data.max_leaf_area_change)
 
     def add_leaf_area(self) -> None:
         """add new leaf area to the plant
         SWAT Reference: 5:2.1.18"""
-        self.leaf_area_index = max(0, self.previous_leaf_area_index + self.leaf_area_added)
+        self.data.leaf_area_index = max(0., self.data.previous_leaf_area_index + self.data.leaf_area_added)
 
-    @property
-    def is_in_senescence(self) -> bool:
-        """check if the plant is in senescence"""
-        return self.heat_fraction > self.senescent_heat_fraction
+
 
     @staticmethod
     def determine_canopy_height(max_canopy_height: float, optimal_leaf_area_fraction: float) -> float:

--- a/SC_redesign/Crop_and_Soil/crop/water_dynamics.py
+++ b/SC_redesign/Crop_and_Soil/crop/water_dynamics.py
@@ -5,8 +5,7 @@ from SC_redesign.Crop_and_Soil.crop.crop_data import CropData
 
 class WaterDynamics:
     def __init__(self, crop_data: Optional[CropData] = None):
-        data = crop_data or CropData()  # initialize with defaults, if not given
-        self.data = crop_data or CropData()
+        self.data = crop_data or CropData()  # initialize with defaults, if not given
 
     def cycle_water(self, evaporation: float, transpiration: float, max_evapotranspiration: float) -> None:
         self.data.cumulative_evaporation = evaporation

--- a/SC_redesign/Crop_and_Soil/crop/yields.py
+++ b/SC_redesign/Crop_and_Soil/crop/yields.py
@@ -10,9 +10,6 @@ class Yields():
     def __init__(self, crop_data: Optional[CropData] = None):
         self.data = crop_data or CropData()  # initialize with defaults, if not given
 
-    # ---- Properties ----
-
-
     # ---- Main Method ----
     def obtain_yields(self) -> None:
         """Main yields function; determines the season's cumulative crop yield on a given day

--- a/SC_redesign/Crop_and_Soil/tests_SC/test_biomass_allocation.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/test_biomass_allocation.py
@@ -14,7 +14,7 @@ from SC_redesign.Crop_and_Soil.crop.biomass_allocation import *
 def test_calc_intercepted_radiation(rad, ext, lai):
     """ensure that intercepted radiation is correctly calculated by calc_intercepted_radiation()"""
     h_photo = 0.5 * rad * (1 - exp(-ext * lai))
-    result = BiomassAllocation.calc_intercepted_radiation(rad, ext, lai)
+    result = BiomassAllocation._intercept_radiation(rad, ext, lai)
     assert result == h_photo
 
 
@@ -30,7 +30,7 @@ def test_calc_intercepted_radiation(rad, ext, lai):
 ])
 def test_calc_max_accumulation(rad, eff, expected):
     """test that maximum biomass accumulation is properly calculated with calc_max_accumulation()"""
-    assert BiomassAllocation.calc_max_accumulation(rad, eff) == expected
+    assert BiomassAllocation._determine_max_accumulation(rad, eff) == expected
 
 
 @pytest.mark.parametrize("factor,max_growth", [
@@ -43,7 +43,7 @@ def test_calc_max_accumulation(rad, eff, expected):
 ])
 def test_calc_biomass_accumulation(factor, max_growth):
     """ensure that biomass growth is correctly calculated by calc_biomass_accumulation()"""
-    assert BiomassAllocation.calc_biomass_accumulation(factor, max_growth) == max_growth * factor
+    assert BiomassAllocation._determine_accumulated_biomass(factor, max_growth) == max_growth * factor
 
 
 @pytest.mark.parametrize("frac,bmass", [
@@ -60,7 +60,7 @@ def test_calc_biomass_accumulation(factor, max_growth):
 def test_calc_above_ground_biomass(frac, bmass):
     """ensure that above ground biomass is correctly calculated"""
     expect = bmass * (1 - frac)
-    assert BiomassAllocation.calc_above_ground_biomass(frac, bmass) == expect
+    assert BiomassAllocation._determine_above_ground_biomass(frac, bmass) == expect
 
 
 @pytest.mark.parametrize("frac,bmass", [
@@ -76,71 +76,9 @@ def test_calc_above_ground_biomass(frac, bmass):
 ])
 def test_calc_below_ground_biomass(frac, bmass):
     """ensure that below ground biomass is correctly calculated"""
-    assert BiomassAllocation.calc_below_ground_biomass(frac, bmass) == bmass * frac
-
-
-# ---- initialization functions (reusable) ----
-def init_bioal(**kwargs):
-    """helper function to create BiomassAllocation instance, with specified attributes"""
-    bioal = BiomassAllocation()
-    for key, val in kwargs.items():
-        setattr(bioal, key, val)
-    return bioal
-
+    assert BiomassAllocation._determine_below_ground_biomass(frac, bmass) == bmass * frac
 
 # ---- member function tests ----
-@pytest.mark.parametrize("rad,ext,lai", [
-    (1, 1, 1),
-    (0, 0, 0),
-    (1, 0, 1),
-    (.6, -.42, 0.35),
-    (.26, .28, 0.44)
-])
-def test_intercept_radiation(rad, ext, lai):
-    """check that usable_light is properly updated"""
-    data = CropData(light_extinction=ext, leaf_area_index=lai)
-    bioal = BiomassAllocation(data)
-    bioal.intercept_radiation(rad)
-    assert data.usable_light == BiomassAllocation.calc_intercepted_radiation(rad, ext, lai)
-
-
-@pytest.mark.parametrize("rad, eff", [
-    (0, 1),
-    (1, 0),
-    (1, 1),
-    (1350.86, 15.21),  # arbitrary rad >> eff
-    (20.7, 15.3),  # rad near eff
-    (12.86, 20.37)  # rad < eff
-])
-def test_determine_max_growth(rad, eff):
-    """ensure that max_evapotranspiration growth is properly updated"""
-    data = CropData(light_conversion=eff, usable_light=rad)
-    bioal = BiomassAllocation(data)
-    bioal.determine_max_growth()
-    assert data.biomass_growth_max == BiomassAllocation.calc_max_accumulation(rad, eff)
-
-
-@pytest.mark.parametrize("start,factor,gmax", [
-    (10, 1, 1000),
-    (.8, 1, 1000),
-    (10, .8, 1000),
-    (8, .75, 1000),
-    (8, .75, 833.9),
-    (8, 1.2, 833.9)
-])
-def test_accumulate_biomass(start, factor, gmax):
-    """check that biomass attributes are correctly updated by accumulate_biomass()"""
-    data = CropData(biomass=start, growth_factor=factor, biomass_growth_max=gmax)
-    bioal = BiomassAllocation(data)
-    bioal.accumulate_biomass()
-    expect_growth = BiomassAllocation.calc_biomass_accumulation(factor, gmax)
-    expect_end = start + expect_growth
-
-    assert data.previous_biomass == start
-    assert data.biomass == expect_end
-    assert data.biomass_growth == expect_growth
-
-
 @pytest.mark.parametrize("light,ext,conv,gfact,rfrac", [
     (1000, 0.7, 20, 1, 1/3),  # start
     (1000, 0.7, 20, 1, 0.66),  # increased root proportion
@@ -158,13 +96,14 @@ def test_allocate_biomass(light, ext, conv, gfact, rfrac):
     bioal.allocate_biomass(light)
 
     # photosynthesize
-    energy = BiomassAllocation.calc_intercepted_radiation(light, ext, lai=1.87)
-    max_growth = BiomassAllocation.calc_max_accumulation(energy, conv)
-    growth = BiomassAllocation.calc_biomass_accumulation(gfact, max_growth)
+    energy = BiomassAllocation._intercept_radiation(light, ext, lai=1.87)
+    max_growth = BiomassAllocation._determine_max_accumulation(energy, conv)
+    growth = BiomassAllocation._determine_accumulated_biomass(gfact, max_growth)
     mass = 89.0 + growth
+    # TODO: test photosynthesize() and partition_biomass() separately?
     # partition_biomass
-    green = BiomassAllocation.calc_above_ground_biomass(rfrac, mass)
-    root = BiomassAllocation.calc_below_ground_biomass(rfrac, mass)
+    green = BiomassAllocation._determine_above_ground_biomass(rfrac, mass)
+    root = BiomassAllocation._determine_below_ground_biomass(rfrac, mass)
 
     assert data.usable_light == energy
     assert data.biomass_growth_max == max_growth

--- a/SC_redesign/Crop_and_Soil/tests_SC/test_biomass_allocation.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/test_biomass_allocation.py
@@ -14,7 +14,7 @@ from SC_redesign.Crop_and_Soil.crop.biomass_allocation import *
 def test_calc_intercepted_radiation(rad, ext, lai):
     """ensure that intercepted radiation is correctly calculated by calc_intercepted_radiation()"""
     h_photo = 0.5 * rad * (1 - exp(-ext * lai))
-    result = calc_intercepted_radiation(rad, ext, lai)
+    result = BiomassAllocation.calc_intercepted_radiation(rad, ext, lai)
     assert result == h_photo
 
 
@@ -30,7 +30,7 @@ def test_calc_intercepted_radiation(rad, ext, lai):
 ])
 def test_calc_max_accumulation(rad, eff, expected):
     """test that maximum biomass accumulation is properly calculated with calc_max_accumulation()"""
-    assert calc_max_accumulation(rad, eff) == expected
+    assert BiomassAllocation.calc_max_accumulation(rad, eff) == expected
 
 
 @pytest.mark.parametrize("factor,max_growth", [
@@ -43,7 +43,7 @@ def test_calc_max_accumulation(rad, eff, expected):
 ])
 def test_calc_biomass_accumulation(factor, max_growth):
     """ensure that biomass growth is correctly calculated by calc_biomass_accumulation()"""
-    assert calc_biomass_accumulation(factor, max_growth) == max_growth * factor
+    assert BiomassAllocation.calc_biomass_accumulation(factor, max_growth) == max_growth * factor
 
 
 @pytest.mark.parametrize("frac,bmass", [
@@ -60,7 +60,7 @@ def test_calc_biomass_accumulation(factor, max_growth):
 def test_calc_above_ground_biomass(frac, bmass):
     """ensure that above ground biomass is correctly calculated"""
     expect = bmass * (1 - frac)
-    assert calc_above_ground_biomass(frac, bmass) == expect
+    assert BiomassAllocation.calc_above_ground_biomass(frac, bmass) == expect
 
 
 @pytest.mark.parametrize("frac,bmass", [
@@ -76,7 +76,7 @@ def test_calc_above_ground_biomass(frac, bmass):
 ])
 def test_calc_below_ground_biomass(frac, bmass):
     """ensure that below ground biomass is correctly calculated"""
-    assert calc_below_ground_biomass(frac, bmass) == bmass * frac
+    assert BiomassAllocation.calc_below_ground_biomass(frac, bmass) == bmass * frac
 
 
 # ---- initialization functions (reusable) ----
@@ -98,9 +98,10 @@ def init_bioal(**kwargs):
 ])
 def test_intercept_radiation(rad, ext, lai):
     """check that usable_light is properly updated"""
-    bioal = init_bioal(light_extinction=ext, leaf_area_index=lai)
+    data = CropData(light_extinction=ext, leaf_area_index=lai)
+    bioal = BiomassAllocation(data)
     bioal.intercept_radiation(rad)
-    assert bioal.usable_light == calc_intercepted_radiation(rad, ext, lai)
+    assert data.usable_light == BiomassAllocation.calc_intercepted_radiation(rad, ext, lai)
 
 
 @pytest.mark.parametrize("rad, eff", [
@@ -113,9 +114,10 @@ def test_intercept_radiation(rad, ext, lai):
 ])
 def test_determine_max_growth(rad, eff):
     """ensure that max_evapotranspiration growth is properly updated"""
-    bioal = init_bioal(light_conversion=eff, usable_light=rad)
+    data = CropData(light_conversion=eff, usable_light=rad)
+    bioal = BiomassAllocation(data)
     bioal.determine_max_growth()
-    assert bioal.biomass_growth_max == calc_max_accumulation(rad, eff)
+    assert data.biomass_growth_max == BiomassAllocation.calc_max_accumulation(rad, eff)
 
 
 @pytest.mark.parametrize("start,factor,gmax", [
@@ -128,14 +130,15 @@ def test_determine_max_growth(rad, eff):
 ])
 def test_accumulate_biomass(start, factor, gmax):
     """check that biomass attributes are correctly updated by accumulate_biomass()"""
-    bioal = init_bioal(biomass=start, growth_factor=factor, biomass_growth_max=gmax)
+    data = CropData(biomass=start, growth_factor=factor, biomass_growth_max=gmax)
+    bioal = BiomassAllocation(data)
     bioal.accumulate_biomass()
-    expect_growth = calc_biomass_accumulation(factor, gmax)
+    expect_growth = BiomassAllocation.calc_biomass_accumulation(factor, gmax)
     expect_end = start + expect_growth
 
-    assert bioal.previous_biomass == start
-    assert bioal.biomass == expect_end
-    assert bioal.biomass_growth == expect_growth
+    assert data.previous_biomass == start
+    assert data.biomass == expect_end
+    assert data.biomass_growth == expect_growth
 
 
 @pytest.mark.parametrize("light,ext,conv,gfact,rfrac", [
@@ -149,23 +152,24 @@ def test_accumulate_biomass(start, factor, gmax):
 ])
 def test_allocate_biomass(light, ext, conv, gfact, rfrac):
     """integration check to check that biomass gets allocated correctly"""
-    bioal = init_bioal(light_extinction=ext, leaf_area_index=1.87, light_conversion=conv, growth_factor=gfact,
-                       root_fraction=rfrac, biomass=89.0)
+    data = CropData(light_extinction=ext, leaf_area_index=1.87, light_conversion=conv, growth_factor=gfact,
+                    root_fraction=rfrac, biomass=89.0)
+    bioal = BiomassAllocation(data)
     bioal.allocate_biomass(light)
 
     # photosynthesize
-    energy = calc_intercepted_radiation(light, ext, lai=1.87)
-    max_growth = calc_max_accumulation(energy, conv)
-    growth = calc_biomass_accumulation(gfact, max_growth)
+    energy = BiomassAllocation.calc_intercepted_radiation(light, ext, lai=1.87)
+    max_growth = BiomassAllocation.calc_max_accumulation(energy, conv)
+    growth = BiomassAllocation.calc_biomass_accumulation(gfact, max_growth)
     mass = 89.0 + growth
     # partition_biomass
-    green = calc_above_ground_biomass(rfrac, mass)
-    root = calc_below_ground_biomass(rfrac, mass)
+    green = BiomassAllocation.calc_above_ground_biomass(rfrac, mass)
+    root = BiomassAllocation.calc_below_ground_biomass(rfrac, mass)
 
-    assert bioal.usable_light == energy
-    assert bioal.biomass_growth_max == max_growth
-    assert bioal.previous_biomass == 89.0
-    assert bioal.biomass_growth == growth
-    assert bioal.biomass == mass
-    assert bioal.green_biomass == green
-    assert bioal.root_biomass == root
+    assert data.usable_light == energy
+    assert data.biomass_growth_max == max_growth
+    assert data.previous_biomass == 89.0
+    assert data.biomass_growth == growth
+    assert data.biomass == mass
+    assert data.above_ground_biomass == green
+    assert data.root_biomass == root

--- a/SC_redesign/Crop_and_Soil/tests_SC/test_heat_units.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/test_heat_units.py
@@ -156,23 +156,23 @@ def test_absorb_heat_units(mean, mint, maxt, use_heat_unit_temp):
         expect_heat_unit_temp = (expect_min_heat_unit_temp / 2) + (expect_max_heat_unit_temp / 2)
         assert expect_heat_unit_temp == data.heat_unit_temperature
 
-    # if use_heat_unit_temp or mean is None:
-    #     use_temp = expect_heat_unit_temp
-    # else:
-    #     use_temp = mean
-    #
-    # if 20 <= use_temp <= 38:
-    #     expect_is_growing = True
-    # else:
-    #     expect_is_growing = False
-    # assert expect_is_growing == data.is_growing
-    #
-    # if use_heat_unit_temp or (mean is None):
-    #     expect_new_heat_units = HeatUnits._determine_new_heat_units(expect_heat_unit_temp, 20)
-    # else:
-    #     expect_new_heat_units = HeatUnits._determine_new_heat_units(mean, 20)
-    # assert data.use_heat_unit_temperature == use_heat_unit_temp
-    # assert expect_new_heat_units == data.accumulated_heat_units
-    # assert data.previous_heat_fraction is None
-    # expect_heat_fraction = expect_new_heat_units / 800
-    # assert expect_heat_fraction == data.heat_fraction
+    if use_heat_unit_temp or mean is None:
+        use_temp = expect_heat_unit_temp
+    else:
+        use_temp = mean
+
+    if 20 <= use_temp <= 38:
+        expect_is_growing = True
+    else:
+        expect_is_growing = False
+    assert expect_is_growing == data.is_growing
+
+    if use_heat_unit_temp or (mean is None):
+        expect_new_heat_units = HeatUnits._determine_new_heat_units(expect_heat_unit_temp, 20)
+    else:
+        expect_new_heat_units = HeatUnits._determine_new_heat_units(mean, 20)
+    assert data.use_heat_unit_temperature == use_heat_unit_temp
+    assert expect_new_heat_units == data.accumulated_heat_units
+    assert data.previous_heat_fraction is None
+    expect_heat_fraction = expect_new_heat_units / 800
+    assert expect_heat_fraction == data.heat_fraction

--- a/SC_redesign/Crop_and_Soil/tests_SC/test_heat_units.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/test_heat_units.py
@@ -70,7 +70,8 @@ def init_heat(**kwargs):
 ])
 def test_check_absorb_heat_for_input_errors(use_alt, meant, min_t, max_t):
     """check that errors are thrown when improper input is given, using _check_absorb_heat_for_input_errors"""
-    heat = init_heat(use_heat_unit_temperature=use_alt)
+    data = CropData(use_heat_unit_temperature=use_alt)
+    heat = HeatUnits(data)
     with pytest.raises(ValueError):
         heat._check_absorb_heat_for_input_errors(meant, min_t, max_t)
 
@@ -85,7 +86,7 @@ def test_accumulate_heat_units(temp, mocker: MockerFixture):
     heat.accumulate_heat_units(temp)
     expect.assign_new_heat_units(temp)
     expect.add_heat_units()
-    assert heat.accumulated_heat_units == expect.accumulated_heat_units
+    assert heat.data.accumulated_heat_units == expect.data.accumulated_heat_units
     assert patch_a.assert_called_once
     assert patch_b.assert_called_once
 
@@ -102,13 +103,14 @@ def test_accumulate_heat_units(temp, mocker: MockerFixture):
 ])
 def test_assign_new_heat_units(use_alt, temp):
     """check that assign_new_heat_units properly assigns heat units"""
-    heat = init_heat(use_heat_unit_temperature=use_alt, heat_unit_temperature=25,
-                     minimum_temperature=15)
+    data = CropData(use_heat_unit_temperature=use_alt, heat_unit_temperature=25,
+                    minimum_temperature=15)
+    heat = HeatUnits(data)
     heat.assign_new_heat_units(temp)
     if use_alt or (temp is None):
-        assert heat.new_heat_units == HeatUnits._determine_new_heat_units(25, 15)
+        assert data.new_heat_units == HeatUnits._determine_new_heat_units(25, 15)
     else:
-        assert heat.new_heat_units == HeatUnits._determine_new_heat_units(temp, 15)
+        assert data.new_heat_units == HeatUnits._determine_new_heat_units(temp, 15)
 
 
 @pytest.mark.parametrize("start,new", [
@@ -120,12 +122,13 @@ def test_assign_new_heat_units(use_alt, temp):
 ])
 def test_add_heat_units(start, new):
     """check that heat units are accumulated properly"""
-    heat = init_heat(accumulated_heat_units=start, new_heat_units=new)
+    data = CropData(accumulated_heat_units=start, new_heat_units=new)
+    heat = HeatUnits(data)
     heat.add_heat_units()
-    assert heat.accumulated_heat_units == start + new
+    assert data.accumulated_heat_units == start + new
 
 
-@pytest.mark.parametrize("mean,min,max,use_heat_unit_temp", [
+@pytest.mark.parametrize("mean,mint,maxt,use_heat_unit_temp", [
     (25, 21, 28, True),
     (25, 21, 28, False),
     (None, 21, 28, True),
@@ -138,36 +141,38 @@ def test_add_heat_units(start, new):
     (None, 18, 13, True),   # Min greater than max
     (26, 18, 14, False)     # Same as above
 ])
-def test_absorb_heat_units(mean, min, max, use_heat_unit_temp):
-    heat = init_heat(use_heat_unit_temperature=use_heat_unit_temp)
-    heat.absorb_heat_units(mean, min, max)
-    assert heat.use_heat_unit_temperature == use_heat_unit_temp
+def test_absorb_heat_units(mean, mint, maxt, use_heat_unit_temp):
+    data = CropData(use_heat_unit_temperature=use_heat_unit_temp, maximum_temperature=38, minimum_temperature=20)
+    heat = HeatUnits(data)
+    heat.absorb_heat_units(mean, mint, maxt)
+    assert data.use_heat_unit_temperature == use_heat_unit_temp
 
+    expect_heat_unit_temp = None  # declaration
     if use_heat_unit_temp:
-        expect_max_heat_unit_temp = HeatUnits._determine_maximum_heat_unit_temperature(max, 38)
-        assert expect_max_heat_unit_temp == heat.maximum_heat_unit_temperature
-        expect_min_heat_unit_temp = HeatUnits._determine_minimum_heat_unit_temperature(min, 20)
-        assert expect_min_heat_unit_temp == heat.minimum_heat_unit_temperature
+        expect_max_heat_unit_temp = HeatUnits._determine_maximum_heat_unit_temperature(maxt, 38)
+        assert expect_max_heat_unit_temp == data.maximum_heat_unit_temperature
+        expect_min_heat_unit_temp = HeatUnits._determine_minimum_heat_unit_temperature(mint, 20)  #x
+        assert expect_min_heat_unit_temp == data.minimum_heat_unit_temperature
         expect_heat_unit_temp = (expect_min_heat_unit_temp / 2) + (expect_max_heat_unit_temp / 2)
-        assert expect_heat_unit_temp == heat.heat_unit_temperature
+        assert expect_heat_unit_temp == data.heat_unit_temperature
 
-    if use_heat_unit_temp or mean is None:
-        use_temp = expect_heat_unit_temp
-    else:
-        use_temp = mean
-
-    if 20 <= use_temp <= 38:
-        expect_is_growing = True
-    else:
-        expect_is_growing = False
-    assert expect_is_growing == heat.is_growing
-
-    if use_heat_unit_temp or (mean is None):
-        expect_new_heat_units = HeatUnits._determine_new_heat_units(expect_heat_unit_temp, 20)
-    else:
-        expect_new_heat_units = HeatUnits._determine_new_heat_units(mean, 20)
-    assert heat.use_heat_unit_temperature == use_heat_unit_temp
-    assert expect_new_heat_units == heat.accumulated_heat_units
-    assert heat.previous_heat_fraction is None
-    expect_heat_fraction = expect_new_heat_units / 800
-    assert expect_heat_fraction == heat.heat_fraction
+    # if use_heat_unit_temp or mean is None:
+    #     use_temp = expect_heat_unit_temp
+    # else:
+    #     use_temp = mean
+    #
+    # if 20 <= use_temp <= 38:
+    #     expect_is_growing = True
+    # else:
+    #     expect_is_growing = False
+    # assert expect_is_growing == data.is_growing
+    #
+    # if use_heat_unit_temp or (mean is None):
+    #     expect_new_heat_units = HeatUnits._determine_new_heat_units(expect_heat_unit_temp, 20)
+    # else:
+    #     expect_new_heat_units = HeatUnits._determine_new_heat_units(mean, 20)
+    # assert data.use_heat_unit_temperature == use_heat_unit_temp
+    # assert expect_new_heat_units == data.accumulated_heat_units
+    # assert data.previous_heat_fraction is None
+    # expect_heat_fraction = expect_new_heat_units / 800
+    # assert expect_heat_fraction == data.heat_fraction

--- a/SC_redesign/Crop_and_Soil/tests_SC/test_leaf_area_index.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/test_leaf_area_index.py
@@ -192,7 +192,7 @@ def test_grow_canopy(heatfrac):
     if heatfrac <= 0.9:  # normal growth
         assert data.is_in_senescence is False
         max_change = LeafAreaIndex._determine_max_leaf_area_change(optimal_lai, 0.01, 3.0, 0.1)
-        assert data.max_leaf_area_change == max_change
+        assert data.optimal_leaf_area_change == max_change
         added = max_change*sqrt(0.95)
         if max_change < added:  # when heatfrac = 0, no growth occurs
             added = max_change

--- a/SC_redesign/Crop_and_Soil/tests_SC/test_leaf_area_index.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/test_leaf_area_index.py
@@ -176,29 +176,30 @@ def init_lai(**kwargs):
 def test_grow_canopy(heatfrac):
     """integration test for leaf area processes via grow_canopy()"""
     # observe
-    lai = init_lai(heat_fraction=heatfrac, leaf_area_index=0.7,
-                   first_heat_fraction_point=0.2, second_heat_fraction_point=0.33, first_leaf_fraction_point=0.05,
-                   second_leaf_fraction_point=0.95, max_canopy_height=2.5, growth_factor=0.95, max_leaf_area_index=3.0,
-                   senescent_heat_fraction=0.9, previous_leaf_area_index=0.1, previous_optimal_leaf_area_fraction=0.01)
+    data = CropData(heat_fraction=heatfrac, leaf_area_index=0.7,
+                    first_heat_fraction_point=0.2, second_heat_fraction_point=0.33, first_leaf_fraction_point=0.05,
+                    second_leaf_fraction_point=0.95, max_canopy_height=2.5, growth_factor=0.95, max_leaf_area_index=3.0,
+                    senescent_heat_fraction=0.9, previous_leaf_area_index=0.1, previous_optimal_leaf_area_fraction=0.01)
+    lai = LeafAreaIndex(data)
     lai.grow_canopy()
     # expect
     shapes = LeafAreaIndex._determine_lai_shapes(0.2, 0.33, 0.05, 0.95)
-    assert lai._lai_shapes == shapes
+    assert data._lai_shapes == shapes
     optimal_lai = LeafAreaIndex._determine_optimal_leaf_area_fraction(heatfrac, shapes[0], shapes[1])
-    assert lai.optimal_leaf_area_fraction == optimal_lai
-    assert lai.canopy_height == LeafAreaIndex.determine_canopy_height(lai.max_canopy_height,
-                                                                      lai.optimal_leaf_area_fraction)
+    assert data.optimal_leaf_area_fraction == optimal_lai
+    assert data.canopy_height == LeafAreaIndex.determine_canopy_height(data.max_canopy_height,
+                                                                       data.optimal_leaf_area_fraction)
     if heatfrac <= 0.9:  # normal growth
-        assert lai.is_in_senescence is False
+        assert data.is_in_senescence is False
         max_change = LeafAreaIndex._determine_max_leaf_area_change(optimal_lai, 0.01, 3.0, 0.1)
-        assert lai.max_leaf_area_change == max_change
+        assert data.max_leaf_area_change == max_change
         added = max_change*sqrt(0.95)
         if max_change < added:  # when heatfrac = 0, no growth occurs
             added = max_change
-        assert lai.leaf_area_added == added
-        assert lai.leaf_area_index == 0.1 + added
-        assert lai.previous_leaf_area_index == lai.leaf_area_index
-        assert lai.previous_optimal_leaf_area_fraction == optimal_lai
+        assert data.leaf_area_added == added
+        assert data.leaf_area_index == 0.1 + added
+        assert data.previous_leaf_area_index == data.leaf_area_index
+        assert data.previous_optimal_leaf_area_fraction == optimal_lai
     else:  # senescence
-        assert lai.is_in_senescence is True
-        assert lai.leaf_area_index == LeafAreaIndex._determine_senescent_leaf_area_index(heatfrac, 0.9, optimal_lai)
+        assert data.is_in_senescence is True
+        assert data.leaf_area_index == LeafAreaIndex._determine_senescent_leaf_area_index(heatfrac, 0.9, optimal_lai)


### PR DESCRIPTION
## Summary
This PR will restructure, and document the `LeafAreaIndex` and `HeatUnits` class. It addresses the following tasks:
* [x] switch `LeafAreaIndex` to composition design
* [x] update `LeafAreaIndex` docstrings
* [x] switch `HeatUnits` to composition design
* [x] update `HeatUnits` docstrings

## Notes:
This PR also contains changes that are in #274, so `biomass_allocation.py` and `test_biomass_allocation.py` can be ignored.