### PR TITLE
residue_partition.py refactor pt.1

### DIFF
--- a/RUFAS/routines/field/soil/carbon_cycling/residue_partitioning.py
+++ b/RUFAS/routines/field/soil/carbon_cycling/residue_partitioning.py
@@ -1,5 +1,6 @@
 import math
 
+
 def update_all(soil, crop, weather, time):
     """
     Description:
@@ -59,37 +60,37 @@ def residue_partitioning(soil, crop_type, weather, time):
         AG_met_to_BG_met = layer.AG_met * layer.tillage_percent
 
         # S.6.B.I.4 / S.6.B.I.7
-       
-        if layer_number == 0: #for top layer
+
+        if layer_number == 0:  # for top layer
 
             # S.6.B.I.11
 
             AG_struct_to_BG_struct = layer.AG_struct * layer.tillage_percent
 
-            if crop_type.extracted == True: #if we extract biomass
-                
+            if crop_type.extracted == True:  # if we extract biomass
+
                 ag_biomass = soil.residue_harvest
-                
+
                 residue_incorp = layer.tillage_percent * ag_biomass
 
-            else: #if we incorporate biomass
+            else:  # if we incorporate biomass
                 ag_biomass = crop_type.yield_actual
-                
+
                 residue_incorp = layer.tillage_percent * ag_biomass
-            
+
             soil.ag_biomass += ag_biomass
 
-        else: #non top layers
-            
+        else:  # non top layers
+
             AG_struct_to_BG_struct = 0
 
-            residue_incorp =  0
+            residue_incorp = 0
 
             ag_biomass = 0
-        
+
         # S.6.B.I.4 / S.6.B.I.7
         layer.AG_met += ag_biomass * AG_met_percent - (
-            (layer.AG_met_to_C_active - AG_met_to_BG_met) + AG_met_to_BG_met)
+                (layer.AG_met_to_C_active - AG_met_to_BG_met) + AG_met_to_BG_met)
 
         # above ground structural residue
         K1 = 0.010857
@@ -101,16 +102,13 @@ def residue_partitioning(soil, crop_type, weather, time):
         layer.AG_struct_to_C_active = AG_struct_decomp * layer.M_d * soil.T_d * layer.AG_struct
         layer.AG_struct_to_C_slow = AG_struct_decomp * layer.M_d * soil.T_d * layer.AG_struct
 
-
-
         layer.AG_struct += ((ag_biomass * (1 - AG_met_percent)) - AG_struct_to_BG_struct) - \
-                        (layer.AG_struct_to_C_active + layer.AG_struct_to_C_slow)
+                           (layer.AG_struct_to_C_active + layer.AG_struct_to_C_slow)
 
         # S.6.B.I.10
         layer.AG_struct_to_C_active = AG_struct_decomp * layer.M_d * soil.T_d * layer.AG_struct
-        
-        layer.AG_struct_to_C_slow = AG_struct_decomp * layer.M_d * soil.T_d * layer.AG_struct
 
+        layer.AG_struct_to_C_slow = AG_struct_decomp * layer.M_d * soil.T_d * layer.AG_struct
 
         # below ground metabolic residue and roots
         # S.6.B.II
@@ -128,7 +126,7 @@ def residue_partitioning(soil, crop_type, weather, time):
         BG_L_to_N = 0
         if crop_type.fr_N != 0:
             BG_L_to_N = AG_L_to_N * lignin_res_percent + (((soil.BG_lignin_res_percent / 100) / crop_type.fr_N) / 100) \
-                          * (1 - lignin_res_percent)
+                        * (1 - lignin_res_percent)
 
         # S.6.B.II.5
         BG_met_percent = 0.85 - 0.18 * BG_L_to_N
@@ -156,7 +154,8 @@ def residue_partitioning(soil, crop_type, weather, time):
 
         # S.6.B.II.9 / S.6.B.II.11
         layer.BG_struct += (AG_struct_to_BG_struct + crop_type.bio_BG * (1 - BG_met_percent)) - \
-                          ((layer.BG_struct_to_C_active + layer.BG_struct_to_C_slow) + AG_struct_to_BG_struct)
+                           ((layer.BG_struct_to_C_active + layer.BG_struct_to_C_slow) + AG_struct_to_BG_struct)
+
 
 # TODO: add docstrings & pseudocode reference(s) - GitHub Issue #169
 def ADJ_crop_type_bio_BG_fun(layer_thickness, soil_profile_depth, crop_type_bio_BG):

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/residue_partition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/residue_partition.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 
 """
