### PR TITLE
Refactor and test `soil_temp.py`

### DIFF
--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -32,7 +32,7 @@ class LayerData:
 
     # --- Percolation
     temperature: float = 15.05
-    """temperature of soil layer (degrees Celsius)"""
+    """temperature of soil layer (degrees C)"""
     saturated_hydraulic_conductivity: float = 9.5
     """saturated hydraulic conductivity for this layer of soil (mm per hour)"""
     available_water_capacity: float = 0.2
@@ -41,6 +41,8 @@ class LayerData:
     # --- Temperature
     bulk_density: float = 1.4
     """bulk density of the soil layer (Mg per cubic meter)"""
+    previous_day_temperature: Optional[float] = None
+    """temperature of soil layer on the previous day (degrees C)"""
 
     def __post_init__(self):
         """This function initializes all attributes in the dataclass that depend on"""
@@ -50,6 +52,11 @@ class LayerData:
     def layer_thickness(self) -> float:
         """thickness of soil layer in mm"""
         return self.bottom_depth - self.top_depth
+
+    @property
+    def depth_of_layer_center(self) -> float:
+        """depth beneath the surface of the center this layer (mm)"""
+        return self.top_depth + (self.layer_thickness / 2)
 
     @property
     def field_capacity_content(self) -> float:
@@ -62,7 +69,7 @@ class LayerData:
         return self.wilting_point_water_concentration * self.layer_thickness
 
     @property
-    def excess_water_available(self):
+    def excess_water_available(self) -> float:
         """volume of water available for percolation in the soil layer in mm
 
         SWAT Reference: 2:3.2.1, 2
@@ -76,5 +83,5 @@ class LayerData:
 
     @property
     def acceptable_percolation_amount(self) -> float:
-        """volume of water that can be accepted by layer before reaching saturation (in mm)"""
+        """volume of water that can be accepted by layer before reaching saturation (mm)"""
         return max(0, self.saturation_content - self.soil_water_content)

--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -40,7 +40,8 @@ class LayerData:
 
     # --- Temperature
     bulk_density: float = 1.4
-    """bulk density of the soil layer (Mg per cubic meter)"""
+    """bulk density of the soil layer (Mg per cubic meter) (provided by user, but SWAT 2:3.1.1 has an equation for 
+        calculating this field as well)"""
     previous_day_temperature: Optional[float] = None
     """temperature of soil layer on the previous day (degrees C)"""
 

--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -38,6 +38,10 @@ class LayerData:
     available_water_capacity: float = 0.2
     """available water capacity expressed as fraction of total soil volume"""
 
+    # --- Temperature
+    bulk_density: float = 1.4
+    """bulk density of the soil layer (Mg per cubic meter)"""
+
     def __post_init__(self):
         """This function initializes all attributes in the dataclass that depend on"""
         self.soil_water_content = self.soil_water_concentration * self.layer_thickness

--- a/SC_redesign/Crop_and_Soil/soil/soil.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil.py
@@ -25,3 +25,4 @@ class Soil:
         Warning("create from config file not yet implement, returning default Soil()")
         return Soil()
 
+

--- a/SC_redesign/Crop_and_Soil/soil/soil.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil.py
@@ -6,6 +6,7 @@ from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 from SC_redesign.Crop_and_Soil.soil.evapotranspiration import Evapotranspiration
 from SC_redesign.Crop_and_Soil.soil.infiltration import Infiltration
 from SC_redesign.Crop_and_Soil.soil.percolation import Percolation
+from SC_redesign.Crop_and_Soil.soil.soil_temp import SoilTemp
 
 
 class Soil:
@@ -14,6 +15,7 @@ class Soil:
         self.evapotranspiration = Evapotranspiration(data)
         self.infiltration = Infiltration(data)
         self.percolation = Percolation(data)
+        self.soil_temp = SoilTemp(data)
 
     @classmethod
     def make_from_config(cls, soil_config) -> Soil:

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -41,6 +41,15 @@ class SoilData:
     time_step: float = 24
     """length of time step over which percolation occurs (hours) """
 
+    # ---- temperature
+    albedo: float = 0.16
+    """ratio of reflected to solar radiation (unitless)"""
+    # TODO: check above definition with a SME because all I did to get it was google 'soil albedo'
+    previous_temperature_effect: float = 0.8
+    """variable that controls the influence of previous day's temperature on current day's temperature, range is from 0
+    to 1, inclusive. SWAT sets the lag coefficient to 0.8 (paragraph between equations 1:1.3.3, 4) (unitless)
+    """
+
     def __post_init__(self):
         if self.soil_layers is None:
             # sets the soil layers to a default set if user does not provide any
@@ -53,15 +62,6 @@ class SoilData:
                                            bottom_depth=10000000,    # bottom depth is 10,000 meters by default
                                            soil_water_concentration=0,
                                            saturation_point_water_concentration=inf)
-
-    # ---- temperature
-    albedo: float = 0.16
-    """ratio of reflected to solar radiation (unitless)"""
-    # TODO: check above definition with a SME because all I did to get it was google 'soil albedo'
-    lag_coefficient: float = 0.8
-    """variable that controls the influence of previous day's temperature on current day's temperature, range is from 0
-    to 1, inclusive. SWAT sets the lag coefficient to 0.8 (paragraph between equations 1:1.3.3, 4) (unitless)
-    """
 
     @property
     def profile_soil_water_content(self) -> float:

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -41,6 +41,15 @@ class SoilData:
     time_step: float = 24
     """length of time step over which percolation occurs (hours) """
 
+    # ---- temperature
+    albedo: float = 0.16
+    """ratio of reflected to solar radiation (unitless)"""
+    # TODO: check above definition with a SME because all I did to get it was google 'soil albedo'
+    lag_coefficient: float = 0.8
+    """variable that controls the influence of previous day's temperature on current day's temperature, range is from 0
+    to 1, inclusive. SWAT sets the lag coefficient to 0.8 (paragraph between equations 1:1.3.3, 4) (unitless)
+    """
+
     @property
     def profile_soil_water_content(self) -> float:
         """

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -108,3 +108,18 @@ class SoilData:
     #   - soil evaporation adjusted is always less than or equal to maximum soil evaporation
     #   - potential evapotranspiration adjusted is always less than or equal to maximum evapotranspiration
     #   - average slope fraction is always in the range 0 to 1 inclusive (I think)
+
+    @property
+    def profile_bulk_density(self):
+        """
+
+        Returns: average bulk density of the soil profile based on the bulk density of each soil layer and weighted by
+            the thickness of that layer
+
+        """
+        weighted_densities_sum = 0
+        weights_sum = 0
+        for layer in self.soil_layers:
+            weighted_densities_sum += (layer.layer_thickness * layer.bulk_density)
+            weights_sum += layer.layer_thickness
+        return weighted_densities_sum / weights_sum

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -39,7 +39,7 @@ class SoilData:
     vadose_zone_layer: Optional[LayerData] = None
     """Datalayer object that represents the vadose zone, arbitrary top and bottom depths, starts with no water"""
     time_step: float = 24
-    """length of time step over which percolatigit adon occurs (hours) """
+    """length of time step over which percolation occurs (hours) """
 
     def __post_init__(self):
         if self.soil_layers is None:

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -56,8 +56,7 @@ class SoilData:
 
     # ---- temperature
     albedo: float = 0.16
-    """ratio of reflected to solar radiation (unitless)"""
-    # TODO: check above definition with a SME because all I did to get it was google 'soil albedo'
+    """proportion of solar radiation that is reflected by the soil surface (unitless)"""
     lag_coefficient: float = 0.8
     """variable that controls the influence of previous day's temperature on current day's temperature, range is from 0
     to 1, inclusive. SWAT sets the lag coefficient to 0.8 (paragraph between equations 1:1.3.3, 4) (unitless)
@@ -103,7 +102,7 @@ class SoilData:
     def profile_field_capacity(self) -> float:
         """
 
-        Returns: total amount of water contained in the soil profile at field capacity (but not saturated) (mm)
+        Returns: total amount of water contained in the entire soil profile at field capacity (but not saturated) (mm)
 
         """
         if self.soil_layers is None:
@@ -133,11 +132,8 @@ class SoilData:
 
     @property
     def profile_bulk_density(self):
-        """
-
-        Returns: average bulk density of the soil profile based on the bulk density of each soil layer and weighted by
-            the thickness of that layer
-
+        """average bulk density of the soil profile based on the bulk density of each soil layer, weighted by
+            the thickness
         """
         weighted_densities_sum = 0
         weights_sum = 0

--- a/SC_redesign/Crop_and_Soil/soil/soil_temp.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_temp.py
@@ -338,17 +338,19 @@ class SoilTemp:
         """this is the main routine that updates the soil temperature
 
         Args:
-            solar_radiation: solar radiation reaching the ground on a given day (MJ per square meter per day)
-            avg_temp: average temperature of a given day (degrees C)
-            min_temp: minimum temperature of a given day (degrees C)
-            max_temp: maximum temperature of a given day (degrees C)
-            plant_cover: total aboveground plant biomass and residue on a given day (kg per hectare)
-            snow_cover: water content of the snow cover on a given day (mm)
+            solar_radiation: solar radiation reaching the ground on the current day (MJ per square meter per day)
+            avg_temp: average temperature of the current day (degrees C)
+            min_temp: minimum temperature of the current day (degrees C)
+            max_temp: maximum temperature of the current day (degrees C)
+            plant_cover: total aboveground plant biomass and residue on the current day (kg per hectare)
+            snow_cover: water content of the snow cover on the current day (mm)
             avg_annual_air_temp: average annual air temperature (degrees C)
 
         Important: SWAT does not specify how to start the simulation i.e. it does not specify what to do on day 0, when
             there is no previous day's temperature. Currently, the implementation just uses the temperature that the
-            soil starts (it sets the previous days temperature equal to the current day's temperature)
+            soil starts (it sets the previous days temperature equal to the current day's temperature). This assumption
+            is fairly reasonable due to temporal auto-correlation, but does not account for the random fluctuations
+            that can occur throughout the year.
 
         SWAT Reference: section 1:1.3.3
         """
