### PR TITLE
Refactor and test `SoilErosion` module

### DIFF
--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -71,7 +71,7 @@ class CropData:
     # SWAT Table A-6
     minimum_cover_management_factor: float = 0.2
     """minimum value for cover and management factor for water erosion applicable to land cover/plant (unitless) (SWAT 
-        Reference: 4:1.1.11"""
+        Reference: 4:1.1.11)"""
 
     # SWAT Table A-7
     emergence_nitrogen_fraction: float = 0.05

--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -64,7 +64,10 @@ class CropData:
     # stressed_light_use_efficiency  # UNUSED (BIOEHI, $RUE_{hi}$)
     # carbon_dioxide_stress_level = 660 # UNUSED (CO2HI, $CO_{2hi}$)
 
-    # SWAT Table A-6 UNUSED
+    # SWAT Table A-6
+    minimum_cover_management_factor: float = 0.2
+    """minimum value for cover and management factor for water erosion applicable to land cover/plant (unitless) (SWAT 
+        Reference: 4:1.1.11"""
 
     # SWAT Table A-7
     emergence_nitrogen_fraction: float = 0.05

--- a/SC_redesign/Crop_and_Soil/soil/infiltration.py
+++ b/SC_redesign/Crop_and_Soil/soil/infiltration.py
@@ -15,7 +15,7 @@ class Infiltration:
 
     def infiltrate(self, second_moisture_condition_parameter: float, rainfall: float,
                    weighting_coefficient: float) -> None:
-        """main routine for determining accumulated_runoff and infiltration of soil for a given day"""
+        """main routine for determining runoff and infiltration of soil for a given day"""
         third_moisture_condition_parameter = self._determine_third_moisture_condition_parameter(
                                                                                     second_moisture_condition_parameter)
 
@@ -112,10 +112,10 @@ class Infiltration:
 
     @staticmethod
     def _determine_retention_parameter_for_moisture_condition(moisture_condition_parameter: float) -> float:
-        """calculates the retention parameter used to determine accumulated_runoff
+        """calculates the retention parameter used to determine runoff
 
         Args:
-            moisture_condition_parameter: curve number for the day (from SCS accumulated_runoff equations (SWAT 2:1.1)) (unitless)
+            moisture_condition_parameter: curve number for the day (from SCS runoff equations (SWAT 2:1.1)) (unitless)
 
         Returns:
             retention parameter (mm)
@@ -234,14 +234,14 @@ class Infiltration:
 
     @staticmethod
     def _determine_accumulated_runoff(rainfall: float, retention_parameter: float) -> float:
-        """calculates accumulated accumulated_runoff or rainfall excess
+        """calculates accumulated runoff or rainfall excess
 
         Args:
             rainfall: rainfall depth of given day (mm)
             retention_parameter: retention parameter based on curve number (mm)
 
         Returns:
-            accumulated accumulated_runoff or rainfall excess (mm)
+            accumulated runoff or rainfall excess (mm)
 
         Details:
             Runoff only occurs when rainfall is greater than initial abstractions (about surface storage, interception,
@@ -269,7 +269,7 @@ class Infiltration:
             potential_evapotranspiration: potential evapotranspiration for current day (mm per day)
             max_retention_parameter: maximum retention parameter for the current day (mm)
             rainfall: rainfall depth of current day (mm)
-            runoff: surface accumulated_runoff of current day (mm)
+            runoff: surface runoff of current day (mm)
             weighting_coefficient: weighting coefficient used to calculate retention coefficient for daily curve number
                 calculations dependent on plant evapotranspiration (unitless)
 

--- a/SC_redesign/Crop_and_Soil/soil/infiltration.py
+++ b/SC_redesign/Crop_and_Soil/soil/infiltration.py
@@ -20,9 +20,9 @@ class Infiltration:
                                                                                     second_moisture_condition_parameter)
 
         # --- adjust moisture condition parameters for slope of soil, if necessary -------------------------------------
-        if abs(self.data.average_slope_fraction - 0.05) != 0:
+        if abs(self.data.average_subbasin_slope - 0.05) != 0:
             adjusted_second_moisture_condition_parameter = self._determine_second_moisture_condition_adjusted(
-                                                                                    self.data.average_slope_fraction,
+                                                                                    self.data.average_subbasin_slope,
                                                                                     second_moisture_condition_parameter,
                                                                                     third_moisture_condition_parameter)
             adjusted_third_moisture_condition_parameter = self._determine_third_moisture_condition_parameter(

--- a/SC_redesign/Crop_and_Soil/soil/infiltration.py
+++ b/SC_redesign/Crop_and_Soil/soil/infiltration.py
@@ -15,7 +15,7 @@ class Infiltration:
 
     def infiltrate(self, second_moisture_condition_parameter: float, rainfall: float,
                    weighting_coefficient: float) -> None:
-        """main routine for determining runoff and infiltration of soil for a given day"""
+        """main routine for determining accumulated_runoff and infiltration of soil for a given day"""
         third_moisture_condition_parameter = self._determine_third_moisture_condition_parameter(
                                                                                     second_moisture_condition_parameter)
 
@@ -62,7 +62,7 @@ class Infiltration:
                                                                         retention_parameter)
         # --------------------------------------------------------------------------------------------------------------
 
-        runoff = self._determine_accumulated_runoff(rainfall, retention_parameter)
+        self.data.accumulated_runoff = self._determine_accumulated_runoff(rainfall, retention_parameter)
 
         # --- Update previous retention parameter ----------------------------------------------------------------------
         if self.data.previous_retention_parameter is None:
@@ -73,7 +73,7 @@ class Infiltration:
                                                                         self.data.potential_evapotranspiration,
                                                                         first_moisture_condition_retention_parameter,
                                                                         rainfall,
-                                                                        runoff,
+                                                                        self.data.accumulated_runoff,
                                                                         weighting_coefficient)
         # --------------------------------------------------------------------------------------------------------------
 
@@ -112,10 +112,10 @@ class Infiltration:
 
     @staticmethod
     def _determine_retention_parameter_for_moisture_condition(moisture_condition_parameter: float) -> float:
-        """calculates the retention parameter used to determine runoff
+        """calculates the retention parameter used to determine accumulated_runoff
 
         Args:
-            moisture_condition_parameter: curve number for the day (from SCS runoff equations (SWAT 2:1.1)) (unitless)
+            moisture_condition_parameter: curve number for the day (from SCS accumulated_runoff equations (SWAT 2:1.1)) (unitless)
 
         Returns:
             retention parameter (mm)
@@ -234,14 +234,14 @@ class Infiltration:
 
     @staticmethod
     def _determine_accumulated_runoff(rainfall: float, retention_parameter: float) -> float:
-        """calculates accumulated runoff or rainfall excess
+        """calculates accumulated accumulated_runoff or rainfall excess
 
         Args:
             rainfall: rainfall depth of given day (mm)
             retention_parameter: retention parameter based on curve number (mm)
 
         Returns:
-            accumulated runoff or rainfall excess (mm)
+            accumulated accumulated_runoff or rainfall excess (mm)
 
         Details:
             Runoff only occurs when rainfall is greater than initial abstractions (about surface storage, interception,
@@ -269,7 +269,7 @@ class Infiltration:
             potential_evapotranspiration: potential evapotranspiration for current day (mm per day)
             max_retention_parameter: maximum retention parameter for the current day (mm)
             rainfall: rainfall depth of current day (mm)
-            runoff: surface runoff of current day (mm)
+            runoff: surface accumulated_runoff of current day (mm)
             weighting_coefficient: weighting coefficient used to calculate retention coefficient for daily curve number
                 calculations dependent on plant evapotranspiration (unitless)
 

--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -43,6 +43,10 @@ class LayerData:
     previous_day_temperature: Optional[float] = None
     """temperature of soil layer on the previous day (degrees C)"""
 
+    # --- Erosion
+    percent_organic_carbon_content: float = 0.012
+    """percent organic carbon content of this layer"""
+
     def __post_init__(self):
         """Initialize all attributes in the dataclass that depend on other attributes"""
         self.water_content = self.soil_water_concentration * self.layer_thickness
@@ -84,3 +88,14 @@ class LayerData:
     def acceptable_percolation_amount(self) -> float:
         """volume of water that can be accepted by layer before reaching saturation (mm)"""
         return max(0, self.saturation_content - self.water_content)
+
+    @property
+    def percent_organic_matter_content(self) -> float:
+        """percent organic matter content of this soil layer
+
+        TODO: remove this field from all the soil inputs, because the given values for OM_percent are not equal to value
+            that SWAT would calculate based on the percent organic carbon content
+
+        SWAT Reference: 4:1.1.4
+        """
+        return 1.72 * self.percent_organic_carbon_content

--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -46,6 +46,8 @@ class LayerData:
     # --- Erosion
     percent_organic_carbon_content: float = 0.012
     """percent organic carbon content of this layer"""
+    percent_clay_content: float = 24
+    """percent clay content of this layer"""
 
     def __post_init__(self):
         """Initialize all attributes in the dataclass that depend on other attributes"""

--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -46,10 +46,16 @@ class LayerData:
     """temperature of soil layer on the previous day (degrees C)"""
 
     # --- Erosion
-    percent_organic_carbon_content: float = 0.012
-    """percent organic carbon content of this layer"""
-    percent_clay_content: float = 24
-    """percent clay content of this layer"""
+    percent_organic_carbon_content: float = 1.2
+    """organic carbon content expressed as percent of soil in this layer (unitless)"""
+    percent_clay_content: float = 18.7
+    """clay content expressed as percent of soil in this layer (unitless)"""
+    percent_sand_content: float = 14.5
+    """sand content expressed as percent of soil in this layer (unitless)"""
+    percent_silt_content: float = 64.5
+    """silt content expressed as percent of soil in this layer (unitless)"""
+    percent_rock_content: float = 1
+    """rock content expressed as percent of soil in this layer (unitless)"""
 
     def __post_init__(self):
         """Initialize all attributes in the dataclass that depend on other attributes"""

--- a/SC_redesign/Crop_and_Soil/soil/soil.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil.py
@@ -7,6 +7,7 @@ from SC_redesign.Crop_and_Soil.soil.evapotranspiration import Evapotranspiration
 from SC_redesign.Crop_and_Soil.soil.infiltration import Infiltration
 from SC_redesign.Crop_and_Soil.soil.percolation import Percolation
 from SC_redesign.Crop_and_Soil.soil.soil_temp import SoilTemp
+from SC_redesign.Crop_and_Soil.soil.soil_erosion import SoilErosion
 
 
 class Soil:
@@ -16,6 +17,7 @@ class Soil:
         self.infiltration = Infiltration(data)
         self.percolation = Percolation(data)
         self.soil_temp = SoilTemp(data)
+        self.soil_erosion = SoilErosion(data)
 
     @classmethod
     def make_from_config(cls, soil_config) -> Soil:

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -67,6 +67,7 @@ class SoilData:
     """the peak runoff rate (meters cubed per second)"""
     field_size: float = 1
     """area of the field which contains this soil (hectares)
+    
         NOTE: the field is treated as its own HRU, so this attribute may be used as the area of the HRU
     """
     snow_cover_water_content: float = 0

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -34,6 +34,8 @@ class SoilData:
     """average slope fraction of the subbasin (unitless)"""
     moisture_condition_parameter: Optional[float] = None
     """curve number value adjusted for moisture content (unitless) (SWAT 2:1.1.11)"""
+    accumulated_runoff: Optional[float] = None
+    """accumulated runoff or rainfall excess (mm)"""
 
     # ---- percolation
     vadose_zone_layer: Optional[LayerData] = None
@@ -49,6 +51,26 @@ class SoilData:
     """variable that controls the influence of previous day's temperature on current day's temperature, range is from 0
     to 1, inclusive. SWAT sets the lag coefficient to 0.8 (paragraph between equations 1:1.3.3, 4) (unitless)
     """
+
+    # ---- Erosion
+    slope_length: float = 3
+    """length of the slope (meters)"""
+    percent_sand_content: float = 15
+    """percent sand content in the soil profile (unitless)"""
+    percent_silt_content: float = 65
+    """percent silt content in the soil profile (unitless)"""
+    percent_rock_content: float = 0.1
+    """percent rock content in the first layer of soil (unitless)"""
+    manning: float = 0.4
+    """the Manning roughness coefficient for this subbasin (unitless)"""
+    peak_runoff_rate: Optional[float] = None
+    """the peak runoff rate (meters cubed per second)"""
+    field_size: float = 1
+    """area of the field which contains this soil (hectares)
+        NOTE: the field is treated as its own HRU, so this attribute may be used as the area of the HRU
+    """
+    eroded_sediment: float = 0
+    """cumulative amount of sediment that has been eroded off of the field (metric tons)"""
 
     def __post_init__(self):
         if self.soil_layers is None:
@@ -82,14 +104,12 @@ class SoilData:
             water_sum = 0
             for layer in self.soil_layers:
                 water_sum += max(0, (layer.water_content - layer.wilting_point_content))
-            return
+            return water_sum
 
     @property
     def profile_saturation(self) -> float:
         """
-
         Returns: amount of water in the soil profile when completely saturated (mm)
-
         """
         if self.soil_layers is None:
             return 0
@@ -102,9 +122,7 @@ class SoilData:
     @property
     def profile_field_capacity(self) -> float:
         """
-
-        Returns: total amount of water contained in the entire soil profile at field capacity (but not saturated) (mm)
-
+         Returns: total amount of water contained in the entire soil profile at field capacity (but not saturated) (mm)
         """
         if self.soil_layers is None:
             return 0
@@ -115,10 +133,8 @@ class SoilData:
             return field_capacity_sum
 
     @property
-    def soil_water_factor(self):
-        """
-
-        Returns: the soil water factor (unitless)
+    def soil_water_factor(self) -> float:
+        """Returns: the soil water factor (unitless)
 
         SWAT Reference: 5:2.3.18
         """
@@ -132,9 +148,9 @@ class SoilData:
     #   - average slope fraction is always in the range 0 to 1 inclusive (I think)
 
     @property
-    def profile_bulk_density(self):
-        """average bulk density of the soil profile based on the bulk density of each soil layer, weighted by
-            the thickness
+    def profile_bulk_density(self) -> float:
+        """average bulk density of the soil profile based on the bulk density of each soil layer, weighted by the
+            thickness
         """
         weighted_densities_sum = 0
         weights_sum = 0
@@ -142,3 +158,13 @@ class SoilData:
             weighted_densities_sum += (layer.layer_thickness * layer.bulk_density)
             weights_sum += layer.layer_thickness
         return weighted_densities_sum / weights_sum
+
+    @property
+    def surface_runoff_volume(self) -> float:
+        """volume of surface runoff (mm per hectare)
+
+        Used in SWAT equation 4:1.1.1
+        """
+        if self.accumulated_runoff is None or self.field_size is None:
+            return None
+        return self.accumulated_runoff / self.field_size

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -30,8 +30,8 @@ class SoilData:
     # ---- infiltration
     previous_retention_parameter: Optional[float] = None
     """retention parameter for the previous day (mm) (used in SWAT 2:1.1.9)"""
-    average_slope_fraction: float = 0.05
-    """average slope fraction of the subbasin (unitless)"""
+    average_subbasin_slope: float = 0.05
+    """average slope of the subbasin expressed as rise over run (meters / meters)"""
     moisture_condition_parameter: Optional[float] = None
     """curve number value adjusted for moisture content (unitless) (SWAT 2:1.1.11)"""
     accumulated_runoff: Optional[float] = None
@@ -55,12 +55,6 @@ class SoilData:
     # ---- Erosion
     slope_length: float = 3
     """length of the slope (meters)"""
-    percent_sand_content: float = 15
-    """percent sand content in the soil profile (unitless)"""
-    percent_silt_content: float = 65
-    """percent silt content in the soil profile (unitless)"""
-    first_rock_percent: float = 0.1
-    """percent rock content in the first layer of soil (unitless)"""
     manning: float = 0.4
     """the Manning roughness coefficient for this subbasin (unitless)"""
     peak_runoff_rate: Optional[float] = None

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -59,7 +59,7 @@ class SoilData:
     """percent sand content in the soil profile (unitless)"""
     percent_silt_content: float = 65
     """percent silt content in the soil profile (unitless)"""
-    percent_rock_content: float = 0.1
+    first_rock_percent: float = 0.1
     """percent rock content in the first layer of soil (unitless)"""
     manning: float = 0.4
     """the Manning roughness coefficient for this subbasin (unitless)"""

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -65,14 +65,12 @@ class SoilData:
     """the Manning roughness coefficient for this subbasin (unitless)"""
     peak_runoff_rate: Optional[float] = None
     """the peak runoff rate (meters cubed per second)"""
-    field_size: float = 1
-    """area of the field which contains this soil (hectares)
-        NOTE: the field is treated as its own HRU, so this attribute may be used as the area of the HRU
-    """
     snow_cover_water_content: float = 0
     """water content of the snow cover (mm)"""
     eroded_sediment: float = 0
     """cumulative amount of sediment that has been eroded off of the field (metric tons)"""
+    surface_volume_runoff: Optional[float] = None
+    """volume of surface runoff (mm per hectare), used in SWAT equation 4:1.1.1."""
 
     def __post_init__(self):
         if self.soil_layers is None:
@@ -160,13 +158,3 @@ class SoilData:
             weighted_densities_sum += (layer.layer_thickness * layer.bulk_density)
             weights_sum += layer.layer_thickness
         return weighted_densities_sum / weights_sum
-
-    @property
-    def surface_runoff_volume(self) -> float:
-        """volume of surface runoff (mm per hectare)
-
-        Used in SWAT equation 4:1.1.1
-        """
-        if self.accumulated_runoff is None or self.field_size is None:
-            return None
-        return self.accumulated_runoff / self.field_size

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -69,6 +69,8 @@ class SoilData:
     """area of the field which contains this soil (hectares)
         NOTE: the field is treated as its own HRU, so this attribute may be used as the area of the HRU
     """
+    snow_cover_water_content: float = 0
+    """water content of the snow cover (mm)"""
     eroded_sediment: float = 0
     """cumulative amount of sediment that has been eroded off of the field (metric tons)"""
 

--- a/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
@@ -48,14 +48,18 @@ class SoilErosion:
     # --- Static methods ---
     @staticmethod
     def _determine_coarse_sand_factor(percent_sand_content: float, percent_silt_content: float) -> float:
-        """calculates factor based on sand content for use in determining soil erodibility factor
+        """calculates the coarseness factor of soil erodbility
 
         Args:
             percent_sand_content: percent of soil content that is sand
             percent_silt_content: percent of soil content that is silt
+            
+        Details: 
+          The coarseness of a soil effects the overall erodibility of the soil. Specifically, soils with high-levels of 
+          coarse-sand content will have relatively low erodibility compared to soils with less sand. 
 
         Returns:
-            factor based on sand content (unitless)
+            coarseness factor of erodibility, based on sand content (unitless)
 
         SWAT Reference: 4:1.1.6
         """

--- a/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
@@ -27,16 +27,16 @@ class SoilErosion:
             soil, how the soil is being farmed, how much rainfall there is and how much of that rain gets absorbed into
             the soil, and the geometry of the field.
         """
-        erodibility_factor = self._determine_soil_erodibility_factor(self.data.percent_sand_content,
-                                                                     self.data.percent_silt_content,
+        erodibility_factor = self._determine_soil_erodibility_factor(self.data.soil_layers[0].percent_sand_content,
+                                                                     self.data.soil_layers[0].percent_silt_content,
                                                                      self.data.soil_layers[0].percent_clay_content,
                                                                      self.data.soil_layers[0]
                                                                      .percent_organic_carbon_content)
         cover_factor = self._determine_cover_management_factor(minimum_cover_management_factor, surface_residue)
         support_practice_factor = self._determine_support_practice_factor()
         topographic_factor = self._determine_topographic_factor(self.data.slope_length,
-                                                                self.data.average_slope_fraction)
-        fragment_factor = self._determine_coarse_fragment_factor(self.data.first_rock_percent)
+                                                                self.data.average_subbasin_slope)
+        fragment_factor = self._determine_coarse_fragment_factor(self.data.soil_layers[0].percent_rock_content)
 
         if self.data.peak_runoff_rate is None:
             raise TypeError("SoilData peak_runoff_rate cannot be NoneType")

--- a/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
@@ -1,0 +1,393 @@
+# """
+# RUFAS: Ruminant Farm Systems Model
+#
+# File name: soil_erosion.py
+#
+# Author(s): William Donovan, wmdonovan@wisc.edu
+#
+# Description: This module contains the necessary functions for calculating and
+#              updating the soil erosion on a given day. Currently the only
+#              function meant to be used outside of this file is the update_all()
+#              function. The other functions are meant to serve as helper
+#              functions within this file.
+# """
+#
+# from math import exp, log, atan, sin
+#
+#
+# def update_all(soil, crop, weather, time):
+#     """
+#     Description:
+#         Updates all soil erosion information
+#
+#     Args:
+#         soil: instance of the Soil class specified in soil.py
+#         crop: instance of the Crop class specified in crop.py
+#         weather: instance of the Weather class specified in classes.py
+#         time: instance of the Time class specified in classes.py
+#     """
+#     for crop_types in crop.current_crop.values():
+#         calc_sed(soil, crop_types, weather, time)
+#
+#
+# def calc_sed(soil, crop_type, weather, time):
+#     """
+#     Description:
+#         Calculates sed, sediment yield on a given day (metric tons)
+#         "pseudocode_soil" S.3.A.1/17
+#
+#     Args:
+#         soil: instance of the Soil class specified in soil.py
+#         crop: instance of the Crop class specified in crop.py
+#         weather: instance of the Weather class specified in classes.py
+#         time: instance of the Time class specified in classes.py
+#     """
+#
+#     runoff = soil.runoff
+#     peak_runoff = calc_peak_runoff(soil, weather, time)
+#     K = calc_K(soil)
+#     C = calc_C(soil, crop_type)
+#
+#     # P = soil.practice_factor
+#     # we get the corresponding tillage year mapped to using time.calendar_year as the key
+#     P = soil.tillage[str(time.calendar_year)]
+#
+#     LS = calc_LS(soil)
+#
+#     sed = 11.8 * ((runoff * peak_runoff) ** 0.56) * K * C * P * LS
+#
+#     # Sediment yield is adjusted for snow on the range day < 60 or day > 350
+#     # "pseudocode_soil" S.3.A.17
+#     # TODO: arbitrary snow flag - GitHub Issue #164
+#     if time.day < 60 or time.day > 350:
+#         exp_part = exp(3 * 20 / 25.4)
+#         sed = sed / exp_part
+#
+#     soil.sed += sed
+#
+#
+# def calc_peak_runoff(soil, weather, time):
+#     """
+#     Description:
+#         Calculates the peak runoff rate (m^3/sec)
+#         "pseudocode_soil" S.3.A.2/3
+#
+#     Args:
+#         soil: instance of the Soil class specified in soil.py
+#         weather: instance of the Weather class specified in classes.py
+#         time: instance of the Time class specified in classes.py
+#
+#     Returns:
+#         int: peak_runoff, the peak runoff rate on the current day (m^3/sec
+#     """
+#
+#     R = weather.rainfall[time.year - 1][time.day - 1] + weather.irrigation[time.year - 1][time.day - 1]
+#
+#     if R == 0:
+#         return 0
+#
+#     # "pseudocode_soil" S.3.A.3
+#     runoff = soil.runoff
+#     RC = runoff / R
+#
+#     I = calc_I(soil, weather, time)
+#     area = soil.area
+#
+#     peak_runoff = (RC * I * area) / 3.6
+#
+#     return peak_runoff
+#
+#
+# def calc_I(soil, weather, time):
+#     """
+#     Description:
+#         Calculates I, the rainfall intensity (mm/hr)
+#         "pseudocode_soil" S.3.A.4
+#
+#     Args:
+#         soil: instance of the Soil class specified in soil.py
+#         weather: instance of the Weather class specified in classes.py
+#         time: instance of the Time class specified in classes.py
+#
+#     Returns:
+#         int: I, rainfall intensity (mm/hr)
+#     """
+#
+#     T_conc = calc_T_conc(soil)
+#     Rtc = calc_Rtc(soil, weather, time)
+#
+#     return Rtc / T_conc
+#
+#
+# def calc_T_conc(soil):
+#     """
+#     Description:
+#         Calculates T_conc (the time of concentration (h))
+#         "pseudocode_soil" S.3.A.5
+#
+#     Args:
+#         soil: instance of the Soil class specified in soil.py
+#
+#     Returns:
+#         int: T_conc, time of greatest concentration (h)
+#     """
+#
+#     length = soil.slope_length ** 0.6
+#     n = soil.manning ** 0.6
+#     slope = soil.field_slope ** 0.3
+#
+#     return (length * n) / (18 * slope)
+#
+#
+# def calc_Rtc(soil, weather, time):
+#     """
+#     Description:
+#         Calculates Rtc, the amount of rain during time of concentration (mm)
+#         "pseudocode_soil" S.3.A.6
+#
+#     Args:
+#         soil: instance of the Soil class specified in soil.py
+#         weather: instance of the Weather class specified in classes.py
+#         time: instance of the Time class specified in classes.py
+#
+#     Returns:
+#         int: Rtc, rainfall during time of concentration (mm)
+#     """
+#
+#     alpha = calc_alpha(soil, weather, time)
+#     R = weather.rainfall[time.year - 1][time.day - 1] + weather.irrigation[time.year - 1][time.day - 1]
+#
+#     return alpha * R
+#
+#
+# def calc_alpha(soil, weather, time):
+#     """
+#     Description:
+#        Calculates alpha, the fraction of daily rain during the time of concentration
+#         "pseudocode_soil" S.3.A.7
+#
+#     Args:
+#         soil: instance of the Soil class specified in soil.py
+#         weather: instance of the Weather class specified in classes.py
+#         time: instance of the Time class specified in classes.py
+#
+#     Returns:
+#         int: alpha, fraction of rain that occurs during time of concentration
+#     """
+#
+#     T_conc = calc_T_conc(soil)
+#     alpha_05 = calc_alpha_05(weather, time)
+#
+#     log_part = log(1 - alpha_05)
+#     exp_part = exp(2 * T_conc * log_part)
+#
+#     return 1 - exp_part
+#
+#
+# def calc_alpha_05(weather, time):
+#     """
+#     Description:
+#         Calculates alpha_05, the fraction of daily rain in the 1/2 hour of
+#         highest intensity.
+#         "pseudocode_soil" S.3.A.8
+#
+#     Args:
+#         weather: instance of the Weather class specified in classes.py
+#         time: instance of the Time class specified in classes.py
+#
+#     Returns:
+#         int: alpha_05, fraction of daily rain in the 1/2 hour of highest intensity
+#     """
+#
+#     R = weather.rainfall[time.year - 1][time.day - 1] + weather.irrigation[time.year - 1][time.day - 1]
+#
+#     exp_part = exp(-125 / (R + 5))
+#
+#     return (0.02083 + (1 - exp_part)) / 2
+#
+#
+# def calc_K(soil):
+#     """
+#     Description:
+#         Calculates the soil erodibility factor K.
+#         "pseudocode_soil" S.3.A.9
+#
+#     Args:
+#         soil: instance of the Soil class specified in soil.py
+#
+#     Returns:
+#         int: K, unitless soil erodibility factor
+#     """
+#
+#     Fc_sand = calc_Fc_sand(soil)
+#     Fcl_si = calc_Fcl_si(soil)
+#     F_org_C = calc_F_org_C(soil)
+#     F_sand = calc_F_sand(soil)
+#
+#     return Fc_sand * Fcl_si * F_org_C * F_sand
+#
+#
+# def calc_Fc_sand(soil):
+#     """
+#     Description:
+#         Calculates Fc_sand. Fc_sand gives low factors for soils with high sand
+#         contents and high values for soils with little sand when calculating K
+#         "pseudocode_soil" S.3.A.10
+#
+#     Args:
+#         soil: an instance of the Soil class
+#
+#     Returns:
+#         int: Fc_sand, unitless sand factor
+#     """
+#
+#     sand = soil.sand
+#     silt = soil.silt
+#
+#     exp_part = exp(-0.256 * sand * (1 - (silt / 100)))
+#
+#     return 0.2 + 0.3 * exp_part
+#
+#
+# def calc_Fcl_si(soil):
+#     """
+#     Description:
+#         Calculates Fcl_si. Fcl_si gives low factors for soils with high clay to silt
+#         ratios when calculating K
+#         "pseudocode_soil" S.3.A.11
+#
+#     Args:
+#         soil: an instance of the Soil class
+#
+#     Returns:
+#         int: Fcl_si, unitless clay:silt ratio factor
+#     """
+#
+#     silt = soil.silt
+#     clay = soil.soil_layers[0].clay
+#
+#     return (silt / (clay + silt)) ** 0.3
+#
+#
+# def calc_F_org_C(soil):
+#     """
+#     Description:
+#         Calculates F_org_C. F_org_C reduces soil erodibility for soils with
+#         high organic carbon content when calculating K
+#         "pseudocode_soil" S.3.A.12
+#
+#     Args:
+#         soil: an instance of the Soil class
+#
+#     Returns:
+#         int: F_org_C, unitless organic carbon factor
+#     """
+#
+#     org_C = soil.soil_layers[0].org_C
+#
+#     exp_part = exp(3.72 - 2.95 * org_C)
+#
+#     return 1 - ((0.25 * org_C) / (org_C + exp_part))
+#
+#
+# def calc_F_sand(soil):
+#     """
+#     Description:
+#         Calculates F_sand. F_sand reduces soil erodibility for soils with high
+#         sand contents when calculating K
+#         "pseudocode_soil" S.3.A.13
+#
+#     Args:
+#         soil: an instance of the Soil class
+#
+#     Returns:
+#         int: F_sand, unitless sand factor
+#     """
+#
+#     sand = soil.sand
+#
+#     exp_part = exp(-5.51 + 22.9 * (1 / (sand / 100)))
+#
+#     return 1 - (0.7 * (1 - sand / 100) / ((1 - sand / 100) + exp_part))
+#
+#
+# def calc_C(soil, crop_type):
+#     """
+#     Definitions:
+#         Calculates the cover and management factor, C, as the ratio of soil
+#         loss from land cropped under specified conditions to loss from
+#         clean-tilled, continuous fallow. The minimum value for C is estimated
+#         at 0.05
+#         "pseudocode_soil" S.3.A.14
+#
+#     Args:
+#         soil: an instance of the Soil class
+#         crop: an instance of the Crop class
+#
+#     Returns:
+#         int: C, unitless cover and management factor
+#     """
+#
+#     bio_AG = crop_type.bio_AG
+#
+#     residue = soil.residue
+#     Cover = bio_AG + residue
+#
+#     l1 = log(0.8)
+#     l2 = log(0.05)
+#     exp_part = exp(-0.00115 * Cover)
+#
+#     return exp((l1 - l2) * exp_part + l2)
+#
+#
+# def calc_LS(soil):
+#     """
+#     Description:
+#         Calculates the topographic factor LS (the expected ratio of soil loss
+#         per unit area from a 22.1-m length of uniform 9 percent slope under
+#         identical conditions
+#         "pseudocode_soil" S.3.A.15
+#
+#     Args:
+#         soil: an instance of the Soil class
+#
+#     Returns:
+#         int: LS, unitless topographic factor
+#     """
+#
+#     L_hill = soil.slope_length
+#     alpha_hill = atan(soil.field_slope)
+#     m = calc_m(soil)
+#
+#     sin2_alpha_hill = sin(alpha_hill) ** 2
+#     sin_alpha_hill = sin(alpha_hill)
+#
+#     return ((L_hill / 22.1) ** m) * \
+#         (65.41 * sin2_alpha_hill + 4.56 * sin_alpha_hill + 0.065)
+#
+#
+# def calc_m(soil):
+#     """
+#     Description:
+#         Calculates the exponent m as a function of field slope
+#         "pseudocode_soil" S.3.A.16
+#
+#     Args:
+#         soil: an instance of the Soil class
+#
+#     Returns:
+#         int: m, unitless field slope exponent
+#     """
+#
+#     slope = soil.field_slope
+#
+#     exp_part = exp(-35.835 * slope)
+#
+#     return 0.6 * (1 - exp_part)
+
+from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
+
+
+class SoilErosion:
+    def __init__(self, soil_data: Optional[SoilData]):
+        self.data = soil_data or SoilData()

--- a/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
@@ -23,7 +23,9 @@ class SoilErosion:
             surface_residue: amount of residue on the soil surface (kg per hectare)
 
         Details:
-
+            This method calculates the mass of soil that gets eroded from the soil profile based on the content of the
+            soil, how the soil is being farmed, how much rainfall there is and how much of that rain gets absorbed into
+            the soil, and the geometry of the field.
         """
         erodibility_factor = self._determine_soil_erodibility_factor(self.data.percent_sand_content,
                                                                      self.data.percent_silt_content,

--- a/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
@@ -157,9 +157,9 @@ class SoilErosion:
         return exp(first_multiplicative_term * second_multiplicative_term + second_additive_term)
 
     @staticmethod
-    def _determine_support_practice_factor() -> float:
-        """TODO: implement this for version 2 (only applies to fields that are doing contour tillage/planting,
-            stripcropping, and/or terracing) SWAT Reference: section 4:1.1.3"""
+    def _determine_support_practice_factor() -> float:  # TODO: implement this for version 2
+        """SWAT Reference: section 4:1.1.3 (only applies to fields that are doing contour tillage/planting,
+            stripcropping, and/or terracing)"""
         return 1
 
     @staticmethod

--- a/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
@@ -4,7 +4,7 @@ from math import exp, log, atan, sin
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 
 """
-This module follows MUSLE (Modified Universal Soil Loss Equation) in section 4:1.1 of SWAT
+This module follows MUSLE (Modified Universal Soil Loss Equation) in section 4:1.1 of SWAT.
 """
 
 
@@ -13,7 +13,7 @@ class SoilErosion:
         self.data = soil_data or SoilData()  # Initialize with defaults, if not given
 
     def erode(self, minimum_cover_management_factor: float, surface_residue: float) -> None:
-        """this is the main routine for SoilErosion. It is responsible for running all the necessary soil erosion
+        """This is the main routine for SoilErosion. It is responsible for running all the necessary soil erosion
             methods and updating attributes as necessary
 
         Args:
@@ -35,10 +35,8 @@ class SoilErosion:
 
         if self.data.peak_runoff_rate is None:
             raise TypeError("SoilData peak_runoff_rate cannot be NoneType")
-            return
         elif self.data.surface_runoff_volume is None:
             raise TypeError("SoilData surface_runoff_rate cannot be NoneType")
-            return
         sediment_yield = self._determine_sediment_yield(self.data.surface_runoff_volume, self.data.peak_runoff_rate,
                                                         self.data.field_size, erodibility_factor, cover_factor,
                                                         support_practice_factor, topographic_factor, fragment_factor)
@@ -48,14 +46,14 @@ class SoilErosion:
     # --- Static methods ---
     @staticmethod
     def _determine_coarse_sand_factor(percent_sand_content: float, percent_silt_content: float) -> float:
-        """calculates factor based on sand content for use in determining soil erodibility factor
+        """Calculates factor based on sand content for use in determining soil erodibility factor
 
         Args:
             percent_sand_content: percent of soil content that is sand
             percent_silt_content: percent of soil content that is silt
 
         Returns:
-            factor based on sand content (unitless)
+            Factor based on sand content (unitless)
 
         SWAT Reference: 4:1.1.6
         """
@@ -63,14 +61,14 @@ class SoilErosion:
 
     @staticmethod
     def _determine_clay_silt_ratio_factor(percent_silt_content: float, percent_clay_content: float) -> float:
-        """calculates factor based on the clay-silt ratio for use in calculating soil erodibility factor
+        """Calculates factor based on the clay-silt ratio for use in calculating soil erodibility factor
 
         Args:
             percent_silt_content: percent of silt in the given layer of soil
             percent_clay_content: percent of clay in the given layer of soil
 
         Returns:
-            clay-silt ratio factor (unitless)
+            Clay-silt ratio factor (unitless)
 
         SWAT Reference: 4:1.1.7
         """
@@ -80,13 +78,13 @@ class SoilErosion:
 
     @staticmethod
     def _determine_carbon_content_factor(percent_organic_carbon: float) -> float:
-        """calculates factor based on percent of organic carbon content for use in calculating soil erodibility factor
+        """Calculates factor based on percent of organic carbon content for use in calculating soil erodibility factor
 
         Args:
             percent_organic_carbon: percent of organic carbon content in the given layer of soil
 
         Returns:
-            organic carbon percent factor in the given layer of soil
+            Organic carbon percent factor in the given layer of soil
 
         SWAT Reference: 4:1.1.8
         """
@@ -95,13 +93,13 @@ class SoilErosion:
 
     @staticmethod
     def _determine_high_sand_factor(percent_sand_content: float) -> float:
-        """calculates factor based on percent sand content for use in calculating soil erodibility factor
+        """Calculates factor based on percent sand content for use in calculating soil erodibility factor
 
         Args:
             percent_sand_content: percent of sand in the given layer of soil
 
         Returns:
-            factor for adjusting soil erodibility factor based on high sand contents
+            Factor for adjusting soil erodibility factor based on high sand contents
 
         SWAT Reference: 4:1.1.9
         """
@@ -113,7 +111,7 @@ class SoilErosion:
     @staticmethod
     def _determine_soil_erodibility_factor(percent_sand_content: float, percent_silt_content: float,
                                            percent_clay_content: float, percent_organic_carbon_content: float) -> float:
-        """calculates the soil erodibility factor for use in calculating the sediment yield on a given day
+        """Calculates the soil erodibility factor for use in calculating the sediment yield on a given day
 
         Args:
             percent_sand_content: percent of sand in the given layer of soil
@@ -122,7 +120,7 @@ class SoilErosion:
             percent_organic_carbon_content: percent of organic carbon content in the given layer of soil
 
         Returns:
-            the soil erodibility factor (unitless)
+            The soil erodibility factor (unitless)
 
         SWAT Reference: 4:1.1.5
         """
@@ -134,14 +132,14 @@ class SoilErosion:
 
     @staticmethod
     def _determine_cover_management_factor(minimum_cover_management_factor: float, surface_residue: float) -> float:
-        """calculates cover and management factor for use in calculating sediment yield
+        """Calculates cover and management factor for use in calculating sediment yield
 
         Args:
             minimum_cover_management_factor: minimum value for cover and management factor for land cover (unitless)
             surface_residue: amount of residue on the soil surface (kg per hectare)
 
         Returns:
-            the cover and management factor (unitless)
+            The cover and management factor (unitless)
 
         SWAT Reference: 4:1.1.10
         """
@@ -155,18 +153,18 @@ class SoilErosion:
     @staticmethod
     def _determine_support_practice_factor() -> float:
         """TODO: implement this for version 2 (only applies to fields that are doing contour tillage/planting,
-            stripcropping, and/or terracing) SWAT Reference: section 4:1.1.3"""
+            stripcropping, and/or terracing) SWAT Reference: section 4:1.1.3 (GitHub issue #348)"""
         return 1
 
     @staticmethod
     def _determine_exponential_term(average_subbasin_slope: float) -> float:
-        """calculates the exponential term, which is used to calculate the topographic factor
+        """Calculates the exponential term, which is used to calculate the topographic factor
 
         Args:
             average_subbasin_slope: average slope fraction of the subbasin (unitless)
 
         Returns:
-            the exponential term (unitless)
+            The exponential term (unitless)
 
         SWAT Reference: 4:1.1.13
         """
@@ -174,7 +172,7 @@ class SoilErosion:
 
     @staticmethod
     def _determine_topographic_factor(slope_length: float, average_subbasin_slope: float) -> float:
-        """calculates expected ratio of soil loss per unit area from a field slope to that from a 22.1 m length of
+        """Calculates expected ratio of soil loss per unit area from a field slope to that from a 22.1 m length of
             uniform 9% slope under otherwise identical conditions (a.k.a the topographic factor)
 
         Args:
@@ -182,7 +180,7 @@ class SoilErosion:
             average_subbasin_slope: average slope fraction of the subbasin (m rise over m run)
 
         Returns:
-            the topographic factor (unitless)
+            The topographic factor (unitless)
 
         SWAT Reference: 4:1.1.12
         """
@@ -196,13 +194,13 @@ class SoilErosion:
 
     @staticmethod
     def _determine_coarse_fragment_factor(percent_rock_content: float) -> float:
-        """calculates coarse fragment factor for use in calculating sediment yield
+        """Calculates coarse fragment factor for use in calculating sediment yield
 
         Args:
             percent_rock_content: percent rock in first soil layer
 
         Returns:
-            coarse fragment factor (unitless)
+            Coarse fragment factor (unitless)
 
         SWAT Reference: 4:1.1.15
         """
@@ -213,7 +211,7 @@ class SoilErosion:
                                   soil_erodibility_factor: float, cover_management_factor: float,
                                   support_practice_factor: float, topographic_factor: float,
                                   coarse_fragment_factor: float) -> float:
-        """calculates the sediment yield for a given day
+        """Calculates the sediment yield for a given day
 
         Args:
             surface_area_runoff: surface runoff volume (mm per hectare)
@@ -229,7 +227,7 @@ class SoilErosion:
             coarse_fragment_factor: factor that adjusts for percent rock in the first soil layer (unitless)
 
         Returns:
-            sediment yield on a given day (metric tons)
+            Sediment yield on a given day (metric tons)
         """
         term_with_exponent = (surface_area_runoff * peak_runoff_rate * field_area) ** 0.56
         return (11.8 * term_with_exponent * soil_erodibility_factor * cover_management_factor * support_practice_factor
@@ -237,14 +235,14 @@ class SoilErosion:
 
     @staticmethod
     def _determine_adjusted_sediment_yield(sediment_yield: float, snow_water_content: float) -> float:
-        """adjusts the sediment yield based on how much snow cover there is
+        """Adjusts the sediment yield based on how much snow cover there is
 
         Args:
             sediment_yield: sediment yield on a given day (metric tons)
             snow_water_content: water content of the snow cover (mm)
 
         Returns:
-            the sediment yield on a given day adjusted for water content of the snow cover
+            The sediment yield on a given day adjusted for water content of the snow cover
 
         SWAT Reference: 4:1.3.1
         """

--- a/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
@@ -63,7 +63,7 @@ class SoilErosion:
 
     @staticmethod
     def _determine_clay_silt_ratio_factor(percent_silt_content: float, percent_clay_content: float) -> float:
-        """calculates factor based on the clay-silt ratio for use in calculating soil erodibility factor
+        """calculates the component factor of erodibility that is based on the clay-silt ratio.
 
         Args:
             percent_silt_content: percent of silt in the given layer of soil

--- a/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
@@ -36,7 +36,7 @@ class SoilErosion:
         support_practice_factor = self._determine_support_practice_factor()
         topographic_factor = self._determine_topographic_factor(self.data.slope_length,
                                                                 self.data.average_slope_fraction)
-        fragment_factor = self._determine_coarse_fragment_factor(self.data.percent_rock_content)
+        fragment_factor = self._determine_coarse_fragment_factor(self.data.first_rock_percent)
 
         if self.data.peak_runoff_rate is None:
             raise TypeError("SoilData peak_runoff_rate cannot be NoneType")

--- a/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
@@ -12,14 +12,17 @@ class SoilErosion:
     def __init__(self, soil_data: Optional[SoilData]):
         self.data = soil_data or SoilData()  # Initialize with defaults, if not given
 
-    def erode(self, minimum_cover_management_factor: float, surface_residue: float) -> None:
+    def erode(self, field_size: float, minimum_cover_management_factor: float, surface_residue: float) -> None:
         """This is the main routine for SoilErosion. It is responsible for running all the necessary soil erosion
-            methods and updating attributes as necessary
+            methods and updating attributes as necessary.
 
         Args:
+            field_size: size of the field that contains this Soil object (hectares)
             minimum_cover_management_factor: minimum value for cover and management factor for water erosion applicable
                 to land cover/plant (unitless)
             surface_residue: amount of residue on the soil surface (kg per hectare)
+
+        Details:
 
         """
         erodibility_factor = self._determine_soil_erodibility_factor(self.data.percent_sand_content,
@@ -35,10 +38,11 @@ class SoilErosion:
 
         if self.data.peak_runoff_rate is None:
             raise TypeError("SoilData peak_runoff_rate cannot be NoneType")
-        elif self.data.surface_runoff_volume is None:
-            raise TypeError("SoilData surface_runoff_rate cannot be NoneType")
+        elif self.data.accumulated_runoff is None:
+            raise TypeError("SoilData accumulated_runoff cannot be NoneType")
+        self.data.surface_runoff_volume = self.data.accumulated_runoff / field_size
         sediment_yield = self._determine_sediment_yield(self.data.surface_runoff_volume, self.data.peak_runoff_rate,
-                                                        self.data.field_size, erodibility_factor, cover_factor,
+                                                        field_size, erodibility_factor, cover_factor,
                                                         support_practice_factor, topographic_factor, fragment_factor)
         self.data.eroded_sediment += self._determine_adjusted_sediment_yield(sediment_yield,
                                                                              self.data.snow_cover_water_content)
@@ -46,7 +50,7 @@ class SoilErosion:
     # --- Static methods ---
     @staticmethod
     def _determine_coarse_sand_factor(percent_sand_content: float, percent_silt_content: float) -> float:
-        """Calculates factor based on sand content for use in determining soil erodibility factor
+        """Calculates factor based on sand content for use in determining soil erodibility factor.
 
         Args:
             percent_sand_content: percent of soil content that is sand
@@ -61,14 +65,18 @@ class SoilErosion:
 
     @staticmethod
     def _determine_clay_silt_ratio_factor(percent_silt_content: float, percent_clay_content: float) -> float:
-        """Calculates factor based on the clay-silt ratio for use in calculating soil erodibility factor
+        """Calculates the clay-silt ratio for use in calculating soil erodibility factor.
 
         Args:
             percent_silt_content: percent of silt in the given layer of soil
             percent_clay_content: percent of clay in the given layer of soil
 
+        Details:
+            The clay-silt ratio effects the erodibility of the soil, specifically soils with a high ratio of clay to
+            silt are less susceptible to erosion than soils with lower ratios of clay to silt.
+
         Returns:
-            Clay-silt ratio factor (unitless)
+            The clay-silt ratio factor, based on clay and silt content (unitless)
 
         SWAT Reference: 4:1.1.7
         """
@@ -78,13 +86,17 @@ class SoilErosion:
 
     @staticmethod
     def _determine_carbon_content_factor(percent_organic_carbon: float) -> float:
-        """Calculates factor based on percent of organic carbon content for use in calculating soil erodibility factor
+        """Calculates factor based on percent of organic carbon content for use in calculating soil erodibility factor.
 
         Args:
             percent_organic_carbon: percent of organic carbon content in the given layer of soil
 
+        Details:
+            The amount of organic carbon content in the soil effects the erodibility of the soil, specifically soils
+            with higher amounts of organic carbon content will have less erosion than soils with less.
+
         Returns:
-            Organic carbon percent factor in the given layer of soil
+            Carbon factor of erodibility based on organic carbon content of the soil (unitless)
 
         SWAT Reference: 4:1.1.8
         """
@@ -93,20 +105,22 @@ class SoilErosion:
 
     @staticmethod
     def _determine_high_sand_factor(percent_sand_content: float) -> float:
-        """Calculates factor based on percent sand content for use in calculating soil erodibility factor
+        """Calculates factor based on percent sand content for use in calculating soil erodibility factor.
 
         Args:
             percent_sand_content: percent of sand in the given layer of soil
 
+        Details:
+            When a soil has an extremely high sand content, it reduces the erodibility of that soil.
+
         Returns:
-            Factor for adjusting soil erodibility factor based on high sand contents
+            The high sand content factor of erodibility, based on the amount of sand in the soil (unitless)
 
         SWAT Reference: 4:1.1.9
         """
-        inverse_sand_percentage = 1 - (percent_sand_content / 100)
-        # TODO: better name for this variable
-        return 1 - ((0.7 * inverse_sand_percentage) / (inverse_sand_percentage + exp(-5.51 + 22.9 *
-                                                                                     inverse_sand_percentage)))
+        not_sand_fraction = 1 - (percent_sand_content / 100)
+        return 1 - ((0.7 * not_sand_fraction) / (not_sand_fraction + exp(-5.51 + 22.9 *
+                                                                         not_sand_fraction)))
 
     @staticmethod
     def _determine_soil_erodibility_factor(percent_sand_content: float, percent_silt_content: float,
@@ -119,8 +133,13 @@ class SoilErosion:
             percent_clay_content: percent of clay in the given layer of soil
             percent_organic_carbon_content: percent of organic carbon content in the given layer of soil
 
+        Details:
+            Some soils are more prone to erosion than others, based on how much sand, silt, clay, and organic carbon
+            they contain.
+
         Returns:
-            The soil erodibility factor (unitless)
+            The soil erodibility factor based on its coarse sand content, clay-silt ratio, clay content, and organic
+            carbon content (compound unit, irrelevant)
 
         SWAT Reference: 4:1.1.5
         """
@@ -137,6 +156,11 @@ class SoilErosion:
         Args:
             minimum_cover_management_factor: minimum value for cover and management factor for land cover (unitless)
             surface_residue: amount of residue on the soil surface (kg per hectare)
+
+        Details:
+            This factor accounts for what is planted in and/or physically covering the field. Erodibility is effected by
+            this because rainfall energy is either reduced or entirely eliminated when it hits the plant canopy or
+            residue on the soil surface, which means less energy is transferred to soil when the water reaches it.
 
         Returns:
             The cover and management factor (unitless)
@@ -179,6 +203,13 @@ class SoilErosion:
             slope_length: length of the slope (m)
             average_subbasin_slope: average slope fraction of the subbasin (m rise over m run)
 
+        Details:
+            The length and slope of a soil have an effect on erodibility, with shorter lengths and steeper slopes
+            resulting in more soil erosion. A shorter length means more erosion because sediment does not have to travel
+            as far to reach channels and be removed from the soil. A steeper slope means that there is less
+            resistance against the gravitational forces acting on a piece of sediment as it moves down the slope,
+            resulting in the soil eroding more easily.
+
         Returns:
             The topographic factor (unitless)
 
@@ -199,8 +230,13 @@ class SoilErosion:
         Args:
             percent_rock_content: percent rock in first soil layer
 
+        Details:
+            Since the mass of rocks are so much greater than particles of sand, silt, clay, etc., they require
+            significantly more force to move them off of a field, in other words erode them. So by having more rocks in
+            a soil, that soil erodes slower.
+
         Returns:
-            Coarse fragment factor (unitless)
+            Coarse fragment factor based on the rock content of the soil (unitless)
 
         SWAT Reference: 4:1.1.15
         """

--- a/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
@@ -26,7 +26,7 @@ class SoilErosion:
                                                                      self.data.percent_silt_content,
                                                                      self.data.soil_layers[0].percent_clay_content,
                                                                      self.data.soil_layers[0]
-                                                                                        .percent_organic_carbon_content)
+                                                                     .percent_organic_carbon_content)
         cover_factor = self._determine_cover_management_factor(minimum_cover_management_factor, surface_residue)
         support_practice_factor = self._determine_support_practice_factor()
         topographic_factor = self._determine_topographic_factor(self.data.slope_length,
@@ -39,11 +39,11 @@ class SoilErosion:
         elif self.data.surface_runoff_volume is None:
             raise TypeError("SoilData surface_runoff_rate cannot be NoneType")
             return
-        self.data.eroded_sediment += self._determine_sediment_yield(self.data.surface_runoff_volume,
-                                                                   self.data.peak_runoff_rate, self.data.field_size,
-                                                                   erodibility_factor, cover_factor,
-                                                                   support_practice_factor, topographic_factor,
-                                                                   fragment_factor)
+        sediment_yield = self._determine_sediment_yield(self.data.surface_runoff_volume, self.data.peak_runoff_rate,
+                                                        self.data.field_size, erodibility_factor, cover_factor,
+                                                        support_practice_factor, topographic_factor, fragment_factor)
+        self.data.eroded_sediment += self._determine_adjusted_sediment_yield(sediment_yield,
+                                                                             self.data.snow_cover_water_content)
 
     # --- Static methods ---
     @staticmethod
@@ -234,3 +234,18 @@ class SoilErosion:
         term_with_exponent = (surface_area_runoff * peak_runoff_rate * field_area) ** 0.56
         return (11.8 * term_with_exponent * soil_erodibility_factor * cover_management_factor * support_practice_factor
                 * topographic_factor * coarse_fragment_factor)
+
+    @staticmethod
+    def _determine_adjusted_sediment_yield(sediment_yield: float, snow_water_content: float) -> float:
+        """adjusts the sediment yield based on how much snow cover there is
+
+        Args:
+            sediment_yield: sediment yield on a given day (metric tons)
+            snow_water_content: water content of the snow cover (mm)
+
+        Returns:
+            the sediment yield on a given day adjusted for water content of the snow cover
+
+        SWAT Reference: 4:1.3.1
+        """
+        return sediment_yield / exp((3 * snow_water_content) / 25.4)

--- a/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
@@ -1,389 +1,3 @@
-# """
-# RUFAS: Ruminant Farm Systems Model
-#
-# File name: soil_erosion.py
-#
-# Author(s): William Donovan, wmdonovan@wisc.edu
-#
-# Description: This module contains the necessary functions for calculating and
-#              updating the soil erosion on a given day. Currently the only
-#              function meant to be used outside of this file is the update_all()
-#              function. The other functions are meant to serve as helper
-#              functions within this file.
-# """
-#
-# from math import exp, log, atan, sin
-#
-#
-# def update_all(soil, crop, weather, time):
-#     """
-#     Description:
-#         Updates all soil erosion information
-#
-#     Args:
-#         soil: instance of the Soil class specified in soil.py
-#         crop: instance of the Crop class specified in crop.py
-#         weather: instance of the Weather class specified in classes.py
-#         time: instance of the Time class specified in classes.py
-#     """
-#     for crop_types in crop.current_crop.values():
-#         calc_sed(soil, crop_types, weather, time)
-#
-#
-# def calc_sed(soil, crop_type, weather, time):
-#     """
-#     Description:
-#         Calculates sed, sediment yield on a given day (metric tons)
-#         "pseudocode_soil" S.3.A.1/17
-#
-#     Args:
-#         soil: instance of the Soil class specified in soil.py
-#         crop: instance of the Crop class specified in crop.py
-#         weather: instance of the Weather class specified in classes.py
-#         time: instance of the Time class specified in classes.py
-#     """
-#
-#     runoff = soil.runoff
-#     peak_runoff = calc_peak_runoff(soil, weather, time)
-#     K = calc_K(soil)
-#     C = calc_C(soil, crop_type)
-#
-#     # P = soil.practice_factor
-#     # we get the corresponding tillage year mapped to using time.calendar_year as the key
-#     P = soil.tillage[str(time.calendar_year)]
-#
-#     LS = calc_LS(soil)
-#
-#     sed = 11.8 * ((runoff * peak_runoff) ** 0.56) * K * C * P * LS
-#
-#     # Sediment yield is adjusted for snow on the range day < 60 or day > 350
-#     # "pseudocode_soil" S.3.A.17
-#     # TODO: arbitrary snow flag - GitHub Issue #164
-#     if time.day < 60 or time.day > 350:
-#         exp_part = exp(3 * 20 / 25.4)
-#         sed = sed / exp_part
-#
-#     soil.sed += sed
-#
-#
-# def calc_peak_runoff(soil, weather, time):
-#     """
-#     Description:
-#         Calculates the peak runoff rate (m^3/sec)
-#         "pseudocode_soil" S.3.A.2/3
-#
-#     Args:
-#         soil: instance of the Soil class specified in soil.py
-#         weather: instance of the Weather class specified in classes.py
-#         time: instance of the Time class specified in classes.py
-#
-#     Returns:
-#         int: peak_runoff, the peak runoff rate on the current day (m^3/sec
-#     """
-#
-#     R = weather.rainfall[time.year - 1][time.day - 1] + weather.irrigation[time.year - 1][time.day - 1]
-#
-#     if R == 0:
-#         return 0
-#
-#     # "pseudocode_soil" S.3.A.3
-#     runoff = soil.runoff
-#     RC = runoff / R
-#
-#     I = calc_I(soil, weather, time)
-#     area = soil.area
-#
-#     peak_runoff = (RC * I * area) / 3.6
-#
-#     return peak_runoff
-#
-#
-# def calc_I(soil, weather, time):
-#     """
-#     Description:
-#         Calculates I, the rainfall intensity (mm/hr)
-#         "pseudocode_soil" S.3.A.4
-#
-#     Args:
-#         soil: instance of the Soil class specified in soil.py
-#         weather: instance of the Weather class specified in classes.py
-#         time: instance of the Time class specified in classes.py
-#
-#     Returns:
-#         int: I, rainfall intensity (mm/hr)
-#     """
-#
-#     T_conc = calc_T_conc(soil)
-#     Rtc = calc_Rtc(soil, weather, time)
-#
-#     return Rtc / T_conc
-#
-#
-# def calc_T_conc(soil):
-#     """
-#     Description:
-#         Calculates T_conc (the time of concentration (h))
-#         "pseudocode_soil" S.3.A.5
-#
-#     Args:
-#         soil: instance of the Soil class specified in soil.py
-#
-#     Returns:
-#         int: T_conc, time of greatest concentration (h)
-#     """
-#
-#     length = soil.slope_length ** 0.6
-#     n = soil.manning ** 0.6
-#     slope = soil.field_slope ** 0.3
-#
-#     return (length * n) / (18 * slope)
-#
-#
-# def calc_Rtc(soil, weather, time):
-#     """
-#     Description:
-#         Calculates Rtc, the amount of rain during time of concentration (mm)
-#         "pseudocode_soil" S.3.A.6
-#
-#     Args:
-#         soil: instance of the Soil class specified in soil.py
-#         weather: instance of the Weather class specified in classes.py
-#         time: instance of the Time class specified in classes.py
-#
-#     Returns:
-#         int: Rtc, rainfall during time of concentration (mm)
-#     """
-#
-#     alpha = calc_alpha(soil, weather, time)
-#     R = weather.rainfall[time.year - 1][time.day - 1] + weather.irrigation[time.year - 1][time.day - 1]
-#
-#     return alpha * R
-#
-#
-# def calc_alpha(soil, weather, time):
-#     """
-#     Description:
-#        Calculates alpha, the fraction of daily rain during the time of concentration
-#         "pseudocode_soil" S.3.A.7
-#
-#     Args:
-#         soil: instance of the Soil class specified in soil.py
-#         weather: instance of the Weather class specified in classes.py
-#         time: instance of the Time class specified in classes.py
-#
-#     Returns:
-#         int: alpha, fraction of rain that occurs during time of concentration
-#     """
-#
-#     T_conc = calc_T_conc(soil)
-#     alpha_05 = calc_alpha_05(weather, time)
-#
-#     log_part = log(1 - alpha_05)
-#     exp_part = exp(2 * T_conc * log_part)
-#
-#     return 1 - exp_part
-#
-#
-# def calc_alpha_05(weather, time):
-#     """
-#     Description:
-#         Calculates alpha_05, the fraction of daily rain in the 1/2 hour of
-#         highest intensity.
-#         "pseudocode_soil" S.3.A.8
-#
-#     Args:
-#         weather: instance of the Weather class specified in classes.py
-#         time: instance of the Time class specified in classes.py
-#
-#     Returns:
-#         int: alpha_05, fraction of daily rain in the 1/2 hour of highest intensity
-#     """
-#
-#     R = weather.rainfall[time.year - 1][time.day - 1] + weather.irrigation[time.year - 1][time.day - 1]
-#
-#     exp_part = exp(-125 / (R + 5))
-#
-#     return (0.02083 + (1 - exp_part)) / 2
-#
-#
-# def calc_K(soil):
-#     """
-#     Description:
-#         Calculates the soil erodibility factor K.
-#         "pseudocode_soil" S.3.A.9
-#
-#     Args:
-#         soil: instance of the Soil class specified in soil.py
-#
-#     Returns:
-#         int: K, unitless soil erodibility factor
-#     """
-#
-#     Fc_sand = calc_Fc_sand(soil)
-#     Fcl_si = calc_Fcl_si(soil)
-#     F_org_C = calc_F_org_C(soil)
-#     F_sand = calc_F_sand(soil)
-#
-#     return Fc_sand * Fcl_si * F_org_C * F_sand
-#
-#
-# def calc_Fc_sand(soil):
-#     """
-#     Description:
-#         Calculates Fc_sand. Fc_sand gives low factors for soils with high sand
-#         contents and high values for soils with little sand when calculating K
-#         "pseudocode_soil" S.3.A.10
-#
-#     Args:
-#         soil: an instance of the Soil class
-#
-#     Returns:
-#         int: Fc_sand, unitless sand factor
-#     """
-#
-#     sand = soil.sand
-#     silt = soil.silt
-#
-#     exp_part = exp(-0.256 * sand * (1 - (silt / 100)))
-#
-#     return 0.2 + 0.3 * exp_part
-#
-#
-# def calc_Fcl_si(soil):
-#     """
-#     Description:
-#         Calculates Fcl_si. Fcl_si gives low factors for soils with high clay to silt
-#         ratios when calculating K
-#         "pseudocode_soil" S.3.A.11
-#
-#     Args:
-#         soil: an instance of the Soil class
-#
-#     Returns:
-#         int: Fcl_si, unitless clay:silt ratio factor
-#     """
-#
-#     silt = soil.silt
-#     clay = soil.soil_layers[0].clay
-#
-#     return (silt / (clay + silt)) ** 0.3
-#
-#
-# def calc_F_org_C(soil):
-#     """
-#     Description:
-#         Calculates F_org_C. F_org_C reduces soil erodibility for soils with
-#         high organic carbon content when calculating K
-#         "pseudocode_soil" S.3.A.12
-#
-#     Args:
-#         soil: an instance of the Soil class
-#
-#     Returns:
-#         int: F_org_C, unitless organic carbon factor
-#     """
-#
-#     org_C = soil.soil_layers[0].org_C
-#
-#     exp_part = exp(3.72 - 2.95 * org_C)
-#
-#     return 1 - ((0.25 * org_C) / (org_C + exp_part))
-#
-#
-# def calc_F_sand(soil):
-#     """
-#     Description:
-#         Calculates F_sand. F_sand reduces soil erodibility for soils with high
-#         sand contents when calculating K
-#         "pseudocode_soil" S.3.A.13
-#
-#     Args:
-#         soil: an instance of the Soil class
-#
-#     Returns:
-#         int: F_sand, unitless sand factor
-#     """
-#
-#     sand = soil.sand
-#
-#     exp_part = exp(-5.51 + 22.9 * (1 / (sand / 100)))
-#
-#     return 1 - (0.7 * (1 - sand / 100) / ((1 - sand / 100) + exp_part))
-#
-#
-# def calc_C(soil, crop_type):
-#     """
-#     Definitions:
-#         Calculates the cover and management factor, C, as the ratio of soil
-#         loss from land cropped under specified conditions to loss from
-#         clean-tilled, continuous fallow. The minimum value for C is estimated
-#         at 0.05
-#         "pseudocode_soil" S.3.A.14
-#
-#     Args:
-#         soil: an instance of the Soil class
-#         crop: an instance of the Crop class
-#
-#     Returns:
-#         int: C, unitless cover and management factor
-#     """
-#
-#     bio_AG = crop_type.bio_AG
-#
-#     residue = soil.residue
-#     Cover = bio_AG + residue
-#
-#     l1 = log(0.8)
-#     l2 = log(0.05)
-#     exp_part = exp(-0.00115 * Cover)
-#
-#     return exp((l1 - l2) * exp_part + l2)
-#
-#
-# def calc_LS(soil):
-#     """
-#     Description:
-#         Calculates the topographic factor LS (the expected ratio of soil loss
-#         per unit area from a 22.1-m length of uniform 9 percent slope under
-#         identical conditions
-#         "pseudocode_soil" S.3.A.15
-#
-#     Args:
-#         soil: an instance of the Soil class
-#
-#     Returns:
-#         int: LS, unitless topographic factor
-#     """
-#
-#     L_hill = soil.slope_length
-#     alpha_hill = atan(soil.field_slope)
-#     m = calc_m(soil)
-#
-#     sin2_alpha_hill = sin(alpha_hill) ** 2
-#     sin_alpha_hill = sin(alpha_hill)
-#
-#     return ((L_hill / 22.1) ** m) * \
-#         (65.41 * sin2_alpha_hill + 4.56 * sin_alpha_hill + 0.065)
-#
-#
-# def calc_m(soil):
-#     """
-#     Description:
-#         Calculates the exponent m as a function of field slope
-#         "pseudocode_soil" S.3.A.16
-#
-#     Args:
-#         soil: an instance of the Soil class
-#
-#     Returns:
-#         int: m, unitless field slope exponent
-#     """
-#
-#     slope = soil.field_slope
-#
-#     exp_part = exp(-35.835 * slope)
-#
-#     return 0.6 * (1 - exp_part)
 from typing import Optional
 from math import exp, log, atan, sin
 
@@ -396,7 +10,40 @@ This module follows MUSLE (Modified Universal Soil Loss Equation) in section 4:1
 
 class SoilErosion:
     def __init__(self, soil_data: Optional[SoilData]):
-        self.data = soil_data or SoilData() # Initialize with defaults, if not given
+        self.data = soil_data or SoilData()  # Initialize with defaults, if not given
+
+    def erode(self, minimum_cover_management_factor: float, surface_residue: float) -> None:
+        """this is the main routine for SoilErosion. It is responsible for running all the necessary soil erosion
+            methods and updating attributes as necessary
+
+        Args:
+            minimum_cover_management_factor: minimum value for cover and management factor for water erosion applicable
+                to land cover/plant (unitless)
+            surface_residue: amount of residue on the soil surface (kg per hectare)
+
+        """
+        erodibility_factor = self._determine_soil_erodibility_factor(self.data.percent_sand_content,
+                                                                     self.data.percent_silt_content,
+                                                                     self.data.soil_layers[0].percent_clay_content,
+                                                                     self.data.soil_layers[0]
+                                                                                        .percent_organic_carbon_content)
+        cover_factor = self._determine_cover_management_factor(minimum_cover_management_factor, surface_residue)
+        support_practice_factor = self._determine_support_practice_factor()
+        topographic_factor = self._determine_topographic_factor(self.data.slope_length,
+                                                                self.data.average_slope_fraction)
+        fragment_factor = self._determine_coarse_fragment_factor(self.data.percent_rock_content)
+
+        if self.data.peak_runoff_rate is None:
+            raise TypeError("SoilData peak_runoff_rate cannot be NoneType")
+            return
+        elif self.data.surface_runoff_volume is None:
+            raise TypeError("SoilData surface_runoff_rate cannot be NoneType")
+            return
+        self.data.eroded_sediment += self._determine_sediment_yield(self.data.surface_runoff_volume,
+                                                                   self.data.peak_runoff_rate, self.data.field_size,
+                                                                   erodibility_factor, cover_factor,
+                                                                   support_practice_factor, topographic_factor,
+                                                                   fragment_factor)
 
     # --- Static methods ---
     @staticmethod
@@ -494,7 +141,7 @@ class SoilErosion:
             surface_residue: amount of residue on the soil surface (kg per hectare)
 
         Returns:
-            cover and management factor (unitless)
+            the cover and management factor (unitless)
 
         SWAT Reference: 4:1.1.10
         """
@@ -560,3 +207,30 @@ class SoilErosion:
         SWAT Reference: 4:1.1.15
         """
         return exp(-0.053 * percent_rock_content)
+
+    @staticmethod
+    def _determine_sediment_yield(surface_area_runoff: float, peak_runoff_rate: float, field_area: float,
+                                  soil_erodibility_factor: float, cover_management_factor: float,
+                                  support_practice_factor: float, topographic_factor: float,
+                                  coarse_fragment_factor: float) -> float:
+        """calculates the sediment yield for a given day
+
+        Args:
+            surface_area_runoff: surface runoff volume (mm per hectare)
+            peak_runoff_rate: peak runoff rate (meters cubed per second)
+            field_area: area of the field/HRU that contains this soil (hectares)
+            soil_erodibility_factor: factor for how easily the soil erodes (unitless)
+            cover_management_factor: ratio of soil loss from land cropped under given conditions to corresponding loss
+                from clean-tilled, continuous fallow(unitless)
+            support_practice_factor: ratio of soil loss with specific support practice to corresponding loss with
+                up-and-down slope culture (unitless)
+            topographic_factor: expected ratio of soil loss per unit area from a field slope to that from a 22.1 m
+                length of uniform 9% slope under identical conditions (unitless)
+            coarse_fragment_factor: factor that adjusts for percent rock in the first soil layer (unitless)
+
+        Returns:
+            sediment yield on a given day (metric tons)
+        """
+        term_with_exponent = (surface_area_runoff * peak_runoff_rate * field_area) ** 0.56
+        return (11.8 * term_with_exponent * soil_erodibility_factor * cover_management_factor * support_practice_factor
+                * topographic_factor * coarse_fragment_factor)

--- a/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
@@ -384,8 +384,13 @@
 #     exp_part = exp(-35.835 * slope)
 #
 #     return 0.6 * (1 - exp_part)
+from typing import Optional
 
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
+
+"""
+This module follows MUSLE (Modified Universal Soil Loss Equation) in section 4:1.1 of SWAT
+"""
 
 
 class SoilErosion:

--- a/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
@@ -385,6 +385,7 @@
 #
 #     return 0.6 * (1 - exp_part)
 from typing import Optional
+from math import exp
 
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 
@@ -395,4 +396,92 @@ This module follows MUSLE (Modified Universal Soil Loss Equation) in section 4:1
 
 class SoilErosion:
     def __init__(self, soil_data: Optional[SoilData]):
-        self.data = soil_data or SoilData()
+        self.data = soil_data or SoilData() # Initialize with defaults, if not given
+
+    # --- Static methods ---
+    @staticmethod
+    def _determine_coarse_sand_factor(percent_sand_content: float, percent_silt_content: float) -> float:
+        """calculates factor based on sand content for use in determining soil erodibility factor
+
+        Args:
+            percent_sand_content: percent of soil content that is sand
+            percent_silt_content: percent of soil content that is silt
+
+        Returns:
+            factor based on sand content (unitless)
+
+        SWAT Reference: 4:1.1.6
+        """
+        return 0.2 + 0.3 * exp((-0.256) * percent_sand_content * (1 - (percent_silt_content / 100)))
+
+    @staticmethod
+    def _determine_clay_silt_ratio_factor(percent_silt_content: float, percent_clay_content: float) -> float:
+        """calculates factor based on the clay-silt ratio for use in calculating soil erodibility factor
+
+        Args:
+            percent_silt_content: percent of silt in the given layer of soil
+            percent_clay_content: percent of clay in the given layer of soil
+
+        Returns:
+            clay-silt ratio factor (unitless)
+
+        SWAT Reference: 4:1.1.7
+        """
+        if percent_silt_content == 0 and percent_clay_content == 0:
+            raise ValueError("Cannot have percent silt content and percent clay content both be 0")
+        return (percent_silt_content / (percent_clay_content + percent_silt_content)) ** 0.3
+
+    @staticmethod
+    def _determine_carbon_content_factor(percent_organic_carbon: float) -> float:
+        """calculates factor based on percent of organic carbon content for use in calculating soil erodibility factor
+
+        Args:
+            percent_organic_carbon: percent of organic carbon content in the given layer of soil
+
+        Returns:
+            organic carbon percent factor in the given layer of soil
+
+        SWAT Reference: 4:1.1.8
+        """
+        return 1 - ((0.25 * percent_organic_carbon) / (percent_organic_carbon +
+                                                       exp(3.72 - (2.95 * percent_organic_carbon))))
+
+    @staticmethod
+    def _determine_high_sand_factor(percent_sand_content: float) -> float:
+        """calculates factor based on percent sand content for use in calculating soil erodibility factor
+
+        Args:
+            percent_sand_content: percent of sand in the given layer of soil
+
+        Returns:
+            factor for adjusting soil erodibility factor based on high sand contents
+
+        SWAT Reference: 4:1.1.9
+        """
+        inverse_sand_percentage = 1 - (percent_sand_content / 100)
+        # TODO: better name for this variable
+        return 1 - ((0.7 * inverse_sand_percentage) / (inverse_sand_percentage + exp(-5.51 + 22.9 *
+                                                                                     inverse_sand_percentage)))
+
+    @staticmethod
+    def _determine_soil_erodibility_factor(percent_sand_content: float, percent_silt_content: float,
+                                           percent_clay_content: float, percent_organic_carbon_content: float) -> float:
+        """calculates the soil erodibility factor for use in calculating the sediment yield on a given day
+
+        Args:
+            percent_sand_content: percent of sand in the given layer of soil
+            percent_silt_content: percent of silt in the given layer of soil
+            percent_clay_content: percent of clay in the given layer of soil
+            percent_organic_carbon_content: percent of organic carbon content in the given layer of soil
+
+        Returns:
+            the soil erodibility factor (unitless)
+
+        SWAT Reference: 4:1.1.5
+        """
+        coarse_sand_factor = SoilErosion._determine_coarse_sand_factor(percent_sand_content, percent_silt_content)
+        clay_silt_factor = SoilErosion._determine_clay_silt_ratio_factor(percent_silt_content, percent_clay_content)
+        carbon_content_factor = SoilErosion._determine_carbon_content_factor(percent_organic_carbon_content)
+        high_sand_factor = SoilErosion._determine_high_sand_factor(percent_sand_content)
+        return coarse_sand_factor * clay_silt_factor * carbon_content_factor * high_sand_factor
+

--- a/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_erosion.py
@@ -385,7 +385,7 @@
 #
 #     return 0.6 * (1 - exp_part)
 from typing import Optional
-from math import exp
+from math import exp, log, atan, sin
 
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 
@@ -485,3 +485,78 @@ class SoilErosion:
         high_sand_factor = SoilErosion._determine_high_sand_factor(percent_sand_content)
         return coarse_sand_factor * clay_silt_factor * carbon_content_factor * high_sand_factor
 
+    @staticmethod
+    def _determine_cover_management_factor(minimum_cover_management_factor: float, surface_residue: float) -> float:
+        """calculates cover and management factor for use in calculating sediment yield
+
+        Args:
+            minimum_cover_management_factor: minimum value for cover and management factor for land cover (unitless)
+            surface_residue: amount of residue on the soil surface (kg per hectare)
+
+        Returns:
+            cover and management factor (unitless)
+
+        SWAT Reference: 4:1.1.10
+        """
+        if minimum_cover_management_factor <= 0:
+            raise ValueError("Minimum cover and management cannot be less than or equal to 0")
+        first_multiplicative_term = log(0.8) - log(minimum_cover_management_factor)
+        second_multiplicative_term = exp(-0.00115 * surface_residue)
+        second_additive_term = log(minimum_cover_management_factor)
+        return exp(first_multiplicative_term * second_multiplicative_term + second_additive_term)
+
+    @staticmethod
+    def _determine_support_practice_factor() -> float:
+        """TODO: implement this for version 2 (only applies to fields that are doing contour tillage/planting,
+            stripcropping, and/or terracing) SWAT Reference: section 4:1.1.3"""
+        return 1
+
+    @staticmethod
+    def _determine_exponential_term(average_subbasin_slope: float) -> float:
+        """calculates the exponential term, which is used to calculate the topographic factor
+
+        Args:
+            average_subbasin_slope: average slope fraction of the subbasin (unitless)
+
+        Returns:
+            the exponential term (unitless)
+
+        SWAT Reference: 4:1.1.13
+        """
+        return 0.6 * (1 - exp(-35.835 * average_subbasin_slope))
+
+    @staticmethod
+    def _determine_topographic_factor(slope_length: float, average_subbasin_slope: float) -> float:
+        """calculates expected ratio of soil loss per unit area from a field slope to that from a 22.1 m length of
+            uniform 9% slope under otherwise identical conditions (a.k.a the topographic factor)
+
+        Args:
+            slope_length: length of the slope (m)
+            average_subbasin_slope: average slope fraction of the subbasin (m rise over m run)
+
+        Returns:
+            the topographic factor (unitless)
+
+        SWAT Reference: 4:1.1.12
+        """
+        # Note: arctan(tan(x)) == x does not always hold, it is only true from -90 to 90 degrees, inclusive. It is safe
+        # to use here because there will never be a field at an angle < -90 or > 90 degrees
+        slope_angle_in_rad = atan(average_subbasin_slope)
+        exponential_term = SoilErosion._determine_exponential_term(average_subbasin_slope)
+        first_term = (slope_length / 22.1) ** exponential_term
+        second_term = 65.41 * (sin(slope_angle_in_rad) ** 2) + 4.56 * sin(slope_angle_in_rad) + 0.065
+        return first_term * second_term
+
+    @staticmethod
+    def _determine_coarse_fragment_factor(percent_rock_content: float) -> float:
+        """calculates coarse fragment factor for use in calculating sediment yield
+
+        Args:
+            percent_rock_content: percent rock in first soil layer
+
+        Returns:
+            coarse fragment factor (unitless)
+
+        SWAT Reference: 4:1.1.15
+        """
+        return exp(-0.053 * percent_rock_content)

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_infiltration.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_infiltration.py
@@ -234,3 +234,4 @@ def test_infiltrate(second_moisture_parameter, rainfall, is_top_frozen, coeffici
     assert incorp._determine_moisture_condition_parameter.call_count == 1
     assert incorp.data.previous_retention_parameter == 21.34
     assert incorp.data.moisture_condition_parameter == 50
+    assert incorp.data.accumulated_runoff == 0.95

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_infiltration.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_infiltration.py
@@ -191,14 +191,14 @@ def test_infiltrate(second_moisture_parameter, rainfall, is_top_frozen, coeffici
     """test that infiltrate() correctly stores all values in SoilData object and calls all the methods it should"""
     # initialize objects
     if is_top_frozen:
-        data = SoilData(potential_evapotranspiration=1.5, average_slope_fraction=0.07, previous_retention_parameter=27,
+        data = SoilData(potential_evapotranspiration=1.5, average_subbasin_slope=0.07, previous_retention_parameter=27,
                         soil_layers=[LayerData(top_depth=0, bottom_depth=10, temperature=-1)])
     else:
-        data = SoilData(potential_evapotranspiration=1.5, average_slope_fraction=0.07, previous_retention_parameter=27,
+        data = SoilData(potential_evapotranspiration=1.5, average_subbasin_slope=0.07, previous_retention_parameter=27,
                         soil_layers=[LayerData(top_depth=0, bottom_depth=10, temperature=14)])
     incorp = Infiltration(data)
     assert incorp.data.potential_evapotranspiration == 1.5
-    assert incorp.data.average_slope_fraction == 0.07
+    assert incorp.data.average_subbasin_slope == 0.07
     assert incorp.data.previous_retention_parameter == 27
 
     # mock helper functions

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_erosion.py
@@ -2,6 +2,7 @@ import pytest
 from math import exp, log, atan, sin
 from unittest.mock import MagicMock
 
+from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 from SC_redesign.Crop_and_Soil.soil.soil_erosion import SoilErosion
 
 
@@ -151,7 +152,6 @@ def test_determine_exponential_term(average_slope):
     observe = SoilErosion._determine_exponential_term(average_slope)
     exp_term = exp(-35.835 * average_slope)
     expect = 0.6 * (1 - exp_term)
-    # print(str(observe))
     assert observe == expect
 
 
@@ -192,3 +192,57 @@ def test_determine_coarse_fragment_factor(percent_rock):
     """tests _determine_coarse_fragment_factor() in soil_erosion.py"""
     observe = SoilErosion._determine_coarse_fragment_factor(percent_rock)
     expect = exp((-0.053) * percent_rock)
+    assert observe == expect
+
+
+@pytest.mark.parametrize("surface_runoff,peak_runoff_rate,field_area,erodibility_factor,cover_factor,practice_factor,"
+                         "topographic_factor,fragment_factor", [
+                             (10, 0.15, 1, 0.98, 0.79, 1, 0.88, 0.93),
+                             (34.59648, 0.2139485, 3.2294823, 0.99, 0.784248, 0.109401, 0.728394, 0.6569382),
+                             (18.91918429, 0.09184013, 0.8391984, 0.8729485473, 0.8192847, 0.7348924, 0.89717392,
+                              0.459683)
+                         ])
+def test_determine_sediment_yield(surface_runoff, peak_runoff_rate, field_area, erodibility_factor, cover_factor,
+                                  practice_factor, topographic_factor, fragment_factor):
+    """tests _determine_sediment_yield() in soil_erosion.py"""
+    observe = SoilErosion._determine_sediment_yield(surface_runoff, peak_runoff_rate, field_area, erodibility_factor,
+                                                    cover_factor, practice_factor, topographic_factor, fragment_factor)
+    expect = (11.8 * ((surface_runoff * peak_runoff_rate * field_area) ** 0.56) * erodibility_factor * cover_factor *
+              practice_factor * topographic_factor * fragment_factor)
+    assert observe == expect
+
+
+# --- Integration tests ---
+@pytest.mark.parametrize("min_cover_factor,residue", [
+    (0.2, 800),
+    (0.001, 500),
+    (0.003, 80),
+    (0.01, 0),
+    (0.05, 928.948569),
+])
+def test_erode(min_cover_factor, residue):
+    """tests that erode() properly calls methods and stores values"""
+
+    # Initialize objects
+    data = SoilData(accumulated_runoff= 13,peak_runoff_rate=0.11)
+    incorp = SoilErosion(data)
+
+    # Mock helper function
+    incorp._determine_soil_erodibility_factor = MagicMock(return_value=0.95)
+    incorp._determine_cover_management_factor = MagicMock(return_value=0.95)
+    incorp._determine_support_practice_factor = MagicMock(return_value=0.95)
+    incorp._determine_topographic_factor = MagicMock(return_value=0.95)
+    incorp._determine_coarse_fragment_factor = MagicMock(return_value=0.95)
+    incorp._determine_sediment_yield = MagicMock(return_value=0.05)
+
+    # Run method
+    incorp.erode(min_cover_factor, residue)
+
+    # Check everything
+    incorp._determine_soil_erodibility_factor.assert_called_once()
+    incorp._determine_cover_management_factor.assert_called_once()
+    incorp._determine_support_practice_factor.assert_called_once()
+    incorp._determine_topographic_factor.assert_called_once()
+    incorp._determine_coarse_fragment_factor.assert_called_once()
+    incorp._determine_sediment_yield.assert_called_once()
+    assert incorp.data.eroded_sediment == 0.05

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_erosion.py
@@ -15,12 +15,11 @@ from SC_redesign.Crop_and_Soil.soil.soil_erosion import SoilErosion
     (12.339485, 61.1938549),
     (23.4958769, 58.1093485),
 ])
-def test_determine_coarse_sand_factor(sand, silt):
-    """tests _determine_coarse_sand_factor() in soil_erosion.py"""
+def test_determine_coarse_sand_factor(sand: float, silt: float) -> None:
+    """Tests _determine_coarse_sand_factor() in soil_erosion.py"""
     observe = SoilErosion._determine_coarse_sand_factor(sand, silt)
     expect_exp_term = exp((-0.256) * sand * (1 - (silt / 100)))
     expect = 0.2 + 0.3 * expect_exp_term
-    # print(str(observe))
     assert observe == expect
 
 
@@ -31,21 +30,21 @@ def test_determine_coarse_sand_factor(sand, silt):
     (57.129485, 30.19485),
     (83.49482, 13.390458),
 ])
-def test_determine_clay_silt_ratio_factor(silt, clay):
-    """tests _determine_clay_silt_ratio_factor() in soil_erosion.py"""
+def test_determine_clay_silt_ratio_factor(silt: float, clay: float) -> None:
+    """Tests _determine_clay_silt_ratio_factor() in soil_erosion.py"""
     observe = SoilErosion._determine_clay_silt_ratio_factor(silt, clay)
     expect = silt / (clay + silt)
     expect = expect ** 0.3
-    # print(str(observe))
     assert observe == expect
 
 
 @pytest.mark.parametrize("silt,clay", [
     (0, 0),
 ])
-def test_error_clay_silt_ratio_factor(silt, clay):
-    """tests that _determine_clay_silt_ratio_factor() in soil_erosion.py correctly raises an error when invalid input is
-        given"""
+def test_error_clay_silt_ratio_factor(silt: float, clay: float) -> None:
+    """Tests that _determine_clay_silt_ratio_factor() in soil_erosion.py correctly raises an error when invalid input is
+        given
+    """
     with pytest.raises(Exception):
         SoilErosion._determine_clay_silt_ratio_factor(silt, clay)
 
@@ -58,12 +57,11 @@ def test_error_clay_silt_ratio_factor(silt, clay):
     0.029684,
     0.01395986,
 ])