@@ -94,7 +94,7 @@ class ResiduePartition:
     @staticmethod
     def _determine_plant_metabolic_carbon_amount(plant_metabolic_carbon_amount: float,
                                                  plant_residue_metabolic_fraction: float,
-                                                 plant_dry_matter_harvest_residue_amount: float,
+                                                 plant_dry_matter_residue_amount: float,
                                                  plant_metabolic_active_carbon_usage: float,
                                                  plant_metabolic_to_soil_carbon_amount: float) -> float:
         """This method calculates a return the updated plant metabolic carbon amount after adding the metabolic carbon
@@ -106,7 +106,7 @@ class ResiduePartition:
             plant metabolic carbon amount (kg/ha)
         plant_residue_metabolic_fraction: float
             fraction of plant residue that is metabolic (unitless)
-        plant_dry_matter_harvest_residue_amount: float
+        plant_dry_matter_residue_amount: float
             amount of dry matter residue at harvest (kg/ha)
         plant_metabolic_active_carbon_usage: float
             plant metabolic carbon decomposed into active carbon (kg/ha)
@@ -123,7 +123,7 @@ class ResiduePartition:
         pseudocode_soil S.6.B.I.4, S.6.B.I.7
 
         """
-        plant_metabolic_carbon_amount += plant_dry_matter_harvest_residue_amount \
+        plant_metabolic_carbon_amount += plant_dry_matter_residue_amount \
             * plant_residue_metabolic_fraction - \
             (plant_metabolic_active_carbon_usage + plant_metabolic_to_soil_carbon_amount)
         return plant_metabolic_carbon_amount

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/residue_partition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/residue_partition.py
@@ -80,7 +80,7 @@ class ResiduePartition:
         Parameters
         ----------
         plant_lignin_nitrogen_ratio : float
-            plant lignin to nitrogen ratio (Dmnl)
+            plant lignin to nitrogen ratio (Dimensionless unit)
 
         Returns
         -------

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/residue_partition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/residue_partition.py
@@ -36,6 +36,8 @@ class ResiduePartition:
     @staticmethod
     def _determine_metabolic_plant_residue_ratio(plant_residue_lignin_composition: float,
                                                  nitrogen_fraction_plant_residue=0.4) -> float:
+        # TODO nitrogen_fraction_plant_residue calculate in RuFaS [C.5.B.1] but not "accurate" for carbon use -
+        #  GitHub Issue #163
         """This method calculates the plant lignin to nitrogen ratio when nitrogen in plant residue at harvest
         is greater than zero
 
@@ -61,12 +63,12 @@ class ResiduePartition:
             return 0
 
     @staticmethod
-    def _determine_plant_resdiue_metabolic_fraction(metabolic_plant_residue_ratio: float) -> float:
+    def _determine_plant_residue_metabolic_fraction(plant_lignin_nitrogen_ratio: float) -> float:
         """This method calculates the fraction of plant residue that is metabolic
 
         Parameters
         ----------
-        metabolic_plant_residue_ratio : float
+        plant_lignin_nitrogen_ratio : float
             plant lignin to nitrogen ratio (Dmnl)
 
         Returns