@@ -396,7 +398,7 @@ class SoilTemp:
         Returns:
             the maximum damping depth (mm)
 
-        SWAT Reference: 1:1.3.7
+        SWAT Reference: 1:1.3.6
         """
         top_term = 2500 * bulk_density
         bottom_term = bulk_density + (686 * exp(-5.63 * bulk_density))
@@ -529,7 +531,7 @@ class SoilTemp:
         Args:
             lag_coefficient: coefficient that controls influence of previous day's temp on current day's temp (degrees C)
             previous_day_soil_temp: soil temperature in the layer from the previous day (degrees C)
-            depth_factor: factor that quantifies the influence of depth below surface on soil temp (unitless)
+            depth_factor: factor that quantifies the influence of depth below surface on soil temperature (unitless)
             avg_annual_air_temp: average annual air temperature (degrees C)
             soil_surface_temp: soil surface temp on current day (degrees C)
 

--- a/SC_redesign/Crop_and_Soil/soil/soil_temp.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_temp.py
@@ -333,7 +333,57 @@ class SoilTemp:
     def __init__(self, soil_data: Optional[SoilData] = None):
         self.data = soil_data or SoilData()
 
-    def daily_soil_temperature_update(self) -> None:
+    def daily_soil_temperature_update(self, solar_radiation: float, avg_temp: float, min_temp: float, max_temp: float,
+                                      plant_cover: float, snow_cover: float, avg_annual_air_temp: float) -> None:
+        """this is the main routine that updates the soil temperature
+
+        Args:
+            solar_radiation: solar radiation reaching the ground on a given day (MJ per square meter per day)
+            avg_temp: average temperature of a given day (degrees C)
+            min_temp: minimum temperature of a given day (degrees C)
+            max_temp: maximum temperature of a given day (degrees C)
+            plant_cover: total aboveground plant biomass and residue on a given day (kg per hectare)
+            snow_cover: water content of the snow cover on a given day (mm)
+            avg_annual_air_temp: average annual air temperature (degrees C)
+
+        Important: SWAT does not specify how to start the simulation i.e. it does not specify what to do on day 0, when
+            there is no previous day's temperature. Currently, the implementation just uses the temperature that the
+            soil starts (it sets the previous days temperature equal to the current day's temperature)
+
+        SWAT Reference: section 1:1.3.3
+        """
+        max_damping_depth = self._determine_maximum_damping_depth(self.data.profile_bulk_density)
+        scaling_factor = self._determine_scaling_factor(self.data.profile_soil_water_content,
+                                                        self.data.profile_bulk_density,
+                                                        self.data.soil_layers[-1].bottom_depth)
+        damping_depth = self._determine_damping_depth(max_damping_depth, scaling_factor)
+        radiation_factor = self._determine_radiation_factor(solar_radiation, self.data.albedo)
+        bare_soil_surface_temp = self._determine_bare_soil_surface_temp(radiation_factor, avg_temp, min_temp, max_temp)
+        cover_factor = self._determine_cover_weighting_factor(plant_cover, snow_cover)
+        if self.data.soil_layers[0].previous_day_temperature is not None:
+            actual_soil_surface_temp = self._determine_soil_surface_temp(cover_factor,
+                                                                         self.data.soil_layers[0].previous_day_temperature,
+                                                                         bare_soil_surface_temp)
+        else:
+            actual_soil_surface_temp = self._determine_soil_surface_temp(cover_factor,
+                                                                         self.data.soil_layers[0].temperature,
+                                                                         bare_soil_surface_temp)
+        for layer in self.data.soil_layers:
+            new_previous_temperature = layer.temperature
+            layer_depth_factor = self._determine_depth_factor(layer.depth_of_layer_center, damping_depth)
+            if layer.previous_day_temperature is not None:
+                layer.temperature = self._determine_average_soil_temperature(self.data.lag_coefficient,
+                                                                             layer.previous_day_temperature,
+                                                                             layer_depth_factor,
+                                                                             avg_annual_air_temp,
+                                                                             actual_soil_surface_temp)
+            else:
+                layer.temperature = self._determine_average_soil_temperature(self.data.lag_coefficient,
+                                                                             layer.temperature,
+                                                                             layer_depth_factor,
+                                                                             avg_annual_air_temp,
+                                                                             actual_soil_surface_temp)
+            layer.previous_day_temperature = new_previous_temperature
 
     # --- Static methods ---
     @staticmethod
@@ -341,10 +391,10 @@ class SoilTemp:
         """calculates maximum damping depth of a soil profile based on bulk density
 
         Args:
-            bulk_density: the soil profile bulk density in Mg per cubic meter
+            bulk_density: the soil profile bulk density (Mg per cubic meter)
 
         Returns:
-            the maximum damping depth in mm
+            the maximum damping depth (mm)
 
         SWAT Reference: 1:1.3.7
         """
@@ -357,9 +407,9 @@ class SoilTemp:
         """calculates the scaling factor for use in calculating the damping depth
 
         Args:
-            soil_water_content: amount of water in soil profile expressed as depth of water in profile in mm
-            bulk_density: bulk density of the soil profile in Mg per cubic meter
-            bottom_depth: depth from the soil surface of the bottom of the soil profile in mm
+            soil_water_content: amount of water in soil profile expressed as depth of water in profile (mm)
+            bulk_density: bulk density of the soil profile (Mg per cubic meter)
+            bottom_depth: depth from the soil surface of the bottom of the soil profile (mm)
 
         Returns:
             the scaling factor for calculating damping depth (unitless)
@@ -373,11 +423,11 @@ class SoilTemp:
         """calculates the daily value for the damping depth
 
         Args:
-            max_damping_depth: maximum_damping_depth in mm
+            max_damping_depth: maximum_damping_depth (mm)
             scaling_factor: scaling factor for soil water (unitless)
 
         Returns:
-            damping depth for the day in mm
+            damping depth for the day (mm)
 
         SWAT Reference: 1:1.3.8
         """
@@ -390,8 +440,8 @@ class SoilTemp:
         """calculates the depth factor for a given layer of soil
 
         Args:
-            center_depth: depth of the center of a given soil layer in mm
-            damping_depth: damping depth of soil profile in mm
+            center_depth: depth of the center of a given soil layer (mm)
+            damping_depth: damping depth of soil profile (mm)
 
         Returns:
             the depth factor for this layer of soil (unitless)
@@ -408,7 +458,7 @@ class SoilTemp:
         """calculates the radiation term for use in calculating the bare soil surface temp
 
         Args:
-            solar_radiation: solar radiation reaching the ground on a given day in MJ per square meter per day
+            solar_radiation: solar radiation reaching the ground on a given day (MJ per square meter per day)
             albedo: the albedo of the soil (Google says "ratio of reflected to incident solar radiation") (unitless?)
 
         Returns:
@@ -425,12 +475,12 @@ class SoilTemp:
 
         Args:
             radiation_factor: radiation factor for a given day (unitless)
-            avg_temp: average temperature of a given day in degrees C
-            min_temp: minimum temperature of a given day in degrees C
-            max_temp: maximum temperature of a given day in degrees C
+            avg_temp: average temperature of a given day (degrees C)
+            min_temp: minimum temperature of a given day (degrees C)
+            max_temp: maximum temperature of a given day (degrees C)
 
         Returns:
-            the temperature of the surface soil if it were bare in degrees C
+            the temperature of the surface soil if it were bare (degrees C)
 
         SWAT Reference: 1:1.3.9
         """
@@ -441,8 +491,8 @@ class SoilTemp:
         """calculates the weighting factor for use in calculating the soil surface temperature
 
         Args:
-            plant_cover: total aboveground plant biomass and residue on a given day in kg per hectare
-            snow_cover: water content of the snow cover on a given day in mm
+            plant_cover: total aboveground plant biomass and residue on a given day (kg per hectare)
+            snow_cover: water content of the snow cover on a given day (mm)
 
         Returns:
             weighting factor based either snow or plant matter soil cover (unitless)
@@ -460,11 +510,11 @@ class SoilTemp:
 
         Args:
             cover_weighting_factor: weighting factor for soil cover impacts (unitless)
-            previous_top_soil_layer_temp: temperature of the first layer of soil on the previous day in degrees C
-            bare_soil_surface_temp: temperature of the bare soil surface in degrees C
+            previous_top_soil_layer_temp: temperature of the first layer of soil on the previous day (degrees C)
+            bare_soil_surface_temp: temperature of the bare soil surface (degrees C)
 
         Returns:
-            soil surface temperature for a given day in degrees C
+            soil surface temperature for a given day (degrees C)
 
         SWAT Reference: 1:1.3.12
         """
@@ -477,14 +527,14 @@ class SoilTemp:
         """calculates daily average soil temperature at center of a given soil layer
 
         Args:
-            lag_coefficient: coefficient that controls influence of previous day's temp on current day's temp in degrees C
-            previous_day_soil_temp: soil temperature in the layer from the previous day in degrees C
+            lag_coefficient: coefficient that controls influence of previous day's temp on current day's temp (degrees C)
+            previous_day_soil_temp: soil temperature in the layer from the previous day (degrees C)
             depth_factor: factor that quantifies the influence of depth below surface on soil temp (unitless)
-            avg_annual_air_temp: average annual air temperature in degrees C
-            soil_surface_temp: soil surface temp on current day degrees C
+            avg_annual_air_temp: average annual air temperature (degrees C)
+            soil_surface_temp: soil surface temp on current day (degrees C)
 
         Returns:
-            soil temperature at given depth on given day in degrees C
+            soil temperature at given depth on given day (degrees C)
 
         SWAT Reference: 1:1.3.3
         """

--- a/SC_redesign/Crop_and_Soil/soil/soil_temp.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_temp.py
@@ -142,7 +142,7 @@ class SoilTemp:
     @staticmethod
     def _determine_bare_soil_surface_temp(radiation_factor: float, avg_temp: float, min_temp: float,
                                           max_temp: float) -> float:
-        """calculates the temperature of the soil surface if it were bare
+        """calculates the temperature at the surface of bare soil.
 
         Args:
             radiation_factor: radiation factor for a given day (unitless)
@@ -151,7 +151,7 @@ class SoilTemp:
             max_temp: maximum temperature of a given day (degrees C)
 
         Returns:
-            the temperature of the surface soil if it were bare (degrees C)
+            bare soil surface temperature (degrees C)
 
         SWAT Reference: 1:1.3.9
         """

--- a/SC_redesign/Crop_and_Soil/soil/soil_temp.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_temp.py
@@ -1,325 +1,3 @@
-# """
-# RUFAS: Ruminant Farm Systems Model
-#
-# File name: soil_temp.py
-#
-# Author(s): William Donovan, wmdonovan@wisc.edu
-#
-# Description: This module contains the necessary functions for calculating and
-#              updating the soil temperature on a given day. Currently the only
-#              function meant to be used outside of this file is the update_all()
-#              function. The other functions are meant to serve as helper
-#              functions within this file.
-#
-# Soil attribute definitions
-#
-#     T_soil = soil temperature (ºC) at depth z (mm)
-#
-#     L = lag coefficient, set to 0.8
-#
-#     T_soil_prev_day = soil temperature (ºC) at depth z (mm) on the previous day
-#
-#     df = depth factor
-#
-#     T_a_air = average annual air temperature (ºC)
-#
-#     T_surf = Daily soil surface temperature (ºC)
-#
-#     zd = ratio of depth at the center of soil layer to damping depth
-#
-#     dd = damping depth (mm)
-#
-#     z = depth at the center of the soil layer
-#
-#     dd_max = maximum damping depth (mm)
-#
-#     scale = scaling factor for soil water
-#
-#     bd = soil bulk density (g/cm^3)
-#
-#     SW = total soil water in the profile (mm)
-#
-#     Z_tot = total soil profile depth
-#
-#     T_bare = Temperature of bare soil surface (ºC)
-#
-#     T_av = Average daily temperature (ºC)
-#
-#     radiate = radiation term
-#
-#     H_day = daily solar radiation (MJ/m^2)
-#
-#     albedo = daily albedo
-#
-#     albedo_soil = soil albedo constant
-#
-#     cover = soil cover index
-#
-#     CV = above ground biomass and residue (kg/ha)
-#
-#     bcv = weighting factor of ground cover
-#
-#     snow = snow water content on the current day (mm)
-# """
-#
-# from math import exp, log
-#
-#
-# def update_all(soil, crop, weather, time):
-#     """
-#     Description:
-#         This function updates all soil temperature information.
-#
-#     Args:
-#         soil: instance of the Soil class specified in soil.py
-#         crop: instance of the Crop class specified in crop.py
-#         weather: instance of the Weather class specified in classes.py
-#         time: instance of the Time class specified in classes.py
-#     """
-#     for crop_types in crop.current_crop.values():
-#         calc_T_surf(soil, crop_types, weather, time)
-#
-#     calc_T_soil(soil, weather, time)
-#
-#
-# def calc_T_soil(soil, weather, time):
-#     """
-#     Description:
-#         Calculates the soil temperature for each layer given average annual air
-#         temperature. "pseudocode_soil" S.1.A.1-3
-#
-#     Args:
-#         soil: an instance of the Soil class
-#         weather: an instance of the Weather class
-#         time: an instance of the Time class
-#     """
-#
-#     L = 0.8
-#     T_a_air = weather.T_avg_annual[time.year - 1]
-#     dd = calc_dd(soil)
-#
-#     for x in range(len(soil.soil_layers)):
-#
-#         if x == 0:
-#             z = soil.soil_layers[x].bottom_depth / 2
-#         else:
-#             z = (soil.soil_layers[x].bottom_depth +
-#                  soil.soil_layers[x - 1].bottom_depth) / 2
-#
-#         # soil temperature (C) at depth z (mm) on previous day
-#         T_soil_prev_day = soil.soil_layers[x].temperature
-#
-#         # "pseudocode_soil" S.1.A.3
-#         zd = z / dd
-#
-#         # "pseudocode_soil" S.1.A.2
-#         df_exp = exp(-0.867 - 2.078 * zd)
-#         df = zd / (zd + df_exp)
-#
-#         # "pseudocode_soil" S.1.A.1
-#         T_soil = (L * T_soil_prev_day) + (1 - L) * \
-#                  (df * (T_a_air - soil.T_surf) + soil.T_surf)
-#         soil.soil_layers[x].temperature = T_soil
-#
-#
-# def calc_dd(soil):
-#     """
-#     Description:
-#         Calculates damping depth of a given soil profile as a function of soil
-#         water and dd_max.
-#         "pseudocode_soil" S.1.A.4
-#
-#     Args:
-#         soil: an instance of the Soil class
-#
-#     Returns:
-#         int: dd, damping depth of the profile (mm)
-#     """
-#
-#     scale = calc_scale(soil)
-#     dd_max = calc_dd_max(soil)
-#
-#     part_1 = log(500 / dd_max)
-#     part_2 = ((1 - scale) / (1 + scale)) ** 2
-#     exp_part = exp(part_1 * part_2)
-#
-#     return dd_max * exp_part
-#
-#
-# def calc_scale(soil):
-#     """
-#     Description:
-#          Calculates the scaling factor for soil water in a given soil profile.
-#         "pseudocode_soil" S.1.A.5
-#
-#     Args:
-#         soil: an instance of the Soil class
-#
-#     Returns:
-#         int: soil water scaling factor for the profile
-#     """
-#
-#     SW = sum_soil_water(soil)
-#     Z_tot = soil.profile_depth
-#     bd = soil.profile_bulk_density
-#
-#     return SW / ((0.356 - 0.144 * bd) * Z_tot)
-#
-#
-# def calc_dd_max(soil):
-#     """
-#     Description:
-#         Calculates maximum damping depth for a given soil profile.
-#         "pseudocode_soil" S.1.A.6
-#
-#     Args:
-#         soil: an instance of the Soil class
-#
-#     Returns:
-#         int: dd_max, the maximum damping depth fro the profile (mm)
-#     """
-#
-#     bd = soil.profile_bulk_density
-#     exp_part = exp(-5.63 * bd)
-#     return 1000 + (2500 * bd) / (bd + 686 * exp_part)
-#
-#
-# def sum_soil_water(soil):
-#     """
-#     Description:
-#        Helper method to calculates the sum of soil water in the profile.
-#
-#     Args:
-#         soil: an instance of the Soil claass
-#
-#     Returns:
-#         int: total_soil_water (mm)
-#     """
-#
-#     total_soil_water = 0.0
-#
-#     for layer in soil.soil_layers:
-#         total_soil_water += layer.soil_water
-#
-#     return total_soil_water
-#
-#
-# def calc_T_surf(soil, crop_type, weather, time):
-#     """
-#     Description:
-#         Calculates the surface temperature as a function of the previous day's
-#         temperature, the amount of ground cover, and the temperature of a bare
-#         soil surface.
-#         "pseudocode_soil" S.1.A.13
-#
-#     Args:
-#         soil: an instance of the Soil class
-#         crop: an instance of the Crop class
-#         weather: an instance of the Weather class
-#         time: an instance of the Time class
-#     """
-#
-#     T_bare = calc_T_bare(soil, crop_type, weather, time)
-#     bcv = calc_bcv(crop_type, time)
-#
-#     soil.T_surf = (bcv * soil.soil_layers[0].temperature) + ((1 - bcv) * T_bare)
-#
-#
-# def calc_T_bare(soil, crop_type, weather, time):
-#     """
-#     Description:
-#         Calculates the temperature of a bare soil.
-#         "pseudocode_soil" S.1.A.7
-#
-#     Args:
-#         soil: an instance of the Soil class
-#         crop: an instance of the Crop class
-#         weather: an instance of the Weather class
-#         time: an instance of the Time class
-#
-#     Returns:
-#         int: T_bare, the theoretical temperature of the bare soil (ºC)
-#     """
-#     T_av = weather.T_avg[time.year - 1][time.day - 1]
-#     radiate = calc_radiate(soil, crop_type, weather, time)
-#
-#     return T_av + radiate * T_av
-#
-#
-# def calc_radiate(soil, crop_type, weather, time):
-#     """
-#     Description:
-#         Calculates the radiation term for the temperature of bare soil.
-#         "pseudocode_soil" S.1.A.8
-#
-#     Args:
-#         soil: an instance of the Soil class
-#         crop: an instance of the Crop class
-#         weather: an instance of the Weather class
-#         time: an instance of the Time class
-#
-#     Returns:
-#         int: radiate, the radiation term for the temperature of bare soil
-#     """
-#
-#     H_day = weather.radiation[time.year - 1][time.day - 1]
-#     albedo = calc_albedo(soil, crop_type)
-#
-#     return (H_day * (1 - albedo) - 14) / 20
-#
-#
-# def calc_albedo(soil, crop_type):
-#     """
-#     Description:
-#         Calculates the daily albedo as a function of soil type, plant cover,
-#         and snow cover.
-#         "pseudocode_soil" S.1.A.9/10
-#
-#     Args:
-#         soil: an instance of the Soil class
-#         crop: an instance of the Crop class
-#
-#     Returns:
-#         int: soil albedo
-#     """
-#
-#     CV = crop_type.bio_AG
-#
-#     # "pseudocode_soil" S.1.A.10
-#     cover = exp(-0.00005 * CV)
-#
-#     # "pseudocode_soil" S.1.A.9
-#     return 0.23 * (1 - cover) + soil.soil_albedo * cover
-#
-#
-# def calc_bcv(crop_type, time):
-#     """
-#     Description:
-#         Calculates the weighting factor for ground cover
-#         "pseudocode_soil" S.1.A.11/12
-#
-#     Args:
-#         crop: an instance of the Crop class
-#         time: an instance of the Time class
-#
-#     Returns:
-#         int: bcv, the bio-cover weighting factor for ground cover
-#     """
-#
-#     CV = crop_type.bio_AG
-#     exp_part = exp(7.563 - 0.0001297 * (-CV))
-#
-#     bcv = CV / (CV + exp_part)
-#
-#     snow = 0
-#     # TODO: arbitrary snow flag - GitHub Issue #164
-#     if time.day > 335 or time.day < 59:
-#         albedo_snow = 0.8
-#         snow = 10 * albedo_snow
-#
-#     bcv_snow = (snow / (snow + exp(6.055 - 0.3002 * snow)))
-#
-#     return max(bcv, bcv_snow)
 from typing import Optional
 from math import exp, log
 
@@ -360,29 +38,20 @@ class SoilTemp:
         radiation_factor = self._determine_radiation_factor(solar_radiation, self.data.albedo)
         bare_soil_surface_temp = self._determine_bare_soil_surface_temp(radiation_factor, avg_temp, min_temp, max_temp)
         cover_factor = self._determine_cover_weighting_factor(plant_cover, snow_cover)
-        if self.data.soil_layers[0].previous_day_temperature is not None:
-            actual_soil_surface_temp = self._determine_soil_surface_temp(cover_factor,
-                                                                         self.data.soil_layers[0].previous_day_temperature,
-                                                                         bare_soil_surface_temp)
-        else:
-            actual_soil_surface_temp = self._determine_soil_surface_temp(cover_factor,
-                                                                         self.data.soil_layers[0].temperature,
-                                                                         bare_soil_surface_temp)
+        if self.data.soil_layers[0].previous_day_temperature is None:
+            self.data.soil_layers[0].previous_day_temperature = self.data.soil_layers[0].temperature
+        actual_soil_surface_temp = self._determine_soil_surface_temp(cover_factor,
+                                                                     self.data.soil_layers[0].previous_day_temperature,
+                                                                     bare_soil_surface_temp)
         for layer in self.data.soil_layers:
             new_previous_temperature = layer.temperature
             layer_depth_factor = self._determine_depth_factor(layer.depth_of_layer_center, damping_depth)
-            if layer.previous_day_temperature is not None:
-                layer.temperature = self._determine_average_soil_temperature(self.data.lag_coefficient,
-                                                                             layer.previous_day_temperature,
-                                                                             layer_depth_factor,
-                                                                             avg_annual_air_temp,
-                                                                             actual_soil_surface_temp)
-            else:
-                layer.temperature = self._determine_average_soil_temperature(self.data.lag_coefficient,
-                                                                             layer.temperature,
-                                                                             layer_depth_factor,
-                                                                             avg_annual_air_temp,
-                                                                             actual_soil_surface_temp)
+            if layer.previous_day_temperature is None:
+                layer.previous_day_temperature = layer.temperature
+            layer.temperature = self._determine_average_soil_temperature(self.data.previous_temperature_effect,
+                                                                         layer.previous_day_temperature,
+                                                                         layer_depth_factor, avg_annual_air_temp,
+                                                                         actual_soil_surface_temp)
             layer.previous_day_temperature = new_previous_temperature
 
     # --- Static methods ---
@@ -459,7 +128,7 @@ class SoilTemp:
 
         Args:
             solar_radiation: solar radiation reaching the ground on a given day (MJ per square meter per day)
-            albedo: the albedo of the soil (Google says "ratio of reflected to incident solar radiation") (unitless?)
+            albedo: proportion of solar radiation that is reflected by the soil surface (unitless)
 
         Returns:
             the radiation factor for the day (unitless)
@@ -522,12 +191,12 @@ class SoilTemp:
             (1 - cover_weighting_factor) * bare_soil_surface_temp
 
     @staticmethod
-    def _determine_average_soil_temperature(lag_coefficient: float, previous_day_soil_temp: float, depth_factor: float,
+    def _determine_average_soil_temperature(prev_temperature_effect: float, previous_day_soil_temp: float, depth_factor: float,
                                             avg_annual_air_temp: float, soil_surface_temp: float) -> float:
         """calculates daily average soil temperature at center of a given soil layer
 
         Args:
-            lag_coefficient: coefficient that controls influence of previous day's temp on current day's temp (degrees C)
+            prev_temperature_effect: coefficient that controls influence of previous day's temp on current day's temp (unitless)
             previous_day_soil_temp: soil temperature in the layer from the previous day (degrees C)
             depth_factor: factor that quantifies the influence of depth below surface on soil temp (unitless)
             avg_annual_air_temp: average annual air temperature (degrees C)
@@ -538,7 +207,7 @@ class SoilTemp:
 
         SWAT Reference: 1:1.3.3
         """
-        first_term = lag_coefficient * previous_day_soil_temp
-        second_term = (1 - lag_coefficient) * (depth_factor * (avg_annual_air_temp - soil_surface_temp)
-                                               + soil_surface_temp)
+        first_term = prev_temperature_effect * previous_day_soil_temp
+        second_term = (1 - prev_temperature_effect) * (depth_factor * (avg_annual_air_temp - soil_surface_temp)
+                                                       + soil_surface_temp)
         return first_term + second_term

--- a/SC_redesign/Crop_and_Soil/soil/soil_temp.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_temp.py
@@ -1,0 +1,468 @@
+# """
+# RUFAS: Ruminant Farm Systems Model
+#
+# File name: soil_temp.py
+#
+# Author(s): William Donovan, wmdonovan@wisc.edu
+#
+# Description: This module contains the necessary functions for calculating and
+#              updating the soil temperature on a given day. Currently the only
+#              function meant to be used outside of this file is the update_all()
+#              function. The other functions are meant to serve as helper
+#              functions within this file.
+#
+# Soil attribute definitions
+#
+#     T_soil = soil temperature (ºC) at depth z (mm)
+#
+#     L = lag coefficient, set to 0.8
+#
+#     T_soil_prev_day = soil temperature (ºC) at depth z (mm) on the previous day
+#
+#     df = depth factor
+#
+#     T_a_air = average annual air temperature (ºC)
+#
+#     T_surf = Daily soil surface temperature (ºC)
+#
+#     zd = ratio of depth at the center of soil layer to damping depth
+#
+#     dd = damping depth (mm)
+#
+#     z = depth at the center of the soil layer
+#
+#     dd_max = maximum damping depth (mm)
+#
+#     scale = scaling factor for soil water
+#
+#     bd = soil bulk density (g/cm^3)
+#
+#     SW = total soil water in the profile (mm)
+#
+#     Z_tot = total soil profile depth
+#
+#     T_bare = Temperature of bare soil surface (ºC)
+#
+#     T_av = Average daily temperature (ºC)
+#
+#     radiate = radiation term
+#
+#     H_day = daily solar radiation (MJ/m^2)
+#
+#     albedo = daily albedo
+#
+#     albedo_soil = soil albedo constant
+#
+#     cover = soil cover index
+#
+#     CV = above ground biomass and residue (kg/ha)
+#
+#     bcv = weighting factor of ground cover
+#
+#     snow = snow water content on the current day (mm)
+# """
+#
+# from math import exp, log
+#
+#
+# def update_all(soil, crop, weather, time):
+#     """
+#     Description:
+#         This function updates all soil temperature information.
+#
+#     Args:
+#         soil: instance of the Soil class specified in soil.py
+#         crop: instance of the Crop class specified in crop.py
+#         weather: instance of the Weather class specified in classes.py
+#         time: instance of the Time class specified in classes.py
+#     """
+#     for crop_types in crop.current_crop.values():
+#         calc_T_surf(soil, crop_types, weather, time)
+#
+#     calc_T_soil(soil, weather, time)
+#
+#
+# def calc_T_soil(soil, weather, time):
+#     """
+#     Description:
+#         Calculates the soil temperature for each layer given average annual air
+#         temperature. "pseudocode_soil" S.1.A.1-3
+#
+#     Args:
+#         soil: an instance of the Soil class
+#         weather: an instance of the Weather class
+#         time: an instance of the Time class
+#     """
+#
+#     L = 0.8
+#     T_a_air = weather.T_avg_annual[time.year - 1]
+#     dd = calc_dd(soil)
+#
+#     for x in range(len(soil.soil_layers)):
+#
+#         if x == 0:
+#             z = soil.soil_layers[x].bottom_depth / 2
+#         else:
+#             z = (soil.soil_layers[x].bottom_depth +
+#                  soil.soil_layers[x - 1].bottom_depth) / 2
+#
+#         # soil temperature (C) at depth z (mm) on previous day
+#         T_soil_prev_day = soil.soil_layers[x].temperature
+#
+#         # "pseudocode_soil" S.1.A.3
+#         zd = z / dd
+#
+#         # "pseudocode_soil" S.1.A.2
+#         df_exp = exp(-0.867 - 2.078 * zd)
+#         df = zd / (zd + df_exp)
+#
+#         # "pseudocode_soil" S.1.A.1
+#         T_soil = (L * T_soil_prev_day) + (1 - L) * \
+#                  (df * (T_a_air - soil.T_surf) + soil.T_surf)
+#         soil.soil_layers[x].temperature = T_soil
+#
+#
+# def calc_dd(soil):
+#     """
+#     Description:
+#         Calculates damping depth of a given soil profile as a function of soil
+#         water and dd_max.
+#         "pseudocode_soil" S.1.A.4
+#
+#     Args:
+#         soil: an instance of the Soil class
+#
+#     Returns:
+#         int: dd, damping depth of the profile (mm)
+#     """
+#
+#     scale = calc_scale(soil)
+#     dd_max = calc_dd_max(soil)
+#
+#     part_1 = log(500 / dd_max)
+#     part_2 = ((1 - scale) / (1 + scale)) ** 2
+#     exp_part = exp(part_1 * part_2)
+#
+#     return dd_max * exp_part
+#
+#
+# def calc_scale(soil):
+#     """
+#     Description:
+#          Calculates the scaling factor for soil water in a given soil profile.
+#         "pseudocode_soil" S.1.A.5
+#
+#     Args:
+#         soil: an instance of the Soil class
+#
+#     Returns:
+#         int: soil water scaling factor for the profile
+#     """
+#
+#     SW = sum_soil_water(soil)
+#     Z_tot = soil.profile_depth
+#     bd = soil.profile_bulk_density
+#
+#     return SW / ((0.356 - 0.144 * bd) * Z_tot)
+#
+#
+# def calc_dd_max(soil):
+#     """
+#     Description:
+#         Calculates maximum damping depth for a given soil profile.
+#         "pseudocode_soil" S.1.A.6
+#
+#     Args:
+#         soil: an instance of the Soil class
+#
+#     Returns:
+#         int: dd_max, the maximum damping depth fro the profile (mm)
+#     """
+#
+#     bd = soil.profile_bulk_density
+#     exp_part = exp(-5.63 * bd)
+#     return 1000 + (2500 * bd) / (bd + 686 * exp_part)
+#
+#
+# def sum_soil_water(soil):
+#     """
+#     Description:
+#        Helper method to calculates the sum of soil water in the profile.
+#
+#     Args:
+#         soil: an instance of the Soil claass
+#
+#     Returns:
+#         int: total_soil_water (mm)
+#     """
+#
+#     total_soil_water = 0.0
+#
+#     for layer in soil.soil_layers:
+#         total_soil_water += layer.soil_water
+#
+#     return total_soil_water
+#
+#
+# def calc_T_surf(soil, crop_type, weather, time):
+#     """
+#     Description:
+#         Calculates the surface temperature as a function of the previous day's
+#         temperature, the amount of ground cover, and the temperature of a bare
+#         soil surface.
+#         "pseudocode_soil" S.1.A.13
+#
+#     Args:
+#         soil: an instance of the Soil class
+#         crop: an instance of the Crop class
+#         weather: an instance of the Weather class
+#         time: an instance of the Time class
+#     """
+#
+#     T_bare = calc_T_bare(soil, crop_type, weather, time)
+#     bcv = calc_bcv(crop_type, time)
+#
+#     soil.T_surf = (bcv * soil.soil_layers[0].temperature) + ((1 - bcv) * T_bare)
+#
+#
+# def calc_T_bare(soil, crop_type, weather, time):
+#     """
+#     Description:
+#         Calculates the temperature of a bare soil.
+#         "pseudocode_soil" S.1.A.7
+#
+#     Args:
+#         soil: an instance of the Soil class
+#         crop: an instance of the Crop class
+#         weather: an instance of the Weather class
+#         time: an instance of the Time class
+#
+#     Returns:
+#         int: T_bare, the theoretical temperature of the bare soil (ºC)
+#     """
+#     T_av = weather.T_avg[time.year - 1][time.day - 1]
+#     radiate = calc_radiate(soil, crop_type, weather, time)
+#
+#     return T_av + radiate * T_av
+#
+#
+# def calc_radiate(soil, crop_type, weather, time):
+#     """
+#     Description:
+#         Calculates the radiation term for the temperature of bare soil.
+#         "pseudocode_soil" S.1.A.8
+#
+#     Args:
+#         soil: an instance of the Soil class
+#         crop: an instance of the Crop class
+#         weather: an instance of the Weather class
+#         time: an instance of the Time class
+#
+#     Returns:
+#         int: radiate, the radiation term for the temperature of bare soil
+#     """
+#
+#     H_day = weather.radiation[time.year - 1][time.day - 1]
+#     albedo = calc_albedo(soil, crop_type)
+#
+#     return (H_day * (1 - albedo) - 14) / 20
+#
+#
+# def calc_albedo(soil, crop_type):
+#     """
+#     Description:
+#         Calculates the daily albedo as a function of soil type, plant cover,
+#         and snow cover.
+#         "pseudocode_soil" S.1.A.9/10
+#
+#     Args:
+#         soil: an instance of the Soil class
+#         crop: an instance of the Crop class
+#
+#     Returns:
+#         int: soil albedo
+#     """
+#
+#     CV = crop_type.bio_AG
+#
+#     # "pseudocode_soil" S.1.A.10
+#     cover = exp(-0.00005 * CV)
+#
+#     # "pseudocode_soil" S.1.A.9
+#     return 0.23 * (1 - cover) + soil.soil_albedo * cover
+#
+#
+# def calc_bcv(crop_type, time):
+#     """
+#     Description:
+#         Calculates the weighting factor for ground cover
+#         "pseudocode_soil" S.1.A.11/12
+#
+#     Args:
+#         crop: an instance of the Crop class
+#         time: an instance of the Time class
+#
+#     Returns:
+#         int: bcv, the bio-cover weighting factor for ground cover
+#     """
+#
+#     CV = crop_type.bio_AG
+#     exp_part = exp(7.563 - 0.0001297 * (-CV))
+#
+#     bcv = CV / (CV + exp_part)
+#
+#     snow = 0
+#     # TODO: arbitrary snow flag - GitHub Issue #164
+#     if time.day > 335 or time.day < 59:
+#         albedo_snow = 0.8
+#         snow = 10 * albedo_snow
+#
+#     bcv_snow = (snow / (snow + exp(6.055 - 0.3002 * snow)))
+#
+#     return max(bcv, bcv_snow)
+from typing import Optional
+from math import exp, log
+
+from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
+
+
+class SoilTemp:
+
+    def __init__(self, soil_data: Optional[SoilData] = None):
+        self.data = soil_data or SoilData()
+
+    # --- Static methods ---
+    @staticmethod
+    def _determine_maximum_damping_depth(bulk_density: float) -> float:
+        """calculates maximum damping depth of a soil profile based on bulk density
+
+        Args:
+            bulk_density: the soil profile bulk density in Mg per cubic meter
+
+        Returns:
+            the maximum damping depth in mm
+
+        SWAT Reference: 1:1.3.7
+        """
+        top_term = 2500 * bulk_density
+        bottom_term = bulk_density + (686 * exp(-5.63 * bulk_density))
+        return 1000 + (top_term / bottom_term)
+
+    @staticmethod
+    def _determine_scaling_factor(soil_water_content: float, bulk_density: float, bottom_depth: float) -> float:
+        """calculates the scaling factor for use in calculating the damping depth
+
+        Args:
+            soil_water_content: amount of water in soil profile expressed as depth of water in profile in mm
+            bulk_density: bulk density of the soil profile in Mg per cubic meter
+            bottom_depth: depth from the soil surface of the bottom of the soil profile in mm
+
+        Returns:
+            the scaling factor for calculating damping depth (unitless)
+
+        SWAT Reference: 1:1.3.7
+        """
+        return soil_water_content / ((0.356 - (0.144 * bulk_density)) * bottom_depth)
+
+    @staticmethod
+    def _determine_damping_depth(max_damping_depth: float, scaling_factor: float) -> float:
+        """calculates the daily value for the damping depth
+
+        Args:
+            max_damping_depth: maximum_damping_depth in mm
+            scaling_factor: scaling factor for soil water (unitless)
+
+        Returns:
+            damping depth for the day in mm
+
+        SWAT Reference: 1:1.3.8
+        """
+        first_term = log(500 / max_damping_depth)
+        second_term = ((1 - scaling_factor) / (1 + scaling_factor)) ** 2
+        return max_damping_depth * exp(first_term * second_term)
+
+    @staticmethod
+    def _determine_depth_factor(center_depth: float, damping_depth: float) -> float:
+        """calculates the depth factor for a given layer of soil
+
+        Args:
+            center_depth: depth of the center of a given soil layer in mm
+            damping_depth: damping depth of soil profile in mm
+
+        Returns:
+            the depth factor for this layer of soil (unitless)
+
+        SWAT Reference: 1:1.3.4, 5
+        """
+        # calculate ratio of center depth to damping depth (SWAT 1:1.3.5)
+        ratio = center_depth / damping_depth
+
+        return ratio / (ratio + exp(-0.867 - (2.078 * ratio)))
+
+    @staticmethod
+    def _determine_radiation_factor(solar_radiation: float, albedo: float) -> float:
+        """calculates the radiation term for use in calculating the bare soil surface temp
+
+        Args:
+            solar_radiation: solar radiation reaching the ground on a given day in MJ per square meter per day
+            albedo: the albedo of the soil (Google says "ratio of reflected to incident solar radiation") (unitless?)
+
+        Returns:
+            the radiation factor for the day (unitless)
+
+        SWAT Reference: 1:1.3.10
+        """
+        return ((solar_radiation * (1 - albedo)) - 14) / 20
+
+    @staticmethod
+    def _determine_bare_soil_surface_temp(radiation_factor: float, avg_temp: float, min_temp: float,
+                                          max_temp: float) -> float:
+        """calculates the temperature of the soil surface if it were bare
+
+        Args:
+            radiation_factor: radiation factor for a given day (unitless)
+            avg_temp: average temperature of a given day in degrees C
+            min_temp: minimum temperature of a given day in degrees C
+            max_temp: maximum temperature of a given day in degrees C
+
+        Returns:
+            the temperature of the surface soil if it were bare in degrees C
+
+        SWAT Reference: 1:1.3.9
+        """
+        return avg_temp + (radiation_factor * ((max_temp - min_temp) / 2))
+
+    @staticmethod
+    def _determine_cover_weighting_factor(plant_cover: float, snow_cover: float) -> float:
+        """calculates the weighting factor for use in calculating the soil surface temperature
+
+        Args:
+            plant_cover: total aboveground plant biomass and residue on a given day in kg per hectare
+            snow_cover: water content of the snow cover on a given day in mm
+
+        Returns:
+            weighting factor based either snow or plant matter soil cover (unitless)
+
+        SWAT Reference: 1:1.3.11
+        """
+        plant_factor = plant_cover / (plant_cover + exp(7.563 - ((1.297 * 10 ** (-4)) * plant_cover)))
+        snow_factor = snow_cover / (snow_cover + exp(6.055 - (0.3002 * snow_cover)))
+        return max(plant_factor, snow_factor)
+
+    @staticmethod
+    def _determine_soil_surface_temp(cover_weighting_factor: float, previous_top_soil_layer_temp: float,
+                                     bare_soil_surface_temp: float) -> float:
+        """calculates the soil surface temperature for a given day
+
+        Args:
+            cover_weighting_factor: weighting factor for soil cover impacts (unitless)
+            previous_top_soil_layer_temp: temperature of the first layer of soil on the previous day in degrees C
+            bare_soil_surface_temp: temperature of the bare soil surface in degrees C
+
+        Returns:
+            soil surface temperature for a given day in degrees C
+
+        SWAT Reference: 1:1.3.12
+        """
+        return cover_weighting_factor * previous_top_soil_layer_temp + \
+            (1 - cover_weighting_factor) * bare_soil_surface_temp

--- a/SC_redesign/Crop_and_Soil/soil/soil_temp.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_temp.py
@@ -325,11 +325,15 @@ from math import exp, log
 
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 
-
+"""
+This module is based on the "Soil Temperature" section of SWAT (1:1.3.3)
+"""
 class SoilTemp:
 
     def __init__(self, soil_data: Optional[SoilData] = None):
         self.data = soil_data or SoilData()
+
+    def daily_soil_temperature_update(self) -> None:
 
     # --- Static methods ---
     @staticmethod

--- a/SC_redesign/Crop_and_Soil/soil/soil_temp.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_temp.py
@@ -466,3 +466,25 @@ class SoilTemp:
         """
         return cover_weighting_factor * previous_top_soil_layer_temp + \
             (1 - cover_weighting_factor) * bare_soil_surface_temp
+
+    @staticmethod
+    def _determine_average_soil_temperature(lag_coefficient: float, previous_day_soil_temp: float, depth_factor: float,
+                                            avg_annual_air_temp: float, soil_surface_temp: float) -> float:
+        """calculates daily average soil temperature at center of a given soil layer
+
+        Args:
+            lag_coefficient: coefficient that controls influence of previous day's temp on current day's temp in degrees C
+            previous_day_soil_temp: soil temperature in the layer from the previous day in degrees C
+            depth_factor: factor that quantifies the influence of depth below surface on soil temp (unitless)
+            avg_annual_air_temp: average annual air temperature in degrees C
+            soil_surface_temp: soil surface temp on current day degrees C
+
+        Returns:
+            soil temperature at given depth on given day in degrees C
+
+        SWAT Reference: 1:1.3.3
+        """
+        first_term = lag_coefficient * previous_day_soil_temp
+        second_term = (1 - lag_coefficient) * (depth_factor * (avg_annual_air_temp - soil_surface_temp)
+                                               + soil_surface_temp)
+        return first_term + second_term

--- a/SC_redesign/Crop_and_Soil/soil/soil_temp.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_temp.py
@@ -9,7 +9,7 @@ This module is based on the "Soil Temperature" section of SWAT (1:1.3.3)
 class SoilTemp:
 
     def __init__(self, soil_data: Optional[SoilData] = None):
-        self.data = soil_data or SoilData()
+        self.data = soil_data or SoilData()     # Initialize with defaults, if not given
 
     def daily_soil_temperature_update(self, solar_radiation: float, avg_temp: float, min_temp: float, max_temp: float,
                                       plant_cover: float, snow_cover: float, avg_annual_air_temp: float) -> None:
@@ -129,7 +129,7 @@ class SoilTemp:
         """calculates the radiation term for use in calculating the bare soil surface temp
 
         Args:
-            solar_radiation: solar radiation reaching the ground on a given day (MJ per square meter per day)
+            solar_radiation: solar radiation reaching the ground on the current day (MJ per square meter per day)
             albedo: proportion of solar radiation that is reflected by the soil surface (unitless)
 
         Returns:
@@ -146,9 +146,9 @@ class SoilTemp:
 
         Args:
             radiation_factor: radiation factor for a given day (unitless)
-            avg_temp: average temperature of a given day (degrees C)
-            min_temp: minimum temperature of a given day (degrees C)
-            max_temp: maximum temperature of a given day (degrees C)
+            avg_temp: average temperature of the current day (degrees C)
+            min_temp: minimum temperature of the current day (degrees C)
+            max_temp: maximum temperature of the current day (degrees C)
 
         Returns:
             the temperature of the surface soil if it were bare (degrees C)
@@ -162,8 +162,8 @@ class SoilTemp:
         """calculates the weighting factor for use in calculating the soil surface temperature
 
         Args:
-            plant_cover: total aboveground plant biomass and residue on a given day (kg per hectare)
-            snow_cover: water content of the snow cover on a given day (mm)
+            plant_cover: total aboveground plant biomass and residue on the current day (kg per hectare)
+            snow_cover: water content of the snow cover on the current day (mm)
 
         Returns:
             weighting factor based either snow or plant matter soil cover (unitless)
@@ -185,7 +185,7 @@ class SoilTemp:
             bare_soil_surface_temp: temperature of the bare soil surface (degrees C)
 
         Returns:
-            soil surface temperature for a given day (degrees C)
+            soil surface temperature for the current day (degrees C)
 
         SWAT Reference: 1:1.3.12
         """
@@ -198,14 +198,15 @@ class SoilTemp:
         """calculates daily average soil temperature at center of a given soil layer
 
         Args:
-            prev_temperature_effect: coefficient that controls influence of previous day's temp on current day's temp (unitless)
+            prev_temperature_effect: coefficient that controls influence of previous day's temp on the current day's
+                temp (unitless)
             previous_day_soil_temp: soil temperature in the layer from the previous day (degrees C)
             depth_factor: factor that quantifies the influence of depth below surface on soil temperature (unitless)
             avg_annual_air_temp: average annual air temperature (degrees C)
-            soil_surface_temp: soil surface temp on current day (degrees C)
+            soil_surface_temp: soil surface temp on the current day (degrees C)
 
         Returns:
-            soil temperature at given depth on given day (degrees C)
+            soil temperature at given depth on the current day (degrees C)
 
         SWAT Reference: 1:1.3.3
         """

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_temp.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_temp.py
@@ -125,3 +125,19 @@ def test_determine_soil_surface_temp(cover_factor, previous_top_layer_temp, bare
     observe = SoilTemp._determine_soil_surface_temp(cover_factor, previous_top_layer_temp, bare_surface_temp)
     expect = (cover_factor * previous_top_layer_temp) + ((1 - cover_factor) * bare_surface_temp)
     assert observe == expect
+
+
+@pytest.mark.parametrize("lag,prev_soil_temp,depth_factor,avg_annual_air_temp,soil_surface_temp", [
+    (0.8, 15, 0.5, 19, 16),
+    (0.78, -2, 0.18, 21, -4),
+    (0.80198, 12, 0.89, 22.9485, 20.3847),
+    (0.892, 17, 0.0989, 21.99843, 19.98332),
+    (0.677534, 13.9683, 0.892, 19.33854, 15.10393),
+])
+def test_determine_average_soil_temperature(lag, prev_soil_temp, depth_factor, avg_annual_air_temp, soil_surface_temp):
+    """tests _determine_average_soil_temperature() in soil_tests.py"""
+    observe = SoilTemp._determine_average_soil_temperature(lag, prev_soil_temp, depth_factor, avg_annual_air_temp,
+                                                           soil_surface_temp)
+    expect = (lag * prev_soil_temp) + ((1 - lag) * ((depth_factor * (avg_annual_air_temp - soil_surface_temp))
+                                                    + soil_surface_temp))
+    assert observe == expect

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_temp.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_temp.py
@@ -181,11 +181,15 @@ def test_daily_soil_temperature_update(radiation, avg_temp, min_temp, max_temp, 
     incorp._determine_radiation_factor.assert_called_with(radiation, incorp.data.albedo)
     incorp._determine_bare_soil_surface_temp.assert_called_with(0.5, avg_temp, min_temp, max_temp)
     incorp._determine_cover_weighting_factor.assert_called_with(plant_cover, snow_cover)
-    incorp._determine_soil_surface_temp.assert_called_with(0.5, incorp.data.soil_layers[0].previous_day_temperature)
-    # TODO: the hardcoded values here based off the number of layers in the default configuration for soil_layers,
-    #  should they be made dynamic that that the tests won't fail if the default soil profile is updated?
+    incorp._determine_soil_surface_temp.assert_called_with(0.5, incorp.data.soil_layers[0].previous_day_temperature,
+                                                           20)
+
+    # TODO: the hardcoded values below based off the number of layers in the default configuration for soil_layers,
+    #  should they be made dynamic that that the tests won't fail if the default soil profile is changed?
     assert incorp._determine_depth_factor.call_count == 3
     assert incorp._determine_average_soil_temperature.call_count == 3
+    for layer in incorp.data.soil_layers:
+        assert 14 == layer.temperature
 
     # Run method a second time for expanded code coverage
     incorp.daily_soil_temperature_update(radiation, avg_temp, min_temp, max_temp, plant_cover, snow_cover,
@@ -200,6 +204,8 @@ def test_daily_soil_temperature_update(radiation, avg_temp, min_temp, max_temp, 
     incorp._determine_radiation_factor.assert_called_with(radiation, incorp.data.albedo)
     incorp._determine_bare_soil_surface_temp.assert_called_with(0.5, avg_temp, min_temp, max_temp)
     incorp._determine_cover_weighting_factor.assert_called_with(plant_cover, snow_cover)
-    incorp._determine_soil_surface_temp.assert_called_with(0.5, 14)
+    incorp._determine_soil_surface_temp.assert_called_with(0.5, 14, 20)
     assert incorp._determine_depth_factor.call_count == 6
     assert incorp._determine_average_soil_temperature.call_count == 6
+    for layer in incorp.data.soil_layers:
+        assert 14 == layer.temperature

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_temp.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_temp.py
@@ -1,0 +1,127 @@
+import pytest
+
+from SC_redesign.Crop_and_Soil.soil.soil_temp import *
+
+
+# --- Static function tests ---
+@pytest.mark.parametrize("bulk_density", [
+    0,
+    1.89,
+    1.23223,
+    1.5321,
+    1.4013,
+])
+def test_determine_maximum_damping_depth(bulk_density):
+    """tests _determine_maximum_damping_depth() in soil_temp.py"""
+    observe = SoilTemp._determine_maximum_damping_depth(bulk_density)
+    expect = 1000 + ((2500 * bulk_density) / (bulk_density + (686 * exp(-5.63 * bulk_density))))
+    # print(observe)
+    assert observe == expect
+
+
+@pytest.mark.parametrize("water_content,density,bottom_depth", [
+    (21.456, 1.78, 2000),
+    (24.534, 1.8694, 2130),
+    (50.67, 2.0194, 1924),
+    (45.8395, 1.543, 1874),
+])
+def test_determine_scaling_factor(water_content, density, bottom_depth):
+    """tests _determine_scaling_factor() in soil_temp.py"""
+    observe = SoilTemp._determine_scaling_factor(water_content, density, bottom_depth)
+    bottom_term = (0.356 - (0.144 * density)) * bottom_depth
+    expect = water_content / bottom_term
+    # print(observe)
+    assert observe == expect
+
+
+@pytest.mark.parametrize("max_damping_depth,scaling_factor", [
+    (1000, 0.189),
+    (3000, 0.3942),
+    (2457, 0.23423),
+    (2958, 0.3058),
+])
+def test_determine_damping_depth(max_damping_depth, scaling_factor):
+    """tests _determine_damping_depth() in soil_temp.py"""
+    observe = SoilTemp._determine_damping_depth(max_damping_depth, scaling_factor)
+    expect = max_damping_depth * exp(log(500 / max_damping_depth) * ((1 - scaling_factor) / (1 + scaling_factor))**2)
+    # print(observe)
+    assert observe == expect
+
+
+@pytest.mark.parametrize("center_depth,damping_depth", [
+    (14, 2198.9583),
+    (80, 2003.95),
+    (158, 1894.596),
+    (365, 2304.786),
+    (904, 1569.852323),
+    (1784, 1995.38547),
+    (2104, 2058.5853),
+    (2594.4859, 2394.5857),
+])
+def test_determine_depth_factor(center_depth, damping_depth):
+    """tests _determine_depth_factor() in soil_temp.py"""
+    observe = SoilTemp._determine_depth_factor(center_depth, damping_depth)
+    expect = (center_depth / damping_depth) / ((center_depth / damping_depth) + exp(-0.867 - (2.078 * (center_depth /
+                                                                                                       damping_depth))))
+    # print(observe)
+    assert observe == expect
+
+
+@pytest.mark.parametrize("radiation,albedo", [
+    (102.3, 0.16),
+    (0, 0),
+    (303.564, 0.18),
+    (78.9837, 0.199),
+    (586, 0.2354),
+    (238.384, 0.3885),
+])
+def test_determine_radiation_factor(radiation, albedo):
+    """tests _determine_radiation_factor() in soil_temp.py"""
+    observe = SoilTemp._determine_radiation_factor(radiation, albedo)
+    expect_top = radiation * (1 - albedo) - 14
+    expect = expect_top / 20
+    # print(observe)
+    assert observe == expect
+
+
+@pytest.mark.parametrize("radiation,avg_temp,min_temp,max_temp", [
+    (20, 21, 18, 23),
+    (18.93845, 23.985, 28, 16),
+    (12.9983, 26.848, 30, 23),
+    (35.69458, 22.3847, 24, 17),
+    (41.3932, 16.93845, 19, 10),
+])
+def test_determine_bare_soil_surface_temp(radiation, avg_temp, min_temp, max_temp):
+    """tests _determine_bare_soil_surface_temp() in soil_tests.py"""
+    observed = SoilTemp._determine_bare_soil_surface_temp(radiation, avg_temp, min_temp, max_temp)
+    expect = avg_temp + radiation * ((max_temp - min_temp) / 2)
+    assert observed == expect
+
+
+@pytest.mark.parametrize("plant_cover,snow_cover", [
+    (137.93, 13.95),
+    (102.495, 18.9585),
+    (0, 0),
+    (32.495, 56.94385),
+    (203.0459, 34.958),
+])
+def test_determine_cover_weighting_factor(plant_cover, snow_cover):
+    observe = SoilTemp._determine_cover_weighting_factor(plant_cover, snow_cover)
+    plant_factor = plant_cover / (plant_cover + exp(7.563 - (0.001297 * plant_cover)))
+    snow_factor = snow_cover / (snow_cover + exp(6.055 - (0.3002 * snow_cover)))
+    expect = max(plant_factor, snow_factor)
+    print(observe)
+    assert observe == expect
+
+
+@pytest.mark.parametrize("cover_factor,previous_top_layer_temp,bare_surface_temp", [
+    (0, 0, 0),
+    (0.5, 12, 15),
+    (0.88, 23, 28),
+    (0.11, -3, -1),
+    (0.42495, 17.8547, 20.4857),
+])
+def test_determine_soil_surface_temp(cover_factor, previous_top_layer_temp, bare_surface_temp):
+    observe = SoilTemp._determine_soil_surface_temp(cover_factor, previous_top_layer_temp, bare_surface_temp)
+    expect = (cover_factor * previous_top_layer_temp) + ((1 - cover_factor) * bare_surface_temp)
+    assert observe == expect

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_temp.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_temp.py
@@ -16,7 +16,6 @@ def test_determine_maximum_damping_depth(bulk_density):
     """tests _determine_maximum_damping_depth() in soil_temp.py"""
     observe = SoilTemp._determine_maximum_damping_depth(bulk_density)
     expect = 1000 + ((2500 * bulk_density) / (bulk_density + (686 * exp(-5.63 * bulk_density))))
-    # print(observe)
     assert observe == expect
 
 
@@ -31,7 +30,6 @@ def test_determine_scaling_factor(water_content, density, bottom_depth):
     observe = SoilTemp._determine_scaling_factor(water_content, density, bottom_depth)
     bottom_term = (0.356 - (0.144 * density)) * bottom_depth
     expect = water_content / bottom_term
-    # print(observe)
     assert observe == expect
 
 
@@ -45,7 +43,6 @@ def test_determine_damping_depth(max_damping_depth, scaling_factor):
     """tests _determine_damping_depth() in soil_temp.py"""
     observe = SoilTemp._determine_damping_depth(max_damping_depth, scaling_factor)
     expect = max_damping_depth * exp(log(500 / max_damping_depth) * ((1 - scaling_factor) / (1 + scaling_factor))**2)
-    # print(observe)
     assert observe == expect
 
 
@@ -64,7 +61,6 @@ def test_determine_depth_factor(center_depth, damping_depth):
     observe = SoilTemp._determine_depth_factor(center_depth, damping_depth)
     expect = (center_depth / damping_depth) / ((center_depth / damping_depth) + exp(-0.867 - (2.078 * (center_depth /
                                                                                                        damping_depth))))
-    # print(observe)
     assert observe == expect
 
 
@@ -81,7 +77,6 @@ def test_determine_radiation_factor(radiation, albedo):
     observe = SoilTemp._determine_radiation_factor(radiation, albedo)
     expect_top = radiation * (1 - albedo) - 14
     expect = expect_top / 20
-    # print(observe)
     assert observe == expect
 
 
@@ -111,7 +106,6 @@ def test_determine_cover_weighting_factor(plant_cover, snow_cover):
     plant_factor = plant_cover / (plant_cover + exp(7.563 - (0.001297 * plant_cover)))
     snow_factor = snow_cover / (snow_cover + exp(6.055 - (0.3002 * snow_cover)))
     expect = max(plant_factor, snow_factor)
-    print(observe)
     assert observe == expect
 
 
@@ -168,6 +162,11 @@ def test_daily_soil_temperature_update(radiation, avg_temp, min_temp, max_temp, 
     incorp._determine_depth_factor = MagicMock(return_value=0.5)
     incorp._determine_average_soil_temperature = MagicMock(return_value=14)
 
+    # Record expected previous day temperature values
+    expect_prev_temps = []
+    for layer in incorp.data.soil_layers:
+        expect_prev_temps.append(layer.temperature)
+
     # Run method
     incorp.daily_soil_temperature_update(radiation, avg_temp, min_temp, max_temp, plant_cover, snow_cover,
                                          avg_annual_temp)
@@ -188,8 +187,9 @@ def test_daily_soil_temperature_update(radiation, avg_temp, min_temp, max_temp, 
     #  should they be made dynamic that that the tests won't fail if the default soil profile is changed?
     assert incorp._determine_depth_factor.call_count == 3
     assert incorp._determine_average_soil_temperature.call_count == 3
-    for layer in incorp.data.soil_layers:
-        assert 14 == layer.temperature
+    for layer_index in range(len(incorp.data.soil_layers)):
+        assert 14 == incorp.data.soil_layers[layer_index].temperature
+        assert expect_prev_temps[layer_index] == incorp.data.soil_layers[layer_index].previous_day_temperature
 
     # Run method a second time for expanded code coverage
     incorp.daily_soil_temperature_update(radiation, avg_temp, min_temp, max_temp, plant_cover, snow_cover,
@@ -204,8 +204,9 @@ def test_daily_soil_temperature_update(radiation, avg_temp, min_temp, max_temp, 
     incorp._determine_radiation_factor.assert_called_with(radiation, incorp.data.albedo)
     incorp._determine_bare_soil_surface_temp.assert_called_with(0.5, avg_temp, min_temp, max_temp)
     incorp._determine_cover_weighting_factor.assert_called_with(plant_cover, snow_cover)
-    incorp._determine_soil_surface_temp.assert_called_with(0.5, 14, 20)
+    incorp._determine_soil_surface_temp.assert_called_with(0.5, expect_prev_temps[0], 20)
     assert incorp._determine_depth_factor.call_count == 6
     assert incorp._determine_average_soil_temperature.call_count == 6
     for layer in incorp.data.soil_layers:
         assert 14 == layer.temperature
+        assert 14 == layer.previous_day_temperature

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_temp.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_temp.py
@@ -1,7 +1,8 @@
 import pytest
 
+from unittest.mock import MagicMock
 from SC_redesign.Crop_and_Soil.soil.soil_temp import *
-
+from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 
 # --- Static function tests ---
 @pytest.mark.parametrize("bulk_density", [
@@ -141,3 +142,64 @@ def test_determine_average_soil_temperature(lag, prev_soil_temp, depth_factor, a
     expect = (lag * prev_soil_temp) + ((1 - lag) * ((depth_factor * (avg_annual_air_temp - soil_surface_temp))
                                                     + soil_surface_temp))
     assert observe == expect
+
+# ---- Integration tests ----
+@pytest.mark.parametrize("radiation,avg_temp,min_temp,max_temp,plant_cover,snow_cover,avg_annual_temp", [
+    (100.596, 20.6958, 16.395, 23.59568, 80.938, 2.3948, 9),
+    (0, 0, 0, 0, 0, 0, 0),  # apocalypse
+    (300, 28, 26, 31, 1200, 0, 12),
+    (170, 24, 20, 30, 400, 3, 8.95),
+])
+def test_daily_soil_temperature_update(radiation, avg_temp, min_temp, max_temp, plant_cover, snow_cover,
+                                       avg_annual_temp):
+    """tests that daily_soil_update() in soil_temp.py correctly uses and updates all functions"""
+    # Initialize objects
+    data = SoilData()
+    incorp = SoilTemp(data)
+
+    # Mock helper functions
+    incorp._determine_maximum_damping_depth = MagicMock(return_value=1000)
+    incorp._determine_scaling_factor = MagicMock(return_value=0.35)
+    incorp._determine_damping_depth = MagicMock(return_value=1995)
+    incorp._determine_radiation_factor = MagicMock(return_value=0.5)
+    incorp._determine_bare_soil_surface_temp = MagicMock(return_value=20)
+    incorp._determine_cover_weighting_factor = MagicMock(return_value=0.5)
+    incorp._determine_soil_surface_temp = MagicMock(return_value=18.5)
+    incorp._determine_depth_factor = MagicMock(return_value=0.5)
+    incorp._determine_average_soil_temperature = MagicMock(return_value=14)
+
+    # Run method
+    incorp.daily_soil_temperature_update(radiation, avg_temp, min_temp, max_temp, plant_cover, snow_cover,
+                                         avg_annual_temp)
+
+    # Check everything
+    incorp._determine_maximum_damping_depth.assert_called_with(incorp.data.profile_bulk_density)
+    incorp._determine_scaling_factor.assert_called_with(incorp.data.profile_soil_water_content,
+                                                        incorp.data.profile_bulk_density,
+                                                        incorp.data.soil_layers[-1].bottom_depth)
+    incorp._determine_damping_depth.assert_called_with(1000, 0.35)
+    incorp._determine_radiation_factor.assert_called_with(radiation, incorp.data.albedo)
+    incorp._determine_bare_soil_surface_temp.assert_called_with(0.5, avg_temp, min_temp, max_temp)
+    incorp._determine_cover_weighting_factor.assert_called_with(plant_cover, snow_cover)
+    incorp._determine_soil_surface_temp.assert_called_with(0.5, incorp.data.soil_layers[0].previous_day_temperature)
+    # TODO: the hardcoded values here based off the number of layers in the default configuration for soil_layers,
+    #  should they be made dynamic that that the tests won't fail if the default soil profile is updated?
+    assert incorp._determine_depth_factor.call_count == 3
+    assert incorp._determine_average_soil_temperature.call_count == 3
+
+    # Run method a second time for expanded code coverage
+    incorp.daily_soil_temperature_update(radiation, avg_temp, min_temp, max_temp, plant_cover, snow_cover,
+                                         avg_annual_temp)
+
+    # Re-check everything
+    incorp._determine_maximum_damping_depth.assert_called_with(incorp.data.profile_bulk_density)
+    incorp._determine_scaling_factor.assert_called_with(incorp.data.profile_soil_water_content,
+                                                        incorp.data.profile_bulk_density,
+                                                        incorp.data.soil_layers[-1].bottom_depth)
+    incorp._determine_damping_depth.assert_called_with(1000, 0.35)
+    incorp._determine_radiation_factor.assert_called_with(radiation, incorp.data.albedo)
+    incorp._determine_bare_soil_surface_temp.assert_called_with(0.5, avg_temp, min_temp, max_temp)
+    incorp._determine_cover_weighting_factor.assert_called_with(plant_cover, snow_cover)
+    incorp._determine_soil_surface_temp.assert_called_with(0.5, 14)
+    assert incorp._determine_depth_factor.call_count == 6
+    assert incorp._determine_average_soil_temperature.call_count == 6


### PR DESCRIPTION
# Summary
This PR refactors the `SoilTemp` module (`soil_temp.py`) in the `Soil` module based on section 1:1.3.3 of SWAT. It contains only `@staticmethods` except for `daily_soil_temperature_update()`, which is the main routine of this module. 

Every method is tested, and in the test for `daily_soil_temperature_update()` the method is run twice, to test that the method works initially (no previous day temperatures present) and for all calls after the first (when there is a temperature for the previous day recorded)
# Note
This PR should only be merged *AFTER* #328. All changes can be ignored in 
- `evapotranspiration.py`
- `infiltration.py` and `test_infiltration.py`
- `percolation.py` and `test_percolation.py`
# Changes
All of the below files have changes from both this PR and #328. For all changes that should be ignored, it should be assumed that they will be reviewed for #328
- `soil_data.py`: the only changes that need to be reviewed for this PR are the addition of the `@property` `profile_bulk_density()` method. All other changes should be ignored.
- `soil.py` has had an import statement and attribute added for `SoilTemp`. All other changes should be ignored.
- `layer_data.py` has had two attributes added, both under the comment `# ---- Temperature`. All other changes should be ignored.