### PR TITLE
Small changes missed from first `Soil` PR (#355)

### DIFF
--- a/SC_redesign/Crop_and_Soil/crop/crop.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop.py
@@ -24,27 +24,27 @@ class Crop:
             If crop_data is not given, the default specifications are used.
         """
         # Common data object that is updated throughout routines
-        data = crop_data or CropData()  # defaults if not given
+        self.data = crop_data or CropData()  # defaults if not given
         """reference to the crop data; tracks all crop variables through the simulation"""
 
         # growth process components
-        self.growth_constraints = GrowthConstraints(data)
+        self.growth_constraints = GrowthConstraints(self.data)
         """Process component controlling growth constraints, limits plant growth as a function of stressors"""
-        self.biomass_allocation = BiomassAllocation(data)
+        self.biomass_allocation = BiomassAllocation(self.data)
         """Process component controlling allocation of plant biomass as a function of growth and photosynthesis"""
-        self.water_dynamics = WaterDynamics(data)
+        self.water_dynamics = WaterDynamics(self.data)
         """Process component controlling plant water dynamics"""
-        self.nitrogen_incorporation = NitrogenIncorporation(data)
+        self.nitrogen_incorporation = NitrogenIncorporation(self.data)
         """Process component controlling plant nitrogen incorporation, including uptake and fixation"""
-        self.phosphorus_incorporation = PhosphorusIncorporation(data)
+        self.phosphorus_incorporation = PhosphorusIncorporation(self.data)
         """Process component controlling plant phosphorus uptake and incorporation"""
-        self.heat_units = HeatUnits(data)  # TODO: rename module and component (e.g., "HeatAccumulation")?
+        self.heat_units = HeatUnits(self.data)  # TODO: rename module and component (e.g., "HeatAccumulation")?
         """Process component controlling plant heat accumulation"""
-        self.leaf_area_index = LeafAreaIndex(data)  # TODO: rename module and component (e.g., "CanopyGrowth")?
+        self.leaf_area_index = LeafAreaIndex(self.data)  # TODO: rename module and component (e.g., "CanopyGrowth")?
         """Process component controlling canopy growth, including leaf area index"""
-        self.root_development = RootDevelopment(data)
+        self.root_development = RootDevelopment(self.data)
         """Process component controlling plant root development"""
-        self.crop_yields = Yields(data)
+        self.crop_yields = Yields(self.data)
         """Process component controlling calculation of end-of-season production"""
 
     def grow_crop(self, layer_nitrates: List[float], layer_depths: List[float],

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -54,7 +54,7 @@ class Field:
         # daily soil routine
 
         # determine total amount of residue and above-ground biomass present on the given day
-        total_plant_cover = self.field_data.current_residue + self._total_above_ground_biomass()
+        total_plant_cover = self.field_data.current_residue + self._determine_total_above_ground_biomass()
 
         self.soil.daily_soil_routine(current_weather.incoming_light, current_weather.mean_air_temperature,
                                      current_weather.min_air_temperature, current_weather.max_air_temperature,
@@ -257,11 +257,11 @@ class Field:
         self.soil.daily_soil_water_routine(current_weather.rainfall, 1, self.field_data.seasonal_high_water_table,
                                            current_weather.incoming_light, current_weather.max_air_temperature,
                                            current_weather.min_air_temperature, current_weather.mean_air_temperature,
-                                           self._total_above_ground_biomass(), self.field_data.current_residue,
+                                           self._determine_total_above_ground_biomass(), self.field_data.current_residue,
                                            current_weather.snow_fall, total_initial_canopy_free_water, 0.2)
         pass
 
-    def _total_above_ground_biomass(self) -> float:
+    def _determine_total_above_ground_biomass(self) -> float:
         """Calculate the total amount of above-ground biomass still on the plant(s) in the field (kg / ha)"""
         total_above_ground_biomass = 0
         for crop in self.crops:
@@ -274,7 +274,6 @@ class Field:
     def perform_annual_reset(self) -> None:
         """Collect all annual accumulated totals from Field, Crop, and Soil modules, write them to some sort of output
             file, and then reset all annual totals"""
-        # TODO: come up with design pattern that allows SoilData objects to be accessed by the Soil object that is a
-        #       part of this class, so that its do_annual_reset() method can be called
+        self.soil.data.do_annual_reset()
 
         pass

--- a/SC_redesign/Crop_and_Soil/soil/soil.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil.py
@@ -21,19 +21,19 @@ class Soil:
         Details:
             If no SoilData object is passed, default configuration is used.
         """
-        data = soil_data or SoilData()
+        self.data = soil_data or SoilData()
         """object that tracks all soil variable throughout the simulation"""
 
         # Process components
-        self.evapotranspiration = Evapotranspiration(data)
+        self.evapotranspiration = Evapotranspiration(self.data)
         """Process component that controls evapotranspiration from the soil"""
-        self.infiltration = Infiltration(data)
+        self.infiltration = Infiltration(self.data)
         """Process component that controls water infiltration from the soil surface into the profile"""
-        self.percolation = Percolation(data)
+        self.percolation = Percolation(self.data)
         """Process component that controls percolation of water from upper layers to lower layers"""
-        self.soil_temp = SoilTemp(data)
+        self.soil_temp = SoilTemp(self.data)
         """Process component that tracks and updates the temperatures within the soil profile"""
-        self.soil_erosion = SoilErosion(data)
+        self.soil_erosion = SoilErosion(self.data)
         """Process component that track erosion from the soil profile"""
 
     @classmethod


### PR DESCRIPTION
# Summary
This is a very small PR to change the structure of `Crop` and `Soil` objects. Before `CropData` and `SoilData` were not attributes of `Crop` and `Soil` respectively, now they are. Methods from these data objects are now called when appropriate in `Field`

# Other Changes
One of the `Field` method names starts with a verb