-def test_determine_carbon_content_factor(carbon):
-    """tests _determine_carbon_content_factor() in soil_erosion.py"""
+def test_determine_carbon_content_factor(carbon: float) -> None:
+    """Tests _determine_carbon_content_factor() in soil_erosion.py"""
     observe = SoilErosion._determine_carbon_content_factor(carbon)
     expect_bottom_term = carbon + exp(3.72 - 2.95 * carbon)
     expect = 1 - ((0.25 * carbon) / expect_bottom_term)
-    # print(str(observe))
     assert observe == expect
 
 
@@ -78,14 +76,13 @@ def test_determine_carbon_content_factor(carbon):
     8.1019843912,
     4.1938402,
 ])
-def test_determine_high_sand_factor(sand):
-    """tests _determine_high_sand_factor() in soil_erosion.py"""
+def test_determine_high_sand_factor(sand: float) -> None:
+    """Tests _determine_high_sand_factor() in soil_erosion.py"""
     observe = SoilErosion._determine_high_sand_factor(sand)
     top_term = 0.7 * (1 - (sand / 100))
     first_bottom_term = (1 - (sand / 100))
     second_bottom_term = exp(-5.51 + 22.9 * first_bottom_term)
     expect = 1 - (top_term / (first_bottom_term + second_bottom_term))
