### PR TITLE
fixed failing tests in old SC module

### DIFF
--- a/RUFAS/routines/field/crop/leaf_area_index.py
+++ b/RUFAS/routines/field/crop/leaf_area_index.py
@@ -147,4 +147,4 @@ def calculate_d_LAI_actual(crop_type, d_LAI_max):
         float: change in LAI actual
     """
     #print('d_LAI_max',d_LAI_max,'crop_type.gamma_reg',crop_type.gamma_reg)
-    return min(d_LAI_max * sqrt(crop_type.gamma_reg),0.01)
+    return min(d_LAI_max * sqrt(crop_type.gamma_reg), 0.01)

--- a/tests/tests_SoilCrop/tests_crop/test_growth_constraints.py
+++ b/tests/tests_SoilCrop/tests_crop/test_growth_constraints.py
@@ -51,7 +51,7 @@ def test_calc_nutrient_stress(opt, phi):
 def test_calc_nutrient_stress_scaling_factor(act, opt):
     """ensure that nitrogen scaling factor is correctly calculated by calc_nitrogen_stress_scaling_factor()."""
     if opt == 0:
-        phi = 300
+        phi = 100
     else:
         phi = max(0., (200 * ((act / opt) - 0.5)))
 

--- a/tests/tests_SoilCrop/tests_crop/test_leaf_area_index.py
+++ b/tests/tests_SoilCrop/tests_crop/test_leaf_area_index.py
@@ -109,7 +109,7 @@ def test_calc_fr_LAI_max_all_correct():
 # the following tests are for the calculate_d_LAI_actual() function:
 def test_calculate_d_LAI_actual_correctly_calculates_change_in_LAI_actual():
     crop = mock_crop()
-    assert pytest.approx(calculate_d_LAI_actual(crop, .55)) == 0.55 * sqrt(0.7)
+    assert pytest.approx(calculate_d_LAI_actual(crop, .55)) == min(0.55 * sqrt(0.7), 0.01)
 
 
 # the following tests are for the calculate_LAI_actual() function

--- a/tests/tests_SoilCrop/tests_crop/test_nitrogen_uptake.py
+++ b/tests/tests_SoilCrop/tests_crop/test_nitrogen_uptake.py
@@ -382,7 +382,7 @@ def test_update_nitrogen(hf, hf50, hf100, phf, nf1, nf2, nfn, nf3, bm, nmo, ns, 
     # observe
     mc = mock_crop(fr_PHU_50=hf50, fr_PHU_100=hf100, fr_n1=nf1, fr_n2=nf2, fr_n3ish=nfn, fr_n3=nf3,
                    prev_fr_PHU=phf, bio_N_opt=nmo, bio_N=ns, d_biomass_max=mg, z_root=rd, beta_n=nds,
-                   biomass_actual=bm, fr_PHU=hf, N_fix=nfx, is_nitrogen_fixer=fix)
+                   biomass_actual=bm, fr_PHU=hf, N_fix=nfx, is_nitrogen_fixer=fix, fix_nitrogen=fix)
     ms = mock_soil(soil_layers=[])
     for depth, nitrate, water, cap_water in zip(sbs, sns, sw, scw):
         ml = mock_soil_layer(bottom_depth=depth, NO3=nitrate, N_uptake=0, soil_water=water, fc_water=cap_water)

--- a/tests/tests_SoilCrop/tests_soil/test_soil_temp.py
+++ b/tests/tests_SoilCrop/tests_soil/test_soil_temp.py
@@ -97,18 +97,18 @@ def mock_weather(radiation = [[3.5]],T_avg = [[20]]):
 
 #test 1 uses time.day = 250, which would not activate the snow flag
 def test_calc_bcv_correctly_calculates_weighing_factor():
-    crop = mock_crop()
-    time = mock_time(day = 250)
+    crop = mock_base_crop()
+    time = mock_time(day=250)
 
     bcv = 5.0 / (5.0 + exp(7.563 - .0001297 * (-5.0)))
-    bcv_snow = (0/ (0+ exp(6.055 - 0.3002 * 0)))
+    bcv_snow = (0 / (0 + exp(6.055 - 0.3002 * 0)))
 
-    weigh_factor = calc_bcv(crop,time)
-    assert pytest.approx(weigh_factor) == max(bcv,bcv_snow)
+    weigh_factor = calc_bcv(crop, time)
+    assert pytest.approx(weigh_factor) == max(bcv, bcv_snow)
 
 #this test uses time.day = 360, which activates the snow flag
 def test_calc_bcv_correctly_calculates_weighing_factor_snow():
-    crop = mock_crop()
+    crop = mock_base_crop()
     time = mock_time(day = 360)
 
     bcv = 5.0 / (5.0 + exp(7.563 - .0001297 * (-5.0)))
@@ -118,7 +118,7 @@ def test_calc_bcv_correctly_calculates_weighing_factor_snow():
     assert pytest.approx(weigh_factor) == max(bcv,bcv_snow)
 
 def test_calc_bcv_correctly_calculates_all_weighing_factor_scenarios():
-    crop = mock_crop()
+    crop = mock_base_crop()
     time1 = mock_time(day = 250)
     time2 = mock_time(day = 360)
 
@@ -139,7 +139,7 @@ def test_calc_bcv_correctly_calculates_all_weighing_factor_scenarios():
 #the following test is for the calc_albedo() function
 def test_calc_albedo_correctly_calculates_albedo():
     soil = mock_soil()
-    crop = mock_crop()
+    crop = mock_base_crop()
 
     albedo = calc_albedo(soil,crop)
 
@@ -192,7 +192,7 @@ def test_calc_dd_correctly_calculates_damping_depth():
 #calc_radiate() tests...assumes dependencies work properly
 def test_calc_radiate_correctly_calculates_radiation_term():
     soil = mock_soil()
-    crop = mock_crop()
+    crop = mock_base_crop()
     weather = mock_weather()
     time = mock_time()
 
@@ -203,7 +203,7 @@ def test_calc_radiate_correctly_calculates_radiation_term():
 #calc_T_bare()...assumes dependencies work properly
 def test_calc_T_bare_correctly_calculates_theoretical_bare_soil_temp():
     soil = mock_soil()
-    crop = mock_crop()
+    crop = mock_base_crop()
     weather = mock_weather()
     time = mock_time()
 
@@ -214,7 +214,7 @@ def test_calc_T_bare_correctly_calculates_theoretical_bare_soil_temp():
 #calc_T_surf...assumes dependencies work correctly
 def test_calc_T_surf_correctly_calculates_surface_temperature():
     soil = mock_soil()
-    crop = mock_crop()
+    crop = mock_base_crop()
     weather = mock_weather()
     time = mock_time()
 


### PR DESCRIPTION
Updating the current SC module with Reid's code (PR #300) broke a few tests that I forgot to fix. This PR implements those fixes.

All of the fixes were very simple changes to reflect the updated functions they were designed to test (e.g., mocking the `BaseCrop` class instead of `Crop`, adding bounds to test expectation, etc.)