### PR TITLE
Crop dormancy

### DIFF
--- a/SC_redesign/Crop_and_Soil/crop/crop.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop.py
@@ -114,10 +114,6 @@ class Crop:
         """resets some attributes for perennial crops at the start of the new growing season"""
         pass
 
-    def destroy(self):  # Needed?
-        """destroys the crop - Destructor class. This removes the crop instance from existence"""
-        pass
-
     def start_dormancy(self):
         """Calls the main routine in Dormancy"""
         self.dormancy.go_into_dormancy()

--- a/SC_redesign/Crop_and_Soil/crop/crop.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop.py
@@ -114,12 +114,6 @@ class Crop:
         """resets some attributes for perennial crops at the start of the new growing season"""
         pass
 
-    def start_dormancy(self):
-        """Calls the main routine in Dormancy"""
-        self.dormancy.go_into_dormancy()
-
-
-
 # ---- Old versions of cut() and kill()
 # def kill(crop_type, field_management, time):
 #     """

--- a/SC_redesign/Crop_and_Soil/crop/crop.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop.py
@@ -118,7 +118,7 @@ class Crop:
         """destroys the crop - Destructor class. This removes the crop instance from existence"""
         pass
 
-    def assess_dormancy(self):
+    def start_dormancy(self):
         """Calls the main routine in Dormancy"""
         self.dormancy.go_into_dormancy()
 

--- a/SC_redesign/Crop_and_Soil/crop/crop.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop.py
@@ -8,6 +8,7 @@ from SC_redesign.Crop_and_Soil.crop.heat_units import HeatUnits
 from SC_redesign.Crop_and_Soil.crop.leaf_area_index import LeafAreaIndex
 from SC_redesign.Crop_and_Soil.crop.root_development import RootDevelopment
 from SC_redesign.Crop_and_Soil.crop.crop_management import CropManagement
+from SC_redesign.Crop_and_Soil.crop.dormancy import Dormancy
 
 from SC_redesign.Crop_and_Soil.crop.crop_data import CropData
 from typing import List, Optional
@@ -46,6 +47,8 @@ class Crop:
         """Process component controlling plant root development"""
         self.crop_management = CropManagement(self.data)
         """Process component controlling calculation of end-of-season production"""