-    # print(str(observe))
     assert observe == expect
 
 
@@ -96,8 +93,8 @@ def test_determine_high_sand_factor(sand):
     (30.104958, 50.1918749, 25.1143534, 0.0123923984),
     (50, 30.1948591, 19.8939582, 0.01139495),
 ])
-def test_determine_soil_erodibility_factor(sand, silt, clay, carbon):
-    """tests _determine_soil_erodibility_factor() in soil_erosion.py"""
+def test_determine_soil_erodibility_factor(sand: float, silt: float, clay: float, carbon: float) -> None:
+    """Tests _determine_soil_erodibility_factor() in soil_erosion.py"""
 
     # Mock helper methods
     SoilErosion._determine_coarse_sand_factor = MagicMock(return_value=0.28)
@@ -123,8 +120,8 @@ def test_determine_soil_erodibility_factor(sand, silt, clay, carbon):
     (0.01, 0),
     (0.05, 928.948569),
 ])
-def test_determine_cover_management_factor(min_cover, residue):
-    """tests _determine_cover_management_factor() in soil_erosion.py"""
+def test_determine_cover_management_factor(min_cover: float, residue: float) -> None:
+    """Tests _determine_cover_management_factor() in soil_erosion.py"""
     observe = SoilErosion._determine_cover_management_factor(min_cover, residue)
     expect = exp((log(0.8) - log(min_cover)) * exp(-0.00115 * residue) + log(min_cover))
     assert observe == expect
