### PR TITLE
Refactor methods to add to phosphorus pools - closes #403

### DIFF
--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 """
@@ -19,7 +19,7 @@ class LayerData:
     """phosphate content of the layer (kg/ha)"""
     soil_water_concentration: float = 0.25  # arbitrary
     """soil water concentration of the layer (mm)"""
-    water_content:  Optional[float] = None
+    water_content:  float = field(init=False)
     """water present in the layer (mm)"""
     field_capacity_water_concentration: float = 0.3  # arbitrary
     """water concentration of soil layer at field capacity (mm water / mm soil)"""

--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -76,9 +76,9 @@ class LayerData:
 
         Parameters
         ----------
-            phosphorus_to_add: float
+            phosphorus_to_add : float
                 Amount of phosphorus to add (kg)
-            field_size: float
+            field_size : float
                 Size of the field (ha)
 
         """
@@ -91,9 +91,9 @@ class LayerData:
 
         Parameters
         ----------
-            phosphorus_to_add: float
+            phosphorus_to_add : float
                 Amount of phosphorus to add (kg)
-            field_size: float
+            field_size : float
                 Size of the field (ha)
 
         """
@@ -101,7 +101,7 @@ class LayerData:
                                                                       field_size)
 
     @staticmethod
-    def _add_phosphorus_to_pool(self, pool_to_add_to: float, phosphorus_to_add: float, field_size: float) -> float:
+    def _add_phosphorus_to_pool(pool_to_add_to: float, phosphorus_to_add: float, field_size: float) -> float:
         """This is a generic method to be used by wrapper functions to add phosphorus to any of the phosphorus pools.
 
         Parameters

--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -70,6 +70,65 @@ class LayerData:
         """Initialize all attributes in the dataclass that depend on other attributes"""
         self.water_content = self.soil_water_concentration * self.layer_thickness
 
+    def add_to_labile_phosphorus(self, phosphorus_to_add: float, field_size: float) -> None:
+        """This method is a wrapper for adding a specified mass of phosphorus to the labile phosphorus content of this
+            soil layer.
+
+        Parameters
+        ----------
+            phosphorus_to_add: float
+                Amount of phosphorus to add (kg)
+            field_size: float
+                Size of the field (ha)
+
+        """
+        self.labile_phosphorus_content = self._add_phosphorus_to_pool(self.labile_phosphorus_content, phosphorus_to_add,
+                                                                      field_size)
+
+    def add_to_active_phosphorus(self, phosphorus_to_add: float, field_size: float) -> None:
+        """This method is a wrapper for adding a specified mass of phosphorus to the active phosphorus content of this
+            soil layer.
+
+        Parameters
+        ----------
+            phosphorus_to_add: float
+                Amount of phosphorus to add (kg)
+            field_size: float
+                Size of the field (ha)
+
+        """
+        self.active_phosphorus_content = self._add_phosphorus_to_pool(self.active_phosphorus_content, phosphorus_to_add,
+                                                                      field_size)
+
+    @staticmethod
+    def _add_phosphorus_to_pool(self, pool_to_add_to: float, phosphorus_to_add: float, field_size: float) -> float:
+        """This is a generic method to be used by wrapper functions to add phosphorus to any of the phosphorus pools.
+
+        Parameters
+        ----------
+        pool_to_add_to : float
+            The phosphorus pool in this soil layer that is having phosphorus added (kg phosphorus / ha)
+        phosphorus_to_add : float
+            Amount of phosphorus to add (kg)
+        field_size : float
+            Size of the field (ha)
+
+        Returns
+        -------
+        float
+            The new value of the phosphorus pool that was added to (kg phosphorus / ha)
+
+        Notes
+        -----
+        Before adding the new phosphorus to the specified pool, it first extracts the current amount of phosphorus
+        in the pool in kg, then adds the new phosphorus, and then converts the new amount of phosphorus from kg to kg
+        per ha.
+
+        """
+        phosphorus_pool_amount = pool_to_add_to * field_size
+        phosphorus_pool_amount += phosphorus_to_add
+        return phosphorus_pool_amount / field_size
+
     @property
     def layer_thickness(self) -> float:
         """thickness of soil layer (mm)"""