@@ -79,4 +81,41 @@ class ResiduePartition:
         -------
         pseudocode_soil S.6.B.I.3
         """
-        return 0.85 - 0.18 * metabolic_plant_residue_ratio
+        return 0.85 - 0.18 * plant_lignin_nitrogen_ratio
+
+    @staticmethod
+    def _determine_plant_metabolic_carbon_amount(plant_metabolic_carbon_amount: float,
+                                                 plant_residue_metabolic_fraction: float,
+                                                 plant_dry_matter_harvest_residue_amount: float,
+                                                 plant_metabolic_active_carbon_usage: float,
+                                                 plant_metabolic_to_soil_carbon_amount: float) -> float:
+        """This method calculates a return the updated plant metabolic carbon amount after adding the metabolic carbon
+        in dry matter at harvest and and reduced my the amount that's decomposed and incorporated
+
+        Parameters
+        ----------
+        plant_metabolic_carbon_amount: float
+            plant metabolic carbon amount (kg/ha)
+        plant_residue_metabolic_fraction: float
+            fraction of plant residue that is metabolic (unitless)
+        plant_dry_matter_harvest_residue_amount: float
+            amount of dry matter residue at harvest (kg/ha)
+        plant_metabolic_active_carbon_usage: float
+            plant metabolic carbon decomposed into active carbon (kg/ha)
+        plant_metabolic_to_soil_carbon_amount: float
+            metabolic carbon incorporated into soil during tillage (kg/ha)
+
+        Returns
+        -------
+        float
+            updated plant metabolic carbon amount (hg/ha)
+
+        References
+        -------
+        pseudocode_soil S.6.B.I.4, S.6.B.I.7
+
+        """
+        plant_metabolic_carbon_amount += plant_dry_matter_harvest_residue_amount \
+            * plant_residue_metabolic_fraction - \
+            (plant_metabolic_active_carbon_usage + plant_metabolic_to_soil_carbon_amount)
+        return plant_metabolic_carbon_amount

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/residue_partition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/residue_partition.py
@@ -34,9 +34,9 @@ class ResiduePartition:
         # TODO: check source, 0.1 or 0.01, ask Hector about the value
 
     @staticmethod
-    def _determine_metabolic_plant_residue_ration(plant_residue_lignin_composition: float,
-                                                  nitrogen_fraction_plant_residue=0.4) -> float:
-        """This method calculates the above ground lignin to nitrogen ratio when nitrogen in plant residue at harvest
+    def _determine_metabolic_plant_residue_ratio(plant_residue_lignin_composition: float,
+                                                 nitrogen_fraction_plant_residue=0.4) -> float:
+        """This method calculates the plant lignin to nitrogen ratio when nitrogen in plant residue at harvest
         is greater than zero
 
         Parameters
@@ -49,7 +49,7 @@ class ResiduePartition:
         Returns
         -------
         float
-            above ground lignin to nitrogen ration (Dmnl)
+            plant lignin to nitrogen ratio (Dmnl)
 
         References
         -------
@@ -59,3 +59,24 @@ class ResiduePartition:
             return (plant_residue_lignin_composition / 100) / nitrogen_fraction_plant_residue
         else:
             return 0
+
+    @staticmethod
+    def _determine_plant_resdiue_metabolic_fraction(metabolic_plant_residue_ratio: float) -> float:
+        """This method calculates the fraction of plant residue that is metabolic
+
+        Parameters
+        ----------
+        metabolic_plant_residue_ratio : float
+            plant lignin to nitrogen ratio (Dmnl)
+
+        Returns
+        -------
+        float
+            plant residue fraction that is metabolic (unitless)
+
+
+        References
+        -------
+        pseudocode_soil S.6.B.I.3
+        """
+        return 0.85 - 0.18 * metabolic_plant_residue_ratio

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/residue_partition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/residue_partition.py
@@ -1,6 +1,14 @@
-import math
 from typing import Optional, List
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
+
+"""
+This class contains all necessary methods that involves residue partition, including both plant and soil and also 
+considers the case of tillage for plants
+
+References
+-------
+pseudocode_soil S.6.B
+"""
 
 
 class ResiduePartition:
@@ -116,6 +124,36 @@ class ResiduePartition:
 
         """
         plant_metabolic_carbon_amount += plant_dry_matter_harvest_residue_amount \
