### PR TITLE
Info map objects fix

### DIFF
--- a/RUFAS/classes.py
+++ b/RUFAS/classes.py
@@ -88,8 +88,8 @@ class Config:
         """
 
         info_map = {"class": self.__class__.__name__,
-                    "function": self.__init__.__name__, 
-                    "data": data, 
+                    "function": self.__init__.__name__,
+                    "config_data": data,
                     "weather_file_path": weather_file, }
 
         # gets a start/end date in the format year:julian-day. That way the program

--- a/RUFAS/classes.py
+++ b/RUFAS/classes.py
@@ -88,8 +88,8 @@ class Config:
         """
 
         info_map = {"class": self.__class__.__name__,
-                    "function": self.__init__.__name__,
-                    "data": data,
+                    "function": self.__init__.__name__, 
+                    "data": data, 
                     "weather_file_path": weather_file, }
 
         # gets a start/end date in the format year:julian-day. That way the program

--- a/RUFAS/classes.py
+++ b/RUFAS/classes.py
@@ -333,8 +333,7 @@ class Weather:
 
         info_map = {"class": self.__class__.__name__,
                     "function": self.__init__.__name__,
-                    "weather_file": weather_file,
-                    "config": config, }
+                    "weather_file": weather_file, }
 
         years = config.years
         w_start_year = config.w_start_year

--- a/RUFAS/output_handler/output_handler.py
+++ b/RUFAS/output_handler/output_handler.py
@@ -86,7 +86,7 @@ class OutputHandler:
         """Transfer needed (initial) data from state to report handlers."""
 
         info_map = {"class": self.__class__.__name__, 
-                    "function": self.initialize_reports.__name__,}
+                    "function": self.initialize_reports.__name__, }
 
         for report_name in self.reports:
             report = self.reports[report_name]

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -1,6 +1,7 @@
 # !/usr/bin/env python3
 
 from typing import Any, Dict, List, Union
+import json
 import os
 import time
 
@@ -242,7 +243,7 @@ class OutputManager (object):
         """Saves a dictionary into a JSON file"""
         try:
             with open(path, 'w') as json_file:
-                json_file.write(str(dict))
+                json_file.write(json.dumps(dict))
         except Exception as e:
             raise e
 

--- a/RUFAS/routines/animal/animal_management.py
+++ b/RUFAS/routines/animal/animal_management.py
@@ -239,9 +239,7 @@ class AnimalManagement:
 
         info_map = {
             "class": self.__class__.__name__,
-            "function": self._print_animal_num_warnings.__name__,
-            "herd_data": herd_data
-        }
+            "function": self._print_animal_num_warnings.__name__, }
 
         counter = 0
 

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -384,9 +384,7 @@ class Pen:
                 ration[key] = ration_per_animal[key] * num_animals
         
         info_map = {"class": self.__class__.__name__,
-                    "function": self.calc_ration.__name__, 
-                    "feed": feed, 
-                    "available_feeds": available_feeds, }
+                    "function": self.calc_ration.__name__, }
         om.add_variable("pen_ration_data", self.ration, info_map)
 
         return ration
@@ -449,8 +447,7 @@ class Pen:
         self.dry_total = dry_total
         self.lactating_total = lactating_total
         info_map = {"class": self.__class__.__name__,
-                    "function": self.calc_manure.__name__, 
-                    "feed": feed, }
+                    "function": self.calc_manure.__name__, }
         om.add_variable("pen_manure_data", self.manure, info_map)
 
     def _copy_manure_template(self):

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -385,7 +385,7 @@ class Pen:
         
         info_map = {"class": self.__class__.__name__,
                     "function": self.calc_ration.__name__, }
-        om.add_variable("pen_ration_data", self.ration, info_map)
+        om.add_variable("pen_ration_data", ration, info_map)
 
         return ration
 

--- a/RUFAS/routines/animal/ration/pyomo_solver.py
+++ b/RUFAS/routines/animal/ration/pyomo_solver.py
@@ -165,7 +165,7 @@ def create_model(feeds_data, req_data, feeds):
                 "function": create_model.__name__,
                 "feeds_data": feeds_data,
                 "req_data": req_data,
-                "feeds": feeds,}
+                "feeds": feeds, }
 
     # TODO update "m1" variable to a more descriptive name.
     om.add_variable("m1", m1, info_map)  

--- a/RUFAS/routines/animal/ration/pyomo_solver.py
+++ b/RUFAS/routines/animal/ration/pyomo_solver.py
@@ -161,14 +161,8 @@ def create_model(feeds_data, req_data, feeds):
     m1 = model.create_instance(data)
     results = pyo.SolverFactory('APOPT').solve(m1)
 
-    info_map = {"class": "no_caller_class",
-                "function": create_model.__name__,
-                "feeds_data": feeds_data,
-                "req_data": req_data,
-                "feeds": feeds, }
-
     # TODO update "m1" variable to a more descriptive name.
-    om.add_variable("m1", m1, info_map)  
+    
     
     # for i,j in m1.feed*m1.nrg:
     #     print(i, j, m1.x[i,j]())

--- a/RUFAS/routines/field/crop/crop.py
+++ b/RUFAS/routines/field/crop/crop.py
@@ -37,12 +37,7 @@ def daily_crop_routine(soil, crop, field_management, weather, time):
     daily_reset(crop_type, soil)
 
     info_map = {"class": "no_caller_class",
-                "function": daily_crop_routine.__name__,
-                "soil": soil,
-                "crop": crop,
-                "field_management": field_management,
-                "weather": weather,
-                "time": time, }
+                "function": daily_crop_routine.__name__, }
 
     # If there is no crop in rotation this year, current crop will be named
     # 'null'. The routine is skipped in this case