@@ -113,8 +172,7 @@ class LayerData:
     @property
     def percent_organic_matter_content(self) -> float:
         """percent organic matter content of this soil layer
-        TODO: remove this field from all the soil inputs, because the given values for OM_percent are not equal to value
-            that SWAT would calculate based on the percent organic carbon content
+
         SWAT Reference: 4:1.1.4
         """
         return 1.72 * self.percent_organic_carbon_content

--- a/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/fertilizer.py
+++ b/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/fertilizer.py
@@ -58,7 +58,7 @@ class Fertilizer:
         first_rainfall_occurred = self.data.rain_events_after_fertilizer_application == 1 \
             and self.data.available_phosphorus_pool > 0
         if first_rainfall_occurred and runoff == 0:
-            self._add_to_labile_phosphorus(self.data.available_phosphorus_pool, field_size)
+            self.data.soil_layers[0].add_to_labile_phosphorus(self.data.available_phosphorus_pool, field_size)
             self.data.available_phosphorus_pool = 0
             return
         elif first_rainfall_occurred and runoff > 0:
@@ -68,7 +68,7 @@ class Fertilizer:
             absorbed_phosphorus_to_remove = amounts_to_remove["absorbed_phosphorus"]
             self.data.available_phosphorus_pool -= (runoff_phosphorus_to_remove + absorbed_phosphorus_to_remove)
             self.data.annual_runoff_fertilizer_phosphorus += runoff_phosphorus_to_remove
-            self._add_to_labile_phosphorus(absorbed_phosphorus_to_remove, field_size)
+            self.data.soil_layers[0].add_to_labile_phosphorus(absorbed_phosphorus_to_remove, field_size)
             return
 
     def _update_after_first_rain(self, rainfall: float, runoff: float, field_size: float) -> None:
@@ -165,24 +165,6 @@ class Fertilizer:
         return_dict["absorbed_phosphorus"] = absorbed_phosphorus
 
         return return_dict
-
-    def _add_to_labile_phosphorus(self, phosphorus_to_add: float, field_size: float) -> None:
-        """This method adds a specified mass of phosphorus to the labile phosphorus content of the top layer of the soil
-            profile.
-
-        Args:
-            phosphorus_to_add: amount of phosphorus to add (kg)
-            field_size: size of the field (ha)
-
-        Details:
-            Before adding the mass of phosphorus to the labile phosphorus content, it first converts the current amount
-            of labile phosphorus in the top layer of soil from kg per ha to kg, then adds the new phosphorus, then
-            converts the new mass to kg per ha.
-        """
-        # TODO: move to LayerData - Issue #403
-        labile_phosphorus_mass = self.data.soil_layers[0].labile_phosphorus_content * field_size
-        labile_phosphorus_mass += phosphorus_to_add
-        self.data.soil_layers[0].labile_phosphorus_content = labile_phosphorus_mass / field_size
 
     # --- Static methods ---
     @staticmethod

--- a/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/fertilizer.py
+++ b/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/fertilizer.py
@@ -83,7 +83,7 @@ class Fertilizer:
         elif runoff == 0:
             solubilized_phosphorus = self.data.recalcitrant_phosphorus_pool * self.data.solubilizing_factor
             self.data.recalcitrant_phosphorus_pool -= solubilized_phosphorus