-            * plant_residue_metabolic_fraction - \
-            (plant_metabolic_active_carbon_usage + plant_metabolic_to_soil_carbon_amount)
+                                         * plant_residue_metabolic_fraction - \
+                                         (plant_metabolic_active_carbon_usage + plant_metabolic_to_soil_carbon_amount)
         return plant_metabolic_carbon_amount
+
+    @staticmethod
+    def _determine_plant_metabolic_active_carbon_usage(decomposition_moisture_effect: float,
+                                                       decomposition_temperature_effect: float,
+                                                       plant_metabolic_carbon_amount: float,
+                                                       metabolic_active_carbon_rate=0.28) -> float:
+        # TODO: Double check the metabolic_active_carbon_rate, again, pseudocode_soil differs from the original code
+        """Calculates the the amount of plant metabolic carbon decomposed to active carbon (kg/ha)
+        Parameters
+        ----------
+        decomposition_moisture_effect: float
+            moisture effect on decomposition factor (unitless)
+        decomposition_temperature_effect: float
+            temperature effect on decomposition factor (unitless)
+        plant_metabolic_carbon_amount: float
+            plant metabolic carbon amount (kg/ha)
+        metabolic_active_carbon_rate: float
+            rate of decomposition from metabolic to active carbon (unitless)
+
+        Returns
+        -------
+        float
+            above ground metabolic carbon decomposed to active carbon (kg/ha)
+
+        References
+        -------
+        pseudocode_soil S.6.B.I.5
+        """
+        return decomposition_moisture_effect * decomposition_temperature_effect * \
+            plant_metabolic_carbon_amount * metabolic_active_carbon_rate

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/residue_partition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/residue_partition.py
@@ -1,0 +1,61 @@
+import math
+from typing import Optional, List
+from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
+
+
+class ResiduePartition:
+
+    def __init__(self, soil_data: Optional[SoilData] = None):
+        self.data = soil_data or SoilData()  # initialize with defaults, if not
+
+    @staticmethod
+    def _determine_plant_residue_lignin_composition(plant_residue_lignin_composition: float,
+                                                    rainfall: float) -> None:
+        """This method calculates and updates the plant_residue_lignin_composition based on the amount of rainfall
+
+        Parameters
+        ----------
+        plant_residue_lignin_composition : float
+            lignin fraction of plant residue (unitless)
+        rainfall : float
+            amount of rain (mm H2O)
+
+        Returns
+        -------
+        float
+            The updated plant_residue_lignin_composition
+
+        References
+        -------
+        pseudocode_soil S.6.B.I.1
+        """
+        plant_residue_lignin_composition += 0.12 * rainfall * 0.1
+        return plant_residue_lignin_composition
+        # TODO: check source, 0.1 or 0.01, ask Hector about the value
+
+    @staticmethod
+    def _determine_metabolic_plant_residue_ration(plant_residue_lignin_composition: float,
+                                                  nitrogen_fraction_plant_residue=0.4) -> float:
+        """This method calculates the above ground lignin to nitrogen ratio when nitrogen in plant residue at harvest
+        is greater than zero
+
+        Parameters
+        ----------
+        plant_residue_lignin_composition : float
+            lignin fraction of plant residue (unitless)
+        nitrogen_fraction_plant_residue : float
+            Nitrogen fraction in plant residue at harvest (unitless)
+
+        Returns
+        -------
+        float
+            above ground lignin to nitrogen ration (Dmnl)
+
+        References
+        -------
+        pseudocode_soil S.6.B.I.2
+        """
+        if nitrogen_fraction_plant_residue != 0:
+            return (plant_residue_lignin_composition / 100) / nitrogen_fraction_plant_residue
+        else:
+            return 0

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/residue_partition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/residue_partition.py
@@ -2,7 +2,7 @@ from typing import Optional
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 
 """
-This class contains all necessary methods that involves residue partition, including both plant and soil and also 
+This class contains all necessary methods that involves residue partition, including both plant and soil and also
 considers the case of tillage for plants
 
 References

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/residue_partition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/residue_partition.py
@@ -124,8 +124,8 @@ class ResiduePartition:
 
         """
         plant_metabolic_carbon_amount += plant_dry_matter_harvest_residue_amount \
