### PR TITLE
Refactor decomposition.py

### DIFF
--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
@@ -1,7 +1,8 @@
 import math
-from typing import Optional
+from typing import Optional, List
 
 from SC_redesign.Crop_and_Soil.soil import soil_data
+from SC_redesign.Crop_and_Soil.soil.layer_data import LayerData
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 
 
@@ -16,16 +17,14 @@ class Decomposition:
             "pseudocode_soil" S.6.A
         Args:
             temp_average:
-            soil: an instance of the Soil class defined in soil.py
-            weather: an instance of the Weather class defined in classes.py
-            time: an instance of the Time class defined in classes.py
-        """
-        self.data.decomposition_temperature_effect = self.calc_temp_factor(temp_average)
 
-        #self.data.decomposition_moisture_effect = self.moisture_factor(soil)
+        """
+        self.data.decomposition_temperature_effect = self._calc_temp_factor(temp_average)
+
+        self.data.decomposition_moisture_effect = self.moisture_factor(self.data.soil_layers)
 
     @staticmethod
-    def calc_temp_factor(temp_average: float) -> float:
+    def _calc_temp_factor(temp_average: float) -> float:
         """
         Description: calculates the Temperature factor for carbon decomposition
             "pseudocode_soil" S.6.A.1
@@ -44,14 +43,14 @@ class Decomposition:
                    (decomposition_inflection_y + (max_min_distance / math.pi) * math.atan(math.pi * inflection_slope * (
                            temp_average - decomposition_inflection_x))) / normalizer)
 
-    #@staticmethod
-    def calc_moisture_factor(self) -> float:
+    @staticmethod
+    def _calc_moisture_factor(soil_layers: List[LayerData]) -> float:
         """
         Description: calculates the moisture factor for carbon decomposition
             "pseudocode_soil" S.6.A.2
             defaults drawn from defac: course soil
         Args:
-            soil
+            soil_layers:
         """
         dimensionless_empirical_factor_a = 0.55
         dimensionless_empirical_factor_b = 1.7
@@ -59,7 +58,7 @@ class Decomposition:
         dimensionless_empirical_factor_e1 = 6.648115
         dimensionless_empirical_factor_e2 = 3.22
 
-        for layer in self.data.soil_layers:
+        for layer in soil_layers:
             # S.6.A.5
             base_1 = (layer.water_fac - dimensionless_empirical_factor_b) / (dimensionless_empirical_factor_a -
                                                                              dimensionless_empirical_factor_b)

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
@@ -5,7 +5,10 @@ from SC_redesign.Crop_and_Soil.soil import soil_data
 from SC_redesign.Crop_and_Soil.soil.layer_data import LayerData
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 
-
+# TODO: the equations for this model, referenced in the soil psuedocode, are derived from the excel file
+#   located on basecamp: https://3.basecamp.com/3486446/buckets/5296287/vaults/2740532358
+#   but the meaning (and validity) of the terms is extremely unclear from either source. The 
+#   documentation cannot be adequately completed without a better understanding of these methods.
 class Decomposition:
     def __init__(self, soil_data: Optional[SoilData] = None):
         self.data = soil_data or SoilData()  # initialize with defaults, if not given

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
@@ -10,7 +10,7 @@ class Decomposition:
     def __init__(self, soil_data: Optional[SoilData] = None):
         self.data = soil_data or SoilData()  # initialize with defaults, if not given
 
-    def decomposite(self, temp_average: float) -> None:
+    def decompose(self, temp_average: float) -> None:
         """
         Description: calculates temperature and moisture decomposition factors for
             Carbon based on weather and soil profile.
@@ -21,7 +21,7 @@ class Decomposition:
         """
         self.data.decomposition_temperature_effect = self._calc_temp_factor(temp_average)
 
-        self.data.decomposition_moisture_effect = self.moisture_factor(self.data.soil_layers)
+        self.data.decomposition_moisture_effect = self._calc_moisture_factor(self.data.soil_layers)
 
     @staticmethod
     def _calc_temp_factor(temp_average: float) -> float:

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
@@ -9,17 +9,18 @@ class Decomposition:
     def __init__(self, soil_data: Optional[SoilData] = None):
         self.data = soil_data or SoilData()  # initialize with defaults, if not given
 
-    def decomposite(self, soil, weather, time):
+    def decomposite(self, temp_average: float) -> None:
         """
         Description: calculates temperature and moisture decomposition factors for
             Carbon based on weather and soil profile.
             "pseudocode_soil" S.6.A
         Args:
+            temp_average:
             soil: an instance of the Soil class defined in soil.py
             weather: an instance of the Weather class defined in classes.py
             time: an instance of the Time class defined in classes.py
         """
-        self.data.decomposition_temperature_effect = self.temp_factor(soil, weather, time)
+        self.data.decomposition_temperature_effect = self.temp_factor(temp_average)
 
         self.data.decomposition_moisture_effect = self.moisture_factor(soil)
 
@@ -44,7 +45,7 @@ class Decomposition:
                            temp_average - decomposition_inflection_x))) / normalizer)
 
     @staticmethod
-    def moisture_factor(soil) -> float:
+    def calc_moisture_factor(soil) -> float:
         """
         Description: calculates the moisture factor for carbon decomposition
             "pseudocode_soil" S.6.A.2

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
@@ -60,10 +60,10 @@ class Decomposition:
 
         for layer in soil_layers:
             # S.6.A.5
-            base_1 = (layer.water_fac - dimensionless_empirical_factor_b) / (dimensionless_empirical_factor_a -
-                                                                             dimensionless_empirical_factor_b)
-            base_2 = (layer.water_fac - dimensionless_empirical_factor_c) / (dimensionless_empirical_factor_a -
-                                                                             dimensionless_empirical_factor_c)
+            base_1 = (layer.water_factor - dimensionless_empirical_factor_b) / (dimensionless_empirical_factor_a -
+                                                                                dimensionless_empirical_factor_b)
+            base_2 = (layer.water_factor - dimensionless_empirical_factor_c) / (dimensionless_empirical_factor_a -
+                                                                                dimensionless_empirical_factor_c)
             hold = (base_1 ** dimensionless_empirical_factor_e1) * (base_2 ** dimensionless_empirical_factor_e2)
 
         return hold

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
@@ -38,9 +38,9 @@ class Decomposition:
             "pseudocode_soil" S.6.A.1
             defaults drawn from defac: course soil
         Args:
-            temp_average: Average temperature (unitless)
+            temp_average: Average temperature (celsius)
 