@@ -133,8 +130,8 @@ def test_determine_cover_management_factor(min_cover, residue):
 @pytest.mark.parametrize("min_cover,residue", [
     (0, 0)
 ])
-def test_error_determine_cover_management_factor(min_cover, residue):
-    """tests that _determine_cover_management_factor() correctly raises error for invalid inputs"""
+def test_error_determine_cover_management_factor(min_cover: float, residue: float) -> None:
+    """Tests that _determine_cover_management_factor() correctly raises error for invalid inputs"""
     with pytest.raises(Exception):
         SoilErosion._determine_cover_management_factor(min_cover, residue)
 
@@ -147,8 +144,8 @@ def test_error_determine_cover_management_factor(min_cover, residue):
     0.084595829,
     0.12593,
 ])
-def test_determine_exponential_term(average_slope):
-    """tests _determine_exponential_term() in soil_erosion.py"""
+def test_determine_exponential_term(average_slope: float) -> None:
+    """Tests _determine_exponential_term() in soil_erosion.py"""
     observe = SoilErosion._determine_exponential_term(average_slope)
     exp_term = exp(-35.835 * average_slope)
     expect = 0.6 * (1 - exp_term)
@@ -163,8 +160,8 @@ def test_determine_exponential_term(average_slope):
     (1, 0.28),
     (8.194894, 0.089493),
 ])