-                                         * plant_residue_metabolic_fraction - \
-                                         (plant_metabolic_active_carbon_usage + plant_metabolic_to_soil_carbon_amount)
+            * plant_residue_metabolic_fraction - \
+            (plant_metabolic_active_carbon_usage + plant_metabolic_to_soil_carbon_amount)
         return plant_metabolic_carbon_amount
 
     @staticmethod

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/residue_partition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/residue_partition.py
@@ -2,7 +2,7 @@ from typing import Optional
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 
 """
-This class contains all necessary methods that involves residue partition, including both plant and soil and also
+This class contains all necessary methods that involve residue partition, including both plant and soil and also
 considers the case of tillage for plants
 
 References
@@ -53,7 +53,7 @@ class ResiduePartition:
         ----------
         plant_residue_lignin_composition : float
             lignin fraction of plant residue (unitless)
-        nitrogen_fraction_plant_residue : float
+        nitrogen_fraction_plant_residue : float, default = 0.4
             Nitrogen fraction in plant residue at harvest (unitless)
 
         Returns
@@ -65,10 +65,13 @@ class ResiduePartition:
         -------
         pseudocode_soil S.6.B.I.2
         """
-        if nitrogen_fraction_plant_residue != 0:
+        if 0 < nitrogen_fraction_plant_residue < 1.0:
             return (plant_residue_lignin_composition / 100) / nitrogen_fraction_plant_residue
-        else:
+        elif nitrogen_fraction_plant_residue == 0:
             return 0
+        else:
+            raise ValueError("Expected nitrogen_fraction_plant_residue be between 0.0-1.0, received "
+                             + str(nitrogen_fraction_plant_residue))
 
     @staticmethod
     def _determine_plant_residue_metabolic_fraction(plant_lignin_nitrogen_ratio: float) -> float:
@@ -97,8 +100,8 @@ class ResiduePartition:
                                                  plant_dry_matter_residue_amount: float,
                                                  plant_metabolic_active_carbon_usage: float,
                                                  plant_metabolic_to_soil_carbon_amount: float) -> float:
-        """This method calculates a return the updated plant metabolic carbon amount after adding the metabolic carbon
-        in dry matter at harvest and and reduced my the amount that's decomposed and incorporated
+        """This method calculates the updated plant metabolic carbon amount after adding the metabolic carbon
+        in dry matter at harvest and and reduced by the amount that's decomposed and incorporated
 
         Parameters
         ----------

--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -63,7 +63,7 @@ class LayerData:
     # --- pool_gas_partition
     # (pseudocode_soil S.6.A.1)
     plant_metabolic_active_carbon_usage: Optional[float] = None
-    """plant metabolic carbon decomposed into active carbon (kg/ha) (pseudocode_soil S.6.B.I.6)"""
+    """plant metabolic carbon decomposed into active carbon (kg/ha) (pseudocode_soil S.6.B.I.)"""
     plant_metabolic_active_carbon_loss: Optional[float] = None
     """plant metabolic carbon being lost as carbon dioxide during decomposition into active carbon (kg/ha)"""
     plant_metabolic_active_carbon_remaining: Optional[float] = None

--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -164,6 +164,10 @@ class LayerData:
     active_phosphorus_content: float = 0
     """Active phosphorus content of this soil layer (kg phosphorus / ha)"""
 