-        Returns: temperature effect
+        Returns: temperature effect (unitless)
         """
         # S.6.A.4
         return (y_inflection + (point_distance / math.pi) * math.atan(math.pi * inflection_slope * (
@@ -55,7 +55,7 @@ class Decomposition:
             "pseudocode_soil" S.6.A.2
             defaults drawn from defac: course soil
         Args:
-            soil_layers: Layer data
+            water_factor: relative water saturation (%)
         Returns: moisture effect (unitless)
         """
         # S.6.A.5

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
@@ -20,9 +20,9 @@ class Decomposition:
             weather: an instance of the Weather class defined in classes.py
             time: an instance of the Time class defined in classes.py
         """
-        self.data.decomposition_temperature_effect = self.temp_factor(temp_average)
+        self.data.decomposition_temperature_effect = self.calc_temp_factor(temp_average)
 
-        self.data.decomposition_moisture_effect = self.moisture_factor(soil)
+        #self.data.decomposition_moisture_effect = self.moisture_factor(soil)
 
     @staticmethod
     def calc_temp_factor(temp_average: float) -> float:
@@ -31,7 +31,7 @@ class Decomposition:
             "pseudocode_soil" S.6.A.1
             defaults drawn from defac: course soil
         Args:
-            temp_average:
+            temp_average: Average temperature
         """
         decomposition_inflection_x = 15.400
         decomposition_inflection_y = 11.750
@@ -44,8 +44,8 @@ class Decomposition:
                    (decomposition_inflection_y + (max_min_distance / math.pi) * math.atan(math.pi * inflection_slope * (
                            temp_average - decomposition_inflection_x))) / normalizer)
 
-    @staticmethod
-    def calc_moisture_factor(soil) -> float:
+    #@staticmethod
+    def calc_moisture_factor(self) -> float:
         """
         Description: calculates the moisture factor for carbon decomposition
             "pseudocode_soil" S.6.A.2
@@ -53,16 +53,18 @@ class Decomposition:
         Args:
             soil
         """
-        a = 0.55
-        b = 1.7
-        c = -0.007
-        e1 = 6.648115
-        e2 = 3.22
+        dimensionless_empirical_factor_a = 0.55
+        dimensionless_empirical_factor_b = 1.7
+        dimensionless_empirical_factor_c = -0.007
+        dimensionless_empirical_factor_e1 = 6.648115
+        dimensionless_empirical_factor_e2 = 3.22
 
-        for layer in soil.soil_layers:
+        for layer in self.data.soil_layers:
             # S.6.A.5
-            base_1 = (layer.water_fac - b) / (a - b)
-            base_2 = (layer.water_fac - c) / (a - c)
-            hold = (base_1 ** e1) * (base_2 ** e2)
+            base_1 = (layer.water_fac - dimensionless_empirical_factor_b) / (dimensionless_empirical_factor_a -
+                                                                             dimensionless_empirical_factor_b)
+            base_2 = (layer.water_fac - dimensionless_empirical_factor_c) / (dimensionless_empirical_factor_a -
+                                                                             dimensionless_empirical_factor_c)
+            hold = (base_1 ** dimensionless_empirical_factor_e1) * (base_2 ** dimensionless_empirical_factor_e2)
 
         return hold

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
@@ -1,0 +1,58 @@
+import math
+
+
+def update_all(soil, weather, time):
+    """
+    Description: calculates temperature and moisture decomposition factors for
+        Carbon based on weather and soil profile.
+        "pseudocode_soil" S.6.A
+    Args:
+        soil: an instance of the Soil class defined in soil.py
+        weather: an instance of the Weather class defined in classes.py
+        time: an instance of the Time class defined in classes.py
+    """
+    temp_factor(soil, weather, time)
+
+    moisture_factor(soil)
+
+
+def temp_factor(soil, weather, time):
+    """
+    Description: calculates the Temperature factor for carbon decomposition
+        "pseudocode_soil" S.6.A.1
+        defaults drawn from defac: course soil
+    Args:
+        soil
+        weather
+        time
+    """
+    teff_1 = 15.400
+    teff_2 = 11.750
+    teff_3 = 29.700
+    teff_4 = 0.03
+    normalizer = 20.80546
+
+    # S.6.A.4
+    soil.T_d = max(0.0, (teff_2 + (teff_3 / math.pi) * math.atan(math.pi * teff_4 * (
+            weather.T_avg[time.year - 1][time.day - 1] - teff_1))) / normalizer)
+
+
+def moisture_factor(soil):
+    """
+    Description: calculates the moisture factor for carbon decomposition
+        "pseudocode_soil" S.6.A.2
+        defaults drawn from defac: course soil
+    Args:
+        soil
+    """
+    a = 0.55
+    b = 1.7
+    c = -0.007
+    e1 = 6.648115
+    e2 = 3.22
+
+    for layer in soil.soil_layers:
+        # S.6.A.5
+        base_1 = (layer.water_fac - b) / (a - b)
+        base_2 = (layer.water_fac - c) / (a - c)
+        layer.M_d = (base_1 ** e1) * (base_2 ** e2)

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
@@ -5,6 +5,7 @@ from SC_redesign.Crop_and_Soil.soil import soil_data
 from SC_redesign.Crop_and_Soil.soil.layer_data import LayerData
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 
+
 # TODO: the equations for this model, referenced in the soil psuedocode, are derived from the excel file
 #   located on basecamp: https://3.basecamp.com/3486446/buckets/5296287/vaults/2740532358
 #   but the meaning (and validity) of the terms is extremely unclear from either source. The 
@@ -25,7 +26,8 @@ class Decomposition:
         """
         self.data.decomposition_temperature_effect = self._calc_temp_factor(temp_average)
 
-        self.data.decomposition_moisture_effect = self._calc_moisture_factor(self.data.soil_layers)
+        for layer in self.data.soil_layers:
+            layer.decomposition_moisture_effect = self._calc_moisture_factor(layer.water_factor)
 
     @staticmethod
     def _calc_temp_factor(temp_average, x_inflection: float = 15.4, y_inflection: float = 11.75,
@@ -42,25 +44,22 @@ class Decomposition:
         """
         # S.6.A.4
         return (y_inflection + (point_distance / math.pi) * math.atan(math.pi * inflection_slope * (
-                                                                temp_average - x_inflection))) / normalizer
+                temp_average - x_inflection))) / normalizer
 
     @staticmethod