-            self._add_to_labile_phosphorus(solubilized_phosphorus, field_size)
+            self.data.soil_layers[0].add_to_labile_phosphorus(solubilized_phosphorus, field_size)
             return
         else:
             amounts_to_remove = self._determine_leached_phosphorus(rainfall, runoff, field_size,
@@ -92,7 +92,7 @@ class Fertilizer:
             absorbed_phosphorus_to_remove = amounts_to_remove["absorbed_phosphorus"]
             self.data.recalcitrant_phosphorus_pool -= (runoff_phosphorus_to_remove + absorbed_phosphorus_to_remove)
             self.data.annual_runoff_fertilizer_phosphorus += runoff_phosphorus_to_remove
-            self._add_to_labile_phosphorus(absorbed_phosphorus_to_remove, field_size)
+            self.data.soil_layers[0].add_to_labile_phosphorus(absorbed_phosphorus_to_remove, field_size)
             return
 
     def add_fertilizer_phosphorus(self, fertilizer_phosphorus_applied: float) -> None:

--- a/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure_application.py
+++ b/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure_application.py
@@ -204,10 +204,10 @@ class ManureApplication:
         mass_to_add_to_labile_P += total_phosphorus_mass * water_extractable_organic_phosphorus_fraction * \
             soil_infiltration * 0.95
         mass_to_add_to_labile_P += total_phosphorus_mass * stable_organic_phosphorus_fraction * soil_infiltration * 0.95
-        self._add_to_labile_phosphorus(mass_to_add_to_labile_P, field_size)
+        self.data.soil_layers[0].add_to_labile_phosphorus(mass_to_add_to_labile_P, field_size)
 
         mass_to_add_to_active_P = total_phosphorus_mass * stable_inorganic_phosphorus_fraction * soil_infiltration
-        self._add_to_active_phosphorus(mass_to_add_to_active_P, field_size)
+        self.data.soil_layers[0].add_to_active_phosphorus(mass_to_add_to_active_P, field_size)
 
         adjusted_field_coverage = field_coverage * 0.5
         adjusted_dry_matter_mass = dry_matter_mass * 0.8

--- a/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure_application.py
+++ b/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure_application.py
@@ -220,52 +220,6 @@ class ManureApplication:
         self.data.machine_manure_moisture_factor = new_vals.get("new_moisture_factor")
         self.data.machine_manure_field_coverage = new_vals.get("new_field_coverage")
 
-    def _add_to_labile_phosphorus(self, phosphorus_to_add: float, field_size: float) -> None:
-        """This method adds a specified mass of phosphorus to the labile phosphorus content of the top layer of the soil
-            profile.
-
-        Parameters
-        ----------
-            phosphorus_to_add: float
-                Amount of phosphorus to add (kg)
-            field_size: float
-                Size of the field (ha)
-
-        Notes
-        -----
-        Before adding the mass of phosphorus to the labile phosphorus content, it first converts the current amount of
-        labile phosphorus in the top layer of soil from kg per ha to kg, then adds the new phosphorus, then converts the
-        new mass to kg per ha.
-
-        """
-        # TODO: move to LayerData - Issue #403
-        labile_phosphorus_mass = self.data.soil_layers[0].labile_phosphorus_content * field_size
-        labile_phosphorus_mass += phosphorus_to_add
-        self.data.soil_layers[0].labile_phosphorus_content = labile_phosphorus_mass / field_size
-
-    def _add_to_active_phosphorus(self, phosphorus_to_add: float, field_size: float) -> None:
-        """This method adds a specified mass of phosphorus to the active phosphorus content of the top layer of the soil
-            profile.
-
-        Parameters
-        ----------
-            phosphorus_to_add: float
-                Amount of phosphorus to add (kg)
-            field_size: float
-                Size of the field (ha)
-
-        Notes
-        -----
-        Before adding the mass of phosphorus to the active phosphorus content, it first converts the current amount of
-        active phosphorus in the top layer of soil from kg per ha to kg, then adds the new phosphorus, then converts the
-        new mass to kg per ha.
-
-        """
-        # TODO: move to LayerData - Issue #403
-        active_phosphorus_mass = self.data.soil_layers[0].active_phosphorus_content * field_size
-        active_phosphorus_mass += phosphorus_to_add
-        self.data.soil_layers[0].active_phosphorus_content = active_phosphorus_mass / field_size
-
     # --- Static Methods ---
     @staticmethod
     def _determine_grazing_manure_field_coverage(field_size: float, total_manure_applied: float) -> float:

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_fertilizer.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_fertilizer.py
@@ -50,29 +50,6 @@ def test_determine_dissolved_phosphorus_concentration(phosphorus, frac_released,
 
 
 # --- Helper function tests ---
-@pytest.mark.parametrize("added_phosphorus,initial_labile_phosphorus,field_size", [
-    (3, 6.8, 1.5),
-    (0.87, 1.235, 1),
-    (8.9284921, 5.18393, 2.393481),
-    (0.34, 2.495821, 4.10184),
-    (2.39854, 0, 3.29184)
-])
-def test_add_to_labile_phosphorus(added_phosphorus: float, initial_labile_phosphorus: float, field_size: float) -> None:
-    """Tests that the labile phosphorus content of the top soil layer has phosphorus correctly added to it."""
-    data = SoilData()
-    data.soil_layers[0].labile_phosphorus_content = initial_labile_phosphorus
-    fert = Fertilizer(data)
-
-    fert._add_to_labile_phosphorus(added_phosphorus, field_size)
-    observe = fert.data.soil_layers[0].labile_phosphorus_content
-
-    expect = initial_labile_phosphorus * field_size
-    expect += added_phosphorus
-    expect /= field_size
-
-    assert observe == expect
-
-
 @pytest.mark.parametrize("initial_pool_amount,available_pool_amount,days_since_application,cover_type,field_size", [
     (100, 100, 1, "BARE", 1.56),
     (120, 96, 5, "GRASSED", 2.876),
@@ -162,7 +139,7 @@ def test_update_before_and_at_first_rain(rainfall: float, runoff: float, field_s
                     days_since_application=days_since_application)
     fert = Fertilizer(data)
 
-    fert._add_to_labile_phosphorus = MagicMock()
+    fert.data.soil_layers[0].add_to_labile_phosphorus = MagicMock()
     fert._absorb_from_available_pool = MagicMock(return_value=10)
     fert._determine_leached_phosphorus = MagicMock(return_value={"runoff_phosphorus": (0.5 * available_pool),
                                                                  "absorbed_phosphorus": (0.5 * available_pool)})
@@ -170,16 +147,16 @@ def test_update_before_and_at_first_rain(rainfall: float, runoff: float, field_s
     fert._update_before_and_at_first_rain(rainfall, runoff, field_size)
 
     if not rainfall and not days_since_application:
-        assert fert._add_to_labile_phosphorus.call_count == 0
+        assert fert.data.soil_layers[0].add_to_labile_phosphorus.call_count == 0
         assert fert._absorb_from_available_pool.call_count == 0
         assert fert._determine_leached_phosphorus.call_count == 0
         assert fert.data.available_phosphorus_pool == full_available_pool
     elif rainfall and not runoff and not days_since_application:
-        fert._add_to_labile_phosphorus.assert_called_once_with(available_pool, field_size)
+        fert.data.soil_layers[0].add_to_labile_phosphorus.assert_called_once_with(available_pool, field_size)
         assert fert.data.available_phosphorus_pool == 0
     elif rainfall and runoff and not days_since_application:
         fert._determine_leached_phosphorus.assert_called_once_with(rainfall, runoff, field_size, available_pool)
-        fert._add_to_labile_phosphorus.assert_called_once_with(0.5 * available_pool, field_size)
+        fert.data.soil_layers[0].add_to_labile_phosphorus.assert_called_once_with(0.5 * available_pool, field_size)
         assert fert.data.annual_runoff_fertilizer_phosphorus == 0.5 * available_pool
         assert fert.data.available_phosphorus_pool == 0
 

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_fertilizer.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_fertilizer.py
@@ -199,7 +199,7 @@ def test_update_after_first_rain(recalcitrant_pool: float, rain_events: int, rai
                     rain_events_after_fertilizer_application=rain_events)
     fert = Fertilizer(data)
 
-    fert._add_to_labile_phosphorus = MagicMock()
+    fert.data.soil_layers[0].add_to_labile_phosphorus = MagicMock()
     fert._determine_leached_phosphorus = MagicMock(
         return_value={"runoff_phosphorus": (0.5 * (recalcitrant_pool * fert.data.solubilizing_factor)),
                       "absorbed_phosphorus": (0.5 * (recalcitrant_pool * fert.data.solubilizing_factor))})
@@ -207,19 +207,21 @@ def test_update_after_first_rain(recalcitrant_pool: float, rain_events: int, rai
     fert._update_after_first_rain(rainfall, runoff, field_size)
 
     if not rainfall:
-        assert fert._add_to_labile_phosphorus.call_count == 0
+        assert fert.data.soil_layers[0].add_to_labile_phosphorus.call_count == 0
         assert fert._determine_leached_phosphorus.call_count == 0
         assert fert.data.recalcitrant_phosphorus_pool == recalcitrant_pool
     elif rainfall and not runoff:
-        fert._add_to_labile_phosphorus.assert_called_once_with(recalcitrant_pool * fert.data.solubilizing_factor,
-                                                               field_size)
+        fert.data.soil_layers[0].add_to_labile_phosphorus.assert_called_once_with(recalcitrant_pool *
+                                                                                  fert.data.solubilizing_factor,
+                                                                                  field_size)
         assert fert.data.recalcitrant_phosphorus_pool == \
                (recalcitrant_pool - (recalcitrant_pool * fert.data.solubilizing_factor))
     else:
         fert._determine_leached_phosphorus.assert_called_once_with(rainfall, runoff, field_size, recalcitrant_pool)
-        fert._add_to_labile_phosphorus.assert_called_once_with(0.5 *
-                                                               (recalcitrant_pool * fert.data.solubilizing_factor),
-                                                               field_size)
+        fert.data.soil_layers[0].add_to_labile_phosphorus.assert_called_once_with(0.5 *
+                                                                                  (recalcitrant_pool *
+                                                                                   fert.data.solubilizing_factor),
+                                                                                  field_size)
         assert fert.data.recalcitrant_phosphorus_pool == \
                (recalcitrant_pool - (recalcitrant_pool * fert.data.solubilizing_factor))
 

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_manure_application.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_manure_application.py
@@ -99,52 +99,6 @@ def test_determine_infiltration_factor(wet_rate: float) -> None:
 
 
 # ---- Helper function tests
-@pytest.mark.parametrize("added_phosphorus,initial_labile_phosphorus,field_size", [
-    (3, 6.8, 1.5),
-    (0.87, 1.235, 1),
-    (8.9284921, 5.18393, 2.393481),
-    (0.34, 2.495821, 4.10184),
-    (2.39854, 0, 3.29184)
-])
-def test_add_to_labile_phosphorus(added_phosphorus: float, initial_labile_phosphorus: float, field_size: float) -> None:
-    """Tests that the labile phosphorus content of the top soil layer has phosphorus correctly added to it."""
-    data = SoilData()
-    data.soil_layers[0].labile_phosphorus_content = initial_labile_phosphorus
-    incorp = ManureApplication(data)
-
-    incorp._add_to_labile_phosphorus(added_phosphorus, field_size)
-    observe = incorp.data.soil_layers[0].labile_phosphorus_content
-
-    expect = initial_labile_phosphorus * field_size
-    expect += added_phosphorus
-    expect /= field_size
-
-    assert observe == expect
-
-
-@pytest.mark.parametrize("added_phosphorus,initial_labile_phosphorus,field_size", [
-    (3, 6.8, 1.5),
-    (0.87, 1.235, 1),
-    (8.9284921, 5.18393, 2.393481),
-    (0.34, 2.495821, 4.10184),
-    (2.39854, 0, 3.29184)
-])
-def test_add_to_stable_phosphorus(added_phosphorus: float, initial_labile_phosphorus: float, field_size: float) -> None:
-    """Tests that the stable phosphorus content of the top soil layer has phosphorus correctly added to it."""
-    data = SoilData()
-    data.soil_layers[0].labile_phosphorus_content = initial_labile_phosphorus
-    incorp = ManureApplication(data)
-
-    incorp._add_to_labile_phosphorus(added_phosphorus, field_size)
-    observe = incorp.data.soil_layers[0].labile_phosphorus_content
-
-    expect = initial_labile_phosphorus * field_size
-    expect += added_phosphorus
-    expect /= field_size
-
-    assert observe == expect
-
-
 @pytest.mark.parametrize("dry_mass,dry_fraction,phosphorus_mass,field_coverage,weiP_frac", [
     (1000, 0.18, 200, 0.89, 0.5),
     (955, 0.44, 100, 0.76, 0.47),

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_manure_application.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_manure_application.py
@@ -190,8 +190,8 @@ def test_apply_liquid_machine_manure(dry_mass: float, dry_frac: float, phosphoru
     incorp = ManureApplication(data)
     incorp._determine_wet_rate_factor = MagicMock(return_value=2000)
     incorp._determine_infiltration_factor = MagicMock(return_value=0.5)
-    incorp._add_to_labile_phosphorus = MagicMock()
-    incorp._add_to_active_phosphorus = MagicMock()
+    incorp.data.soil_layers[0].add_to_labile_phosphorus = MagicMock()
+    incorp.data.soil_layers[0].add_to_active_phosphorus = MagicMock()
     incorp._determine_weighted_manure_attributes = MagicMock(return_value={"new_dry_matter_mass": 2050,
                                                                            "new_moisture_factor": 0.93,
                                                                            "new_field_coverage": 0.98})
@@ -213,8 +213,8 @@ def test_apply_liquid_machine_manure(dry_mass: float, dry_frac: float, phosphoru
     incorp._determine_infiltration_factor.assert_called_once_with(2000)
     incorp._determine_weighted_manure_attributes.assert_called_once_with(1000, 0.8, 0.9, expect_adjusted_dry_mass,
                                                                          dry_frac, expect_adjusted_coverage)
-    incorp._add_to_labile_phosphorus.assert_called_once_with(expect_labile, area)
-    incorp._add_to_active_phosphorus.assert_called_once_with(expect_active, area)
+    incorp.data.soil_layers[0].add_to_labile_phosphorus.assert_called_once_with(expect_labile, area)
+    incorp.data.soil_layers[0].add_to_active_phosphorus.assert_called_once_with(expect_active, area)
     assert incorp.data.machine_manure_dry_mass == 2050
     assert incorp.data.machine_manure_moisture_factor == 0.93
     assert incorp.data.machine_manure_field_coverage == 0.98

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_data_and_config_factory.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_data_and_config_factory.py
@@ -450,6 +450,7 @@ def test_add_to_active_phosphorus(added_phosphorus: float, initial_labile_phosph
     (0, 221, 2.334),
 ])
 def test_add_phosphorus_to_pool(pool: float, added_phosphorus: float, area: float) -> None:
+    """Tests that this method correctly calculates the new value of the soil phosphorus pool being added to."""
     observe = LayerData._add_phosphorus_to_pool(pool, added_phosphorus, area)
     expect = pool + (added_phosphorus / area)
     assert observe == expect

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_data_and_config_factory.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_data_and_config_factory.py
@@ -2,7 +2,7 @@ import pytest
 from typing import Dict, List
 from math import inf
 from dataclasses import asdict
-from unittest.mock import patch, PropertyMock
+from unittest.mock import patch, PropertyMock, MagicMock
 
 from SC_redesign.Crop_and_Soil.soil.soil_config_factory import SoilConfiguration, SoilConfigFactory
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
@@ -406,4 +406,50 @@ def test_percent_organic_matter_content(percent_organic_carbon_content: float) -
     layer = LayerData(top_depth=0, bottom_depth=30, percent_organic_carbon_content=percent_organic_carbon_content)
     observe = layer.percent_organic_matter_content
     expect = 1.72 * percent_organic_carbon_content
+    assert observe == expect
+
+
+@pytest.mark.parametrize("added_phosphorus,initial_labile_phosphorus,field_size", [
+    (100, 450, 1.5),
+    (78, 335, 1),
+    (150, 800, 2.393481),
+    (200, 467, 4.10184),
+    (138, 0, 3.29184),
+])
+def test_add_to_labile_phosphorus(added_phosphorus: float, initial_labile_phosphorus: float, field_size: float) -> None:
+    """Tests that the labile phosphorus content of the top soil layer has phosphorus correctly added to it."""
+    layer = LayerData(top_depth=0, bottom_depth=30, labile_phosphorus_content=initial_labile_phosphorus)
+    layer._add_phosphorus_to_pool = MagicMock(return_value=100)
+
+    layer.add_to_labile_phosphorus(added_phosphorus, field_size)
+
+    layer._add_phosphorus_to_pool.assert_called_once_with(initial_labile_phosphorus, added_phosphorus, field_size)
+    assert layer.labile_phosphorus_content == 100
+
+
+@pytest.mark.parametrize("added_phosphorus,initial_labile_phosphorus,field_size", [
+    (210, 460, 1.8),
+    (135, 540, 2.37),
+    (95, 300, 1.88),
+    (215, 0, 4.15),
+])
+def test_add_to_active_phosphorus(added_phosphorus: float, initial_labile_phosphorus: float, field_size: float) -> None:
+    """Tests that the stable phosphorus content of the top soil layer has phosphorus correctly added to it."""
+    layer = LayerData(top_depth=0, bottom_depth=27, labile_phosphorus_content=initial_labile_phosphorus)
+    layer._add_phosphorus_to_pool = MagicMock(return_value=200)
+
+    layer.add_to_labile_phosphorus(added_phosphorus, field_size)
+
+    layer._add_phosphorus_to_pool.assert_called_once_with(initial_labile_phosphorus, added_phosphorus, field_size)
+    assert layer.labile_phosphorus_content == 200
+
+
+@pytest.mark.parametrize("pool,added_phosphorus,area", [
+    (400, 35, 1.8),
+    (166, 84, 3.8),
+    (0, 221, 2.334),
+])
+def test_add_phosphorus_to_pool(pool: float, added_phosphorus: float, area: float) -> None:
+    observe = LayerData._add_phosphorus_to_pool(pool, added_phosphorus, area)
+    expect = pool + (added_phosphorus / area)
     assert observe == expect

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_data_and_config_factory.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_data_and_config_factory.py
@@ -166,7 +166,8 @@ def test_profile_soil_water_content() -> None:
     """Test that SoilData correctly calculates amount of water in the entire soil profile"""
     # Set water content and wilting point content of every soil layer to certain amount
     with patch.multiple("SC_redesign.Crop_and_Soil.soil.layer_data.LayerData",
-                        water_content=PropertyMock(return_value=0.87),
+                        soil_water_concentration=PropertyMock(return_value=0.87),
+                        layer_thickness=PropertyMock(return_value=1),
                         wilting_point_content=PropertyMock(return_value=0.32)):
         soil_data = SoilData()
         observe = soil_data.profile_soil_water_content
@@ -363,7 +364,8 @@ def test_excess_water_available(water_content: float, field_capacity_content: fl
     """Test that excess_water_available() in LayerData correctly calculates the amount of excess water available in a
         layer"""
     with patch.multiple('SC_redesign.Crop_and_Soil.soil.layer_data.LayerData',
-                        water_content=PropertyMock(return_value=water_content),
+                        soil_water_concentration=PropertyMock(return_value=water_content),
+                        layer_thickness=PropertyMock(return_value=1),
                         field_capacity_content=PropertyMock(return_value=field_capacity_content)):
         layer = LayerData(top_depth=0, bottom_depth=30)
         observe = layer.excess_water_available
@@ -384,7 +386,8 @@ def test_acceptable_percolation_amount(water_content: float, saturation_content:
     """Test that acceptable_percolation_amount() in LayerData correctly calculates the maximum amount of water that can
         be percolated into it"""
     with patch.multiple("SC_redesign.Crop_and_Soil.soil.layer_data.LayerData",
-                        water_content=PropertyMock(return_value=water_content),
+                        soil_water_concentration=PropertyMock(return_value=water_content),
+                        layer_thickness=PropertyMock(return_value=1),
                         saturation_content=PropertyMock(return_value=saturation_content)):
         layer = LayerData(top_depth=0, bottom_depth=30)
         observe = layer.acceptable_percolation_amount


### PR DESCRIPTION
# Summary
This PR eliminates a method for adding phosphorus to a soil pool that was duplicated across modules (`fertilizer.py` and `manure_application.py`), by moving it to `layer_data.py` where it can now be accessed by any module. It also changes the design from having a method to add phosphorus to each individual pool to having a single base method that can calculate the new value of any pool, and different wrapper methods for calling the base method and resetting the pool to the result.

# Main Changes
- `layer_data.py`
  - `add_to_labile_phosphorus()`, `add_to_stable_phosphorus()` (the wrapper methods) and `_add_phosphorus_to_pool()` (the base method) have been added.
  - All are tested in `test_soil_data_and_config_factory.py`
- `fertilizer.py` and `manure_application.py`
  - All uses of the old methods that add to soil phosphorus pools have been changed to use the new ones, and all tests have been updated to mock the new functions.
  - The old methods and their tests have been removed from both of these modules.

# Other Changes
- `layer_data.py` has had a stale TODO removed

# Notes
- Please scrutinize the pattern for the base and wrapper methods, there may be a cleaner or more efficient way to implement them.
- Closes #403 