+    # --- Residue partition
+    plant_metabolic_to_soil_carbon_amount: Optional[float] = None
+    """metabolic carbon incorporated into soil during tillage (kg/ha)"""
+
     def __post_init__(self):
         """Initialize all attributes in the dataclass that depend on other attributes"""
         self.water_content = self.soil_water_concentration * self.layer_thickness

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_residue_partition.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_residue_partition.py
@@ -1,0 +1,85 @@
+import pytest
+
+from SC_redesign.Crop_and_Soil.soil.carbon_cycling.residue_partition import ResiduePartition
+
+
+@pytest.mark.parametrize("plant_residue_lignin_composition, rainfall", [
+    (3, 2),  # lower values
+    (50, 6),  # higher value
+    (1.8, 1.1),  # arbitrary values
+])
+def test_determine_plant_residue_lignin_composition(plant_residue_lignin_composition: float, rainfall: float) -> None:
+    """Tests that the plant residue lignin composition will be updated correctly as the equation with given rainfall"""
+    expected = plant_residue_lignin_composition + 0.12 * rainfall * 0.1
+    assert expected == ResiduePartition._determine_plant_residue_lignin_composition(plant_residue_lignin_composition,
+                                                                                    rainfall)
+
+
+@pytest.mark.parametrize("plant_residue_lignin_composition", [
+    5,  # lower values
+    100,  # higher values
+    35.8,  # arbitrary
+])
+def test_determine_metabolic_plant_residue_ratio(plant_residue_lignin_composition: float) -> None:
+    """Test that metabolic plant residue ration is correctly determined under current nitrogen_fraction_plant_residue
+    """
+    nitrogen_fraction_plant_residue = 0.4
+    if nitrogen_fraction_plant_residue != 0:
+        expected = (plant_residue_lignin_composition / 100) / nitrogen_fraction_plant_residue
+    else:
+        expected = 0
+
+    assert expected == ResiduePartition._determine_metabolic_plant_residue_ratio(plant_residue_lignin_composition)
+
+
+@pytest.mark.parametrize("plant_lignin_nitrogen_ratio", [
+    7,  # lower values
+    56,  # higher values
+    35.8,  # arbitrary
+])
+def test_determine_plant_residue_metabolic_fraction(plant_lignin_nitrogen_ratio: float) -> None:
+    """Tests to see if the fraction of plant residue that is metabolic is calculated correctly"""
+    expected = 0.85 - 0.18 * plant_lignin_nitrogen_ratio
+    assert expected == ResiduePartition._determine_plant_residue_metabolic_fraction(plant_lignin_nitrogen_ratio)
+
+
+@pytest.mark.parametrize("plant_metabolic_carbon_amount, plant_residue_metabolic_fraction,"
+                         "plant_dry_matter_harvest_residue_amount, plant_metabolic_active_carbon_usage, "
+                         "plant_metabolic_to_soil_carbon_amount", [
+                             (3, 8, 7, 1, 2),
+                             (60, 64, 85, 40, 30),
+                             (1.8, 1.1, 3.2, 0.8, 0.7),
+                         ])
+def test_determine_plant_metabolic_carbon_amount(plant_metabolic_carbon_amount: float,
+                                                 plant_residue_metabolic_fraction: float,
+                                                 plant_dry_matter_harvest_residue_amount: float,
+                                                 plant_metabolic_active_carbon_usage: float,
+                                                 plant_metabolic_to_soil_carbon_amount: float) -> None:
+    """Tests that the updated plant metabolic carbon amount is calculated correctly"""
+    expected = plant_metabolic_carbon_amount + plant_dry_matter_harvest_residue_amount \
+               * plant_residue_metabolic_fraction - \
+               (plant_metabolic_active_carbon_usage + plant_metabolic_to_soil_carbon_amount)
+    assert expected == ResiduePartition._determine_plant_metabolic_carbon_amount(plant_metabolic_carbon_amount,
+                                                                                 plant_residue_metabolic_fraction,
+                                                                                 plant_dry_matter_harvest_residue_amount
+                                                                                 ,
+                                                                                 plant_metabolic_active_carbon_usage,
+                                                                                 plant_metabolic_to_soil_carbon_amount)
+
+
+@pytest.mark.parametrize("decomposition_moisture_effect, decomposition_temperature_effect, "
+                         "plant_metabolic_carbon_amount", [
+                             (3, 8, 7),
+                             (60, 64, 85),
+                             (1.8, 1.1, 3.27),
+                         ])
+def test_determine_plant_metabolic_active_carbon_usage(decomposition_moisture_effect: float,
+                                                       decomposition_temperature_effect: float,
+                                                       plant_metabolic_carbon_amount: float) -> None:
+    """Tests that plant metabolic active carbon usage amount was calculated correctly"""
+    metabolic_active_carbon_rate = 0.28
+    expected = decomposition_moisture_effect * decomposition_temperature_effect * \
+        plant_metabolic_carbon_amount * metabolic_active_carbon_rate
+    assert expected == ResiduePartition._determine_plant_metabolic_active_carbon_usage(decomposition_moisture_effect,
+                                                                                       decomposition_temperature_effect,
+                                                                                       plant_metabolic_carbon_amount)

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_residue_partition.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_residue_partition.py
@@ -15,21 +15,32 @@ def test_determine_plant_residue_lignin_composition(plant_residue_lignin_composi
                                                                                     rainfall)
 
 