-def test_determine_topographic_factor(length, avg_slope):
-    """tests _determine_topographic_factor() in soil_erosion.py"""
+def test_determine_topographic_factor(length: float, avg_slope: float) -> None:
+    """Tests _determine_topographic_factor() in soil_erosion.py"""
 
     # Mock helper function
     SoilErosion._determine_exponential_term = MagicMock(return_value=0.45)
@@ -188,8 +185,8 @@ def test_determine_topographic_factor(length, avg_slope):
     0.0492184949,
     0.10495492330,
 ])
-def test_determine_coarse_fragment_factor(percent_rock):
-    """tests _determine_coarse_fragment_factor() in soil_erosion.py"""
+def test_determine_coarse_fragment_factor(percent_rock: float) -> None:
+    """Tests _determine_coarse_fragment_factor() in soil_erosion.py"""
     observe = SoilErosion._determine_coarse_fragment_factor(percent_rock)
     expect = exp((-0.053) * percent_rock)
     assert observe == expect
@@ -202,9 +199,10 @@ def test_determine_coarse_fragment_factor(percent_rock):
                              (18.91918429, 0.09184013, 0.8391984, 0.8729485473, 0.8192847, 0.7348924, 0.89717392,
                               0.459683)
                          ])
-def test_determine_sediment_yield(surface_runoff, peak_runoff_rate, field_area, erodibility_factor, cover_factor,
-                                  practice_factor, topographic_factor, fragment_factor):
-    """tests _determine_sediment_yield() in soil_erosion.py"""
+def test_determine_sediment_yield(surface_runoff: float, peak_runoff_rate: float, field_area: float,
+                                  erodibility_factor: float, cover_factor: float, practice_factor: float,
+                                  topographic_factor: float, fragment_factor: float) -> None:
+    """Tests _determine_sediment_yield() in soil_erosion.py"""
     observe = SoilErosion._determine_sediment_yield(surface_runoff, peak_runoff_rate, field_area, erodibility_factor,
                                                     cover_factor, practice_factor, topographic_factor, fragment_factor)
     expect = (11.8 * ((surface_runoff * peak_runoff_rate * field_area) ** 0.56) * erodibility_factor * cover_factor *
@@ -218,8 +216,8 @@ def test_determine_sediment_yield(surface_runoff, peak_runoff_rate, field_area, 
     (0.029385473, 2.49381),
     (0.108481, 6.193943),
 ])