+        self.dormancy = Dormancy(self.data)
+        """Process component performing dormancy operations"""
 
     def grow_crop(self, layer_nitrates: List[float], layer_depths: List[float],
                   layer_phosphates: List[float],
@@ -111,12 +114,11 @@ class Crop:
         pass
 
     def destroy(self):  # Needed?
-        """destoys the crop - Destructor class. This removes the crop instance from existence"""
+        """destroys the crop - Destructor class. This removes the crop instance from existence"""
         pass
 
-    def assess_dormancy(self):  # TODO: implement dormancy method
-        if self.data.is_perennial:
-            pass
+    def assess_dormancy(self):  # TODO: implement dormancy method - handled in CropData
+        self.dormancy.go_into_dormancy()
 
 
 

--- a/SC_redesign/Crop_and_Soil/crop/crop.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop.py
@@ -62,7 +62,8 @@ class Crop:
         """main function for growing the crop on a daily basis
 
         Args:
-            adjusted_potential_evapotranspiration: potential evapotranspiration adjusted for evaporation of free water in canopy in mm
+            adjusted_potential_evapotranspiration: potential evapotranspiration adjusted for evaporation of free water
+                in canopy in mm
             layer_nitrates: nitrates present in each layer of the soil profile (kg/ha)
             layer_depths: the maximum depth of each soil layer
             layer_phosphates: phosphates present in each layer of the soil profile (kg/ha)
@@ -117,7 +118,8 @@ class Crop:
         """destroys the crop - Destructor class. This removes the crop instance from existence"""
         pass
 
-    def assess_dormancy(self):  # TODO: implement dormancy method - handled in CropData
+    def assess_dormancy(self):
+        """Calls the main routine in Dormancy"""
         self.dormancy.go_into_dormancy()
 
 

--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -3,9 +3,7 @@ from dataclasses import dataclass
 from typing import Optional, List
 
 
-# TODO: defaults need to be reviewed and updated. See the SWAT crop database for values
-
-class PlantTypes(Enum):
+class PlantCategory(Enum):
     """Enum of all plant types supported by RuFaS. Listed for supported plant types in SWAT Appendix A, table A-1"""
     WARM_ANNUAL_LEGUME = "warm_annual_legume"
     COOL_ANNUAL_LEGUME = "cool_annual_legume"
@@ -40,8 +38,10 @@ class CropData:
     """4-letter plant code (used by SWAT)"""
     scientific_name: Optional[str] = None
     """taxonomic name of the plant"""
-    plant_type: PlantTypes = PlantTypes("cool_annual")
+    plant_category: Optional[PlantCategory] = PlantCategory("cool_annual")
     """Classification of the plant (Reference SWAT crop.dat file, IDC variable"""
+    is_perennial: Optional[bool] = False
+    """is this plant perennial?"""
     is_nitrogen_fixer: bool = False
     """is the plant a nitrogen fixer?"""
     priority: int = 1
@@ -148,8 +148,6 @@ class CropData:
     """phosphorus stored in plant biomass (kg/ha)"""
     optimal_phosphorus: float = 80
     """optimal amount of phosphorus stored in the plant for the current growth stage (kg/ha)"""
-
-    ##growth_factor: float = 1.0  # duplicate
     water_stress: Optional[float] = None
     """water stress for the day (unitless; [0, 1])"""
     temp_stress: Optional[float] = None
@@ -160,7 +158,6 @@ class CropData:
     """phosphorus stress for the day (unitless; [0, 1])"""
 
     # ---- heat_units
-    ##minimum_temperature: float = 20 # duplicate
     maximum_temperature: float = 38
     """maximum temperature above which plant growth cannot occur (Celsius)"""
     potential_heat_units: float = 800
@@ -168,7 +165,7 @@ class CropData:
     accumulated_heat_units: float = 0  # accumulator
     """total heat units accumulated to date (unitless)"""
     is_growing: bool = True
-    # TODO: not currently using; SWAT 5:2.1.4 (pretty sure this is a section, not equation, reference)
+    # TODO: not currently used; SWAT 5:2.1.4 (pretty sure this is a section, not equation, reference)
     """is the crop currently growing?"""
     is_dormant: bool = False
     """is the crop currently dormant?"""
@@ -189,15 +186,8 @@ class CropData:
     """fraction of potential heat units on the previous day (unitless)"""
 
     # ---- leaf area index
-    # fixed attributes (unchanged during simulations)
     max_canopy_height: float = 2.5  # m
     """maximum canopy height for the plant (m)"""
-    ##growth_factor = 1.0  #duplicate
-
-    # variable attributes (change throughout simulations)
-    ##leaf_area_index = 0 # duplicate
-    ##heat_fraction = 0.73 # duplicate
-    # empty variables
     _lai_shapes: Optional[float] = None
     """shape coefficients used to calculate fraction of max leaf area index (unitless)."""
     optimal_leaf_area_fraction: Optional[float] = None
@@ -214,7 +204,6 @@ class CropData:
     """optimal leaf area fraction on the previous day (unitless)"""
 
     # ---- nitrogen incorporation
-    # constant declarations with defaults (unchanged during simulations)
     half_mature_heat_fraction: float = 0.5
     """expected fraction of potential heat units when the plant is half-way to maturity (unitless)"""
     mature_heat_fraction: float = 1.0
@@ -223,23 +212,14 @@ class CropData:
     """expected fraction of plant biomass comprised of nitrogen for the plant at near-maturity (unitless)"""
     nitrogen_distro_param: float = 10
     """nitrogen uptake distribution parameter (unitless)"""
-
-    # current declarations with defaults (change throughout simulations)
-    # TODO: what module sets/updates these variables?
-    ##nitrogen = 0 # duplicate
-    ##heat_fraction = 0.73  # duplicate
-    ##biomass = 12.5  # duplicate
-    ##biomass_growth_max = 100  # duplicate
     root_depth: float = 1  # arbitrary
     """current depth of the plant roots in the soil (mm)"""
-    # empty declarations
     nitrogen_shapes: Optional[List[float]] = None
     """first and second shape coefficients for the nitrogen uptake equations (unitless)"""
     previous_nitrogen: Optional[float] = None
     """nitrogen stored in plant biomass on the previous day (kg/ha)"""
     optimal_nitrogen_fraction: Optional[float] = None
     """optimal proportion of the plant's biomass comprised of nitrogen for the current growth stage (unitless)"""
-    ##optimal_nitrogen = None # duplicate
     potential_nitrogen_uptake: Optional[float] = None
     """potential nitrogen to be taken up by the plant under ideal circumstances for the current day (kg/ha)"""
     total_soil_layers: Optional[int] = None
@@ -272,7 +252,6 @@ class CropData:
     """expected fraction of plant biomass comprised of nitrogen for the plant near maturity (unitless)"""
     phosphorus_distro_param: float = 10
     """phosphorus uptake distribution parameter (unitless)"""
-
     phosphorus_shapes: Optional[List[float]] = None
     """first and second shape coefficients for the nitrogen uptake equations (unitless)"""
     previous_phosphorus: Optional[float] = None
@@ -285,12 +264,8 @@ class CropData:
     """actual phosphorus to be taken up by the plant from each soil layer (kg/ha)"""
 
     # ---- root development
-    ##heat_fraction = 1 / 3 #duplicate
     max_root_depth: float = 20
     """maximum depth of roots in the soil (mm)"""
-
-    ##root_depth = None # duplicate
-    ##root_fraction = None #duplicate
 
     # ---- water dynamics
     cumulative_evaporation: Optional[float] = None
@@ -307,27 +282,13 @@ class CropData:
     """maximum transpiration on a given day (mm)"""
 
     # ---- yields
-    # constant attributes
-
-    # is_residue_added: bool = False ## not needed?
     harvest_efficiency: float = 1.0
     """efficiency of the harvest operation: the proportion of yield that will be extracted from the field 
     (unitless; [0, 1])"""
-
-    # temporally variable attributes
-    ##heat_fraction = 0.6  # duplicate
-    ##water_deficiency = 0.2  # duplicate
-    ##above_ground_biomass: float = 15  # kg
-    ##biomass = 25  # duplicate
     dry_down_fraction: float = 0.2
     """proportion of plant biomass that is lost to dry-down (unitless; [0, 1])"""
-    ##nitrogen = 15  # duplicate
-    ##phosphorus = 8  # duplicate
-    ##biomass = 100  # duplicate
-    ##optimal_nitrogen_fraction = 0.162  # duplicate
     optimal_phosphorus_fraction: float = 0.073
     """optimal proportion of the plant's biomass comprised of nitrogen for the current growth stage (unitless)"""
-    # Empty declarations
     user_harvest_index: Optional[float] = None  # TODO: handle user input for this. - GitHub Issue #246
     """a user-specified harvest index (unitless). If given, 'harvest-index-override' is triggered"""
     potential_harvest_index: Optional[float] = None
@@ -351,18 +312,28 @@ class CropData:
     """Fraction of biomass the crop loses when it goes dormant. Default 0.1 for perennials, 0.3 for trees
         Reference: SWAT Theoretical 5:1.2, and crop.dat BIO_LEAF description"""
     minimum_lai_during_dormancy: Optional[float] = 0.75
-    """Minimum leaf area index for plants (perennials and trees only) during dormancy (unitless)"""
-    # TODO: SWAT Appendix-A section A.1.12 says that the default 0.75 is from pre-2009 versions of SWAT and users are
-    #  now allowed to modify this value. But it does not provide values for any of the listed plant species and gives no
-    #  information about how this value can be measured or calculated. Also, if leaf area index is less than the minium
-    #  before going into dormancy, should it just stay at its current leaf area index?
+    """Minimum leaf area index for plants (perennials and trees only) during dormancy (unitless)
+    
+    Note: SWAT Appendix-A section A.1.12 says that the default 0.75 is from pre-2009 versions of SWAT and users are
+    now allowed to modify this value. But it does not provide values for any of the listed plant species and gives no
+    information about how this value can be measured or calculated.
+    """
 
     def __post_init__(self):
         """Initialize all attributes with defaults that depend on other attributes"""
-        if self.plant_type == PlantTypes.PERENNIAL or PlantTypes.PERENNIAL_LEGUME:
+
+        # Set dormancy loss
+        if self.plant_category == PlantCategory.PERENNIAL or PlantCategory.PERENNIAL_LEGUME:
             self.dormancy_loss_fraction = 0.1
-        elif self.plant_type == PlantTypes.TREE:
+        elif self.plant_category == PlantCategory.TREE:
             self.dormancy_loss_fraction = 0.3
+
+        # Set perennial status
+        if self.plant_category == PlantCategory.PERENNIAL or self.plant_category == PlantCategory.PERENNIAL_LEGUME or \
+                self.plant_category == PlantCategory.TREE:
+            self.is_perennial = True
+        else:
+            self.is_perennial = False
 
     @property
     def is_mature(self) -> bool:
@@ -378,14 +349,6 @@ class CropData:
     def is_in_senescence(self) -> bool:
         """check if the plant is in senescence"""
         return self.heat_fraction > self.senescent_heat_fraction
-
-    @property
-    def is_perennial(self) -> bool:
-        """Returns True if the plant is a perennial"""
-        if self.plant_type == PlantTypes.PERENNIAL or self.plant_type == PlantTypes.PERENNIAL_LEGUME:
-            return True
-        return False
-
 
 
 """
@@ -408,7 +371,7 @@ class Corn(CropData):
     name: str = "default corn"
     plant_code: str = "CORN"
     scientific_name: str = "Zea mays"
-    plant_type: PlantTypes = PlantTypes("warm_annual")
+    plant_category: PlantCategory = PlantCategory("warm_annual")
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 8.0
@@ -443,7 +406,7 @@ class SpringWheat(CropData):
     name: str = "default spring_wheat"
     plant_code: str = "SWHT"
     scientific_name: str = "Triticum aestivum"
-    plant_type: PlantTypes = PlantTypes("cool_annual")
+    plant_category: PlantCategory = PlantCategory("cool_annual")
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0.0
@@ -478,7 +441,7 @@ class WinterWheat(CropData):
     name: str = "default winter_wheat"
     plant_code: str = "WWHT"
     scientific_name: str = "Triticum aestivum"
-    plant_type: PlantTypes = PlantTypes("cool_annual")
+    plant_category: PlantCategory = PlantCategory("cool_annual")
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0.0
@@ -513,7 +476,7 @@ class CerealRye(CropData):
     name: str = "default cereal_rye"
     plant_code: str = "RYE"
     scientific_name: str = "Secale cereale"
-    plant_type: PlantTypes = PlantTypes("cool_annual")
+    plant_category: PlantCategory = PlantCategory("cool_annual")
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0
@@ -548,7 +511,7 @@ class SpringBarley(CropData):
     name: str = "default spring_barley"
     plant_code: str = "BARL"
     scientific_name: str = "Hordeum vulgare"
-    plant_type: PlantTypes = PlantTypes("cool_annual")
+    plant_category: PlantCategory = PlantCategory("cool_annual")
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0.0
@@ -583,7 +546,7 @@ class FallOats(CropData):
     name: str = "default fall_oats"
     plant_code: str = "OATS"
     scientific_name: str = "Avena sativa"
-    plant_type: PlantTypes = PlantTypes("cool_annual")
+    plant_category: PlantCategory = PlantCategory("cool_annual")
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0.0
@@ -618,7 +581,7 @@ class TallFescue(CropData):
     name: str = "default tall_fescue"
     plant_code: str = "FESC"
     scientific_name: str = "Festuca arundinaceae"
-    plant_type: PlantTypes = PlantTypes("perennial")
+    plant_category: PlantCategory = PlantCategory("perennial")
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0.0
@@ -653,7 +616,7 @@ class Alfalfa(CropData):
     name: str = "default alfalfa"
     plant_code: str = "ALFA"
     scientific_name: str = "Medicago sativa"
-    plant_type: PlantTypes = PlantTypes("perennial_legume")
+    plant_category: PlantCategory = PlantCategory("perennial_legume")
     is_nitrogen_fixer: bool = True
 
     minimum_temperature: float = 4.0
@@ -688,7 +651,7 @@ class Soybean(CropData):
     name: str = "default soybean"
     plant_code: str = "SOYB"
     scientific_name: str = "Glycine max"
-    plant_type: PlantTypes = PlantTypes("warm_annual_legume")
+    plant_category: PlantCategory = PlantCategory("warm_annual_legume")
     is_nitrogen_fixer: bool = True
 
     minimum_temperature: float = 10.0
@@ -723,7 +686,7 @@ class SugarBeet(CropData):
     name: str = "default sugar_beet"
     plant_code: str = "SGBT"
     scientific_name: str = "Beta vulgaris saccharifera"
-    plant_type: PlantTypes = PlantTypes("warm_annual")
+    plant_category: PlantCategory = PlantCategory("warm_annual")
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 4.0
@@ -758,7 +721,7 @@ class Potato(CropData):
     name: str = "default potato"
     plant_code: str = "POTA"
     scientific_name: str = "Solanum tuberosum"
-    plant_type: PlantTypes = PlantTypes("cool_annual")
+    plant_category: PlantCategory = PlantCategory("cool_annual")
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 7.0

--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -29,9 +29,6 @@ class CropData:
       The upside is that this facilitates dataclass inheritance. For example, the CornData class inherits from CropData
       but will have its values set to different defaults.
     """
-
-    # TODO: do we want to add a mechanism to strictly enforce attribute type annotations?
-
     # ID variables (SWAT Table A-1 ish)
     species: Optional[str] = "generic"
     """the species of the crop"""

--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -8,7 +8,7 @@ from typing import Optional, List
 class PlantTypes(Enum):
     """Enum of all plant types supported by RuFaS. Listed for supported plant types in SWAT Appendix A, table A-1"""
     WARM_ANNUAL_LEGUME = "warm_annual_legume"
-    COLD_ANNUAL_LEGUME = "cold_annual_legume"
+    COOL_ANNUAL_LEGUME = "cool_annual_legume"
     PERENNIAL_LEGUME = "perennial_legume"
     WARM_ANNUAL = "warm_annual"
     COOL_ANNUAL = "cool_annual"

--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -349,11 +349,18 @@ class CropData:
     """phosphorus contained in the harvested yield (kg/ha)"""
 
     # ---- dormancy
-    is_dormant = False
-    """is the crop dormant?"""
-    dormancy_loss_fraction = 0.1
-    """fraction of biomass the crop loses when it goes dormant. Always 10% for perennials, varies for trees
+    dormancy_loss_fraction: Optional[float] = 0.1
+    """Fraction of biomass the crop loses when it goes dormant. Default 10% for perennials, 30% for trees
         Reference: SWAT Theoretical 5:1.2, and crop.dat BIO_LEAF description"""
+    # TODO: implement __post_init__() to set default based on plant type
+    residue: float = 0
+    """Total amount of residue from this crop that is currently on the soil surface (kg / ha)"""
+    minimum_lai_during_dormancy: Optional[float] = 0.75
+    """Minimum leaf area index for plants (perennials and trees only) during dormancy (unitless)"""
+    # TODO: SWAT Appendix-A section A.1.12 says that the default 0.75 is from pre-2009 versions of SWAT and users are
+    #  now allowed to modify this value. But it does not provide values for any of the listed plant species and gives no
+    #  information about how this value can be measured or calculated. Also, if leaf area index is less than the minium
+    #  before going into dormancy, should it just stay at its current leaf area index?
 
     @property
     def is_mature(self) -> bool:
@@ -373,7 +380,7 @@ class CropData:
     @property
     def is_perennial(self) -> bool:
         """Returns whether the plant is perennial"""
-        if self.plant_type == PlantTypes.PERENNIAL.value or self.plant_type == PlantTypes.PERENNIAL_LEGUME.value:
+        if self.plant_type == PlantTypes.PERENNIAL or self.plant_type == PlantTypes.PERENNIAL_LEGUME:
             return True
         return False
 

--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -353,8 +353,6 @@ class CropData:
     """Fraction of biomass the crop loses when it goes dormant. Default 10% for perennials, 30% for trees
         Reference: SWAT Theoretical 5:1.2, and crop.dat BIO_LEAF description"""
     # TODO: implement __post_init__() to set default based on plant type
-    residue: float = 0
-    """Total amount of residue from this crop that is currently on the soil surface (kg / ha)"""
     minimum_lai_during_dormancy: Optional[float] = 0.75
     """Minimum leaf area index for plants (perennials and trees only) during dormancy (unitless)"""
     # TODO: SWAT Appendix-A section A.1.12 says that the default 0.75 is from pre-2009 versions of SWAT and users are

--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -3,9 +3,7 @@ from dataclasses import dataclass
 from typing import Optional, List
 
 
-# TODO: defaults need to be reviewed and updated. See the SWAT crop database for values
-
-class PlantTypes(Enum):
+class PlantCategory(Enum):
     """Enum of all plant types supported by RuFaS. Listed for supported plant types in SWAT Appendix A, table A-1"""
     WARM_ANNUAL_LEGUME = "warm_annual_legume"
     COOL_ANNUAL_LEGUME = "cool_annual_legume"
@@ -40,8 +38,10 @@ class CropData:
     """4-letter plant code (used by SWAT)"""
     scientific_name: Optional[str] = None
     """taxonomic name of the plant"""
-    plant_type: PlantTypes = PlantTypes("cool_annual")
+    plant_category: Optional[PlantCategory] = PlantCategory("cool_annual")
     """Classification of the plant (Reference SWAT crop.dat file, IDC variable"""
+    is_perennial: Optional[bool] = False
+    """is this plant perennial?"""
     is_nitrogen_fixer: bool = False
     """is the plant a nitrogen fixer?"""
     priority: int = 1
@@ -148,8 +148,6 @@ class CropData:
     """phosphorus stored in plant biomass (kg/ha)"""
     optimal_phosphorus: float = 80
     """optimal amount of phosphorus stored in the plant for the current growth stage (kg/ha)"""
-
-    ##growth_factor: float = 1.0  # duplicate
     water_stress: Optional[float] = None
     """water stress for the day (unitless; [0, 1])"""
     temp_stress: Optional[float] = None
@@ -160,7 +158,6 @@ class CropData:
     """phosphorus stress for the day (unitless; [0, 1])"""
 
     # ---- heat_units
-    ##minimum_temperature: float = 20 # duplicate
     maximum_temperature: float = 38
     """maximum temperature above which plant growth cannot occur (Celsius)"""
     potential_heat_units: float = 800
@@ -168,7 +165,7 @@ class CropData:
     accumulated_heat_units: float = 0  # accumulator
     """total heat units accumulated to date (unitless)"""
     is_growing: bool = True
-    # TODO: not currently using; SWAT 5:2.1.4 (pretty sure this is a section, not equation, reference)
+    # TODO: not currently used; SWAT 5:2.1.4 (pretty sure this is a section, not equation, reference)
     """is the crop currently growing?"""
     is_dormant: bool = False
     """is the crop currently dormant?"""
@@ -189,15 +186,8 @@ class CropData:
     """fraction of potential heat units on the previous day (unitless)"""
 
     # ---- leaf area index
-    # fixed attributes (unchanged during simulations)
     max_canopy_height: float = 2.5  # m
     """maximum canopy height for the plant (m)"""
-    ##growth_factor = 1.0  #duplicate
-
-    # variable attributes (change throughout simulations)
-    ##leaf_area_index = 0 # duplicate
-    ##heat_fraction = 0.73 # duplicate
-    # empty variables
     _lai_shapes: Optional[float] = None
     """shape coefficients used to calculate fraction of max leaf area index (unitless)."""
     optimal_leaf_area_fraction: Optional[float] = None
@@ -214,7 +204,6 @@ class CropData:
     """optimal leaf area fraction on the previous day (unitless)"""
 
     # ---- nitrogen incorporation
-    # constant declarations with defaults (unchanged during simulations)
     half_mature_heat_fraction: float = 0.5
     """expected fraction of potential heat units when the plant is half-way to maturity (unitless)"""
     mature_heat_fraction: float = 1.0
@@ -223,23 +212,14 @@ class CropData:
     """expected fraction of plant biomass comprised of nitrogen for the plant at near-maturity (unitless)"""
     nitrogen_distro_param: float = 10
     """nitrogen uptake distribution parameter (unitless)"""
-
-    # current declarations with defaults (change throughout simulations)
-    # TODO: what module sets/updates these variables?
-    ##nitrogen = 0 # duplicate
-    ##heat_fraction = 0.73  # duplicate
-    ##biomass = 12.5  # duplicate
-    ##biomass_growth_max = 100  # duplicate
     root_depth: float = 1  # arbitrary
     """current depth of the plant roots in the soil (mm)"""
-    # empty declarations
     nitrogen_shapes: Optional[List[float]] = None
     """first and second shape coefficients for the nitrogen uptake equations (unitless)"""
     previous_nitrogen: Optional[float] = None
     """nitrogen stored in plant biomass on the previous day (kg/ha)"""
     optimal_nitrogen_fraction: Optional[float] = None
     """optimal proportion of the plant's biomass comprised of nitrogen for the current growth stage (unitless)"""
-    ##optimal_nitrogen = None # duplicate
     potential_nitrogen_uptake: Optional[float] = None
     """potential nitrogen to be taken up by the plant under ideal circumstances for the current day (kg/ha)"""
     total_soil_layers: Optional[int] = None
@@ -272,7 +252,6 @@ class CropData:
     """expected fraction of plant biomass comprised of nitrogen for the plant near maturity (unitless)"""
     phosphorus_distro_param: float = 10
     """phosphorus uptake distribution parameter (unitless)"""
-
     phosphorus_shapes: Optional[List[float]] = None
     """first and second shape coefficients for the nitrogen uptake equations (unitless)"""
     previous_phosphorus: Optional[float] = None
@@ -285,12 +264,8 @@ class CropData:
     """actual phosphorus to be taken up by the plant from each soil layer (kg/ha)"""
 
     # ---- root development
-    ##heat_fraction = 1 / 3 #duplicate
     max_root_depth: float = 20
     """maximum depth of roots in the soil (mm)"""
-
-    ##root_depth = None # duplicate
-    ##root_fraction = None #duplicate
 
     # ---- water dynamics
     cumulative_evaporation: Optional[float] = None
@@ -307,27 +282,13 @@ class CropData:
     """maximum transpiration on a given day (mm)"""
 
     # ---- yields
-    # constant attributes
-
-    # is_residue_added: bool = False ## not needed?
     harvest_efficiency: float = 1.0
     """efficiency of the harvest operation: the proportion of yield that will be extracted from the field 
     (unitless; [0, 1])"""
-
-    # temporally variable attributes
-    ##heat_fraction = 0.6  # duplicate
-    ##water_deficiency = 0.2  # duplicate
-    ##above_ground_biomass: float = 15  # kg
-    ##biomass = 25  # duplicate
     dry_down_fraction: float = 0.2
     """proportion of plant biomass that is lost to dry-down (unitless; [0, 1])"""
-    ##nitrogen = 15  # duplicate
-    ##phosphorus = 8  # duplicate
-    ##biomass = 100  # duplicate
-    ##optimal_nitrogen_fraction = 0.162  # duplicate
     optimal_phosphorus_fraction: float = 0.073
     """optimal proportion of the plant's biomass comprised of nitrogen for the current growth stage (unitless)"""
-    # Empty declarations
     user_harvest_index: Optional[float] = None  # TODO: handle user input for this. - GitHub Issue #246
     """a user-specified harvest index (unitless). If given, 'harvest-index-override' is triggered"""
     potential_harvest_index: Optional[float] = None
@@ -351,18 +312,32 @@ class CropData:
     """Fraction of biomass the crop loses when it goes dormant. Default 0.1 for perennials, 0.3 for trees
         Reference: SWAT Theoretical 5:1.2, and crop.dat BIO_LEAF description"""
     minimum_lai_during_dormancy: Optional[float] = 0.75
-    """Minimum leaf area index for plants (perennials and trees only) during dormancy (unitless)"""
-    # TODO: SWAT Appendix-A section A.1.12 says that the default 0.75 is from pre-2009 versions of SWAT and users are
-    #  now allowed to modify this value. But it does not provide values for any of the listed plant species and gives no
-    #  information about how this value can be measured or calculated. Also, if leaf area index is less than the minium
-    #  before going into dormancy, should it just stay at its current leaf area index?
+    """Minimum leaf area index for plants (perennials and trees only) during dormancy (unitless)
+    
+    Note: SWAT Appendix-A section A.1.12 says that the default 0.75 is from pre-2009 versions of SWAT and users are
+    now allowed to modify this value. But it does not provide values for any of the listed plant species and gives no
+    information about how this value can be measured or calculated.
+    """
 
     def __post_init__(self):
         """Initialize all attributes with defaults that depend on other attributes"""
-        if self.plant_type == PlantTypes.PERENNIAL or PlantTypes.PERENNIAL_LEGUME:
+
+        # Set dormancy loss
+        if self.plant_category == PlantCategory.PERENNIAL or PlantCategory.PERENNIAL_LEGUME:
             self.dormancy_loss_fraction = 0.1
-        elif self.plant_type == PlantTypes.TREE:
+        elif self.plant_category == PlantCategory.TREE:
             self.dormancy_loss_fraction = 0.3
+
+        # Set perennial status
+        if self.plant_category == PlantCategory.PERENNIAL or self.plant_category == PlantCategory.PERENNIAL_LEGUME or \
+                self.plant_category == PlantCategory.TREE:
+            self.is_perennial = True
+
+        # set Fixation status
+        if self.plant_category == PlantCategory.PERENNIAL_LEGUME or \
+                self.plant_category == PlantCategory.WARM_ANNUAL_LEGUME or \
+                self.plant_category == PlantCategory.COOL_ANNUAL:
+            self.is_nitrogen_fixer = True
 
     @property
     def is_mature(self) -> bool:
@@ -378,14 +353,6 @@ class CropData:
     def is_in_senescence(self) -> bool:
         """check if the plant is in senescence"""
         return self.heat_fraction > self.senescent_heat_fraction
-
-    @property
-    def is_perennial(self) -> bool:
-        """Returns True if the plant is a perennial"""
-        if self.plant_type == PlantTypes.PERENNIAL or self.plant_type == PlantTypes.PERENNIAL_LEGUME:
-            return True
-        return False
-
 
 
 """
@@ -408,7 +375,7 @@ class Corn(CropData):
     name: str = "default corn"
     plant_code: str = "CORN"
     scientific_name: str = "Zea mays"
-    plant_type: PlantTypes = PlantTypes("warm_annual")
+    plant_category: PlantCategory = PlantCategory("warm_annual")
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 8.0
@@ -443,7 +410,7 @@ class SpringWheat(CropData):
     name: str = "default spring_wheat"
     plant_code: str = "SWHT"
     scientific_name: str = "Triticum aestivum"
-    plant_type: PlantTypes = PlantTypes("cool_annual")
+    plant_category: PlantCategory = PlantCategory("cool_annual")
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0.0
@@ -478,7 +445,7 @@ class WinterWheat(CropData):
     name: str = "default winter_wheat"
     plant_code: str = "WWHT"
     scientific_name: str = "Triticum aestivum"
-    plant_type: PlantTypes = PlantTypes("cool_annual")
+    plant_category: PlantCategory = PlantCategory("cool_annual")
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0.0
@@ -513,7 +480,7 @@ class CerealRye(CropData):
     name: str = "default cereal_rye"
     plant_code: str = "RYE"
     scientific_name: str = "Secale cereale"
-    plant_type: PlantTypes = PlantTypes("cool_annual")
+    plant_category: PlantCategory = PlantCategory("cool_annual")
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0
@@ -548,7 +515,7 @@ class SpringBarley(CropData):
     name: str = "default spring_barley"
     plant_code: str = "BARL"
     scientific_name: str = "Hordeum vulgare"
-    plant_type: PlantTypes = PlantTypes("cool_annual")
+    plant_category: PlantCategory = PlantCategory("cool_annual")
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0.0
@@ -583,7 +550,7 @@ class FallOats(CropData):
     name: str = "default fall_oats"
     plant_code: str = "OATS"
     scientific_name: str = "Avena sativa"
-    plant_type: PlantTypes = PlantTypes("cool_annual")
+    plant_category: PlantCategory = PlantCategory("cool_annual")
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0.0
@@ -618,7 +585,7 @@ class TallFescue(CropData):
     name: str = "default tall_fescue"
     plant_code: str = "FESC"
     scientific_name: str = "Festuca arundinaceae"
-    plant_type: PlantTypes = PlantTypes("perennial")
+    plant_category: PlantCategory = PlantCategory("perennial")
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0.0
@@ -653,7 +620,7 @@ class Alfalfa(CropData):
     name: str = "default alfalfa"
     plant_code: str = "ALFA"
     scientific_name: str = "Medicago sativa"
-    plant_type: PlantTypes = PlantTypes("perennial_legume")
+    plant_category: PlantCategory = PlantCategory("perennial_legume")
     is_nitrogen_fixer: bool = True
 
     minimum_temperature: float = 4.0
@@ -688,7 +655,7 @@ class Soybean(CropData):
     name: str = "default soybean"
     plant_code: str = "SOYB"
     scientific_name: str = "Glycine max"
-    plant_type: PlantTypes = PlantTypes("warm_annual_legume")
+    plant_category: PlantCategory = PlantCategory("warm_annual_legume")
     is_nitrogen_fixer: bool = True
 
     minimum_temperature: float = 10.0
@@ -723,7 +690,7 @@ class SugarBeet(CropData):
     name: str = "default sugar_beet"
     plant_code: str = "SGBT"
     scientific_name: str = "Beta vulgaris saccharifera"
-    plant_type: PlantTypes = PlantTypes("warm_annual")
+    plant_category: PlantCategory = PlantCategory("warm_annual")
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 4.0
@@ -758,7 +725,7 @@ class Potato(CropData):
     name: str = "default potato"
     plant_code: str = "POTA"
     scientific_name: str = "Solanum tuberosum"
-    plant_type: PlantTypes = PlantTypes("cool_annual")
+    plant_category: PlantCategory = PlantCategory("cool_annual")
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 7.0

--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -402,7 +402,6 @@ class Corn(CropData):
     plant_code: str = "CORN"
     scientific_name: str = "Zea mays"
     plant_type: PlantTypes = PlantTypes("warm_annual")
-    # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 8.0
@@ -438,7 +437,6 @@ class SpringWheat(CropData):
     plant_code: str = "SWHT"
     scientific_name: str = "Triticum aestivum"
     plant_type: PlantTypes = PlantTypes("cool_annual")
-    # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0.0
@@ -474,7 +472,6 @@ class WinterWheat(CropData):
     plant_code: str = "WWHT"
     scientific_name: str = "Triticum aestivum"
     plant_type: PlantTypes = PlantTypes("cool_annual")
-    # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0.0
@@ -510,7 +507,6 @@ class CerealRye(CropData):
     plant_code: str = "RYE"
     scientific_name: str = "Secale cereale"
     plant_type: PlantTypes = PlantTypes("cool_annual")
-    # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0
@@ -546,7 +542,6 @@ class SpringBarley(CropData):
     plant_code: str = "BARL"
     scientific_name: str = "Hordeum vulgare"
     plant_type: PlantTypes = PlantTypes("cool_annual")
-    # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0.0
@@ -582,7 +577,6 @@ class FallOats(CropData):
     plant_code: str = "OATS"
     scientific_name: str = "Avena sativa"
     plant_type: PlantTypes = PlantTypes("cool_annual")
-    # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0.0
@@ -618,7 +612,6 @@ class TallFescue(CropData):
     plant_code: str = "FESC"
     scientific_name: str = "Festuca arundinaceae"
     plant_type: PlantTypes = PlantTypes("perennial")
-    # is_perennial: bool = True
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0.0
@@ -654,7 +647,6 @@ class Alfalfa(CropData):
     plant_code: str = "ALFA"
     scientific_name: str = "Medicago sativa"
     plant_type: PlantTypes = PlantTypes("perennial_legume")
-    # is_perennial: bool = True
     is_nitrogen_fixer: bool = True
 
     minimum_temperature: float = 4.0
@@ -690,7 +682,6 @@ class Soybean(CropData):
     plant_code: str = "SOYB"
     scientific_name: str = "Glycine max"
     plant_type: PlantTypes = PlantTypes("warm_annual_legume")
-    # is_perennial: bool = False
     is_nitrogen_fixer: bool = True
 
     minimum_temperature: float = 10.0
@@ -726,7 +717,6 @@ class SugarBeet(CropData):
     plant_code: str = "SGBT"
     scientific_name: str = "Beta vulgaris saccharifera"
     plant_type: PlantTypes = PlantTypes("warm_annual")
-    # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 4.0
@@ -762,7 +752,6 @@ class Potato(CropData):
     plant_code: str = "POTA"
     scientific_name: str = "Solanum tuberosum"
     plant_type: PlantTypes = PlantTypes("cool_annual")
-    # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 7.0

--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -29,6 +29,9 @@ class CropData:
       The upside is that this facilitates dataclass inheritance. For example, the CornData class inherits from CropData
       but will have its values set to different defaults.
     """
+
+    # TODO: do we want to add a mechanism to strictly enforce attribute type annotations?
+
     # ID variables (SWAT Table A-1 ish)
     species: Optional[str] = "generic"
     """the species of the crop"""
@@ -42,9 +45,6 @@ class CropData:
     """taxonomic name of the plant"""
     plant_type: PlantTypes = PlantTypes("cool_annual")
     """Classification of the plant (Reference SWAT crop.dat file, IDC variable"""
-    # TODO: figure out how to only make impossible to initialize with value that is not in the PlantTypes enum
-    # is_perennial: bool = False
-    # """is the plant perennial?"""
     is_nitrogen_fixer: bool = False
     """is the plant a nitrogen fixer?"""
     priority: int = 1

--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -355,7 +355,7 @@ class CropData:
     @property
     def is_perennial(self) -> bool:
         """Returns whether the plant is perennial"""
-        if self.plant_type == PlantTypes.PERENNIAL or self.plant_type == PlantTypes.PERENNIAL_LEGUME:
+        if self.plant_type == PlantTypes.PERENNIAL.value or self.plant_type == PlantTypes.PERENNIAL_LEGUME.value:
             return True
         return False
 

--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -337,6 +337,13 @@ class CropData:
     yield_phosphorus: Optional[float] = None
     """phosphorus contained in the harvested yield (kg/ha)"""
 
+    # ---- dormancy
+    is_dormant = False
+    """is the crop dormant?"""
+    dormancy_loss_fraction = 0.1
+    """fraction of biomass the crop loses when it goes dormant. Always 10% for perennials, varies for trees
+        Reference: SWAT Theoretical 5:1.2, and crop.dat BIO_LEAF description"""
+
     @property
     def is_mature(self) -> bool:
         """checks if maturity has been reached based on the fraction of potential heat units accumulated"""

--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -1,5 +1,7 @@
+from enum import Enum
 from dataclasses import dataclass
 from typing import Optional, List
+
 
 # TODO: defaults need to be reviewed and updated. See the SWAT crop database for values
 
@@ -28,8 +30,10 @@ class CropData:
     """4-letter plant code (used by SWAT)"""
     scientific_name: Optional[str] = None
     """taxonomic name of the plant"""
-    is_perennial: bool = False
-    """is the plant perennial?"""
+    plant_type: Optional[str] = "cool_annual"
+    """Classification of the plant (Reference SWAT crop.dat file, IDC variable"""
+    # is_perennial: bool = False
+    # """is the plant perennial?"""
     is_nitrogen_fixer: bool = False
     """is the plant a nitrogen fixer?"""
     priority: int = 1
@@ -124,7 +128,7 @@ class CropData:
     """biomass stored in the above ground portion of the plant; plant biomass excluding roots (kg/ha)"""
     root_biomass: Optional[float] = None
     """biomass stored in roots (kg/ha)"""
-    
+
     # ---- growth constraints
     water_uptake: float = 18
     """water taken up by the plant for the day (mm)"""
@@ -348,6 +352,24 @@ class CropData:
         """check if the plant is in senescence"""
         return self.heat_fraction > self.senescent_heat_fraction
 
+    @property
+    def is_perennial(self) -> bool:
+        """Returns whether the plant is perennial"""
+        if self.plant_type == PlantTypes.PERENNIAL or self.plant_type == PlantTypes.PERENNIAL_LEGUME:
+            return True
+        return False
+
+
+class PlantTypes(Enum):
+    """Enum of all plant types supported by RuFaS. Listed for supported plant types in SWAT Appendix A, table A-1"""
+    WARM_ANNUAL_LEGUME = "warm_annual_legume"
+    COLD_ANNUAL_LEGUME = "cold_annual_legume"
+    PERENNIAL_LEGUME = "perennial_legume"
+    WARM_ANNUAL = "warm_annual"
+    COOL_ANNUAL = "cool_annual"
+    PERENNIAL = "perennial"
+    TREE = "tree"
+
 
 """
 The species child classes provide default configuration for the supported CropSpecies. 
@@ -369,7 +391,8 @@ class Corn(CropData):
     name: str = "default corn"
     plant_code: str = "CORN"
     scientific_name: str = "Zea mays"
-    is_perennial: bool = False
+    plant_type: str = "warm_annual"
+    # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 8.0
@@ -404,7 +427,8 @@ class SpringWheat(CropData):
     name: str = "default spring_wheat"
     plant_code: str = "SWHT"
     scientific_name: str = "Triticum aestivum"
-    is_perennial: bool = False
+    plant_type: str = "cool_annual"
+    # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0.0
@@ -439,7 +463,8 @@ class WinterWheat(CropData):
     name: str = "default winter_wheat"
     plant_code: str = "WWHT"
     scientific_name: str = "Triticum aestivum"
-    is_perennial: bool = False
+    plant_type: str = "cool_annual"
+    # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0.0
@@ -474,7 +499,8 @@ class CerealRye(CropData):
     name: str = "default cereal_rye"
     plant_code: str = "RYE"
     scientific_name: str = "Secale cereale"
-    is_perennial: bool = False
+    plant_type: str = "cool_annual"
+    # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0
@@ -509,7 +535,8 @@ class SpringBarley(CropData):
     name: str = "default spring_barley"
     plant_code: str = "BARL"
     scientific_name: str = "Hordeum vulgare"
-    is_perennial: bool = False
+    plant_type: str = "cool_annual"
+    # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0.0
@@ -544,7 +571,8 @@ class FallOats(CropData):
     name: str = "default fall_oats"
     plant_code: str = "OATS"
     scientific_name: str = "Avena sativa"
-    is_perennial: bool = False
+    plant_type: str = "cool_annual"
+    # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0.0
@@ -579,7 +607,8 @@ class TallFescue(CropData):
     name: str = "default tall_fescue"
     plant_code: str = "FESC"
     scientific_name: str = "Festuca arundinaceae"
-    is_perennial: bool = True
+    plant_type: str = "perennial"
+    # is_perennial: bool = True
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 0.0
@@ -614,7 +643,8 @@ class Alfalfa(CropData):
     name: str = "default alfalfa"
     plant_code: str = "ALFA"
     scientific_name: str = "Medicago sativa"
-    is_perennial: bool = True
+    plant_type: str = "perennial_legume"
+    # is_perennial: bool = True
     is_nitrogen_fixer: bool = True
 
     minimum_temperature: float = 4.0
@@ -649,7 +679,8 @@ class Soybean(CropData):
     name: str = "default soybean"
     plant_code: str = "SOYB"
     scientific_name: str = "Glycine max"
-    is_perennial: bool = False
+    plant_type: str = "warm_annual_legume"
+    # is_perennial: bool = False
     is_nitrogen_fixer: bool = True
 
     minimum_temperature: float = 10.0
@@ -684,7 +715,8 @@ class SugarBeet(CropData):
     name: str = "default sugar_beet"
     plant_code: str = "SGBT"
     scientific_name: str = "Beta vulgaris saccharifera"
-    is_perennial: bool = False
+    plant_type: str = "warm_annual"
+    # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 4.0
@@ -719,7 +751,8 @@ class Potato(CropData):
     name: str = "default potato"
     plant_code: str = "POTA"
     scientific_name: str = "Solanum tuberosum"
-    is_perennial: bool = False
+    plant_type: str = "cool_annual"
+    # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
     minimum_temperature: float = 7.0
@@ -751,4 +784,4 @@ class Potato(CropData):
 class Triticale(CropData):
     """crop data class with default values for triticale"""
     # TODO: triticale has unknown parameters, since it is not present in SWAT database.
-    #     Duram wheat is likely the closest analog.
+    #     Durum wheat is likely the closest analog.

--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -5,6 +5,16 @@ from typing import Optional, List
 
 # TODO: defaults need to be reviewed and updated. See the SWAT crop database for values
 
+class PlantTypes(Enum):
+    """Enum of all plant types supported by RuFaS. Listed for supported plant types in SWAT Appendix A, table A-1"""
+    WARM_ANNUAL_LEGUME = "warm_annual_legume"
+    COLD_ANNUAL_LEGUME = "cold_annual_legume"
+    PERENNIAL_LEGUME = "perennial_legume"
+    WARM_ANNUAL = "warm_annual"
+    COOL_ANNUAL = "cool_annual"
+    PERENNIAL = "perennial"
+    TREE = "tree"
+
 
 @dataclass(kw_only=True)
 class CropData:
@@ -30,8 +40,9 @@ class CropData:
     """4-letter plant code (used by SWAT)"""
     scientific_name: Optional[str] = None
     """taxonomic name of the plant"""
-    plant_type: Optional[str] = "cool_annual"
+    plant_type: PlantTypes = PlantTypes("cool_annual")
     """Classification of the plant (Reference SWAT crop.dat file, IDC variable"""
+    # TODO: figure out how to only make impossible to initialize with value that is not in the PlantTypes enum
     # is_perennial: bool = False
     # """is the plant perennial?"""
     is_nitrogen_fixer: bool = False
@@ -367,16 +378,6 @@ class CropData:
         return False
 
 
-class PlantTypes(Enum):
-    """Enum of all plant types supported by RuFaS. Listed for supported plant types in SWAT Appendix A, table A-1"""
-    WARM_ANNUAL_LEGUME = "warm_annual_legume"
-    COLD_ANNUAL_LEGUME = "cold_annual_legume"
-    PERENNIAL_LEGUME = "perennial_legume"
-    WARM_ANNUAL = "warm_annual"
-    COOL_ANNUAL = "cool_annual"
-    PERENNIAL = "perennial"
-    TREE = "tree"
-
 
 """
 The species child classes provide default configuration for the supported CropSpecies. 
@@ -398,7 +399,7 @@ class Corn(CropData):
     name: str = "default corn"
     plant_code: str = "CORN"
     scientific_name: str = "Zea mays"
-    plant_type: str = "warm_annual"
+    plant_type: PlantTypes = PlantTypes("warm_annual")
     # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
@@ -434,7 +435,7 @@ class SpringWheat(CropData):
     name: str = "default spring_wheat"
     plant_code: str = "SWHT"
     scientific_name: str = "Triticum aestivum"
-    plant_type: str = "cool_annual"
+    plant_type: PlantTypes = PlantTypes("cool_annual")
     # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
@@ -470,7 +471,7 @@ class WinterWheat(CropData):
     name: str = "default winter_wheat"
     plant_code: str = "WWHT"
     scientific_name: str = "Triticum aestivum"
-    plant_type: str = "cool_annual"
+    plant_type: PlantTypes = PlantTypes("cool_annual")
     # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
@@ -506,7 +507,7 @@ class CerealRye(CropData):
     name: str = "default cereal_rye"
     plant_code: str = "RYE"
     scientific_name: str = "Secale cereale"
-    plant_type: str = "cool_annual"
+    plant_type: PlantTypes = PlantTypes("cool_annual")
     # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
@@ -542,7 +543,7 @@ class SpringBarley(CropData):
     name: str = "default spring_barley"
     plant_code: str = "BARL"
     scientific_name: str = "Hordeum vulgare"
-    plant_type: str = "cool_annual"
+    plant_type: PlantTypes = PlantTypes("cool_annual")
     # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
@@ -578,7 +579,7 @@ class FallOats(CropData):
     name: str = "default fall_oats"
     plant_code: str = "OATS"
     scientific_name: str = "Avena sativa"
-    plant_type: str = "cool_annual"
+    plant_type: PlantTypes = PlantTypes("cool_annual")
     # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
@@ -614,7 +615,7 @@ class TallFescue(CropData):
     name: str = "default tall_fescue"
     plant_code: str = "FESC"
     scientific_name: str = "Festuca arundinaceae"
-    plant_type: str = "perennial"
+    plant_type: PlantTypes = PlantTypes("perennial")
     # is_perennial: bool = True
     is_nitrogen_fixer: bool = False
 
@@ -650,7 +651,7 @@ class Alfalfa(CropData):
     name: str = "default alfalfa"
     plant_code: str = "ALFA"
     scientific_name: str = "Medicago sativa"
-    plant_type: str = "perennial_legume"
+    plant_type: PlantTypes = PlantTypes("perennial_legume")
     # is_perennial: bool = True
     is_nitrogen_fixer: bool = True
 
@@ -686,7 +687,7 @@ class Soybean(CropData):
     name: str = "default soybean"
     plant_code: str = "SOYB"
     scientific_name: str = "Glycine max"
-    plant_type: str = "warm_annual_legume"
+    plant_type: PlantTypes = PlantTypes("warm_annual_legume")
     # is_perennial: bool = False
     is_nitrogen_fixer: bool = True
 
@@ -722,7 +723,7 @@ class SugarBeet(CropData):
     name: str = "default sugar_beet"
     plant_code: str = "SGBT"
     scientific_name: str = "Beta vulgaris saccharifera"
-    plant_type: str = "warm_annual"
+    plant_type: PlantTypes = PlantTypes("warm_annual")
     # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 
@@ -758,7 +759,7 @@ class Potato(CropData):
     name: str = "default potato"
     plant_code: str = "POTA"
     scientific_name: str = "Solanum tuberosum"
-    plant_type: str = "cool_annual"
+    plant_type: PlantTypes = PlantTypes("cool_annual")
     # is_perennial: bool = False
     is_nitrogen_fixer: bool = False
 

--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -167,7 +167,8 @@ class CropData:
     """total heat units required for the plant to reach maturity (unitless)"""
     accumulated_heat_units: float = 0  # accumulator
     """total heat units accumulated to date (unitless)"""
-    is_growing: bool = True  # TODO: not currently using; SWAT 5:2.1.4
+    is_growing: bool = True
+    # TODO: not currently using; SWAT 5:2.1.4 (pretty sure this is a section, not equation, reference)
     """is the crop currently growing?"""
     is_dormant: bool = False
     """is the crop currently dormant?"""
@@ -346,16 +347,22 @@ class CropData:
     """phosphorus contained in the harvested yield (kg/ha)"""
 
     # ---- dormancy
-    dormancy_loss_fraction: Optional[float] = 0.1
-    """Fraction of biomass the crop loses when it goes dormant. Default 10% for perennials, 30% for trees
+    dormancy_loss_fraction: Optional[float] = None
+    """Fraction of biomass the crop loses when it goes dormant. Default 0.1 for perennials, 0.3 for trees
         Reference: SWAT Theoretical 5:1.2, and crop.dat BIO_LEAF description"""
-    # TODO: implement __post_init__() to set default based on plant type
     minimum_lai_during_dormancy: Optional[float] = 0.75
     """Minimum leaf area index for plants (perennials and trees only) during dormancy (unitless)"""
     # TODO: SWAT Appendix-A section A.1.12 says that the default 0.75 is from pre-2009 versions of SWAT and users are
     #  now allowed to modify this value. But it does not provide values for any of the listed plant species and gives no
     #  information about how this value can be measured or calculated. Also, if leaf area index is less than the minium
     #  before going into dormancy, should it just stay at its current leaf area index?
+
+    def __post_init__(self):
+        """Initialize all attributes with defaults that depend on other attributes"""
+        if self.plant_type == PlantTypes.PERENNIAL or PlantTypes.PERENNIAL_LEGUME:
+            self.dormancy_loss_fraction = 0.1
+        elif self.plant_type == PlantTypes.TREE:
+            self.dormancy_loss_fraction = 0.3
 
     @property
     def is_mature(self) -> bool:
@@ -374,7 +381,7 @@ class CropData:
 
     @property
     def is_perennial(self) -> bool:
-        """Returns whether the plant is perennial"""
+        """Returns True if the plant is a perennial"""
         if self.plant_type == PlantTypes.PERENNIAL or self.plant_type == PlantTypes.PERENNIAL_LEGUME:
             return True
         return False

--- a/SC_redesign/Crop_and_Soil/crop/crop_management.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_management.py
@@ -16,11 +16,11 @@ class CropManagement:
     def manage_harvest(self, harvest_op: HarvestOperation):
         self.determine_harvest_index()
 
-        if harvest_op == HarvestOperation.HARVEST:  # harvest and kill the crop
+        if harvest_op == HarvestOperation.HARVEST:
             self.cut_crop(collected_fraction=self.data.harvest_efficiency)
             self.kill()
 
-        if harvest_op == HarvestOperation.HARVEST_NOKILL: # harvest but don't kill the crop
+        if harvest_op == HarvestOperation.HARVEST_NOKILL:
             self.cut_crop(collected_fraction=self.data.harvest_efficiency)
 
 

--- a/SC_redesign/Crop_and_Soil/crop/dormancy.py
+++ b/SC_redesign/Crop_and_Soil/crop/dormancy.py
@@ -2,7 +2,6 @@ from typing import Optional
 
 from SC_redesign.Crop_and_Soil.crop.crop_data import CropData, PlantTypes
 
-
 """
 This module is based on the "Dormancy" module of SWAT (5:1.2)
 """
@@ -38,9 +37,6 @@ class Dormancy:
             self.data.biomass *= (1 - self.data.dormancy_loss_fraction)
             # Leaf area index gets set to minimum leaf area index, if it is less than the current leaf area index
             self.data.leaf_area_index = min(self.data.leaf_area_index, self.data.minimum_lai_during_dormancy)
-
-
-
 
     # TODO: It might be better calculate the two values in FieldData (e.g., post_init), since they don't change?
     @staticmethod
@@ -79,4 +75,3 @@ class Dormancy:
         # Middle
         if 20 <= abs_latitude <= 40:
             return (abs_latitude - 20.0) / 20.0
-        

--- a/SC_redesign/Crop_and_Soil/crop/dormancy.py
+++ b/SC_redesign/Crop_and_Soil/crop/dormancy.py
@@ -68,14 +68,14 @@ class Dormancy:
 
         Returns: the dormancy threshold for this latitude
         """
-        # Near poles
-        if abs_latitude > 40:
+        is_near_pole = abs_latitude > 40
+        if is_near_pole:
             return 1.0
 
-        # Near equator
-        if abs_latitude < 20:
+        is_near_equator = abs_latitude < 20
+        if is_near_equator:
             return 0.0
 
-        # Middle
-        if 20 <= abs_latitude <= 40:
+        is_middle = 20 <= abs_latitude <= 40
+        if is_middle:
             return (abs_latitude - 20.0) / 20.0

--- a/SC_redesign/Crop_and_Soil/crop/dormancy.py
+++ b/SC_redesign/Crop_and_Soil/crop/dormancy.py
@@ -79,3 +79,4 @@ class Dormancy:
         # Middle
         if 20 <= abs_latitude <= 40:
             return (abs_latitude - 20.0) / 20.0
+        

--- a/SC_redesign/Crop_and_Soil/crop/dormancy.py
+++ b/SC_redesign/Crop_and_Soil/crop/dormancy.py
@@ -28,7 +28,7 @@ class Dormancy:
             # Cool annuals and cool annual legumes do not lose any biomass or get their leaf area index reset
 
             # Some fraction of biomass falls off the plant and becomes residue
-            self.data.residue += (self.data.biomass * self.data.dormancy_loss_fraction)
+            self.data.yield_residue += (self.data.biomass * self.data.dormancy_loss_fraction)
             self.data.biomass *= (1 - self.data.dormancy_loss_fraction)
             # Leaf area index gets set to minimum leaf area index, if it is less than the current leaf area index
             if self.data.minimum_lai_during_dormancy < self.data.leaf_area_index:

--- a/SC_redesign/Crop_and_Soil/crop/dormancy.py
+++ b/SC_redesign/Crop_and_Soil/crop/dormancy.py
@@ -12,7 +12,7 @@ class Dormancy:
     def __int__(self, crop_data: Optional[CropData] = None):
         self.data = crop_data or CropData
 
-
+    # TODO: It might be better calculate the two values in FieldData (e.g., post_init), since they don't change?
     @staticmethod
     def _find_threshold_daylength(minimum_daylength: float, dormancy_threshold: float) -> float:
         """calculates the threshold daylength for dormancy

--- a/SC_redesign/Crop_and_Soil/crop/dormancy.py
+++ b/SC_redesign/Crop_and_Soil/crop/dormancy.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from SC_redesign.Crop_and_Soil.crop.crop_data import CropData
+from SC_redesign.Crop_and_Soil.crop.crop_data import CropData, PlantTypes
 
 
 """
@@ -9,7 +9,7 @@ This module is based on the "Dormancy" module of SWAT (5:1.2)
 
 
 class Dormancy:
-    def __int__(self, crop_data: Optional[CropData] = None):
+    def __init__(self, crop_data: Optional[CropData] = None):
         self.data = crop_data or CropData
 
     def go_into_dormancy(self) -> None:
@@ -19,8 +19,22 @@ class Dormancy:
             When method is called, the crop's status is set to dormant and biomass is removed from plant and converted
             to residue
         """
+        if self.data.plant_type == PlantTypes.WARM_ANNUAL or PlantTypes.WARM_ANNUAL_LEGUME:
+            # These types of plants do not go into dormancy
+            return
+
         self.data.is_dormant = True
-        # self.data.residue =
+        if self.data.plant_type == PlantTypes.TREE or self.data.is_perennial:
+            # Cool annuals and cool annual legumes do not lose any biomass or get their leaf area index reset
+
+            # Some fraction of biomass falls off the plant and becomes residue
+            self.data.residue += (self.data.biomass * self.data.dormancy_loss_fraction)
+            self.data.biomass *= (1 - self.data.dormancy_loss_fraction)
+            # Leaf area index gets set to minimum leaf area index, if it is less than the current leaf area index
+            if self.data.minimum_lai_during_dormancy < self.data.leaf_area_index:
+                self.data.leaf_area_index = self.data.minimum_lai_during_dormancy
+
+
 
 
     # TODO: It might be better calculate the two values in FieldData (e.g., post_init), since they don't change?

--- a/SC_redesign/Crop_and_Soil/crop/dormancy.py
+++ b/SC_redesign/Crop_and_Soil/crop/dormancy.py
@@ -12,6 +12,17 @@ class Dormancy:
     def __int__(self, crop_data: Optional[CropData] = None):
         self.data = crop_data or CropData
 
+    def go_into_dormancy(self) -> None:
+        """This method performs the actual transition from active to dormant in a crop.
+
+        Details:
+            When method is called, the crop's status is set to dormant and biomass is removed from plant and converted
+            to residue
+        """
+        self.data.is_dormant = True
+        # self.data.residue =
+
+
     # TODO: It might be better calculate the two values in FieldData (e.g., post_init), since they don't change?
     @staticmethod
     def _find_threshold_daylength(minimum_daylength: float, dormancy_threshold: float) -> float:

--- a/SC_redesign/Crop_and_Soil/crop/dormancy.py
+++ b/SC_redesign/Crop_and_Soil/crop/dormancy.py
@@ -23,6 +23,12 @@ class Dormancy:
             # These types of plants do not go into dormancy
             return
 
+        if self.data.is_dormant:
+            # Crop is already dormant, should not re-perform any dormancy operations on it
+            return
+
+        # TODO: should is_growing be set here?
+
         self.data.is_dormant = True
         if self.data.plant_type == PlantTypes.TREE or self.data.is_perennial:
             # Cool annuals and cool annual legumes do not lose any biomass or get their leaf area index reset
@@ -31,8 +37,7 @@ class Dormancy:
             self.data.yield_residue += (self.data.biomass * self.data.dormancy_loss_fraction)
             self.data.biomass *= (1 - self.data.dormancy_loss_fraction)
             # Leaf area index gets set to minimum leaf area index, if it is less than the current leaf area index
-            if self.data.minimum_lai_during_dormancy < self.data.leaf_area_index:
-                self.data.leaf_area_index = self.data.minimum_lai_during_dormancy
+            self.data.leaf_area_index = min(self.data.leaf_area_index, self.data.minimum_lai_during_dormancy)
 
 
 

--- a/SC_redesign/Crop_and_Soil/crop/dormancy.py
+++ b/SC_redesign/Crop_and_Soil/crop/dormancy.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from SC_redesign.Crop_and_Soil.crop.crop_data import CropData, PlantTypes
+from SC_redesign.Crop_and_Soil.crop.crop_data import CropData, PlantCategory
 
 """
 This module is based on the "Dormancy" module of SWAT (5:1.2)
@@ -11,15 +11,15 @@ class Dormancy:
     def __init__(self, crop_data: Optional[CropData] = None):
         self.data = crop_data or CropData
 
-    def go_into_dormancy(self) -> None:
-        """This method performs the actual transition from active to dormant in a crop.
+    def enter_dormancy(self) -> None:
+        """Performs the actual transition from active to dormant in a crop.
 
         Details:
             When method is called, the crop's status is set to dormant, biomass is removed from plant and converted
             to residue, and the leaf area index is reset (if the current leaf area index is greater than the minimum
             leaf area index during dormancy for this crop).
         """
-        if self.data.plant_type == PlantTypes.WARM_ANNUAL or PlantTypes.WARM_ANNUAL_LEGUME:
+        if self.data.plant_category == PlantCategory.WARM_ANNUAL or PlantCategory.WARM_ANNUAL_LEGUME:
             # These types of plants do not go into dormancy
             return
 
@@ -27,24 +27,18 @@ class Dormancy:
             # Crop is already dormant, so it should not re-lose biomass or have its leaf area index reset again
             return
 
-        # TODO: should is_growing be set here?
-
         self.data.is_dormant = True
-        if self.data.plant_type == PlantTypes.TREE or self.data.is_perennial:
+        if self.data.plant_category == PlantCategory.TREE or self.data.is_perennial:
             # Cool annuals and cool annual legumes do not lose any biomass or get their leaf area index reset
 
             # Some fraction of biomass falls off the plant and becomes residue
             self.data.yield_residue += (self.data.biomass * self.data.dormancy_loss_fraction)
             self.data.biomass *= (1 - self.data.dormancy_loss_fraction)
             # Leaf area index gets set to minimum leaf area index, if it is less than the current leaf area index
-            # TODO: verify this is correct behavior for case when current leaf area index is less than the minimum leaf
-            #   area index during dormancy
             self.data.leaf_area_index = min(self.data.leaf_area_index, self.data.minimum_lai_during_dormancy)
 
-    # TODO: It might be better calculate the two values in FieldData (e.g., post_init), since they don't change?
-    #   Update: these are used in the post_init in FieldData, should they have protected status (i.e., _) removed?
     @staticmethod
-    def _find_threshold_daylength(minimum_daylength: float, dormancy_threshold: float) -> float:
+    def find_threshold_daylength(minimum_daylength: float, dormancy_threshold: float) -> float:
         """calculates the threshold daylength for dormancy
 
         Args:
@@ -58,7 +52,7 @@ class Dormancy:
         return minimum_daylength + dormancy_threshold
 
     @staticmethod
-    def _find_dormancy_threshold(abs_latitude: float) -> float:
+    def find_dormancy_threshold(abs_latitude: float) -> float:
         """calculates the dormancy threshold based on the absolute latitude
 
         Args:

--- a/SC_redesign/Crop_and_Soil/crop/dormancy.py
+++ b/SC_redesign/Crop_and_Soil/crop/dormancy.py
@@ -15,15 +15,16 @@ class Dormancy:
         """This method performs the actual transition from active to dormant in a crop.
 
         Details:
-            When method is called, the crop's status is set to dormant and biomass is removed from plant and converted
-            to residue
+            When method is called, the crop's status is set to dormant, biomass is removed from plant and converted
+            to residue, and the leaf area index is reset (if the current leaf area index is greater than the minimum
+            leaf area index during dormancy for this crop).
         """
         if self.data.plant_type == PlantTypes.WARM_ANNUAL or PlantTypes.WARM_ANNUAL_LEGUME:
             # These types of plants do not go into dormancy
             return
 
         if self.data.is_dormant:
-            # Crop is already dormant, should not re-perform any dormancy operations on it
+            # Crop is already dormant, so it should not re-lose biomass or have its leaf area index reset again
             return
 
         # TODO: should is_growing be set here?
@@ -36,9 +37,12 @@ class Dormancy:
             self.data.yield_residue += (self.data.biomass * self.data.dormancy_loss_fraction)
             self.data.biomass *= (1 - self.data.dormancy_loss_fraction)
             # Leaf area index gets set to minimum leaf area index, if it is less than the current leaf area index
+            # TODO: verify this is correct behavior for case when current leaf area index is less than the minimum leaf
+            #   area index during dormancy
             self.data.leaf_area_index = min(self.data.leaf_area_index, self.data.minimum_lai_during_dormancy)
 
     # TODO: It might be better calculate the two values in FieldData (e.g., post_init), since they don't change?
+    #   Update: these are used in the post_init in FieldData, should they have protected status (i.e., _) removed?
     @staticmethod
     def _find_threshold_daylength(minimum_daylength: float, dormancy_threshold: float) -> float:
         """calculates the threshold daylength for dormancy

--- a/SC_redesign/Crop_and_Soil/crop/dormancy.py
+++ b/SC_redesign/Crop_and_Soil/crop/dormancy.py
@@ -1,0 +1,51 @@
+from typing import Optional
+
+from SC_redesign.Crop_and_Soil.crop.crop_data import CropData
+
+
+"""
+This module is based on the "Dormancy" module of SWAT (5:1.2)
+"""
+
+
+class Dormancy:
+    def __int__(self, crop_data: Optional[CropData] = None):
+        self.data = crop_data or CropData
+
+
+    @staticmethod
+    def _find_threshold_daylength(minimum_daylength: float, dormancy_threshold: float) -> float:
+        """calculates the threshold daylength for dormancy
+
+        Args:
+            minimum_daylength: the minimum daylength for the watershed during the year (hours)
+            dormancy_threshold: the dormancy threshold for this field (hours)
+
+        SWAT Reference: 5:1.2.1
+
+        Returns: threshold daylength for dormancy (hours)
+        """
+        return minimum_daylength + dormancy_threshold
+
+    @staticmethod
+    def _find_dormancy_threshold(abs_latitude: float) -> float:
+        """calculates the dormancy threshold based on the absolute latitude
+
+        Args:
+            abs_latitude: the absolute latitude value (degrees above or below the equator)
+
+        SWAT Reference: 5:1.2.2 - 5:1.2.4
+
+        Returns: the dormancy threshold for this latitude
+        """
+        # Near poles
+        if abs_latitude > 40:
+            return 1.0
+
+        # Near equator
+        if abs_latitude < 20:
+            return 0.0
+
+        # Middle
+        if 20 <= abs_latitude <= 40:
+            return (abs_latitude - 20.0) / 20.0

--- a/SC_redesign/Crop_and_Soil/crop/heat_units.py
+++ b/SC_redesign/Crop_and_Soil/crop/heat_units.py
@@ -135,7 +135,5 @@ class HeatUnits:
         """
         return min(max_air_temp, max_growth_temp)
 
-    # TODO: Dormancy! SWAT 5:1.2 - GitHub PR #365
-
     # TODO: Heat scheduling? SWAT 5:1.1.1 - GitHub Issue #368
 

--- a/SC_redesign/Crop_and_Soil/crop/heat_units.py
+++ b/SC_redesign/Crop_and_Soil/crop/heat_units.py
@@ -5,9 +5,9 @@ from SC_redesign.Crop_and_Soil.crop.crop_data import CropData
 This module primarily follows the Heat Units section of the SWAT model (5:3.1)
 """
 
+
 class HeatUnits:
-    def __init__(self, crop_data: Optional[CropData] = None,
-                 use_heat_unit_temperature: bool = False):
+    def __init__(self, crop_data: Optional[CropData] = None):
         self.data = crop_data or CropData()  # initialize with defaults, if not given
 
     def absorb_heat_units(self, mean_air_temperature: float = None,
@@ -136,4 +136,3 @@ class HeatUnits:
         return min(max_air_temp, max_growth_temp)
 
     # TODO: Heat scheduling? SWAT 5:1.1.1 - GitHub Issue #368
-

--- a/SC_redesign/Crop_and_Soil/crop/root_development.py
+++ b/SC_redesign/Crop_and_Soil/crop/root_development.py
@@ -23,7 +23,7 @@ class RootDevelopment:
 
         # update root depth
         if self.data.is_perennial:
-            self.data.root_depth = self.data.max_root_depth  # TODO: assumption by SWAT - valid perhaps after 1st year?
+            self.data.root_depth = self.data.max_root_depth  # Note: assumption of SWAT
         else:
             self.data.root_depth = self._determine_root_depth(self.data.max_root_depth, self.data.heat_fraction)
 

--- a/SC_redesign/Crop_and_Soil/crop/root_development.py
+++ b/SC_redesign/Crop_and_Soil/crop/root_development.py
@@ -5,6 +5,7 @@ from SC_redesign.Crop_and_Soil.crop.crop_data import CropData
 This module is based upon the "Root Development" section of the SWAT model (5.2.1.3)
 """
 
+
 class RootDevelopment:
     def __init__(self, crop_data: Optional[CropData] = None):
         # data reference

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -67,13 +67,9 @@ class Field:
         # perform remaining tasks if crops currently in field
         if self.crops is not None:
 
-            # put crops into dormancy if daylength is as or below dormancy daylength threshold
-            if current_weather.daylength <= self.field_data.dormancy_threshold_daylength:
-                self.start_dormancy()
-            else:
-                # Bring all crops out of dormancy
-                for crop in self.crops:
-                    crop.data.is_dormant = False
+            #
+            self.start_dormancy(current_weather.daylength)
+
 
             # allow crops to grow
             self.grow_crops(current_weather.incoming_light, current_weather.min_air_temperature,
@@ -237,10 +233,22 @@ class Field:
         """allow grazers to graze in the field during the current day"""
         pass
 
-    def start_dormancy(self) -> None:
-        """Set all crops that can go dormant to being dormant"""
-        for crop in self.crops:
-            crop.assess_dormancy()
+    def assess_dormancy(self, daylength: float) -> None:
+        """Set all crops that can go dormant to being dormant
+
+        Args:
+            daylength: length of time from sunup to sundown on the current day (hours)
+
+        """
+        if daylength <= self.field_data.dormancy_threshold_daylength:
+            # put crops into dormancy if daylength is as or below dormancy daylength threshold
+            for crop in self.crops:
+                crop.start_dormancy()
+        else:
+            # Bring all crops out of dormancy
+            for crop in self.crops:
+                crop.data.is_dormant = False
+
     # </editor-fold>
 
     # <editor-fold desc="--- Field-level Methods ---">

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -70,6 +70,10 @@ class Field:
             # put crops into dormancy if daylength is as or below dormancy daylength threshold
             if current_weather.daylength <= self.field_data.dormancy_threshold_daylength:
                 self.start_dormancy()
+            else:
+                # Bring all crops out of dormancy
+                for crop in self.crops:
+                    crop.data.is_dormant = False
 
             # allow crops to grow
             self.grow_crops(current_weather.incoming_light, current_weather.min_air_temperature,

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -68,7 +68,7 @@ class Field:
         if self.crops is not None:
 
             #
-            self.start_dormancy(current_weather.daylength)
+            self.assess_dormancy(current_weather.daylength)
 
 
             # allow crops to grow
@@ -243,7 +243,7 @@ class Field:
         if daylength <= self.field_data.dormancy_threshold_daylength:
             # put crops into dormancy if daylength is as or below dormancy daylength threshold
             for crop in self.crops:
-                crop.start_dormancy()
+                crop.dormancy.enter_dormancy()
         else:
             # Bring all crops out of dormancy
             for crop in self.crops:

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -67,6 +67,10 @@ class Field:
         # perform remaining tasks if crops currently in field
         if self.crops is not None:
 
+            # put crops into dormancy if daylength is as or below dormancy daylength threshold
+            if current_weather.daylength <= self.field_data.dormancy_threshold_daylength:
+                self.start_dormancy()
+
             # allow crops to grow
             self.grow_crops(current_weather.incoming_light, current_weather.min_air_temperature,
                             current_weather.mean_air_temperature, current_weather.max_air_temperature)
@@ -112,7 +116,7 @@ class Field:
         pass
     # </editor-fold>
 
-    # <editor-fold desc="--- Soil Managemeet Methods ---">
+    # <editor-fold desc="--- Soil Management Methods ---">
     def till_soil(self) -> None:
         """till the soil"""
         pass
@@ -228,6 +232,11 @@ class Field:
     def graze_field(self):  # TODO: placeholder; no grazing method currently implemented in RUFAS
         """allow grazers to graze in the field during the current day"""
         pass
+
+    def start_dormancy(self) -> None:
+        """Set all crops that can go dormant to being dormant"""
+        for crop in self.crops:
+            crop.assess_dormancy()
     # </editor-fold>
 
     # <editor-fold desc="--- Field-level Methods ---">

--- a/SC_redesign/Crop_and_Soil/field/field_data.py
+++ b/SC_redesign/Crop_and_Soil/field/field_data.py
@@ -55,6 +55,6 @@ class FieldData:
 
     def __post_init__(self):
         """Initialize all attributes in FieldData object that need to be set based on other FieldData attributes"""
-        dormancy_threshold = Dormancy._find_dormancy_threshold(self.absolute_latitude)
-        self.dormancy_threshold_daylength = Dormancy._find_threshold_daylength(self.minimum_daylength,
-                                                                               dormancy_threshold)
+        self.dormancy_threshold = Dormancy.find_dormancy_threshold(self.absolute_latitude)
+        self.dormancy_threshold_daylength = Dormancy.find_threshold_daylength(self.minimum_daylength,
+                                                                              self.dormancy_threshold)

--- a/SC_redesign/Crop_and_Soil/field/field_data.py
+++ b/SC_redesign/Crop_and_Soil/field/field_data.py
@@ -1,6 +1,7 @@
 from typing import Optional
 from dataclasses import dataclass
 from SC_redesign.Crop_and_Soil.field.harvest_operations import HarvestOperation
+from SC_redesign.Crop_and_Soil.crop.dormancy import Dormancy
 
 
 
@@ -28,7 +29,14 @@ class FieldData:
     harvest_proportion: float = 1.0
     """proportion of the cut biomass to be removed from the field after the next/current cut event (unitless)"""
     harvest_type: Optional[HarvestOperation] = HarvestOperation("default")
-    "the HarvestOperation, specifying which harvest operation to use"
+    """the HarvestOperation, specifying which harvest operation to use"""
+    absolute_latitude: float = 43.5     # TODO: set default to somewhere other than Wisconsin, or no default?
+    """The absolute latitude value (degrees above or below equator) where field is located (degrees)"""
+    minimum_daylength: float = 6.33     # TODO: set default to somewhere other than Wisconsin, or no default?
+    """Shortest day of the year for this watershed (hours)"""
+    dormancy_threshold_daylength: Optional[float] = None
+    """Threshold daylength to initiate dormancy in a plant (hours)"""
+
 
     # --- Field-level Variables ---
     evaporation: Optional[float] = None
@@ -45,5 +53,8 @@ class FieldData:
     grazers_present: bool = False
     """are grazers currently in the field? is grazing occurring?"""
 
-
-
+    def __post_init__(self):
+        """Initialize all attributes in FieldData object that need to be set based on other FieldData attributes"""
+        dormancy_threshold = Dormancy._find_dormancy_threshold(self.absolute_latitude)
+        self.dormancy_threshold_daylength = Dormancy._find_threshold_daylength(self.minimum_daylength,
+                                                                               dormancy_threshold)

--- a/SC_redesign/Crop_and_Soil/manager/current_weather.py
+++ b/SC_redesign/Crop_and_Soil/manager/current_weather.py
@@ -15,6 +15,8 @@ class CurrentWeather:
     """average air temperature for the day (C)"""
     max_air_temperature: Optional[float] = None
     """maximum air temperature for the day (C)"""
+    daylength: Optional[float] = None
+    """Length of time from sunup to sundown on the day (hours)"""
 
     @classmethod
     def check_current_weather(cls, weather: Weather):  # NOTE: How to specify the correct return type?

--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 
@@ -57,7 +57,6 @@ class LayerData:
     percent_rock_content: float = 1
     """rock content expressed as percent of soil in this layer (unitless)"""
 
-
     # --- Decomposition
     decomposition_moisture_effect: Optional[float] = None
     """moisture effect on decomposition factor (unitless) (pseudocode_soil S.6.A.2)"""
@@ -91,7 +90,7 @@ class LayerData:
         """volume of water available for percolation in the soil layer (mm)
         SWAT Reference: 2:3.2.1, 2
         """
-        return max(0, self.water_content - self.field_capacity_content)
+        return max(0.0, self.water_content - self.field_capacity_content)
 
     @property
     def saturation_content(self) -> float:
@@ -99,10 +98,9 @@ class LayerData:
         return self.saturation_point_water_concentration * self.layer_thickness
 
     @property
-
     def acceptable_percolation_amount(self) -> float:
         """volume of water that can be accepted by layer before reaching saturation (mm)"""
-        return max(0, self.saturation_content - self.water_content)
+        return max(0.0, self.saturation_content - self.water_content)
 
     @property
     def percent_organic_matter_content(self) -> float:
@@ -129,6 +127,3 @@ class LayerData:
         else:
             return (self.saturation_content - self.soil_water_content) / (
                     self.saturation_content - self.field_capacity_content)
-
-
-

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -101,7 +101,7 @@ class SoilData:
         else:
             water_sum = 0
             for layer in self.soil_layers:
-                water_sum += max(0, (layer.water_content - layer.wilting_point_content))
+                water_sum += max(0.0, (layer.water_content - layer.wilting_point_content))
             return water_sum
 
     @property

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -66,6 +66,10 @@ class SoilData:
     surface_volume_runoff: Optional[float] = None
     """volume of surface runoff (mm per hectare), used in SWAT equation 4:1.1.1."""
 
+    # ---- decomposition
+    decomposition_temperature_effect: Optional[float] = None
+    """temperature effect on decomposition factor (unitless) (pseudocode_soil S.6.A.1)"""
+
     def __post_init__(self):
         if self.soil_layers is None:
             # sets the soil layers to a default set if user does not provide any
@@ -78,12 +82,6 @@ class SoilData:
                                            bottom_depth=10000000,    # bottom depth is 10,000 meters by default
                                            soil_water_concentration=0,
                                            saturation_point_water_concentration=inf)
-
-    # ---- decomposition
-    decomposition_temperature_effect: Optional[float] = None
-    """temperature effect on decomposition factor (unitless) (pseudocode_soil S.6.A.1)"""
-
-
 
     @property
     def profile_soil_water_content(self) -> float:

--- a/SC_redesign/Crop_and_Soil/tests_SC/crop_tests/test_dormancy.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/crop_tests/test_dormancy.py
@@ -1,6 +1,6 @@
 import pytest
 from SC_redesign.Crop_and_Soil.crop.dormancy import Dormancy
-from SC_redesign.Crop_and_Soil.crop.crop_data import CropData, PlantTypes
+from SC_redesign.Crop_and_Soil.crop.crop_data import CropData, PlantCategory
 
 
 # --- Static function tests ---
@@ -12,7 +12,7 @@ from SC_redesign.Crop_and_Soil.crop.crop_data import CropData, PlantTypes
 ])
 def test_find_threshold_daylength(min_daylength: float, dormancy_threshold: float) -> None:
     """Tests that _find_threshold_daylength() in Dormancy module works correctly"""
-    observe = Dormancy._find_threshold_daylength(min_daylength, dormancy_threshold)
+    observe = Dormancy.find_threshold_daylength(min_daylength, dormancy_threshold)
     expect = min_daylength + dormancy_threshold
     assert observe == expect
 
@@ -26,7 +26,7 @@ def test_find_threshold_daylength(min_daylength: float, dormancy_threshold: floa
 ])
 def test_find_dormancy_threshold(latitude: float) -> None:
     """Tests that _find_dormancy_threshold() in Dormancy module works correctly"""
-    observe = Dormancy._find_dormancy_threshold(latitude)
+    observe = Dormancy.find_dormancy_threshold(latitude)
     if latitude > 40:
         expect = 1
     elif 20 <= latitude <= 40:
@@ -37,27 +37,27 @@ def test_find_dormancy_threshold(latitude: float) -> None:
 
 # --- Integration tests ---
 @pytest.mark.parametrize("biomass,residue,lai,min_lai,plant_type,loss_frac", [
-    (800, 150, 0.87, 0.75, PlantTypes("perennial"), 0.1),               # Perennial with defaults
-    (2000, 70, 0.91, 0.56, PlantTypes("tree"), 0.3),                    # Tree with tree defaults
-    (1100, 210, 0.78, None, PlantTypes("cool_annual"), None),           # Cool annual
-    (980, 145, 0.8891, None, PlantTypes("warm_annual_legume"), None),   # plant that should not go into dormancy at all
+    (800, 150, 0.87, 0.75, PlantCategory("perennial"), 0.1),               # Perennial with defaults
+    (2000, 70, 0.91, 0.56, PlantCategory("tree"), 0.3),                    # Tree with tree defaults
+    (1100, 210, 0.78, None, PlantCategory("cool_annual"), None),           # Cool annual
+    (980, 145, 0.8891, None, PlantCategory("warm_annual_legume"), None),   # plant that should not go into dormancy at all
 ])
-def test_go_into_dormancy(biomass: float, residue: float, lai: float, min_lai: float, plant_type: PlantTypes,
+def test_go_into_dormancy(biomass: float, residue: float, lai: float, min_lai: float, plant_type: PlantCategory,
                           loss_frac: float) -> None:
     # Initialize objects
     data = CropData(biomass=biomass, yield_residue=residue, leaf_area_index=lai, minimum_lai_during_dormancy=min_lai,
-                    plant_type=plant_type, dormancy_loss_fraction=loss_frac)
+                    plant_category=plant_type, dormancy_loss_fraction=loss_frac)
     incorp = Dormancy(data)
 
     # Run method
-    incorp.go_into_dormancy()
+    incorp.enter_dormancy()
 
     # Check everything
-    if incorp.data.plant_type == PlantTypes.WARM_ANNUAL_LEGUME or PlantTypes.WARM_ANNUAL:
+    if incorp.data.plant_category == PlantCategory.WARM_ANNUAL_LEGUME or PlantCategory.WARM_ANNUAL:
         assert incorp.data.is_dormant is False
     else:
         assert incorp.data.is_dormant is True
-        if incorp.data.plant_type == PlantTypes.PERENNIAL or PlantTypes.PERENNIAL_LEGUME or PlantTypes.TREE:
+        if incorp.data.plant_category == PlantCategory.PERENNIAL or PlantCategory.PERENNIAL_LEGUME or PlantCategory.TREE:
             assert incorp.data.biomass == (biomass * (1 - loss_frac))
             assert incorp.data.residue == (residue + (biomass * loss_frac))
             assert incorp.data.leaf_area_index == min(lai, min_lai)

--- a/SC_redesign/Crop_and_Soil/tests_SC/crop_tests/test_dormancy.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/crop_tests/test_dormancy.py
@@ -37,10 +37,10 @@ def test_find_dormancy_threshold(latitude: float) -> None:
 
 # --- Integration tests ---
 @pytest.mark.parametrize("biomass,residue,lai,min_lai,plant_type,loss_frac", [
-    (800, 150, 0.87, 0.75, PlantTypes("perennial"), 0.1),       # Perennial with defaults
-    (2000, 70, 0.91, 0.56, PlantTypes("tree"), 0.3),            # Tree with tree defaults
-    (1100, 210, 0.78, None, PlantTypes("cool_annual"), None),   # Cool annual
-    (980, 145, 0.8891, None, PlantTypes("warm_annual_legume"), None),  # plant that should not go into dormancy at all
+    (800, 150, 0.87, 0.75, PlantTypes("perennial"), 0.1),               # Perennial with defaults
+    (2000, 70, 0.91, 0.56, PlantTypes("tree"), 0.3),                    # Tree with tree defaults
+    (1100, 210, 0.78, None, PlantTypes("cool_annual"), None),           # Cool annual
+    (980, 145, 0.8891, None, PlantTypes("warm_annual_legume"), None),   # plant that should not go into dormancy at all
 ])
 def test_go_into_dormancy(biomass: float, residue: float, lai: float, min_lai: float, plant_type: PlantTypes,
                           loss_frac: float) -> None:

--- a/SC_redesign/Crop_and_Soil/tests_SC/crop_tests/test_dormancy.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/crop_tests/test_dormancy.py
@@ -45,7 +45,7 @@ def test_find_dormancy_threshold(latitude: float) -> None:
 def test_go_into_dormancy(biomass: float, residue: float, lai: float, min_lai: float, plant_type: PlantTypes,
                           loss_frac: float) -> None:
     # Initialize objects
-    data = CropData(biomass=biomass, residue=residue, leaf_area_index=lai, minimum_lai_during_dormancy=min_lai,
+    data = CropData(biomass=biomass, yield_residue=residue, leaf_area_index=lai, minimum_lai_during_dormancy=min_lai,
                     plant_type=plant_type, dormancy_loss_fraction=loss_frac)
     incorp = Dormancy(data)
 

--- a/SC_redesign/Crop_and_Soil/tests_SC/crop_tests/test_dormancy.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/crop_tests/test_dormancy.py
@@ -1,0 +1,35 @@
+import pytest
+from SC_redesign.Crop_and_Soil.crop.dormancy import Dormancy
+
+
+# --- Static function tests ---
+@pytest.mark.parametrize("min_daylength,dormancy_threshold", [
+    (16, 17),
+    (0, 0),
+    (14, 17),
+    (16.218347349, 16.329438502)
+])
+def test_find_threshold_daylength(min_daylength: float, dormancy_threshold: float) -> float:
+    """Tests that _find_threshold_daylength() in Dormancy module works correctly"""
+    observe = Dormancy._find_threshold_daylength(min_daylength, dormancy_threshold)
+    expect = min_daylength + dormancy_threshold
+    assert observe == expect
+
+
+@pytest.mark.parametrize("latitude", [
+    40,
+    28,
+    8,
+    17.9238487592,
+    56.2948349202,
+])
+def test_find_dormancy_threshold(latitude: float) -> float:
+    """Tests that _find_dormancy_threshold() in Dormancy module works correctly"""
+    observe = Dormancy._find_dormancy_threshold(latitude)
+    if latitude > 40:
+        expect = 1
+    elif 20 <= latitude <= 40:
+        expect = (latitude - 20) / 20
+    else:
+        expect = 0
+    assert observe == expect

--- a/SC_redesign/Crop_and_Soil/tests_SC/crop_tests/test_dormancy.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/crop_tests/test_dormancy.py
@@ -1,5 +1,6 @@
 import pytest
 from SC_redesign.Crop_and_Soil.crop.dormancy import Dormancy
+from SC_redesign.Crop_and_Soil.crop.crop_data import CropData, PlantTypes
 
 
 # --- Static function tests ---
@@ -9,7 +10,7 @@ from SC_redesign.Crop_and_Soil.crop.dormancy import Dormancy
     (14, 17),
     (16.218347349, 16.329438502)
 ])
-def test_find_threshold_daylength(min_daylength: float, dormancy_threshold: float) -> float:
+def test_find_threshold_daylength(min_daylength: float, dormancy_threshold: float) -> None:
     """Tests that _find_threshold_daylength() in Dormancy module works correctly"""
     observe = Dormancy._find_threshold_daylength(min_daylength, dormancy_threshold)
     expect = min_daylength + dormancy_threshold
@@ -23,7 +24,7 @@ def test_find_threshold_daylength(min_daylength: float, dormancy_threshold: floa
     17.9238487592,
     56.2948349202,
 ])
-def test_find_dormancy_threshold(latitude: float) -> float:
+def test_find_dormancy_threshold(latitude: float) -> None:
     """Tests that _find_dormancy_threshold() in Dormancy module works correctly"""
     observe = Dormancy._find_dormancy_threshold(latitude)
     if latitude > 40:
@@ -33,3 +34,31 @@ def test_find_dormancy_threshold(latitude: float) -> float:
     else:
         expect = 0
     assert observe == expect
+
+# --- Integration tests ---
+@pytest.mark.parametrize("biomass,residue,lai,min_lai,plant_type,loss_frac", [
+    (800, 150, 0.87, 0.75, PlantTypes("perennial"), 0.1),       # Perennial with defaults
+    (2000, 70, 0.91, 0.56, PlantTypes("tree"), 0.3),            # Tree with tree defaults
+    (1100, 210, 0.78, None, PlantTypes("cool_annual"), None),   # Cool annual
+    (980, 145, 0.8891, None, PlantTypes("warm_annual_legume"), None),  # plant that should not go into dormancy at all
+])
+def test_go_into_dormancy(biomass: float, residue: float, lai: float, min_lai: float, plant_type: PlantTypes,
+                          loss_frac: float) -> None:
+    # Initialize objects
+    data = CropData(biomass=biomass, residue=residue, leaf_area_index=lai, minimum_lai_during_dormancy=min_lai,
+                    plant_type=plant_type, dormancy_loss_fraction=loss_frac)
+    incorp = Dormancy(data)
+
+    # Run method
+    incorp.go_into_dormancy()
+
+    # Check everything
+    if incorp.data.plant_type == PlantTypes.WARM_ANNUAL_LEGUME or PlantTypes.WARM_ANNUAL:
+        assert incorp.data.is_dormant is False
+    else:
+        assert incorp.data.is_dormant is True
+        if incorp.data.plant_type == PlantTypes.PERENNIAL or PlantTypes.PERENNIAL_LEGUME or PlantTypes.TREE:
+            assert incorp.data.biomass == (biomass * (1 - loss_frac))
+            assert incorp.data.residue == (residue + (biomass * loss_frac))
+            assert incorp.data.leaf_area_index == min(lai, min_lai)
+

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -6,12 +6,12 @@ from SC_redesign.Crop_and_Soil.field.field import Field
 
 # TODO: all methods in field.py need to be added here
 
-def test_grow_crops():
-    assert False
-
-
-def test_harvest_crops():
-    assert False
+# def test_grow_crops():
+#     assert False
+#
+#
+# def test_harvest_crops():
+#     assert False
 
 
 # TODO: make this test more rigorous once a testing pattern has been established for testing Field

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -31,11 +31,11 @@ def test_start_dormancy(daylength: float, threshold_daylength: float) -> None:
     field.crops = [crop]
 
     # Mock functions used
-    crop.dormancy.go_into_dormancy = MagicMock()
+    crop.dormancy.enter_dormancy = MagicMock()
 
     # Run method being tested
     field.assess_dormancy(daylength)
 
     # Check that subroutines were called correct number of times
     if daylength <= threshold_daylength:
-        assert crop.dormancy.go_into_dormancy.call_count == 1
+        assert crop.dormancy.enter_dormancy.call_count == 1

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -14,6 +14,7 @@ def test_harvest_crops():
     assert False
 
 
+# TODO: make this test more rigorous once a testing pattern has been established for testing Field
 def test_start_dormancy():
     """Tests that each crop's dormancy method is called"""
     # Initialize objects

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -1,7 +1,31 @@
+from unittest.mock import MagicMock
+
+from SC_redesign.Crop_and_Soil.crop.crop import Crop
+from SC_redesign.Crop_and_Soil.field.field import Field
+
+
 # TODO: all methods in field.py need to be added here
 
 def test_grow_crops():
     assert False
 
+
 def test_harvest_crops():
     assert False
+
+
+def test_start_dormancy():
+    """Tests that each crop's dormancy method is called"""
+    # Initialize objects
+    crop = Crop()
+    field = Field()
+    field.crops = [crop]
+
+    # Mock functions used
+    crop.dormancy.go_into_dormancy = MagicMock()
+
+    # Run method being tested
+    field.start_dormancy()
+
+    # Check that subroutines were called
+    assert crop.dormancy.go_into_dormancy.call_count == 1

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+import pytest
+
 from SC_redesign.Crop_and_Soil.crop.crop import Crop
 from SC_redesign.Crop_and_Soil.field.field import Field
 
@@ -15,18 +17,25 @@ from SC_redesign.Crop_and_Soil.field.field import Field
 
 
 # TODO: make this test more rigorous once a testing pattern has been established for testing Field
-def test_start_dormancy():
+@pytest.mark.parametrize("daylength,threshold_daylength", [
+    (14, 8),
+    (17.20948239, 9.19183294),
+    (7.293485893, 8.234850920),
+])
+def test_start_dormancy(daylength: float, threshold_daylength: float) -> None:
     """Tests that each crop's dormancy method is called"""
     # Initialize objects
     crop = Crop()
     field = Field()
+    field.field_data.dormancy_threshold_daylength = threshold_daylength
     field.crops = [crop]
 
     # Mock functions used
     crop.dormancy.go_into_dormancy = MagicMock()
 
     # Run method being tested
-    field.start_dormancy()
+    field.assess_dormancy(daylength)
 
-    # Check that subroutines were called
-    assert crop.dormancy.go_into_dormancy.call_count == 1
+    # Check that subroutines were called correct number of times
+    if daylength <= threshold_daylength:
+        assert crop.dormancy.go_into_dormancy.call_count == 1

--- a/SC_redesign/Crop_and_Soil/tests_SC/test_crop_data_and_species_factory.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/test_crop_data_and_species_factory.py
@@ -432,7 +432,7 @@ def test_manual_custom_crop_data():
     ("cereal_rye", {"biomass": 100}),  # change attribute declared only in CropData
     ("spring_barley", {"name": "fancy barley",  # custom new variety/subspecies
                        "plant_code": "FBAR", "scientific_name" : "Hordeum vulgare regalis"}),
-    ("fall_oats", {"plant_type": "perennial"}),  # perennial version of oats
+    ("fall_oats", {"plant_type": PlantTypes("perennial")}),  # perennial version of oats
     ("tall_fescue", {"is_nitrogen_fixer": True}),  # magical nitrogen-fixing grass (egads!)
     ("alfalfa", {"yield_nitrogen_fraction": 0.03}),  # this alfalfa has increased nitrogen in harvest
     ("soybean", {"max_leaf_area_index": 2.4, "light_use_efficiency": 10.8,  # various alterations

--- a/SC_redesign/Crop_and_Soil/tests_SC/test_crop_data_and_species_factory.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/test_crop_data_and_species_factory.py
@@ -1,6 +1,6 @@
 import pytest
 from SC_redesign.Crop_and_Soil.crop.species_data_factory import CropSpecies, CropSpeciesDataFactory
-from SC_redesign.Crop_and_Soil.crop.crop_data import CropData
+from SC_redesign.Crop_and_Soil.crop.crop_data import CropData, PlantTypes
 from dataclasses import asdict
 
 
@@ -44,7 +44,7 @@ def test_species_factory_defaults():
     assert generic.id == 0
     assert generic.plant_code is None
     assert generic.scientific_name is None
-    assert generic.plant_type == "cool_annual"
+    assert generic.plant_type == PlantTypes("cool_annual")
     # assert generic.is_perennial is False
     assert generic.is_nitrogen_fixer is False
     assert generic.minimum_temperature == 0
@@ -79,7 +79,7 @@ def test_species_factory_defaults():
     assert corn.id == 12
     assert corn.plant_code == "CORN"
     assert corn.scientific_name == "Zea mays"
-    assert corn.plant_type == "warm_annual"
+    assert corn.plant_type == PlantTypes("warm_annual")
     # assert corn.is_perennial is False
     assert corn.is_nitrogen_fixer is False
     assert corn.minimum_temperature == 8.0
@@ -109,7 +109,7 @@ def test_species_factory_defaults():
     assert spring_wheat.id == 85
     assert spring_wheat.plant_code == "SWHT"
     assert spring_wheat.scientific_name == "Triticum aestivum"
-    assert spring_wheat.plant_type == "cool_annual"
+    assert spring_wheat.plant_type == PlantTypes("cool_annual")
     # assert spring_wheat.is_perennial is False
     assert spring_wheat.is_nitrogen_fixer is False
     assert spring_wheat.minimum_temperature == 0.0
@@ -139,7 +139,7 @@ def test_species_factory_defaults():
     assert winter_wheat.id == 1000
     assert winter_wheat.plant_code == "WWHT"
     assert winter_wheat.scientific_name == "Triticum aestivum"
-    assert winter_wheat.plant_type == "cool_annual"
+    assert winter_wheat.plant_type == PlantTypes("cool_annual")
     # assert winter_wheat.is_perennial is False
     assert winter_wheat.is_nitrogen_fixer is False
     assert winter_wheat.minimum_temperature == 0.0
@@ -169,7 +169,7 @@ def test_species_factory_defaults():
     assert cereal_rye.id == 123
     assert cereal_rye.plant_code == "RYE"
     assert cereal_rye.scientific_name == "Secale cereale"
-    assert cereal_rye.plant_type == "cool_annual"
+    assert cereal_rye.plant_type == PlantTypes("cool_annual")
     # assert cereal_rye.is_perennial is False
     assert cereal_rye.is_nitrogen_fixer is False
     assert cereal_rye.minimum_temperature == 0.0
@@ -199,7 +199,7 @@ def test_species_factory_defaults():
     assert spring_barley.id == 42  # this is everything
     assert spring_barley.plant_code == "BARL"
     assert spring_barley.scientific_name == "Hordeum vulgare"
-    assert spring_barley.plant_type == "cool_annual"
+    assert spring_barley.plant_type == PlantTypes("cool_annual")
     # assert spring_barley.is_perennial is False
     assert spring_barley.is_nitrogen_fixer is False
     assert spring_barley.minimum_temperature == 0.0
@@ -229,7 +229,7 @@ def test_species_factory_defaults():
     assert fall_oats.id == 9001  # it is, indeed, over 9000
     assert fall_oats.plant_code == "OATS"
     assert fall_oats.scientific_name == "Avena sativa"
-    assert fall_oats.plant_type == "cool_annual"
+    assert fall_oats.plant_type == PlantTypes("cool_annual")
     # assert fall_oats.is_perennial is False
     assert fall_oats.is_nitrogen_fixer is False
     assert fall_oats.minimum_temperature == 0.0
@@ -259,7 +259,7 @@ def test_species_factory_defaults():
     assert tall_fescue.id == -1  # who would do this?
     assert tall_fescue.plant_code == "FESC"
     assert tall_fescue.scientific_name == "Festuca arundinaceae"
-    assert tall_fescue.plant_type == "perennial"
+    assert tall_fescue.plant_type == PlantTypes("perennial")
     # assert tall_fescue.is_perennial is True
     assert tall_fescue.is_nitrogen_fixer is False
     assert tall_fescue.minimum_temperature == 0.0
@@ -289,7 +289,7 @@ def test_species_factory_defaults():
     assert alfalfa.id == 7
     assert alfalfa.plant_code == "ALFA"
     assert alfalfa.scientific_name == "Medicago sativa"
-    assert alfalfa.plant_type == "perennial_legume"
+    assert alfalfa.plant_type == PlantTypes("perennial_legume")
     # assert alfalfa.is_perennial is True
     assert alfalfa.is_nitrogen_fixer is True
     assert alfalfa.minimum_temperature == 4.0
@@ -319,7 +319,7 @@ def test_species_factory_defaults():
     assert soybean.id == 999
     assert soybean.plant_code == "SOYB"
     assert soybean.scientific_name == "Glycine max"
-    assert soybean.plant_type == "warm_annual_legume"
+    assert soybean.plant_type == PlantTypes("warm_annual_legume")
     # assert soybean.is_perennial is False
     assert soybean.is_nitrogen_fixer is True
     assert soybean.minimum_temperature == 10.0
@@ -349,7 +349,7 @@ def test_species_factory_defaults():
     assert sugar_beet.id == 5
     assert sugar_beet.plant_code == "SGBT"
     assert sugar_beet.scientific_name == "Beta vulgaris saccharifera"
-    assert sugar_beet.plant_type == "warm_annual"
+    assert sugar_beet.plant_type == PlantTypes("warm_annual")
     # assert sugar_beet.is_perennial is False
     assert sugar_beet.is_nitrogen_fixer is False
     assert sugar_beet.minimum_temperature == 4.0
@@ -379,7 +379,7 @@ def test_species_factory_defaults():
     assert potato.id == 2
     assert potato.plant_code == "POTA"
     assert potato.scientific_name == "Solanum tuberosum"
-    assert potato.plant_type == "cool_annual"
+    assert potato.plant_type == PlantTypes("cool_annual")
     # assert potato.is_perennial is False
     assert potato.is_nitrogen_fixer is False
     assert potato.minimum_temperature == 7.0
@@ -410,14 +410,14 @@ def test_manual_custom_crop_data():
     """checks (and demonstrates) the alternate way of customizing a crop"""
     # setup custom crop
     aspen = CropData(name="custom crop: aspen", species="aspen", scientific_name="Populus tremuloides",
-                     plant_code="PTREM", plant_type="tree", is_nitrogen_fixer=False, max_leaf_area_index=5.0)
+                     plant_code="PTREM", plant_type=PlantTypes("tree"), is_nitrogen_fixer=False, max_leaf_area_index=5.0)
 
     # check that each attribute is set appropriately
     assert aspen.name == "custom crop: aspen"
     assert aspen.species == "aspen"
     assert aspen.scientific_name == "Populus tremuloides"
     assert aspen.plant_code == "PTREM"
-    assert aspen.plant_type == "tree"
+    assert aspen.plant_type == PlantTypes("tree")
     # assert aspen.is_perennial is True
     assert aspen.is_nitrogen_fixer is False
     assert aspen.max_leaf_area_index == 5.0

--- a/SC_redesign/Crop_and_Soil/tests_SC/test_crop_data_and_species_factory.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/test_crop_data_and_species_factory.py
@@ -45,7 +45,6 @@ def test_species_factory_defaults():
     assert generic.plant_code is None
     assert generic.scientific_name is None
     assert generic.plant_type == PlantTypes("cool_annual")
-    # assert generic.is_perennial is False
     assert generic.is_nitrogen_fixer is False
     assert generic.minimum_temperature == 0
     assert generic.optimal_temperature == 25
@@ -80,7 +79,6 @@ def test_species_factory_defaults():
     assert corn.plant_code == "CORN"
     assert corn.scientific_name == "Zea mays"
     assert corn.plant_type == PlantTypes("warm_annual")
-    # assert corn.is_perennial is False
     assert corn.is_nitrogen_fixer is False
     assert corn.minimum_temperature == 8.0
     assert corn.optimal_temperature == 25.0
@@ -110,7 +108,6 @@ def test_species_factory_defaults():
     assert spring_wheat.plant_code == "SWHT"
     assert spring_wheat.scientific_name == "Triticum aestivum"
     assert spring_wheat.plant_type == PlantTypes("cool_annual")
-    # assert spring_wheat.is_perennial is False
     assert spring_wheat.is_nitrogen_fixer is False
     assert spring_wheat.minimum_temperature == 0.0
     assert spring_wheat.optimal_temperature == 18.0
@@ -140,7 +137,6 @@ def test_species_factory_defaults():
     assert winter_wheat.plant_code == "WWHT"
     assert winter_wheat.scientific_name == "Triticum aestivum"
     assert winter_wheat.plant_type == PlantTypes("cool_annual")
-    # assert winter_wheat.is_perennial is False
     assert winter_wheat.is_nitrogen_fixer is False
     assert winter_wheat.minimum_temperature == 0.0
     assert winter_wheat.optimal_temperature == 18.0
@@ -170,7 +166,6 @@ def test_species_factory_defaults():
     assert cereal_rye.plant_code == "RYE"
     assert cereal_rye.scientific_name == "Secale cereale"
     assert cereal_rye.plant_type == PlantTypes("cool_annual")
-    # assert cereal_rye.is_perennial is False
     assert cereal_rye.is_nitrogen_fixer is False
     assert cereal_rye.minimum_temperature == 0.0
     assert cereal_rye.optimal_temperature == 12.5
@@ -200,7 +195,6 @@ def test_species_factory_defaults():
     assert spring_barley.plant_code == "BARL"
     assert spring_barley.scientific_name == "Hordeum vulgare"
     assert spring_barley.plant_type == PlantTypes("cool_annual")
-    # assert spring_barley.is_perennial is False
     assert spring_barley.is_nitrogen_fixer is False
     assert spring_barley.minimum_temperature == 0.0
     assert spring_barley.optimal_temperature == 25.0
@@ -230,7 +224,6 @@ def test_species_factory_defaults():
     assert fall_oats.plant_code == "OATS"
     assert fall_oats.scientific_name == "Avena sativa"
     assert fall_oats.plant_type == PlantTypes("cool_annual")
-    # assert fall_oats.is_perennial is False
     assert fall_oats.is_nitrogen_fixer is False
     assert fall_oats.minimum_temperature == 0.0
     assert fall_oats.optimal_temperature == 15.0
@@ -260,7 +253,6 @@ def test_species_factory_defaults():
     assert tall_fescue.plant_code == "FESC"
     assert tall_fescue.scientific_name == "Festuca arundinaceae"
     assert tall_fescue.plant_type == PlantTypes("perennial")
-    # assert tall_fescue.is_perennial is True
     assert tall_fescue.is_nitrogen_fixer is False
     assert tall_fescue.minimum_temperature == 0.0
     assert tall_fescue.optimal_temperature == 15.0
@@ -290,7 +282,6 @@ def test_species_factory_defaults():
     assert alfalfa.plant_code == "ALFA"
     assert alfalfa.scientific_name == "Medicago sativa"
     assert alfalfa.plant_type == PlantTypes("perennial_legume")
-    # assert alfalfa.is_perennial is True
     assert alfalfa.is_nitrogen_fixer is True
     assert alfalfa.minimum_temperature == 4.0
     assert alfalfa.optimal_temperature == 25.0
@@ -320,7 +311,6 @@ def test_species_factory_defaults():
     assert soybean.plant_code == "SOYB"
     assert soybean.scientific_name == "Glycine max"
     assert soybean.plant_type == PlantTypes("warm_annual_legume")
-    # assert soybean.is_perennial is False
     assert soybean.is_nitrogen_fixer is True
     assert soybean.minimum_temperature == 10.0
     assert soybean.optimal_temperature == 25.0
@@ -350,7 +340,6 @@ def test_species_factory_defaults():
     assert sugar_beet.plant_code == "SGBT"
     assert sugar_beet.scientific_name == "Beta vulgaris saccharifera"
     assert sugar_beet.plant_type == PlantTypes("warm_annual")
-    # assert sugar_beet.is_perennial is False
     assert sugar_beet.is_nitrogen_fixer is False
     assert sugar_beet.minimum_temperature == 4.0
     assert sugar_beet.optimal_temperature == 18.0
@@ -380,7 +369,6 @@ def test_species_factory_defaults():
     assert potato.plant_code == "POTA"
     assert potato.scientific_name == "Solanum tuberosum"
     assert potato.plant_type == PlantTypes("cool_annual")
-    # assert potato.is_perennial is False
     assert potato.is_nitrogen_fixer is False
     assert potato.minimum_temperature == 7.0
     assert potato.optimal_temperature == 22.0
@@ -470,4 +458,28 @@ def test_factory_errors(species, bad_attr):
     with pytest.raises(AttributeError) as e:
         CropSpeciesDataFactory.create_species_data(CropSpecies(species), **bad_attr)
     assert "is not a valid attribute" in str(e.value)
+
+
+# --- Test @property methods ---
+@pytest.mark.parametrize("plant_type", [
+    PlantTypes.PERENNIAL,
+    PlantTypes.PERENNIAL_LEGUME,
+    PlantTypes.TREE,
+    PlantTypes.WARM_ANNUAL,
+    PlantTypes.WARM_ANNUAL_LEGUME,
+    PlantTypes.COOL_ANNUAL,
+    PlantTypes.COOL_ANNUAL_LEGUME,
+])
+def test_is_perennial(plant_type: PlantTypes) -> None:
+    """Tests that is_perennial() correctly determines whether a plant is a perennial"""
+    # Initialize CropData object
+    crop = CropData(plant_type=plant_type)
+
+    # Determine observed and expected results
+    observe = crop.is_perennial
+    perennial_set = {PlantTypes.PERENNIAL, PlantTypes.PERENNIAL_LEGUME}
+    expect = type in perennial_set
+
+    # Check results
+    assert observe == expect
 

--- a/SC_redesign/Crop_and_Soil/tests_SC/test_crop_data_and_species_factory.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/test_crop_data_and_species_factory.py
@@ -478,7 +478,7 @@ def test_is_perennial(plant_type: PlantTypes) -> None:
     # Determine observed and expected results
     observe = crop.is_perennial
     perennial_set = {PlantTypes.PERENNIAL, PlantTypes.PERENNIAL_LEGUME}
-    expect = type in perennial_set
+    expect = plant_type in perennial_set
 
     # Check results
     assert observe == expect

--- a/SC_redesign/Crop_and_Soil/tests_SC/test_crop_data_and_species_factory.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/test_crop_data_and_species_factory.py
@@ -1,6 +1,6 @@
 import pytest
 from SC_redesign.Crop_and_Soil.crop.species_data_factory import CropSpecies, CropSpeciesDataFactory
-from SC_redesign.Crop_and_Soil.crop.crop_data import CropData, PlantTypes
+from SC_redesign.Crop_and_Soil.crop.crop_data import CropData, PlantCategory
 from dataclasses import asdict
 
 
@@ -44,7 +44,7 @@ def test_species_factory_defaults():
     assert generic.id == 0
     assert generic.plant_code is None
     assert generic.scientific_name is None
-    assert generic.plant_type == PlantTypes("cool_annual")
+    assert generic.plant_category == PlantCategory("cool_annual")
     assert generic.is_nitrogen_fixer is False
     assert generic.minimum_temperature == 0
     assert generic.optimal_temperature == 25
@@ -78,7 +78,7 @@ def test_species_factory_defaults():
     assert corn.id == 12
     assert corn.plant_code == "CORN"
     assert corn.scientific_name == "Zea mays"
-    assert corn.plant_type == PlantTypes("warm_annual")
+    assert corn.plant_category == PlantCategory("warm_annual")
     assert corn.is_nitrogen_fixer is False
     assert corn.minimum_temperature == 8.0
     assert corn.optimal_temperature == 25.0
@@ -107,7 +107,7 @@ def test_species_factory_defaults():
     assert spring_wheat.id == 85
     assert spring_wheat.plant_code == "SWHT"
     assert spring_wheat.scientific_name == "Triticum aestivum"
-    assert spring_wheat.plant_type == PlantTypes("cool_annual")
+    assert spring_wheat.plant_category == PlantCategory("cool_annual")
     assert spring_wheat.is_nitrogen_fixer is False
     assert spring_wheat.minimum_temperature == 0.0
     assert spring_wheat.optimal_temperature == 18.0
@@ -136,7 +136,7 @@ def test_species_factory_defaults():
     assert winter_wheat.id == 1000
     assert winter_wheat.plant_code == "WWHT"
     assert winter_wheat.scientific_name == "Triticum aestivum"
-    assert winter_wheat.plant_type == PlantTypes("cool_annual")
+    assert winter_wheat.plant_category == PlantCategory("cool_annual")
     assert winter_wheat.is_nitrogen_fixer is False
     assert winter_wheat.minimum_temperature == 0.0
     assert winter_wheat.optimal_temperature == 18.0
@@ -165,7 +165,7 @@ def test_species_factory_defaults():
     assert cereal_rye.id == 123
     assert cereal_rye.plant_code == "RYE"
     assert cereal_rye.scientific_name == "Secale cereale"
-    assert cereal_rye.plant_type == PlantTypes("cool_annual")
+    assert cereal_rye.plant_category == PlantCategory("cool_annual")
     assert cereal_rye.is_nitrogen_fixer is False
     assert cereal_rye.minimum_temperature == 0.0
     assert cereal_rye.optimal_temperature == 12.5
@@ -194,7 +194,7 @@ def test_species_factory_defaults():
     assert spring_barley.id == 42  # this is everything
     assert spring_barley.plant_code == "BARL"
     assert spring_barley.scientific_name == "Hordeum vulgare"
-    assert spring_barley.plant_type == PlantTypes("cool_annual")
+    assert spring_barley.plant_category == PlantCategory("cool_annual")
     assert spring_barley.is_nitrogen_fixer is False
     assert spring_barley.minimum_temperature == 0.0
     assert spring_barley.optimal_temperature == 25.0
@@ -223,7 +223,7 @@ def test_species_factory_defaults():
     assert fall_oats.id == 9001  # it is, indeed, over 9000
     assert fall_oats.plant_code == "OATS"
     assert fall_oats.scientific_name == "Avena sativa"
-    assert fall_oats.plant_type == PlantTypes("cool_annual")
+    assert fall_oats.plant_category == PlantCategory("cool_annual")
     assert fall_oats.is_nitrogen_fixer is False
     assert fall_oats.minimum_temperature == 0.0
     assert fall_oats.optimal_temperature == 15.0
@@ -252,7 +252,7 @@ def test_species_factory_defaults():
     assert tall_fescue.id == -1  # who would do this?
     assert tall_fescue.plant_code == "FESC"
     assert tall_fescue.scientific_name == "Festuca arundinaceae"
-    assert tall_fescue.plant_type == PlantTypes("perennial")
+    assert tall_fescue.plant_category == PlantCategory("perennial")
     assert tall_fescue.is_nitrogen_fixer is False
     assert tall_fescue.minimum_temperature == 0.0
     assert tall_fescue.optimal_temperature == 15.0
@@ -281,7 +281,7 @@ def test_species_factory_defaults():
     assert alfalfa.id == 7
     assert alfalfa.plant_code == "ALFA"
     assert alfalfa.scientific_name == "Medicago sativa"
-    assert alfalfa.plant_type == PlantTypes("perennial_legume")
+    assert alfalfa.plant_category == PlantCategory("perennial_legume")
     assert alfalfa.is_nitrogen_fixer is True
     assert alfalfa.minimum_temperature == 4.0
     assert alfalfa.optimal_temperature == 25.0
@@ -310,7 +310,7 @@ def test_species_factory_defaults():
     assert soybean.id == 999
     assert soybean.plant_code == "SOYB"
     assert soybean.scientific_name == "Glycine max"
-    assert soybean.plant_type == PlantTypes("warm_annual_legume")
+    assert soybean.plant_category == PlantCategory("warm_annual_legume")
     assert soybean.is_nitrogen_fixer is True
     assert soybean.minimum_temperature == 10.0
     assert soybean.optimal_temperature == 25.0
@@ -339,7 +339,7 @@ def test_species_factory_defaults():
     assert sugar_beet.id == 5
     assert sugar_beet.plant_code == "SGBT"
     assert sugar_beet.scientific_name == "Beta vulgaris saccharifera"
-    assert sugar_beet.plant_type == PlantTypes("warm_annual")
+    assert sugar_beet.plant_category == PlantCategory("warm_annual")
     assert sugar_beet.is_nitrogen_fixer is False
     assert sugar_beet.minimum_temperature == 4.0
     assert sugar_beet.optimal_temperature == 18.0
@@ -368,7 +368,7 @@ def test_species_factory_defaults():
     assert potato.id == 2
     assert potato.plant_code == "POTA"
     assert potato.scientific_name == "Solanum tuberosum"
-    assert potato.plant_type == PlantTypes("cool_annual")
+    assert potato.plant_category == PlantCategory("cool_annual")
     assert potato.is_nitrogen_fixer is False
     assert potato.minimum_temperature == 7.0
     assert potato.optimal_temperature == 22.0
@@ -398,14 +398,14 @@ def test_manual_custom_crop_data():
     """checks (and demonstrates) the alternate way of customizing a crop"""
     # setup custom crop
     aspen = CropData(name="custom crop: aspen", species="aspen", scientific_name="Populus tremuloides",
-                     plant_code="PTREM", plant_type=PlantTypes("tree"), is_nitrogen_fixer=False, max_leaf_area_index=5.0)
+                     plant_code="PTREM", plant_category=PlantCategory("tree"), is_nitrogen_fixer=False, max_leaf_area_index=5.0)
 
     # check that each attribute is set appropriately
     assert aspen.name == "custom crop: aspen"
     assert aspen.species == "aspen"
     assert aspen.scientific_name == "Populus tremuloides"
     assert aspen.plant_code == "PTREM"
-    assert aspen.plant_type == PlantTypes("tree")
+    assert aspen.plant_category == PlantCategory("tree")
     # assert aspen.is_perennial is True
     assert aspen.is_nitrogen_fixer is False
     assert aspen.max_leaf_area_index == 5.0
@@ -420,7 +420,7 @@ def test_manual_custom_crop_data():
     ("cereal_rye", {"biomass": 100}),  # change attribute declared only in CropData
     ("spring_barley", {"name": "fancy barley",  # custom new variety/subspecies
                        "plant_code": "FBAR", "scientific_name" : "Hordeum vulgare regalis"}),
-    ("fall_oats", {"plant_type": PlantTypes("perennial")}),  # perennial version of oats
+    ("fall_oats", {"plant_category": PlantCategory("perennial")}),  # perennial version of oats
     ("tall_fescue", {"is_nitrogen_fixer": True}),  # magical nitrogen-fixing grass (egads!)
     ("alfalfa", {"yield_nitrogen_fraction": 0.03}),  # this alfalfa has increased nitrogen in harvest
     ("soybean", {"max_leaf_area_index": 2.4, "light_use_efficiency": 10.8,  # various alterations
@@ -462,22 +462,22 @@ def test_factory_errors(species, bad_attr):
 
 # --- Test @property methods ---
 @pytest.mark.parametrize("plant_type", [
-    PlantTypes.PERENNIAL,
-    PlantTypes.PERENNIAL_LEGUME,
-    PlantTypes.TREE,
-    PlantTypes.WARM_ANNUAL,
-    PlantTypes.WARM_ANNUAL_LEGUME,
-    PlantTypes.COOL_ANNUAL,
-    PlantTypes.COOL_ANNUAL_LEGUME,
+    PlantCategory.PERENNIAL,
+    PlantCategory.PERENNIAL_LEGUME,
+    PlantCategory.TREE,
+    PlantCategory.WARM_ANNUAL,
+    PlantCategory.WARM_ANNUAL_LEGUME,
+    PlantCategory.COOL_ANNUAL,
+    PlantCategory.COOL_ANNUAL_LEGUME,
 ])
-def test_is_perennial(plant_type: PlantTypes) -> None:
+def test_is_perennial(plant_type: PlantCategory) -> None:
     """Tests that is_perennial() correctly determines whether a plant is a perennial"""
     # Initialize CropData object
-    crop = CropData(plant_type=plant_type)
+    crop = CropData(plant_category=plant_type)
 
     # Determine observed and expected results
     observe = crop.is_perennial
-    perennial_set = {PlantTypes.PERENNIAL, PlantTypes.PERENNIAL_LEGUME}
+    perennial_set = {PlantCategory.PERENNIAL, PlantCategory.PERENNIAL_LEGUME, PlantCategory.TREE}
     expect = plant_type in perennial_set
 
     # Check results

--- a/SC_redesign/Crop_and_Soil/tests_SC/test_crop_data_and_species_factory.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/test_crop_data_and_species_factory.py
@@ -44,7 +44,8 @@ def test_species_factory_defaults():
     assert generic.id == 0
     assert generic.plant_code is None
     assert generic.scientific_name is None
-    assert generic.is_perennial is False
+    assert generic.plant_type == "cool_annual"
+    # assert generic.is_perennial is False
     assert generic.is_nitrogen_fixer is False
     assert generic.minimum_temperature == 0
     assert generic.optimal_temperature == 25
@@ -78,7 +79,8 @@ def test_species_factory_defaults():
     assert corn.id == 12
     assert corn.plant_code == "CORN"
     assert corn.scientific_name == "Zea mays"
-    assert corn.is_perennial is False
+    assert corn.plant_type == "warm_annual"
+    # assert corn.is_perennial is False
     assert corn.is_nitrogen_fixer is False
     assert corn.minimum_temperature == 8.0
     assert corn.optimal_temperature == 25.0
@@ -107,7 +109,8 @@ def test_species_factory_defaults():
     assert spring_wheat.id == 85
     assert spring_wheat.plant_code == "SWHT"
     assert spring_wheat.scientific_name == "Triticum aestivum"
-    assert spring_wheat.is_perennial is False
+    assert spring_wheat.plant_type == "cool_annual"
+    # assert spring_wheat.is_perennial is False
     assert spring_wheat.is_nitrogen_fixer is False
     assert spring_wheat.minimum_temperature == 0.0
     assert spring_wheat.optimal_temperature == 18.0
@@ -136,7 +139,8 @@ def test_species_factory_defaults():
     assert winter_wheat.id == 1000
     assert winter_wheat.plant_code == "WWHT"
     assert winter_wheat.scientific_name == "Triticum aestivum"
-    assert winter_wheat.is_perennial is False
+    assert winter_wheat.plant_type == "cool_annual"
+    # assert winter_wheat.is_perennial is False
     assert winter_wheat.is_nitrogen_fixer is False
     assert winter_wheat.minimum_temperature == 0.0
     assert winter_wheat.optimal_temperature == 18.0
@@ -165,7 +169,8 @@ def test_species_factory_defaults():
     assert cereal_rye.id == 123
     assert cereal_rye.plant_code == "RYE"
     assert cereal_rye.scientific_name == "Secale cereale"
-    assert cereal_rye.is_perennial is False
+    assert cereal_rye.plant_type == "cool_annual"
+    # assert cereal_rye.is_perennial is False
     assert cereal_rye.is_nitrogen_fixer is False
     assert cereal_rye.minimum_temperature == 0.0
     assert cereal_rye.optimal_temperature == 12.5
@@ -194,7 +199,8 @@ def test_species_factory_defaults():
     assert spring_barley.id == 42  # this is everything
     assert spring_barley.plant_code == "BARL"
     assert spring_barley.scientific_name == "Hordeum vulgare"
-    assert spring_barley.is_perennial is False
+    assert spring_barley.plant_type == "cool_annual"
+    # assert spring_barley.is_perennial is False
     assert spring_barley.is_nitrogen_fixer is False
     assert spring_barley.minimum_temperature == 0.0
     assert spring_barley.optimal_temperature == 25.0
@@ -223,7 +229,8 @@ def test_species_factory_defaults():
     assert fall_oats.id == 9001  # it is, indeed, over 9000
     assert fall_oats.plant_code == "OATS"
     assert fall_oats.scientific_name == "Avena sativa"
-    assert fall_oats.is_perennial is False
+    assert fall_oats.plant_type == "cool_annual"
+    # assert fall_oats.is_perennial is False
     assert fall_oats.is_nitrogen_fixer is False
     assert fall_oats.minimum_temperature == 0.0
     assert fall_oats.optimal_temperature == 15.0
@@ -252,7 +259,8 @@ def test_species_factory_defaults():
     assert tall_fescue.id == -1  # who would do this?
     assert tall_fescue.plant_code == "FESC"
     assert tall_fescue.scientific_name == "Festuca arundinaceae"
-    assert tall_fescue.is_perennial is True
+    assert tall_fescue.plant_type == "perennial"
+    # assert tall_fescue.is_perennial is True
     assert tall_fescue.is_nitrogen_fixer is False
     assert tall_fescue.minimum_temperature == 0.0
     assert tall_fescue.optimal_temperature == 15.0
@@ -281,7 +289,8 @@ def test_species_factory_defaults():
     assert alfalfa.id == 7
     assert alfalfa.plant_code == "ALFA"
     assert alfalfa.scientific_name == "Medicago sativa"
-    assert alfalfa.is_perennial is True
+    assert alfalfa.plant_type == "perennial_legume"
+    # assert alfalfa.is_perennial is True
     assert alfalfa.is_nitrogen_fixer is True
     assert alfalfa.minimum_temperature == 4.0
     assert alfalfa.optimal_temperature == 25.0
@@ -310,7 +319,8 @@ def test_species_factory_defaults():
     assert soybean.id == 999
     assert soybean.plant_code == "SOYB"
     assert soybean.scientific_name == "Glycine max"
-    assert soybean.is_perennial is False
+    assert soybean.plant_type == "warm_annual_legume"
+    # assert soybean.is_perennial is False
     assert soybean.is_nitrogen_fixer is True
     assert soybean.minimum_temperature == 10.0
     assert soybean.optimal_temperature == 25.0
@@ -339,7 +349,8 @@ def test_species_factory_defaults():
     assert sugar_beet.id == 5
     assert sugar_beet.plant_code == "SGBT"
     assert sugar_beet.scientific_name == "Beta vulgaris saccharifera"
-    assert sugar_beet.is_perennial is False
+    assert sugar_beet.plant_type == "warm_annual"
+    # assert sugar_beet.is_perennial is False
     assert sugar_beet.is_nitrogen_fixer is False
     assert sugar_beet.minimum_temperature == 4.0
     assert sugar_beet.optimal_temperature == 18.0
@@ -368,7 +379,8 @@ def test_species_factory_defaults():
     assert potato.id == 2
     assert potato.plant_code == "POTA"
     assert potato.scientific_name == "Solanum tuberosum"
-    assert potato.is_perennial is False
+    assert potato.plant_type == "cool_annual"
+    # assert potato.is_perennial is False
     assert potato.is_nitrogen_fixer is False
     assert potato.minimum_temperature == 7.0
     assert potato.optimal_temperature == 22.0
@@ -398,14 +410,15 @@ def test_manual_custom_crop_data():
     """checks (and demonstrates) the alternate way of customizing a crop"""
     # setup custom crop
     aspen = CropData(name="custom crop: aspen", species="aspen", scientific_name="Populus tremuloides",
-                     plant_code="PTREM", is_perennial=True, is_nitrogen_fixer=False, max_leaf_area_index=5.0)
+                     plant_code="PTREM", plant_type="tree", is_nitrogen_fixer=False, max_leaf_area_index=5.0)
 
     # check that each attribute is set appropriately
     assert aspen.name == "custom crop: aspen"
     assert aspen.species == "aspen"
     assert aspen.scientific_name == "Populus tremuloides"
     assert aspen.plant_code == "PTREM"
-    assert aspen.is_perennial is True
+    assert aspen.plant_type == "tree"
+    # assert aspen.is_perennial is True
     assert aspen.is_nitrogen_fixer is False
     assert aspen.max_leaf_area_index == 5.0
 
@@ -419,7 +432,7 @@ def test_manual_custom_crop_data():
     ("cereal_rye", {"biomass": 100}),  # change attribute declared only in CropData
     ("spring_barley", {"name": "fancy barley",  # custom new variety/subspecies
                        "plant_code": "FBAR", "scientific_name" : "Hordeum vulgare regalis"}),
-    ("fall_oats", {"is_perennial": True}),  # perennial version of oats
+    ("fall_oats", {"plant_type": "perennial"}),  # perennial version of oats
     ("tall_fescue", {"is_nitrogen_fixer": True}),  # magical nitrogen-fixing grass (egads!)
     ("alfalfa", {"yield_nitrogen_fraction": 0.03}),  # this alfalfa has increased nitrogen in harvest
     ("soybean", {"max_leaf_area_index": 2.4, "light_use_efficiency": 10.8,  # various alterations

--- a/SC_redesign/Crop_and_Soil/tests_SC/test_crop_management.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/test_crop_management.py
@@ -86,20 +86,20 @@ def test_given_harvest_index_property(usr_index, expect):
     data = CropData(user_harvest_index=usr_index)
     assert data.do_harvest_index_override == expect
 
-def test_cut_crop():
-    assert False
-
-def test_determine_harvest_index():
-    assert False
-
-def test_dry_down():
-    assert False
-
-def test_kill():
-    assert False
-
-def test_manage_harvest():
-    assert False
+# def test_cut_crop():
+#     assert False
+#
+# def test_determine_harvest_index():
+#     assert False
+#
+# def test_dry_down():
+#     assert False
+#
+# def test_kill():
+#     assert False
+#
+# def test_manage_harvest():
+#     assert False
 
 
 # @pytest.mark.parametrize("usr_index,heat_frac,harv_eff", [

--- a/SC_redesign/Crop_and_Soil/tests_SC/test_root_development.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/test_root_development.py
@@ -1,4 +1,5 @@
 from SC_redesign.Crop_and_Soil.crop.root_development import *
+from SC_redesign.Crop_and_Soil.crop.crop_data import PlantTypes
 import pytest
 
 # ---- Test Static Functions ----
@@ -51,14 +52,14 @@ def test_develop_roots(maxd, heatfrac):
     """integration test for main root development function develop_roots()"""
 
     # ---- perennial crop ----
-    data_perennial = CropData(heat_fraction=heatfrac, max_root_depth=maxd, plant_type="perennial")
+    data_perennial = CropData(heat_fraction=heatfrac, max_root_depth=maxd, plant_type=PlantTypes("perennial"))
     rd = RootDevelopment(data_perennial)
     rd.develop_roots()
     assert data_perennial.root_fraction == RootDevelopment._determine_root_fraction(heatfrac)
     assert data_perennial.root_depth == maxd
 
     # ---- annual crop ----
-    data_annual = CropData(heat_fraction=heatfrac, max_root_depth=maxd, plant_type="warm_annual")
+    data_annual = CropData(heat_fraction=heatfrac, max_root_depth=maxd, plant_type=PlantTypes("warm_annual"))
     rd = RootDevelopment(data_annual)
     rd.develop_roots()
     assert data_annual.root_fraction == RootDevelopment._determine_root_fraction(heatfrac)

--- a/SC_redesign/Crop_and_Soil/tests_SC/test_root_development.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/test_root_development.py
@@ -1,5 +1,5 @@
 from SC_redesign.Crop_and_Soil.crop.root_development import *
-from SC_redesign.Crop_and_Soil.crop.crop_data import PlantTypes
+from SC_redesign.Crop_and_Soil.crop.crop_data import PlantCategory
 import pytest
 
 # ---- Test Static Functions ----
@@ -52,14 +52,14 @@ def test_develop_roots(maxd, heatfrac):
     """integration test for main root development function develop_roots()"""
 
     # ---- perennial crop ----
-    data_perennial = CropData(heat_fraction=heatfrac, max_root_depth=maxd, plant_type=PlantTypes("perennial"))
+    data_perennial = CropData(heat_fraction=heatfrac, max_root_depth=maxd, plant_category=PlantCategory("perennial"))
     rd = RootDevelopment(data_perennial)
     rd.develop_roots()
     assert data_perennial.root_fraction == RootDevelopment._determine_root_fraction(heatfrac)
     assert data_perennial.root_depth == maxd
 
     # ---- annual crop ----
-    data_annual = CropData(heat_fraction=heatfrac, max_root_depth=maxd, plant_type=PlantTypes("warm_annual"))
+    data_annual = CropData(heat_fraction=heatfrac, max_root_depth=maxd, plant_category=PlantCategory("warm_annual"))
     rd = RootDevelopment(data_annual)
     rd.develop_roots()
     assert data_annual.root_fraction == RootDevelopment._determine_root_fraction(heatfrac)

--- a/SC_redesign/Crop_and_Soil/tests_SC/test_root_development.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/test_root_development.py
@@ -51,14 +51,14 @@ def test_develop_roots(maxd, heatfrac):
     """integration test for main root development function develop_roots()"""
 
     # ---- perennial crop ----
-    data_perennial = CropData(heat_fraction=heatfrac, max_root_depth=maxd, is_perennial=True)
+    data_perennial = CropData(heat_fraction=heatfrac, max_root_depth=maxd, plant_type="perennial")
     rd = RootDevelopment(data_perennial)
     rd.develop_roots()
     assert data_perennial.root_fraction == RootDevelopment._determine_root_fraction(heatfrac)
     assert data_perennial.root_depth == maxd
 
     # ---- annual crop ----
-    data_annual = CropData(heat_fraction=heatfrac, max_root_depth=maxd, is_perennial=False)
+    data_annual = CropData(heat_fraction=heatfrac, max_root_depth=maxd, plant_type="warm_annual")
     rd = RootDevelopment(data_annual)
     rd.develop_roots()
     assert data_annual.root_fraction == RootDevelopment._determine_root_fraction(heatfrac)


### PR DESCRIPTION
# Summary
This PR now implements and tests dormancy for plants, based on SWAT section 5:1.2. To achieve this it has introduced some changes to the structure of `CropData`. This PR also integrates crop dormancy (and tests it) at the `Crop` and `Field` levels.

# Main Changes
- `Dormancy` (and test module):
  - there is now a `Dormancy` module, which has two `@staticmethods` which calculate the parameters when dormancy begins, and a main routine that places a crop into dormancy and changes all necessary `CropData` attributes
  - all methods in `Dormancy` are tested in `test_dormancy.py`
- `Crop`:
  - this module now imports `Dormancy` and maintains a `Dormancy` object
  - a small typo is corrected at the bottom of the file
  - `assess_dormancy()` now calls the dormancy method on the crop instead of doing nothing
- `CropData`:
  - there is now the `PlantTypes` enum class that has all the supported types of plants. This was added to ensure the correct operations were performed on a crop when it goes into dormancy
  - the `plant_type` attribute (type is `PlantTypes` member) has replaced the `is_perennial` boolean attribute. All the child classes of `CropData` reflect this change. Note that `is_perennial` still exists in `CropData`, but now as an `@property` method based on the `plant_type` attribute
  - two attributes have been added to track dormancy-related properties of a plant. There are still some TODO's associated with them, but they will need to be implemented after researching how they are measured in the field and what some typical values are for them.
- `CropManagement` (and `test_crop_management.py`):
  - the main routine for this module now takes a member from the `HarvestOperation` enum rather than a couple of booleans
  - the tests for `cut_crop()`, `determine_harvest_index()`, `dry_down()`, `kill()`, and `manage_harvest()` have been commented out because they are not implemented yet.
- `Field` (and test module):
  - `manage_field()` now puts crops in or takes them out of dormancy depending on the length of the current day
  - the `start_dormancy` method has been added which iterates through all crops in the field and calls their dormancy methods
  - a small typo has been corrected
  - the test module now includes a test for the `start_dormancy()` method. The tests `test_grow_crops()` and `test_harvest_crops()` have been commented out because they are not implemented yet
- `test_crop_data_and_species_factory.py`:
  - `test_species_factory_defaults()` now checks that `plant_type` is initialized correctly instead of `is_perennial`
  - `test_manual_custom_crop_data()` sets and checks `plant_type` instead of `is_perennial`
  - `test_factory_alterations()` sets `plant_type` instead of `is_perennial`
  - there is now a test for the `is_perennial` method 
- `FieldData`:
  - docstring for `harvest_type` is now a comment, not a string
  - attributes have been added that are used to determine when crops in the field should go into dormancy
  - a `post_init` method has been added to initialize dormancy-related attributes that are based on other `FieldData` attributes, using `@staticmethods` from `Dormancy`
- `CurrentWeather`:
  - the `daylength` attribute has been added, which determines whether a crop goes into or gets out of dormancy on that day

# Other Changes
- `HeatUnits`:
  - TODO's have had references to related GitHub issues added
- `RootDevelopment` (and test module):
  - minor formatting issue has been fixed
  - test module now sets `plant_type` instead of `is_perennial`
- `SoilData`:
  - the `decomposition_temperature_effect` attribute has been moved to above the `post_init` method 
- added an `init` file to the `crop_tests` directory 
----
**Note** that this PR is merging into `field-manager_SCred` because it is a sub-branch of that branch.