-@pytest.mark.parametrize("plant_residue_lignin_composition", [
-    5,  # lower values
-    100,  # higher values
-    35.8,  # arbitrary
+@pytest.mark.parametrize("plant_residue_lignin_composition, nitrogen_fraction_plant_residue", [
+    (3, 0.4),  # default value
+    (50, 0.5),  # higher value
+    (1.8, 1.1),  # arbitrary values
+    (2.2, 0)  # zeros
 ])
-def test_determine_metabolic_plant_residue_ratio(plant_residue_lignin_composition: float) -> None:
+def test_determine_metabolic_plant_residue_ratio(plant_residue_lignin_composition: float,
+                                                 nitrogen_fraction_plant_residue) -> None:
     """Test that metabolic plant residue ration is correctly determined under current nitrogen_fraction_plant_residue
     """
-    nitrogen_fraction_plant_residue = 0.4
-    if nitrogen_fraction_plant_residue != 0:
+    if 0 < nitrogen_fraction_plant_residue < 1.0:
         expected = (plant_residue_lignin_composition / 100) / nitrogen_fraction_plant_residue
-    else:
+        assert expected == ResiduePartition._determine_metabolic_plant_residue_ratio(plant_residue_lignin_composition,
+                                                                                     nitrogen_fraction_plant_residue)
+    elif nitrogen_fraction_plant_residue == 0:
         expected = 0
-
-    assert expected == ResiduePartition._determine_metabolic_plant_residue_ratio(plant_residue_lignin_composition)
+        assert expected == ResiduePartition._determine_metabolic_plant_residue_ratio(plant_residue_lignin_composition,
+                                                                                     nitrogen_fraction_plant_residue)
+    else:
+        # case of invalid input
+        with pytest.raises(ValueError) as e:
+            ResiduePartition._determine_metabolic_plant_residue_ratio(plant_residue_lignin_composition,
+                                                                      nitrogen_fraction_plant_residue)
+        expected = "Expected nitrogen_fraction_plant_residue be between 0.0-1.0, received " + \
+                   str(nitrogen_fraction_plant_residue)
+        assert expected == str(e.value)
 
 
 @pytest.mark.parametrize("plant_lignin_nitrogen_ratio", [

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_residue_partition.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_residue_partition.py
@@ -44,7 +44,7 @@ def test_determine_plant_residue_metabolic_fraction(plant_lignin_nitrogen_ratio:
 
 
 @pytest.mark.parametrize("plant_metabolic_carbon_amount, plant_residue_metabolic_fraction,"
-                         "plant_dry_matter_harvest_residue_amount, plant_metabolic_active_carbon_usage, "
+                         "plant_dry_matter_residue_amount, plant_metabolic_active_carbon_usage, "
                          "plant_metabolic_to_soil_carbon_amount", [
                              (3, 8, 7, 1, 2),
                              (60, 64, 85, 40, 30),
@@ -52,17 +52,16 @@ def test_determine_plant_residue_metabolic_fraction(plant_lignin_nitrogen_ratio:
                          ])
 def test_determine_plant_metabolic_carbon_amount(plant_metabolic_carbon_amount: float,
                                                  plant_residue_metabolic_fraction: float,
-                                                 plant_dry_matter_harvest_residue_amount: float,
+                                                 plant_dry_matter_residue_amount: float,
                                                  plant_metabolic_active_carbon_usage: float,
                                                  plant_metabolic_to_soil_carbon_amount: float) -> None:
     """Tests that the updated plant metabolic carbon amount is calculated correctly"""
-    expected = plant_metabolic_carbon_amount + plant_dry_matter_harvest_residue_amount \
+    expected = plant_metabolic_carbon_amount + plant_dry_matter_residue_amount \
         * plant_residue_metabolic_fraction - \
         (plant_metabolic_active_carbon_usage + plant_metabolic_to_soil_carbon_amount)
     assert expected == ResiduePartition._determine_plant_metabolic_carbon_amount(plant_metabolic_carbon_amount,
                                                                                  plant_residue_metabolic_fraction,
-                                                                                 plant_dry_matter_harvest_residue_amount
-                                                                                 ,
+                                                                                 plant_dry_matter_residue_amount,
                                                                                  plant_metabolic_active_carbon_usage,
                                                                                  plant_metabolic_to_soil_carbon_amount)
 

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_residue_partition.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_residue_partition.py
@@ -57,8 +57,8 @@ def test_determine_plant_metabolic_carbon_amount(plant_metabolic_carbon_amount: 
                                                  plant_metabolic_to_soil_carbon_amount: float) -> None:
     """Tests that the updated plant metabolic carbon amount is calculated correctly"""
     expected = plant_metabolic_carbon_amount + plant_dry_matter_harvest_residue_amount \
-               * plant_residue_metabolic_fraction - \
-               (plant_metabolic_active_carbon_usage + plant_metabolic_to_soil_carbon_amount)
+        * plant_residue_metabolic_fraction - \
+        (plant_metabolic_active_carbon_usage + plant_metabolic_to_soil_carbon_amount)
     assert expected == ResiduePartition._determine_plant_metabolic_carbon_amount(plant_metabolic_carbon_amount,
                                                                                  plant_residue_metabolic_fraction,
                                                                                  plant_dry_matter_harvest_residue_amount


### PR DESCRIPTION
### Summary
This PR is the first part of refactoring `residue_partition.py` of the Soil module from "pseudocode_soil" S.6.B.I. As for this part, the PR cover methods from S.6.B.I.1 to S.6.B.I.5 and S.6.B.I.7. All methods created are static methods and will be used later on in the main routine to update attributes that will be added in` Layer `and `Soil` class.

Every method is tested covering possibly most edge cases.

### Changes

- All methods in this part are static
- Attribute and method names were changed to be more descriptive
- As for the current PR, there will be no attributes being modified directly

###  Other changes

-  Fixed some errors in the original code that contradicts the pseudocode_soil according to @morrowcj 's clarification, expected more errors in later parts to need to be changed based on other clarifications

**Note**
In S.6.B.I.5, AGmet active decomp contradicts the code again. It's currently following the number given in the psudocode_soil file, it will require future clarification and has been added as TODO, not sure if issues should be created.