-def test_determine_adjusted_sediment_yield(sediment_yield, snow_content):
-    """tests _determine_adjusted_sediment_yield() in soil_erosion.py"""
+def test_determine_adjusted_sediment_yield(sediment_yield: float, snow_content: float) -> float:
+    """Tests _determine_adjusted_sediment_yield() in soil_erosion.py"""
     observe = SoilErosion._determine_adjusted_sediment_yield(sediment_yield, snow_content)
     expect = sediment_yield / exp(3 * snow_content / 25.4)
     assert observe == expect
@@ -233,8 +231,8 @@ def test_determine_adjusted_sediment_yield(sediment_yield, snow_content):
     (0.01, 0),
     (0.05, 928.948569),
 ])
-def test_erode(min_cover_factor, residue):
-    """tests that erode() properly calls methods and stores values"""
+def test_erode(min_cover_factor: float, residue: float) -> float:
+    """Tests that erode() properly calls methods and stores values"""
 
     # Initialize objects
     data = SoilData(accumulated_runoff=13, peak_runoff_rate=0.11)

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_erosion.py
@@ -224,14 +224,14 @@ def test_determine_adjusted_sediment_yield(sediment_yield: float, snow_content: 
 
 
 # --- Integration tests ---
-@pytest.mark.parametrize("min_cover_factor,residue", [
-    (0.2, 800),
-    (0.001, 500),
-    (0.003, 80),
-    (0.01, 0),
-    (0.05, 928.948569),
+@pytest.mark.parametrize("field_size,min_cover_factor,residue", [
+    (1, 0.2, 800),
+    (3, 0.001, 500),
+    (4.69, 0.003, 80),
+    (0.891, 0.01, 0),
+    (0.956, 0.05, 928.948569),
 ])
-def test_erode(min_cover_factor: float, residue: float) -> float:
+def test_erode(field_size: float, min_cover_factor: float, residue: float) -> float:
     """Tests that erode() properly calls methods and stores values"""
 
     # Initialize objects
@@ -248,7 +248,7 @@ def test_erode(min_cover_factor: float, residue: float) -> float:
     incorp._determine_adjusted_sediment_yield = MagicMock(return_value=0.0498)
 
     # Run method
-    incorp.erode(min_cover_factor, residue)
+    incorp.erode(field_size, min_cover_factor, residue)
 
     # Check everything
     incorp._determine_soil_erodibility_factor.assert_called_once()

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_erosion.py
@@ -239,11 +239,11 @@ def test_erode(field_size: float, min_cover_factor: float, residue: float) -> fl
     incorp = SoilErosion(data)
 
     # Mock helper function
-    incorp._determine_soil_erodibility_factor = MagicMock(return_value=0.95)
+    incorp._determine_soil_erodibility_factor = MagicMock(return_value=0.87)
     incorp._determine_cover_management_factor = MagicMock(return_value=0.95)
-    incorp._determine_support_practice_factor = MagicMock(return_value=0.95)
-    incorp._determine_topographic_factor = MagicMock(return_value=0.95)
-    incorp._determine_coarse_fragment_factor = MagicMock(return_value=0.95)
+    incorp._determine_support_practice_factor = MagicMock(return_value=0.98)
+    incorp._determine_topographic_factor = MagicMock(return_value=0.79)
+    incorp._determine_coarse_fragment_factor = MagicMock(return_value=0.91)
     incorp._determine_sediment_yield = MagicMock(return_value=0.05)
     incorp._determine_adjusted_sediment_yield = MagicMock(return_value=0.0498)
 

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_erosion.py
@@ -1,5 +1,5 @@
 import pytest
-from math import exp
+from math import exp, log, atan, sin
 from unittest.mock import MagicMock
 
 from SC_redesign.Crop_and_Soil.soil.soil_erosion import SoilErosion
@@ -113,3 +113,82 @@ def test_determine_soil_erodibility_factor(sand, silt, clay, carbon):
     SoilErosion._determine_carbon_content_factor.assert_called_once()
     SoilErosion._determine_high_sand_factor.assert_called_once()
     assert observe == (0.28 * 0.93 * 0.99 * 0.95)
+
+
+@pytest.mark.parametrize("min_cover,residue", [
+    (0.2, 800),
+    (0.001, 500),
+    (0.003, 80),
+    (0.01, 0),
+    (0.05, 928.948569),
+])
+def test_determine_cover_management_factor(min_cover, residue):
+    """tests _determine_cover_management_factor() in soil_erosion.py"""
+    observe = SoilErosion._determine_cover_management_factor(min_cover, residue)
+    expect = exp((log(0.8) - log(min_cover)) * exp(-0.00115 * residue) + log(min_cover))
+    assert observe == expect
+
+
+@pytest.mark.parametrize("min_cover,residue", [
+    (0, 0)
+])
+def test_error_determine_cover_management_factor(min_cover, residue):
+    """tests that _determine_cover_management_factor() correctly raises error for invalid inputs"""
+    with pytest.raises(Exception):
+        SoilErosion._determine_cover_management_factor(min_cover, residue)
+
+
+@pytest.mark.parametrize("average_slope", [
+    0.02,
+    0,
+    0.001,
+    0.05,
+    0.084595829,
+    0.12593,
+])
+def test_determine_exponential_term(average_slope):
+    """tests _determine_exponential_term() in soil_erosion.py"""
+    observe = SoilErosion._determine_exponential_term(average_slope)
+    exp_term = exp(-35.835 * average_slope)
+    expect = 0.6 * (1 - exp_term)
+    # print(str(observe))
+    assert observe == expect
+
+
+@pytest.mark.parametrize("length, avg_slope", [
+    (3, 0.02),
+    (0, 0),
+    (16, 0.11),
+    (19, 0.19),
+    (1, 0.28),
+    (8.194894, 0.089493),
+])
+def test_determine_topographic_factor(length, avg_slope):
+    """tests _determine_topographic_factor() in soil_erosion.py"""
+
+    # Mock helper function
+    SoilErosion._determine_exponential_term = MagicMock(return_value=0.45)
+
+    # Run method
+    observe = SoilErosion._determine_topographic_factor(length, avg_slope)
+
+    # Calculate expected return value
+    expect = ((length / 22.1) ** 0.45) * (65.41 * (sin(atan(avg_slope)) ** 2) + 4.56 * sin(atan(avg_slope)) + 0.065)
+
+    # Check everything
+    SoilErosion._determine_exponential_term.assert_called_with(avg_slope)
+    assert observe == expect
+
+
+@pytest.mark.parametrize("percent_rock", [
+    0,
+    0.5,
+    0.02194,
+    0.019493,
+    0.0492184949,
+    0.10495492330,
+])
+def test_determine_coarse_fragment_factor(percent_rock):
+    """tests _determine_coarse_fragment_factor() in soil_erosion.py"""
+    observe = SoilErosion._determine_coarse_fragment_factor(percent_rock)
+    expect = exp((-0.053) * percent_rock)

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_erosion.py
@@ -212,6 +212,19 @@ def test_determine_sediment_yield(surface_runoff, peak_runoff_rate, field_area, 
     assert observe == expect
 
 
+@pytest.mark.parametrize("sediment_yield,snow_content", [
+    (0.015, 1),
+    (0.03, 3),
+    (0.029385473, 2.49381),
+    (0.108481, 6.193943),
+])
+def test_determine_adjusted_sediment_yield(sediment_yield, snow_content):
+    """tests _determine_adjusted_sediment_yield() in soil_erosion.py"""
+    observe = SoilErosion._determine_adjusted_sediment_yield(sediment_yield, snow_content)
+    expect = sediment_yield / exp(3 * snow_content / 25.4)
+    assert observe == expect
+
+
 # --- Integration tests ---
 @pytest.mark.parametrize("min_cover_factor,residue", [
     (0.2, 800),
@@ -234,6 +247,7 @@ def test_erode(min_cover_factor, residue):
     incorp._determine_topographic_factor = MagicMock(return_value=0.95)
     incorp._determine_coarse_fragment_factor = MagicMock(return_value=0.95)
     incorp._determine_sediment_yield = MagicMock(return_value=0.05)
+    incorp._determine_adjusted_sediment_yield = MagicMock(return_value=0.0498)
 
     # Run method
     incorp.erode(min_cover_factor, residue)
@@ -245,4 +259,5 @@ def test_erode(min_cover_factor, residue):
     incorp._determine_topographic_factor.assert_called_once()
     incorp._determine_coarse_fragment_factor.assert_called_once()
     incorp._determine_sediment_yield.assert_called_once()
-    assert incorp.data.eroded_sediment == 0.05
+    incorp._determine_adjusted_sediment_yield.assert_called_once()
+    assert incorp.data.eroded_sediment == 0.0498

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_erosion.py
@@ -1,0 +1,115 @@
+import pytest
+from math import exp
+from unittest.mock import MagicMock
+
+from SC_redesign.Crop_and_Soil.soil.soil_erosion import SoilErosion
+
+
+# --- Static method tests ---
+@pytest.mark.parametrize("sand,silt", [
+    (15, 65),
+    (0, 0),
+    (17, 60),
+    (9, 80),
+    (12.339485, 61.1938549),
+    (23.4958769, 58.1093485),
+])
+def test_determine_coarse_sand_factor(sand, silt):
+    """tests _determine_coarse_sand_factor() in soil_erosion.py"""
+    observe = SoilErosion._determine_coarse_sand_factor(sand, silt)
+    expect_exp_term = exp((-0.256) * sand * (1 - (silt / 100)))
+    expect = 0.2 + 0.3 * expect_exp_term
+    # print(str(observe))
+    assert observe == expect
+
+
+@pytest.mark.parametrize("silt,clay", [
+    (65, 20),
+    (66.23948, 20.4958),
+    (78.129348, 10.93845),
+    (57.129485, 30.19485),
+    (83.49482, 13.390458),
+])
+def test_determine_clay_silt_ratio_factor(silt, clay):
+    """tests _determine_clay_silt_ratio_factor() in soil_erosion.py"""
+    observe = SoilErosion._determine_clay_silt_ratio_factor(silt, clay)
+    expect = silt / (clay + silt)
+    expect = expect ** 0.3
+    # print(str(observe))
+    assert observe == expect
+
+
+@pytest.mark.parametrize("silt,clay", [
+    (0, 0),
+])
+def test_error_clay_silt_ratio_factor(silt, clay):
+    """tests that _determine_clay_silt_ratio_factor() in soil_erosion.py correctly raises an error when invalid input is
+        given"""
+    with pytest.raises(Exception):
+        SoilErosion._determine_clay_silt_ratio_factor(silt, clay)
+
+
+@pytest.mark.parametrize("carbon", [
+    0.012,
+    0,
+    0.039124,
+    0.0019485,
+    0.029684,
+    0.01395986,
+])
+def test_determine_carbon_content_factor(carbon):
+    """tests _determine_carbon_content_factor() in soil_erosion.py"""
+    observe = SoilErosion._determine_carbon_content_factor(carbon)
+    expect_bottom_term = carbon + exp(3.72 - 2.95 * carbon)
+    expect = 1 - ((0.25 * carbon) / expect_bottom_term)
+    # print(str(observe))
+    assert observe == expect
+
+
+@pytest.mark.parametrize("sand", [
+    15,
+    0,
+    23.5869348,
+    35.1938403,
+    76.193850,
+    80.10039458,
+    12.9498602,
+    8.1019843912,
+    4.1938402,
+])
+def test_determine_high_sand_factor(sand):
+    """tests _determine_high_sand_factor() in soil_erosion.py"""
+    observe = SoilErosion._determine_high_sand_factor(sand)
+    top_term = 0.7 * (1 - (sand / 100))
+    first_bottom_term = (1 - (sand / 100))
+    second_bottom_term = exp(-5.51 + 22.9 * first_bottom_term)
+    expect = 1 - (top_term / (first_bottom_term + second_bottom_term))
+    # print(str(observe))
+    assert observe == expect
+
+
+@pytest.mark.parametrize("sand,silt,clay,carbon", [
+    (15, 65, 22.5, 0.012),
+    (14.2938495, 68.29285945, 15.1918492, 0.02395923),
+    (10.4829458, 78.19128491, 17.1828402, 0.0300195829),
+    (30.104958, 50.1918749, 25.1143534, 0.0123923984),
+    (50, 30.1948591, 19.8939582, 0.01139495),
+])
+def test_determine_soil_erodibility_factor(sand, silt, clay, carbon):
+    """tests _determine_soil_erodibility_factor() in soil_erosion.py"""
+
+    # Mock helper methods
+    SoilErosion._determine_coarse_sand_factor = MagicMock(return_value=0.28)
+    SoilErosion._determine_clay_silt_ratio_factor = MagicMock(return_value=0.93)
+    SoilErosion._determine_carbon_content_factor = MagicMock(return_value=0.99)
+    SoilErosion._determine_high_sand_factor = MagicMock(return_value=0.95)
+
+    # Run method
+    observe = SoilErosion._determine_soil_erodibility_factor(sand, silt, clay, carbon)
+
+    # Check everything
+    SoilErosion._determine_coarse_sand_factor.assert_called_once()
+    SoilErosion._determine_clay_silt_ratio_factor.assert_called_once()
+    SoilErosion._determine_carbon_content_factor.assert_called_once()
+    SoilErosion._determine_high_sand_factor.assert_called_once()
+    assert observe == (0.28 * 0.93 * 0.99 * 0.95)

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_erosion.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_erosion.py
@@ -224,7 +224,7 @@ def test_erode(min_cover_factor, residue):
     """tests that erode() properly calls methods and stores values"""
 
     # Initialize objects
-    data = SoilData(accumulated_runoff= 13,peak_runoff_rate=0.11)
+    data = SoilData(accumulated_runoff=13, peak_runoff_rate=0.11)
     incorp = SoilErosion(data)
 
     # Mock helper function


### PR DESCRIPTION
# Summary
This PR refactors the `SoilErosion` module housed in the `soil_erosion.py` file based on section 4:1.1 of SWAT. The module is entirely comprised of static methods with the exception of the main routine that handles updating , `erode()`. All methods are tested in `test_soil_erosion.py`

# Changes
- `crop_data.py`: added attribute that is used to calculate erosion
- `layer_data.py`: added two attributes for use in calculating erosion, and one that is calculated in `Infiltration` but is also used by `SoilErosion`
- Also in `layer_data.py`: added the `@property` to calculate `percent_organic_matter_content` based on `percent_organic_carbon_content` in `LayerData` module. `percent_organic_matter_content` is provided in the example soil input files, but it appears to have been calculated with a formula different from the one SWAT specifies (4:1.1.4).
- `soil.py`: added import statement and attribute for `SoilErosion`, removed initialization of `SoilData` attributes which were already being initialized in `SoilData`
- `soil_data.py`:  added a number of attributes for `SoilErosion` to use. Fixed small mistakes in some `@property` methods. Added one `@property` method for `SoilErosion` to use
- `infiltration.py`: now records runoff in a `SoilData` attribute
- `test_infiltration.py`: tests that runoff is stored properly in `SoilData` object

