### PR TITLE
added life_cycle variables to OM pool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,11 +19,13 @@
 build
 others
 
-# Ignore contents of output directory, except for .keep file
-# This is because we want to keep the output direcectory, and git
+# Ignore contents of output directories, except for .keep files
+# This is because we want to keep the output directories, and git
 # only stores non-empty directories
 output/*
 !output/.keep
+RUFAS/routines/manure/output/*
+!RUFAS/routines/manure/output/.keep
 
 # ignore project files
 *.sublime-project
@@ -35,7 +37,6 @@ output/*
 .idea/**
 env/
 venv/
-pycallexp.py
 
 # ignore .DS_store
 .DS_store

--- a/RUFAS/routines/animal/life_cycle/life_cycle.py
+++ b/RUFAS/routines/animal/life_cycle/life_cycle.py
@@ -302,15 +302,38 @@ class LifeCycleManager:
 
         total_animal_num = self._cull_cows_and_record_stats(sim_day, cows, calves_born,
                                                             ids_removed, total_animal_num)
-        # info_map = {"class": self.__class__.__name__,
-        #             "function": self.daily_update.__name__,
-        #             "date": date, }
-
-
+    
         self._calculate_herd_percentages(total_animal_num)
         self._calculate_cow_percentages()
         self._calculate_cull_reason_stats_percent()
         self._calculate_percent_cow_per_parity()
+
+        info_map = {"class": self.__class__.__name__,
+                    "function": self.daily_update.__name__,
+                    "sim_day": sim_day, }
+
+        life_cycle_daily_herd_update = {}
+
+        life_cycle_daily_herd_update_keys = ["calf_num", "heiferI_num", "heiferII_num", "heiferIII_num", "cow_num",
+                                             "sold_heifer_num", "bought_heifer_num", "culled_heifer_num",
+                                             "culled_cow_num", "GnRH_injection_num_h", "GnRH_injection_num",
+                                             "PGF_injection_num", "PGF_injection_num_h", "ai_num", "preg_check_num",
+                                             "preg_check_num_h", "sold_calf_num", "daily_milk_production",
+                                             "open_cow_num", "vwp_cow_num", "preg_cow_num", "milking_cow_num",
+                                             "dry_cow_num", "avg_days_in_milk", "avg_days_in_preg",
+                                             "avg_cow_body_weight", "avg_parity_num", "avg_calving_interval",
+                                             "avg_breeding_to_preg_time", "avg_heifer_culling_age",
+                                             "avg_cow_culling_age", "avg_mature_body_weight"]
+
+        life_cycle_daily_herd_update = {key: vars(self)[key] for key in life_cycle_daily_herd_update_keys}
+
+        life_cycle_daily_herd_update["num_cow_for_parity"] = self.num_cow_for_parity
+        life_cycle_daily_herd_update["avg_age_for_parity"] = self.avg_age_for_parity
+        life_cycle_daily_herd_update["avg_age_for_calving"] = self.avg_age_for_calving
+        life_cycle_daily_herd_update["cull_reason_stats"] = self.cull_reason_stats
+        life_cycle_daily_herd_update["avg_calving_to_preg_time"] = self.avg_calving_to_preg_time
+
+        om.add_variable("life_cycle_daily_herd_update", life_cycle_daily_herd_update, info_map)
 
         return (animals_added, ids_removed, calves_born, calves, heiferIs,
                 heiferIIs, heiferIIIs, cows)
@@ -674,17 +697,6 @@ class LifeCycleManager:
 
             if new_born:
                 self._handle_new_born(sim_day, cow, calves_born)
-                # om.add_variable("average_cow_body_weight",
-                #                 self.avg_cow_body_weight, info_map)
-                # om.add_variable("average_mature_body_weight",
-                #                 self.avg_mature_body_weight, info_map)
-
-                # om.add_variable("daily_milk_production",
-                #                 self.daily_milk_production, info_map)
-                # om.add_variable("milking_cow_num",
-                #                 self.milking_cow_num, info_map)
-                # om.add_variable("average_days_in_milk",
-                #                 self.avg_days_in_milk, info_map)
 
         Utility.remove_items_from_list_by_indices(cows, removed_cows_idx)
         return total_animal_num


### PR DESCRIPTION
## What
Reworking the life_cycle_manager daily update reporting to the OM to be more complete and hopefully easier to track because they are all added at once, once per day. Readding some previous variables removed from OM pool.

## Why
Looking through the current herd_report from the output_handler, there are a number of variables that hadn't been added to the output_manager in part because their names change multiple times throughout the model but I believe this captures everything in the herd_report now.

## How
Looking through the list of variables in the output_handler herd_report and trying to match them up with attributes in the LifeCycleManager class. Added a few more that seemed to go hand in hand with the ones already added. Easy enough to remove any unneeded/unwanted at any point.

### Notes

- One addition to general .gitignore file to prevent output generated in manure module from being added to github.
- At Loi's suggestion, I am closing out the previous version of this PR (#330) which branched off master to this version which is essentially the same but branches off the animal_life_cycle_refactor_pr branch, hopefully preventing merge conflicts down the road.