@@ -241,9 +236,7 @@ class Crop:
         """
 
         info_map = {"class": self.__class__.__name__,
-                    "function": self.__init__.__name__,
-                    "data": data,
-                    "time": time, }
+                    "function": self.__init__.__name__, }
 
         self.crops_list = []
         self.crops_data = data['crops']
@@ -300,8 +293,7 @@ class Crop:
         """
 
         info_map = {"class": self.__class__.__name__,
-                    "function": self.set_grow_regimen.__name__,
-                    "time": time, }
+                    "function": self.set_grow_regimen.__name__, }
 
         for crop_type in self.crops_list:
             for year in crop_type.plant_years:

--- a/RUFAS/routines/field/crop/crop_types/tall_fescue.py
+++ b/RUFAS/routines/field/crop/crop_types/tall_fescue.py
@@ -18,8 +18,7 @@ class TallFescue(BaseCrop):
 
         info_map = {"class": self.__class__.__name__,
                     "function": self.__init__.__name__,
-                    "crop_name": crop_name,
-                    "data": data, }
+                    "crop_name": crop_name, }
 
         if tall_fescue_data['harvest_type'] != 'optimal':
             harvest_type_warning = "Perennial crops are always optimally harvested"

--- a/RUFAS/routines/manure/manure_handlers/manure_handler_classes.py
+++ b/RUFAS/routines/manure/manure_handlers/manure_handler_classes.py
@@ -59,11 +59,7 @@ class BaseManureHandler:
 
         """
         info_map = {"class": self.__class__.__name__,
-                    "function": self.__init__.__name__,
-                    "weather": vars(weather),
-                    "time": vars(time),
-                    "config": vars(manure_handler_config),
-                    }
+                    "function": self.__init__.__name__, }
 
         self.weather = weather
         self.time = time
@@ -109,9 +105,7 @@ class BaseManureHandler:
         """
         info_map = {"class": self.__class__.__name__,
                     "function": self.daily_update.__name__,
-                    "bedding": vars(bedding),
-                    "sim_day": sim_day
-                    }
+                    "sim_day": sim_day, }
 
         NH3_housing_emission = GasEmissions.calc_ammonia_emission(
             num_animals=pen.num_animals,

--- a/RUFAS/routines/manure/manure_handlers/milking_parlor.py
+++ b/RUFAS/routines/manure/manure_handlers/milking_parlor.py
@@ -244,7 +244,7 @@ class MilkingParlor:
         """
         info_map = {"class": self.__class__.__name__,
                     "function": self.calc_manure_mass_deposited_in_milking_parlor.__name__,
-                    "num_cows": num_cows, "manure_mass": manure_mass}
+                    "num_cows": num_cows, "manure_mass": manure_mass, }
 
         manure_mass_deposited_in_milking_parlor = (manure_mass *
                                                    self.total_fraction_of_day_spent_in_milking_parlor) if num_cows > 0 else 0.0
@@ -267,7 +267,7 @@ class MilkingParlor:
         """
         info_map = {"class": self.__class__.__name__,
                     "function": self.calc_manure_volume_deposited_in_milking_parlor.__name__,
-                    "manure_mass": manure_mass}
+                    "manure_mass": manure_mass, }
 
         manure_volume_deposited_in_milking_parlor = self.calc_manure_mass_deposited_in_milking_parlor(
             num_cows, manure_mass) / ManureConstants.MANURE_DENSITY
@@ -290,7 +290,7 @@ class MilkingParlor:
         """
         info_map = {"class": cls.__name__,
                     "function": cls._calc_fraction_of_day_from_minutes.__name__,
-                    "minutes": minutes}
+                    "minutes": minutes, }
 
         minutes_in_a_day = 60.0 * 24.0
         minutes_of_a_day_frac = minutes / minutes_in_a_day

--- a/RUFAS/routines/manure/reception_pits/reception_pit.py
+++ b/RUFAS/routines/manure/reception_pits/reception_pit.py
@@ -32,11 +32,7 @@ class ReceptionPit:
 
         """
         info_map = {"class": cls.__name__,
-                    "function": cls.daily_update.__name__,
-                    "manure_handler_daily_output": vars(manure_handler_daily_output),
-                    "pen": vars(pen),
-                    "bedding": vars(bedding),
-                    }
+                    "function": cls.daily_update.__name__, }
 
         mh = manure_handler_daily_output
         daily_output = ReceptionPitDailyOutput(

--- a/RUFAS/simulation_engine.py
+++ b/RUFAS/simulation_engine.py
@@ -164,12 +164,7 @@ class SimulationEngine:
             InvalidJSONFile: If the json file at the given path does not conform 
             with the format required
         """
-        info_map = {"class": self.__class__.__name__,
-                    "function": self._initialize_simulation.__name__,
-                    "file_path": file_path, }
         print(f"Initializing simulation environment from {file_path}")
-        om.add_variable("simulation_initialization_file_path",
-                        file_path, info_map)
 
         try:
             data = Utility.read_json_file(file_path)

--- a/tests/test_animal_management.py
+++ b/tests/test_animal_management.py
@@ -228,7 +228,6 @@ def test_print_animal_num_warnings(animal_management: AnimalManagement, mocker: 
         expected_info_map = {
             "class": "AnimalManagement",
             "function": "_print_animal_num_warnings",
-            "herd_data": herd_data
         }
 
         # test for simulate_animals = True


### PR DESCRIPTION
**What:**
This PR seeks to address an issue in the Output Manager (OM) converting the the info_map and data collected by the OM throughout a simulation run into a JSON object using the json.dumps() method. 

**Why:**
Certain data types including object instances and file paths are not "serializable" by the json library method dumps().

**How:**
These object instances and file paths need to be removed from info_maps and not added as variables.