-    def _calc_moisture_factor(soil_layers: List[LayerData.water_factor], a_term: float = 0.55, b_term: float = 1.7,
+    def _calc_moisture_factor(water_factor, a_term: float = 0.55, b_term: float = 1.7,
                               c_term: float = -0.007, first_exponent=6.648115,
                               second_exponent=3.22) -> float:
         """
-        Description: calculates the moisture factor for carbon decomposition
+        Description: calculates the moisture factor for carbon decomposition for the layer
             "pseudocode_soil" S.6.A.2
             defaults drawn from defac: course soil
         Args:
             soil_layers: Layer data
         Returns: moisture effect (unitless)
         """
-        for layer in soil_layers:
-            # S.6.A.5
-            base_1 = (layer.water_factor - b_term) / (a_term -
-                                                      b_term)
-            base_2 = (layer.water_factor - c_term) / (a_term -
-                                                      c_term)
+        # S.6.A.5
+        base_1 = (water_factor - b_term) / (a_term - b_term)
+        base_2 = (water_factor - c_term) / (a_term - c_term)
 
         return (base_1 ** first_exponent) * (base_2 ** second_exponent)

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
@@ -1,58 +1,67 @@
 import math
+from typing import Optional
+
+from SC_redesign.Crop_and_Soil.soil import soil_data
+from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 
 
-def update_all(soil, weather, time):
-    """
-    Description: calculates temperature and moisture decomposition factors for
-        Carbon based on weather and soil profile.
-        "pseudocode_soil" S.6.A
-    Args:
-        soil: an instance of the Soil class defined in soil.py
-        weather: an instance of the Weather class defined in classes.py
-        time: an instance of the Time class defined in classes.py
-    """
-    temp_factor(soil, weather, time)
+class Decomposition:
+    def __init__(self, soil_data: Optional[SoilData] = None):
+        self.data = soil_data or SoilData()  # initialize with defaults, if not given
 
-    moisture_factor(soil)
+    def decomposite(self, soil, weather, time):
+        """
+        Description: calculates temperature and moisture decomposition factors for
+            Carbon based on weather and soil profile.
+            "pseudocode_soil" S.6.A
+        Args:
+            soil: an instance of the Soil class defined in soil.py
+            weather: an instance of the Weather class defined in classes.py
+            time: an instance of the Time class defined in classes.py
+        """
+        self.data.decomposition_temperature_effect = self.temp_factor(soil, weather, time)
 
+        self.data.decomposition_moisture_effect = self.moisture_factor(soil)
 
-def temp_factor(soil, weather, time):
-    """
-    Description: calculates the Temperature factor for carbon decomposition
-        "pseudocode_soil" S.6.A.1
-        defaults drawn from defac: course soil
-    Args:
-        soil
-        weather
-        time
-    """
-    teff_1 = 15.400
-    teff_2 = 11.750
-    teff_3 = 29.700
-    teff_4 = 0.03
-    normalizer = 20.80546
+    @staticmethod
+    def calc_temp_factor(temp_average: float) -> float:
+        """
+        Description: calculates the Temperature factor for carbon decomposition
+            "pseudocode_soil" S.6.A.1
+            defaults drawn from defac: course soil
+        Args:
+            temp_average:
+        """
+        decomposition_inflection_x = 15.400
+        decomposition_inflection_y = 11.750
+        max_min_distance = 29.700
+        inflection_slope = 0.03
+        normalizer = 20.80546
 
-    # S.6.A.4
-    soil.T_d = max(0.0, (teff_2 + (teff_3 / math.pi) * math.atan(math.pi * teff_4 * (
-            weather.T_avg[time.year - 1][time.day - 1] - teff_1))) / normalizer)
+        # S.6.A.4
+        return max(0.0,
+                   (decomposition_inflection_y + (max_min_distance / math.pi) * math.atan(math.pi * inflection_slope * (
+                           temp_average - decomposition_inflection_x))) / normalizer)
 
+    @staticmethod
+    def moisture_factor(soil) -> float:
+        """
+        Description: calculates the moisture factor for carbon decomposition
+            "pseudocode_soil" S.6.A.2
+            defaults drawn from defac: course soil
+        Args:
+            soil
+        """
+        a = 0.55
+        b = 1.7
+        c = -0.007
+        e1 = 6.648115
+        e2 = 3.22
 
-def moisture_factor(soil):
-    """
-    Description: calculates the moisture factor for carbon decomposition
-        "pseudocode_soil" S.6.A.2
-        defaults drawn from defac: course soil
-    Args:
-        soil
-    """
-    a = 0.55
-    b = 1.7
-    c = -0.007
-    e1 = 6.648115
-    e2 = 3.22
+        for layer in soil.soil_layers:
+            # S.6.A.5
+            base_1 = (layer.water_fac - b) / (a - b)
+            base_2 = (layer.water_fac - c) / (a - c)
+            hold = (base_1 ** e1) * (base_2 ** e2)
 
-    for layer in soil.soil_layers:
-        # S.6.A.5
-        base_1 = (layer.water_fac - b) / (a - b)
-        base_2 = (layer.water_fac - c) / (a - c)
-        layer.M_d = (base_1 ** e1) * (base_2 ** e2)
+        return hold

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
@@ -1,8 +1,5 @@
 import math
 from typing import Optional, List
-
-from SC_redesign.Crop_and_Soil.soil import soil_data
-from SC_redesign.Crop_and_Soil.soil.layer_data import LayerData
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 
 
@@ -16,10 +13,10 @@ class Decomposition:
 
     def decompose(self, temp_average: float) -> None:
         """
-        Description: Updates and tracks all the related attributes in SoilData class
+        Determines decomposition effect for each layers and temperature effect
 
         Args:
-            temp_average: Average temperature to pass in the _calc_temp_factor(temp_average) function
+            temp_average: Average temperature (Celsius)
 
         Returns: None
 

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
@@ -12,11 +12,12 @@ class Decomposition:
 
     def decompose(self, temp_average: float) -> None:
         """
-        Description: calculates temperature and moisture decomposition factors for
-            Carbon based on weather and soil profile.
-            "pseudocode_soil" S.6.A
+        Description: Updates and tracks all the related attributes in SoilData class
+
         Args:
-            temp_average:
+            temp_average: Average temperature to pass in the _calc_temp_factor(temp_average) function
+
+        Returns: None
 
         """
         self.data.decomposition_temperature_effect = self._calc_temp_factor(temp_average)
@@ -31,6 +32,8 @@ class Decomposition:
             defaults drawn from defac: course soil
         Args:
             temp_average: Average temperature
+
+        Returns: Unitless temperature effect
         """
         decomposition_inflection_x = 15.400
         decomposition_inflection_y = 11.750
@@ -50,7 +53,8 @@ class Decomposition:
             "pseudocode_soil" S.6.A.2
             defaults drawn from defac: course soil
         Args:
-            soil_layers:
+            soil_layers: Layer data
+        Returns: unitless moisture effect
         """
         dimensionless_empirical_factor_a = 0.55
         dimensionless_empirical_factor_b = 1.7

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/decomposition.py
@@ -28,49 +28,39 @@ class Decomposition:
         self.data.decomposition_moisture_effect = self._calc_moisture_factor(self.data.soil_layers)
 
     @staticmethod
-    def _calc_temp_factor(temp_average: float) -> float:
+    def _calc_temp_factor(temp_average, x_inflection: float = 15.4, y_inflection: float = 11.75,
+                          point_distance: float = 29.7, inflection_slope=0.03,
+                          normalizer=20.80546) -> float:
         """
         Description: calculates the Temperature factor for carbon decomposition
             "pseudocode_soil" S.6.A.1
             defaults drawn from defac: course soil
         Args:
-            temp_average: Average temperature
+            temp_average: Average temperature (unitless)
 
-        Returns: Unitless temperature effect
+        Returns: temperature effect
         """
-        decomposition_inflection_x = 15.400
-        decomposition_inflection_y = 11.750
-        max_min_distance = 29.700
-        inflection_slope = 0.03
-        normalizer = 20.80546
-
         # S.6.A.4
-        return max(0.0,
-                   (decomposition_inflection_y + (max_min_distance / math.pi) * math.atan(math.pi * inflection_slope * (
-                           temp_average - decomposition_inflection_x))) / normalizer)
+        return (y_inflection + (point_distance / math.pi) * math.atan(math.pi * inflection_slope * (
+                                                                temp_average - x_inflection))) / normalizer
 
     @staticmethod
-    def _calc_moisture_factor(soil_layers: List[LayerData]) -> float:
+    def _calc_moisture_factor(soil_layers: List[LayerData.water_factor], a_term: float = 0.55, b_term: float = 1.7,
+                              c_term: float = -0.007, first_exponent=6.648115,
+                              second_exponent=3.22) -> float:
         """
         Description: calculates the moisture factor for carbon decomposition
             "pseudocode_soil" S.6.A.2
             defaults drawn from defac: course soil
         Args:
             soil_layers: Layer data
-        Returns: unitless moisture effect
+        Returns: moisture effect (unitless)
         """
-        dimensionless_empirical_factor_a = 0.55
-        dimensionless_empirical_factor_b = 1.7
-        dimensionless_empirical_factor_c = -0.007
-        dimensionless_empirical_factor_e1 = 6.648115
-        dimensionless_empirical_factor_e2 = 3.22
-
         for layer in soil_layers:
             # S.6.A.5
-            base_1 = (layer.water_factor - dimensionless_empirical_factor_b) / (dimensionless_empirical_factor_a -
-                                                                                dimensionless_empirical_factor_b)
-            base_2 = (layer.water_factor - dimensionless_empirical_factor_c) / (dimensionless_empirical_factor_a -
-                                                                                dimensionless_empirical_factor_c)
-            hold = (base_1 ** dimensionless_empirical_factor_e1) * (base_2 ** dimensionless_empirical_factor_e2)
+            base_1 = (layer.water_factor - b_term) / (a_term -
+                                                      b_term)
+            base_2 = (layer.water_factor - c_term) / (a_term -
+                                                      c_term)
 
-        return hold
+        return (base_1 ** first_exponent) * (base_2 ** second_exponent)

--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -130,10 +130,5 @@ class LayerData:
             return (self.saturation_content - self.soil_water_content) / (
                     self.saturation_content - self.field_capacity_content)
 
-        TODO: remove this field from all the soil inputs, because the given values for OM_percent are not equal to value
-            that SWAT would calculate based on the percent organic carbon content
 
-        SWAT Reference: 4:1.1.4
-        """
-        return 1.72 * self.percent_organic_carbon_content
 

--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -50,3 +50,14 @@ class LayerData:
     def saturation_content(self):
         """volume of water in layer when saturated in mm"""
         return self.saturation_point_water_concentration / self.layer_thickness
+
+    @property
+    def water_factor(self):
+        """volume of water in layer when saturated in mm"""
+        if self.soil_water_content <= self.field_capacity_content:
+            return (self.soil_water_content - self.wilting_point_content)/(
+                    self.field_capacity_content - self.wilting_point_content)
+        else:
+            return (self.saturation_content - self.soil_water_content) / (
+                        self.saturation_content - self.field_capacity_content)
+

--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -53,7 +53,9 @@ class LayerData:
 
     @property
     def water_factor(self):
-        """volume of water in layer when saturated in mm"""
+        """relative water saturation (%)"""
+
+        # pseudocode_soil S.4.B.1
         if self.soil_water_content <= self.field_capacity_content:
             return (self.soil_water_content - self.wilting_point_content)/(
                     self.field_capacity_content - self.wilting_point_content)

--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -61,11 +61,6 @@ class LayerData:
     decomposition_moisture_effect: Optional[float] = None
     """moisture effect on decomposition factor (unitless) (pseudocode_soil S.6.A.2)"""
 
-    @property
-    def soil_water_content(self):
-        """volume of soil water in the layer in mm"""
-        return self.soil_water_concentration / self.layer_thickness
-
     def __post_init__(self):
         """Initialize all attributes in the dataclass that depend on other attributes"""
         self.water_content = self.soil_water_concentration * self.layer_thickness
@@ -116,6 +111,10 @@ class LayerData:
         """
         return 1.72 * self.percent_organic_carbon_content
 
+    @property
+    def soil_water_content(self):
+        """volume of soil water in the layer in mm"""
+        return self.soil_water_concentration / self.layer_thickness
 
     @property
     def water_factor(self):

--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -25,6 +25,8 @@ class LayerData:
     """water concentration of soil layer at saturation point (mm)"""
     soil_evaporation_compensation_coefficient: float = 1
     """coefficient that allows user to modify depth distribution used to meet the soil evaporative demand (2:2.3.17)"""
+    decomposition_moisture_effect: Optional[float] = None
+    """moisture effect on decomposition factor (unitless) (pseudocode_soil S.6.A.2)"""
 
     @property
     def layer_thickness(self):

--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -1,5 +1,6 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
+
 
 """
 Each instance of this class represents a layer of soil. Each SoilData object should contain a list of LayerData objects 
@@ -15,43 +16,106 @@ class LayerData:
     """bottom depth of the layer (mm)"""
     nitrate: float = 1.5
     """nitrate level of the layer (kg/ha)"""
+    phosphate: float = 0.05
+    """phosphate content of the layer (kg/ha)"""
     soil_water_concentration: float = 0.25  # arbitrary
     """soil water concentration of the layer (mm)"""
+    water_content:  Optional[float] = None
+    """water present in the layer (mm)"""
     field_capacity_water_concentration: float = 0.3  # arbitrary
-    """water concentration of soil layer at field capacity (mm)"""
+    """water concentration of soil layer at field capacity (mm water / mm soil)"""
     wilting_point_water_concentration: float = 0.2  # arbitrary
-    """water concentration of soil layer at wilting point (mm)"""
+    """water concentration of soil layer at wilting point (mm water / mm soil)"""
     saturation_point_water_concentration: float = 0.5
-    """water concentration of soil layer at saturation point (mm)"""
+    """water concentration of soil layer at saturation point (mm water / mm soil)"""
     soil_evaporation_compensation_coefficient: float = 1
-    """coefficient that allows user to modify depth distribution used to meet the soil evaporative demand (2:2.3.17)"""
+    """coefficient that allows user to modify depth distribution used to meet the soil evaporative demand (unitless) 
+        (SWAT 2:2.3.17)"""
+
+    # --- Percolation
+    temperature: float = 15.05
+    """current temperature of this soil layer (degrees Celsius)"""
+    saturated_hydraulic_conductivity: float = 9.5
+    """saturated hydraulic conductivity for this layer of soil (mm per hour)"""
+
+    # --- Temperature
+    bulk_density: float = 1.4
+    """bulk density of the soil layer (Mg per cubic meter) (provided by user, but SWAT 2:3.1.1 has an equation for 
+        calculating this field as well)"""
+    previous_day_temperature: Optional[float] = None
+    """temperature of soil layer on the previous day (degrees C)"""
+
+    # --- Erosion
+    percent_organic_carbon_content: float = 1.2
+    """organic carbon content expressed as percent of soil in this layer (unitless)"""
+    percent_clay_content: float = 18.7
+    """clay content expressed as percent of soil in this layer (unitless)"""
+    percent_sand_content: float = 14.5
+    """sand content expressed as percent of soil in this layer (unitless)"""
+    percent_silt_content: float = 64.5
+    """silt content expressed as percent of soil in this layer (unitless)"""
+    percent_rock_content: float = 1
+    """rock content expressed as percent of soil in this layer (unitless)"""
+
+    # --- Decomposition
     decomposition_moisture_effect: Optional[float] = None
     """moisture effect on decomposition factor (unitless) (pseudocode_soil S.6.A.2)"""
-
-    @property
-    def layer_thickness(self):
-        """thickness of soil layer in mm"""
-        return self.bottom_depth - self.top_depth
 
     @property
     def soil_water_content(self):
         """volume of soil water in the layer in mm"""
         return self.soil_water_concentration / self.layer_thickness
 
-    @property
-    def field_capacity_content(self):
-        """volume of water in layer when at field capacity in mm"""
-        return self.field_capacity_water_concentration / self.layer_thickness
+    def __post_init__(self):
+        """Initialize all attributes in the dataclass that depend on other attributes"""
+        self.water_content = self.soil_water_concentration * self.layer_thickness
 
     @property
-    def wilting_point_content(self):
-        """volume of water in layer when at wilting point"""
-        return self.wilting_point_water_concentration / self.layer_thickness
+    def layer_thickness(self) -> float:
+        """thickness of soil layer (mm)"""
+        return self.bottom_depth - self.top_depth
 
     @property
-    def saturation_content(self):
-        """volume of water in layer when saturated in mm"""
-        return self.saturation_point_water_concentration / self.layer_thickness
+    def depth_of_layer_center(self) -> float:
+        """depth beneath the surface of the center this layer (mm)"""
+        return self.top_depth + (self.layer_thickness / 2)
+
+    @property
+    def field_capacity_content(self) -> float:
+        """volume of water in layer when at field capacity (mm)"""
+        return self.field_capacity_water_concentration * self.layer_thickness
+
+    @property
+    def wilting_point_content(self) -> float:
+        """amount of water in layer when at wilting point (mm)"""
+        return self.wilting_point_water_concentration * self.layer_thickness
+
+    @property
+    def excess_water_available(self) -> float:
+        """volume of water available for percolation in the soil layer (mm)
+        SWAT Reference: 2:3.2.1, 2
+        """
+        return max(0, self.water_content - self.field_capacity_content)
+
+    @property
+    def saturation_content(self) -> float:
+        """volume of water in layer when saturated (mm)"""
+        return self.saturation_point_water_concentration * self.layer_thickness
+
+    @property
+    def acceptable_percolation_amount(self) -> float:
+        """volume of water that can be accepted by layer before reaching saturation (mm)"""
+        return max(0, self.saturation_content - self.water_content)
+
+    @property
+    def percent_organic_matter_content(self) -> float:
+        """percent organic matter content of this soil layer
+        TODO: remove this field from all the soil inputs, because the given values for OM_percent are not equal to value
+            that SWAT would calculate based on the percent organic carbon content
+        SWAT Reference: 4:1.1.4
+        """
+        return 1.72 * self.percent_organic_carbon_content
+
 
     @property
     def water_factor(self):
@@ -59,9 +123,8 @@ class LayerData:
 
         # pseudocode_soil S.4.B.1
         if self.soil_water_content <= self.field_capacity_content:
-            return (self.soil_water_content - self.wilting_point_content)/(
+            return (self.soil_water_content - self.wilting_point_content) / (
                     self.field_capacity_content - self.wilting_point_content)
         else:
             return (self.saturation_content - self.soil_water_content) / (
-                        self.saturation_content - self.field_capacity_content)
-
+                    self.saturation_content - self.field_capacity_content)

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -37,8 +37,7 @@ class SoilData:
     # ---- decomposition
     decomposition_temperature_effect: Optional[float] = None
     """temperature effect on decomposition factor (unitless) (pseudocode_soil S.6.A.1)"""
-    decomposition_moisture_effect: Optional[float] = None
-    """moisture effect on decomposition factor (unitless) (pseudocode_soil S.6.A.2)"""
+
 
 
     @property

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -36,7 +36,9 @@ class SoilData:
 
     # ---- decomposition
     decomposition_temperature_effect: Optional[float] = None
+    """temperature effect on decomposition factor (unitless) (pseudocode_soil S.6.A.1)"""
     decomposition_moisture_effect: Optional[float] = None
+    """moisture effect on decomposition factor (unitless) (pseudocode_soil S.6.A.2)"""
 
 
     @property

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -34,6 +34,11 @@ class SoilData:
     moisture_condition_parameter: Optional[float] = None
     """curve number value adjusted for moisture content (unitless) (SWAT 2:1.1.11)"""
 
+    # ---- decomposition
+    decomposition_temperature_effect: Optional[float] = None
+    decomposition_moisture_effect: Optional[float] = None
+
+
     @property
     def profile_soil_water_content(self) -> float:
         """

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_decomposition.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_decomposition.py
@@ -17,71 +17,62 @@ def test_calc_temp_factor(temp_average, x_inflection: float = 15.4, y_inflection
                           point_distance: float = 29.7, inflection_slope=0.03,
                           normalizer=20.80546):
     """ensures that temperature effect was calculated according to the formula in "pseudocode_soil" S.6.A.1"""
-    data = SoilData()
-    decomp = Decomposition(data)
-    decomp._calc_temp_factor(temp_average)
     expect = (y_inflection + (point_distance / math.pi) * math.atan(math.pi * inflection_slope * (
-                                                                temp_average - x_inflection))) / normalizer
-    assert decomp._calc_temp_factor(temp_average) == expect
+            temp_average - x_inflection))) / normalizer
+    assert Decomposition._calc_temp_factor(temp_average) == expect
 
 
-@pytest.mark.parametrize("layers", [
-    [LayerData(top_depth=0, bottom_depth=4, soil_water_concentration=1.8, field_capacity_water_concentration=1.6,
-               wilting_point_water_concentration=0.9),
-     LayerData(top_depth=4, bottom_depth=12, soil_water_concentration=0.9, field_capacity_water_concentration=1.2,
-               wilting_point_water_concentration=0.8),
-     LayerData(top_depth=12, bottom_depth=20, soil_water_concentration=0.8, field_capacity_water_concentration=0.8,
-               wilting_point_water_concentration=0.3)],
-    [LayerData(top_depth=0, bottom_depth=3, soil_water_concentration=2.8, field_capacity_water_concentration=2.3,
-               wilting_point_water_concentration=1.8),
-     LayerData(top_depth=3, bottom_depth=15, soil_water_concentration=1.9, field_capacity_water_concentration=1.8,
-               wilting_point_water_concentration=0.8),
-     LayerData(top_depth=15, bottom_depth=22, soil_water_concentration=0.8, field_capacity_water_concentration=1,
-               wilting_point_water_concentration=0.2)],
-    [LayerData(top_depth=0, bottom_depth=8, soil_water_concentration=2.3, field_capacity_water_concentration=2.9,
-               wilting_point_water_concentration=1.8),
-     LayerData(top_depth=8, bottom_depth=20, soil_water_concentration=1.4, field_capacity_water_concentration=1.8,
-               wilting_point_water_concentration=0.8),
-     LayerData(top_depth=20, bottom_depth=22, soil_water_concentration=0.8, field_capacity_water_concentration=1,
-               wilting_point_water_concentration=0.6)],
+@pytest.mark.parametrize("water_factor", [
+    15,  # lower values
+    13,  # higher values
+    16.6,  # arbitrary
 ])
-def test_calc_moisture_factor(layers):
+def test_calc_moisture_factor(water_factor, a_term: float = 0.55, b_term: float = 1.7,
+                              c_term: float = -0.007, first_exponent=6.648115,
+                              second_exponent=3.22):
     """ensures that moisture effect was calculated according to the formula in "pseudocode_soil" S.6.A.2"""
+    base_1 = (water_factor - b_term) / (a_term - b_term)
+    base_2 = (water_factor - c_term) / (a_term - c_term)
+    expect = (base_1 ** first_exponent) * (base_2 ** second_exponent)
+
+    assert Decomposition._calc_moisture_factor(water_factor) == expect
+
+
+@pytest.mark.parametrize("temp_average, layers", [
+    (70, [LayerData(top_depth=0, bottom_depth=4, soil_water_concentration=1.8, field_capacity_water_concentration=1.6,
+                    wilting_point_water_concentration=0.9),
+          LayerData(top_depth=4, bottom_depth=12, soil_water_concentration=0.9, field_capacity_water_concentration=1.2,
+                    wilting_point_water_concentration=0.8),
+          LayerData(top_depth=12, bottom_depth=20, soil_water_concentration=0.8, field_capacity_water_concentration=0.8,
+                    wilting_point_water_concentration=0.3)]),  # lower values
+    (150, [LayerData(top_depth=0, bottom_depth=3, soil_water_concentration=2.8, field_capacity_water_concentration=2.3,
+                     wilting_point_water_concentration=1.8),
+           LayerData(top_depth=3, bottom_depth=15, soil_water_concentration=1.9, field_capacity_water_concentration=1.8,
+                     wilting_point_water_concentration=0.8),
+           LayerData(top_depth=15, bottom_depth=22, soil_water_concentration=0.8, field_capacity_water_concentration=1,
+                     wilting_point_water_concentration=0.2)]),  # higher values
+    (88.8, [LayerData(top_depth=0, bottom_depth=8, soil_water_concentration=2.3, field_capacity_water_concentration=2.9,
+                      wilting_point_water_concentration=1.8),
+            LayerData(top_depth=8, bottom_depth=20, soil_water_concentration=1.4,
+                      field_capacity_water_concentration=1.8,
+                      wilting_point_water_concentration=0.8),
+            LayerData(top_depth=20, bottom_depth=22, soil_water_concentration=0.8, field_capacity_water_concentration=1,
+                      wilting_point_water_concentration=0.6)])  # arbitrary
+])
+def test_decompose(temp_average, layers):
+    """ensures that all SoilData attributes were correctly updated"""
     data = SoilData(soil_layers=layers)
     decomp = Decomposition(data)
+    Decomposition._calc_moisture_factor = MagicMock(return_value=1.89)
+    Decomposition._calc_temp_factor = MagicMock(return_value=3.99)
 
-    dimensionless_empirical_factor_a = 0.55
-    dimensionless_empirical_factor_b = 1.7
-    dimensionless_empirical_factor_c = -0.007
-    dimensionless_empirical_factor_e1 = 6.648115
-    dimensionless_empirical_factor_e2 = 3.22
-
-    for layer in layers:
-        # S.6.A.5
-        base_1 = (layer.water_factor - dimensionless_empirical_factor_b) / (dimensionless_empirical_factor_a -
-                                                                            dimensionless_empirical_factor_b)
-        base_2 = (layer.water_factor - dimensionless_empirical_factor_c) / (dimensionless_empirical_factor_a -
-                                                                            dimensionless_empirical_factor_c)
-
-    assert decomp._calc_moisture_factor(layers) == (base_1 ** dimensionless_empirical_factor_e1) * (base_2 ** dimensionless_empirical_factor_e2)
-
-
-@pytest.mark.parametrize("temp_average", [
-    70,  # lower values
-    150,  # higher values
-    88.8,  # arbitrary
-])
-def test_decompose(temp_average):
-    """ensures that all SoilData attributes were correctly updated"""
-    data = SoilData()
-    decomp = Decomposition(data)
-    decomp._calc_moisture_factor = MagicMock(return_value=1.89)
-    decomp._calc_temp_factor = MagicMock(return_value=3.99)
-
+    # calls function
     decomp.decompose(temp_average)
 
-    decomp._calc_moisture_factor.assert_called_once()
-    decomp._calc_temp_factor.assert_called_once()
+    # making sure functions were called properly
+    Decomposition._calc_temp_factor.assert_called_once()
+    assert Decomposition._calc_moisture_factor.call_count == 3
 
     assert data.decomposition_temperature_effect == 3.99
-    assert data.decomposition_moisture_effect == 1.89
+    for layer in data.soil_layers:
+        assert layer.decomposition_moisture_effect == 1.89

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_decomposition.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_decomposition.py
@@ -76,3 +76,4 @@ def test_decompose(temp_average, layers):
     assert data.decomposition_temperature_effect == 3.99
     for layer in data.soil_layers:
         assert layer.decomposition_moisture_effect == 1.89
+

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_decomposition.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_decomposition.py
@@ -13,19 +13,15 @@ from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
     150,  # higher values
     88.8,  # arbitrary
 ])
-def test_calc_temp_factor(temp_average):
+def test_calc_temp_factor(temp_average, x_inflection: float = 15.4, y_inflection: float = 11.75,
+                          point_distance: float = 29.7, inflection_slope=0.03,
+                          normalizer=20.80546):
     """ensures that temperature effect was calculated according to the formula in "pseudocode_soil" S.6.A.1"""
-    decomposition_inflection_x = 15.400
-    decomposition_inflection_y = 11.750
-    max_min_distance = 29.700
-    inflection_slope = 0.03
-    normalizer = 20.80546
     data = SoilData()
     decomp = Decomposition(data)
     decomp._calc_temp_factor(temp_average)
-    expect = max(0.0,
-                 (decomposition_inflection_y + (max_min_distance / math.pi) * math.atan(math.pi * inflection_slope * (
-                         temp_average - decomposition_inflection_x))) / normalizer)
+    expect = (y_inflection + (point_distance / math.pi) * math.atan(math.pi * inflection_slope * (
+                                                                temp_average - x_inflection))) / normalizer
     assert decomp._calc_temp_factor(temp_average) == expect
 
 
@@ -49,7 +45,7 @@ def test_calc_temp_factor(temp_average):
      LayerData(top_depth=20, bottom_depth=22, soil_water_concentration=0.8, field_capacity_water_concentration=1,
                wilting_point_water_concentration=0.6)],
 ])
-def test_calc_temp_factor(layers):
+def test_calc_moisture_factor(layers):
     """ensures that moisture effect was calculated according to the formula in "pseudocode_soil" S.6.A.2"""
     data = SoilData(soil_layers=layers)
     decomp = Decomposition(data)
@@ -66,9 +62,8 @@ def test_calc_temp_factor(layers):
                                                                             dimensionless_empirical_factor_b)
         base_2 = (layer.water_factor - dimensionless_empirical_factor_c) / (dimensionless_empirical_factor_a -
                                                                             dimensionless_empirical_factor_c)
-        hold = (base_1 ** dimensionless_empirical_factor_e1) * (base_2 ** dimensionless_empirical_factor_e2)
-    expect = hold
-    assert decomp._calc_moisture_factor(layers) == hold
+
+    assert decomp._calc_moisture_factor(layers) == (base_1 ** dimensionless_empirical_factor_e1) * (base_2 ** dimensionless_empirical_factor_e2)
 
 
 @pytest.mark.parametrize("temp_average", [

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_decomposition.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_decomposition.py
@@ -1,0 +1,30 @@
+import pytest
+import math
+
+from SC_redesign.Crop_and_Soil.crop.nitrogen_incorporation import *
+from pytest_mock import MockerFixture
+from unittest.mock import MagicMock
+
+from SC_redesign.Crop_and_Soil.soil.carbon_cycling.decomposition import Decomposition
+from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
+
+
+@pytest.mark.parametrize("temp_average", [
+    70,  # lower values
+    150,  # higher values
+    88.8,  # arbitrary
+])
+def test_calc_temp_factor(temp_average):
+    """ensure that temperature factor was calculated according to the formula in "pseudocode_soil" S.6.A"""
+    decomposition_inflection_x = 15.400
+    decomposition_inflection_y = 11.750
+    max_min_distance = 29.700
+    inflection_slope = 0.03
+    normalizer = 20.80546
+    data = SoilData()
+    decomp = Decomposition(data)
+    decomp.calc_temp_factor(temp_average)
+    assert decomp.calc_temp_factor(temp_average) == max(0.0,
+                   (decomposition_inflection_y + (max_min_distance / math.pi) * math.atan(math.pi * inflection_slope * (
+                           temp_average - decomposition_inflection_x))) / normalizer)
+

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_decomposition.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_decomposition.py
@@ -69,6 +69,26 @@ def test_calc_temp_factor(layers):
     expect = hold
     assert decomp._calc_moisture_factor(layers) == hold
 
+@pytest.mark.parametrize("temp_average", [
+    70,  # lower values
+    150,  # higher values
+    88.8,  # arbitrary
+])
+def test_decompose(temp_average):
+    data = SoilData()
+    decomp = Decomposition(data)
+    decomp._calc_moisture_factor = MagicMock(return_value=1.89)
+    decomp._calc_temp_factor = MagicMock(return_value=3.99)
+
+    decomp.decompose(temp_average)
+
+    decomp._calc_moisture_factor.assert_called_once()
+    decomp._calc_temp_factor.assert_called_once()
+
+    assert data.decomposition_temperature_effect == 3.99
+    assert data.decomposition_moisture_effect == 1.89
+
+
 
 
 

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_decomposition.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_decomposition.py
@@ -30,7 +30,8 @@ def test_calc_temp_factor(temp_average):
     assert decomp._calc_temp_factor(temp_average) == expect
 
 @pytest.mark.parametrize("layers", [
-    [LayerData(water_fac = 10),
+    [LayerData(top_depth=0, bottom_depth=4, soil_water_concentration=1.8, field_capacity_water_concentration=1.6,
+               wilting_point_water_concentration=0.9),
      LayerData(top_depth=4, bottom_depth=12, soil_water_concentration=0.9, field_capacity_water_concentration=1.2,
                wilting_point_water_concentration=0.8),
      LayerData(top_depth=12, bottom_depth=20, soil_water_concentration=0.8, field_capacity_water_concentration=0.8,
@@ -51,7 +52,22 @@ def test_calc_temp_factor(temp_average):
 def test_calc_temp_factor(layers):
     data = SoilData(soil_layers=layers)
     decomp = Decomposition(data)
-    decomp._calc_moisture_factor(layers)
+
+    dimensionless_empirical_factor_a = 0.55
+    dimensionless_empirical_factor_b = 1.7
+    dimensionless_empirical_factor_c = -0.007
+    dimensionless_empirical_factor_e1 = 6.648115
+    dimensionless_empirical_factor_e2 = 3.22
+
+    for layer in layers:
+        # S.6.A.5
+        base_1 = (layer.water_factor - dimensionless_empirical_factor_b) / (dimensionless_empirical_factor_a -
+                                                                            dimensionless_empirical_factor_b)
+        base_2 = (layer.water_factor - dimensionless_empirical_factor_c) / (dimensionless_empirical_factor_a -
+                                                                            dimensionless_empirical_factor_c)
+        hold = (base_1 ** dimensionless_empirical_factor_e1) * (base_2 ** dimensionless_empirical_factor_e2)
+    expect = hold
+    assert decomp._calc_moisture_factor(layers) == hold
 
 
 

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_decomposition.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_decomposition.py
@@ -1,11 +1,11 @@
 import pytest
 import math
 
-from SC_redesign.Crop_and_Soil.crop.nitrogen_incorporation import *
 from pytest_mock import MockerFixture
 from unittest.mock import MagicMock
 
 from SC_redesign.Crop_and_Soil.soil.carbon_cycling.decomposition import Decomposition
+from SC_redesign.Crop_and_Soil.soil.layer_data import LayerData
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 
 
@@ -23,8 +23,36 @@ def test_calc_temp_factor(temp_average):
     normalizer = 20.80546
     data = SoilData()
     decomp = Decomposition(data)
-    decomp.calc_temp_factor(temp_average)
-    assert decomp.calc_temp_factor(temp_average) == max(0.0,
-                   (decomposition_inflection_y + (max_min_distance / math.pi) * math.atan(math.pi * inflection_slope * (
-                           temp_average - decomposition_inflection_x))) / normalizer)
+    decomp._calc_temp_factor(temp_average)
+    expect = max(0.0,
+                 (decomposition_inflection_y + (max_min_distance / math.pi) * math.atan(math.pi * inflection_slope * (
+                         temp_average - decomposition_inflection_x))) / normalizer)
+    assert decomp._calc_temp_factor(temp_average) == expect
+
+@pytest.mark.parametrize("layers", [
+    [LayerData(water_fac = 10),
+     LayerData(top_depth=4, bottom_depth=12, soil_water_concentration=0.9, field_capacity_water_concentration=1.2,
+               wilting_point_water_concentration=0.8),
+     LayerData(top_depth=12, bottom_depth=20, soil_water_concentration=0.8, field_capacity_water_concentration=0.8,
+               wilting_point_water_concentration=0.3)],
+    [LayerData(top_depth=0, bottom_depth=3, soil_water_concentration=2.8, field_capacity_water_concentration=2.3,
+               wilting_point_water_concentration=1.8),
+     LayerData(top_depth=3, bottom_depth=15, soil_water_concentration=1.9, field_capacity_water_concentration=1.8,
+               wilting_point_water_concentration=0.8),
+     LayerData(top_depth=15, bottom_depth=22, soil_water_concentration=0.8, field_capacity_water_concentration=1,
+               wilting_point_water_concentration=0.2)],
+    [LayerData(top_depth=0, bottom_depth=8, soil_water_concentration=2.3, field_capacity_water_concentration=2.9,
+               wilting_point_water_concentration=1.8),
+     LayerData(top_depth=8, bottom_depth=20, soil_water_concentration=1.4, field_capacity_water_concentration=1.8,
+               wilting_point_water_concentration=0.8),
+     LayerData(top_depth=20, bottom_depth=22, soil_water_concentration=0.8, field_capacity_water_concentration=1,
+               wilting_point_water_concentration=0.6)],
+])
+def test_calc_temp_factor(layers):
+    data = SoilData(soil_layers=layers)
+    decomp = Decomposition(data)
+    decomp._calc_moisture_factor(layers)
+
+
+
 

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_decomposition.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_decomposition.py
@@ -1,7 +1,6 @@
 import pytest
 import math
 
-from pytest_mock import MockerFixture
 from unittest.mock import MagicMock
 
 from SC_redesign.Crop_and_Soil.soil.carbon_cycling.decomposition import Decomposition
@@ -15,7 +14,7 @@ from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
     88.8,  # arbitrary
 ])
 def test_calc_temp_factor(temp_average):
-    """ensure that temperature factor was calculated according to the formula in "pseudocode_soil" S.6.A"""
+    """ensures that temperature effect was calculated according to the formula in "pseudocode_soil" S.6.A.1"""
     decomposition_inflection_x = 15.400
     decomposition_inflection_y = 11.750
     max_min_distance = 29.700
@@ -28,6 +27,7 @@ def test_calc_temp_factor(temp_average):
                  (decomposition_inflection_y + (max_min_distance / math.pi) * math.atan(math.pi * inflection_slope * (
                          temp_average - decomposition_inflection_x))) / normalizer)
     assert decomp._calc_temp_factor(temp_average) == expect
+
 
 @pytest.mark.parametrize("layers", [
     [LayerData(top_depth=0, bottom_depth=4, soil_water_concentration=1.8, field_capacity_water_concentration=1.6,
@@ -50,6 +50,7 @@ def test_calc_temp_factor(temp_average):
                wilting_point_water_concentration=0.6)],
 ])
 def test_calc_temp_factor(layers):
+    """ensures that moisture effect was calculated according to the formula in "pseudocode_soil" S.6.A.2"""
     data = SoilData(soil_layers=layers)
     decomp = Decomposition(data)
 
@@ -69,12 +70,14 @@ def test_calc_temp_factor(layers):
     expect = hold
     assert decomp._calc_moisture_factor(layers) == hold
 
+
 @pytest.mark.parametrize("temp_average", [
     70,  # lower values
     150,  # higher values
     88.8,  # arbitrary
 ])
 def test_decompose(temp_average):
+    """ensures that all SoilData attributes were correctly updated"""
     data = SoilData()
     decomp = Decomposition(data)
     decomp._calc_moisture_factor = MagicMock(return_value=1.89)
@@ -87,8 +90,3 @@ def test_decompose(temp_average):
 
     assert data.decomposition_temperature_effect == 3.99
     assert data.decomposition_moisture_effect == 1.89
-
-
-
-
-


### PR DESCRIPTION
### **Summary**
This PR refactors the `Decomposition` sub-module (`decomposition.py`) of the `Soil` module from "pseudocode_soil" S.6.A.1 and "pseudocode_soil" S.6.A.2. All methods except the main routine are static methods.

Every method is tested covering possibly most edge cases.

### **Changes**

-  Except for the main routine `decompose`, all other methods are now static
-  Except for the main routine `decompose`, all methods do not rely on any external classes
-  Descriptive names modified and added
-  Tests added for all methods
-  Now only the main routine `decompose` updates and tracks attributes added in the `SoilData` class

### **Other Changes**

- Added property function in the `LayerData` class to calculate the correct water factor


