### PR TITLE
Reconfigure `flake8` to fail build if it finds any errors

### DIFF
--- a/.github/workflows/lint_flake8.yml
+++ b/.github/workflows/lint_flake8.yml
@@ -27,7 +27,5 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        # stop the build if there are any errors or warnings
+        flake8 SC_redesign/ --count --show-source --statistics --max-line-length=120 --max-complexity=10

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/pool_gas_partition.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/pool_gas_partition.py
@@ -1,5 +1,4 @@
-import math
-from typing import Optional, List
+from typing import Optional
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 
 """
@@ -20,6 +19,7 @@ class PoolGasPartition:
         The SoilData object used by this module to track carbon pool gas partition activity,
         creates new one if one is not provided.
     """
+
     def __init__(self, soil_data: Optional[SoilData] = None):
         self.data = soil_data or SoilData()  # initialize with defaults, if not given
 
@@ -128,7 +128,6 @@ class PoolGasPartition:
                 layer.passive_carbon_amount, layer.slow_to_passive_carbon_amount,
                 layer.active_carbon_to_passive_amount, layer.passive_carbon_decomposition_amount)
 
-
     @staticmethod
     def _determine_soil_passive_carbon_amount(passive_carbon_amount: float, slow_to_passive_carbon_amount: float,
                                               active_carbon_to_passive_amount: float,
@@ -148,12 +147,13 @@ class PoolGasPartition:
 
         """
         return passive_carbon_amount + slow_to_passive_carbon_amount + active_carbon_to_passive_amount - \
-               passive_carbon_decomposition_amount
+            passive_carbon_decomposition_amount
 
     # ---- S.6.C.12
     @staticmethod
     def _determine_soil_slow_carbon_amount(slow_carbon_amount: float, plant_structural_slow_carbon_remaining: float,
-                                           soil_structural_slow_carbon_remaining: float, active_carbon_to_slow_amount: float,
+                                           soil_structural_slow_carbon_remaining: float,
+                                           active_carbon_to_slow_amount: float,
                                            slow_carbon_decomposition_amount: float):
         """
         Aggregate the total amount of slow carbon in the layer
@@ -173,7 +173,7 @@ class PoolGasPartition:
 
         """
         return slow_carbon_amount + plant_structural_slow_carbon_remaining + soil_structural_slow_carbon_remaining + \
-               active_carbon_to_slow_amount - slow_carbon_decomposition_amount
+            active_carbon_to_slow_amount - slow_carbon_decomposition_amount
 
     # ---- S.6.C.11
     @staticmethod
@@ -213,7 +213,8 @@ class PoolGasPartition:
 
     @staticmethod
     def _determine_soil_active_carbon_amount(active_carbon_amount: float, plant_active_decompose_carbon: float,
-                                             soil_active_decompose_carbon: float, passive_to_active_carbon_amount: float,
+                                             soil_active_decompose_carbon: float,
+                                             passive_to_active_carbon_amount: float,
                                              slow_to_active_carbon_amount: float,
                                              active_carbon_decomposition_amount: float) -> float:
         """
@@ -232,7 +233,7 @@ class PoolGasPartition:
         pseudocode_soil Reference: S.6.C.11
         """
         return active_carbon_amount + plant_active_decompose_carbon + soil_active_decompose_carbon \
-               + slow_to_active_carbon_amount + passive_to_active_carbon_amount - active_carbon_decomposition_amount
+            + slow_to_active_carbon_amount + passive_to_active_carbon_amount - active_carbon_decomposition_amount
 
     @staticmethod
     def _determine_passive_to_active_carbon_amount(passive_carbon_decomposition_amount: float,
@@ -283,7 +284,8 @@ class PoolGasPartition:
         return slow_carbon_decomposition_amount * (1 - slow_carbon_loss_rate - slow_carbon_passive_decompose_rate)
 
     @staticmethod
-    def _determine_slow_carbon_co2_lost_amount(slow_carbon_decomposition_amount: float, slow_carbon_loss_rate=0.55) -> float:
+    def _determine_slow_carbon_co2_lost_amount(slow_carbon_decomposition_amount: float,
+                                               slow_carbon_loss_rate=0.55) -> float:
         """
         Calculates slow carbon lost as CO2 during decomposition in the layer(kg/ha)
         Args:
@@ -326,7 +328,8 @@ class PoolGasPartition:
 
     # ---- S.6.C.7
     @staticmethod
-    def _determine_active_carbon_to_slow_loss(active_carbon_decomposition_amount: float, carbon_lost_adjusted_factor: float,
+    def _determine_active_carbon_to_slow_loss(active_carbon_decomposition_amount: float,
+                                              carbon_lost_adjusted_factor: float,
                                               ) -> float:
         """
         Calculate active carbon lost as CO2 during decomposition into slow carbon in the layer (kg/ha)
@@ -341,7 +344,8 @@ class PoolGasPartition:
         return active_carbon_decomposition_amount * carbon_lost_adjusted_factor
 
     @staticmethod
-    def _determine_active_carbon_to_slow_amount(active_carbon_decomposition_amount: float, carbon_lost_adjusted_factor: float,
+    def _determine_active_carbon_to_slow_amount(active_carbon_decomposition_amount: float,
+                                                carbon_lost_adjusted_factor: float,
                                                 ) -> float:
         """
         Calculate active carbon decomposed into slow carbon in the layer (kg/ha)
@@ -387,7 +391,7 @@ class PoolGasPartition:
         pseudocode_soil Reference: S.6.C.5
         """
         return decomposition_moisture_effect * decomposition_temperature_effect * passive_carbon_amount * \
-               passive_carbon_decomposition_factor
+            passive_carbon_decomposition_factor
 
     # ---- S.6.C.4
     @staticmethod
@@ -408,12 +412,13 @@ class PoolGasPartition:
         pseudocode_soil Reference: S.6.C.4
         """
         return decomposition_moisture_effect * decomposition_temperature_effect * slow_carbon_amount * \
-               slow_carbon_decomposition_factor
+            slow_carbon_decomposition_factor
 
     # ---- S.6.C.3
     @staticmethod
     def _determine_active_carbon_decomposition_amount(moisture_effect: float, temperature_effect: float,
-                                                      active_carbon: float, active_carbon_decomposition_rate: float) -> float:
+                                                      active_carbon: float,
+                                                      active_carbon_decomposition_rate: float) -> float:
         """
         Calculates active carbon decomposed into slow or passive carbon and CO2 in the layer (kg/ha)
         Args:

--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -19,7 +19,7 @@ class LayerData:
     """phosphate content of the layer (kg/ha)"""
     soil_water_concentration: float = 0.25  # arbitrary
     """soil water concentration of the layer (mm)"""
-    water_content:  Optional[float] = None
+    water_content: Optional[float] = None
     """water present in the layer (mm)"""
     field_capacity_water_concentration: float = 0.3  # arbitrary
     """water concentration of soil layer at field capacity (mm water / mm soil)"""
@@ -68,7 +68,6 @@ class LayerData:
     """plant metabolic carbon being lost as carbon dioxide during decomposition into active carbon (kg/ha)"""
     plant_metabolic_active_carbon_remaining: Optional[float] = None
     """plant metabolic carbon decomposed to active carbon after accounting for carbon dioxide loss (kg/ha)"""
-
 
     plant_structural_active_carbon_usage: Optional[float] = None
     """plant structural carbon decomposed into active carbon (kg/ha) (pseudocode_soil S.6.B.I.11)"""

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_pool_gas_partition.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_pool_gas_partition.py
@@ -197,7 +197,7 @@ def test_slow_carbon_decomposition_amount(decomposition_moisture_effect: float, 
     """Tests that the slow carbon decomposition amount is calculated correctly"""
     slow_carbon_decomposition_factor = 0.0038
     expected = decomposition_moisture_effect * decomposition_temperature_effect * slow_carbon_amount * \
-               slow_carbon_decomposition_factor
+        slow_carbon_decomposition_factor
     assert expected == PoolGasPartition._determine_slow_carbon_decomposition_amount(decomposition_moisture_effect,
                                                                                     decomposition_temperature_effect,
                                                                                     slow_carbon_amount)
@@ -215,7 +215,7 @@ def test_passive_carbon_decomposition_amount(decomposition_moisture_effect: floa
     """Tests that the passive carbon decomposition amount is calculated correctly"""
     passive_carbon_decomposition_factor = 0.00013
     expected = decomposition_moisture_effect * decomposition_temperature_effect * passive_carbon_amount * \
-               passive_carbon_decomposition_factor
+        passive_carbon_decomposition_factor
     assert expected == PoolGasPartition._determine_passive_carbon_decomposition_amount(decomposition_moisture_effect,
                                                                                        decomposition_temperature_effect,
                                                                                        passive_carbon_amount)
@@ -370,7 +370,7 @@ def test_soil_active_carbon_amount(active_carbon_amount: float, plant_active_dec
                                    active_carbon_decomposition_amount: float) -> None:
     """Tests that total amount of active carbon in the layer is aggregated correctly"""
     expected = active_carbon_amount + plant_active_decompose_carbon + soil_active_decompose_carbon \
-               + slow_to_active_carbon_amount + passive_to_active_carbon_amount - active_carbon_decomposition_amount
+        + slow_to_active_carbon_amount + passive_to_active_carbon_amount - active_carbon_decomposition_amount
     assert expected == PoolGasPartition._determine_soil_active_carbon_amount(active_carbon_amount,
                                                                              plant_active_decompose_carbon,
                                                                              soil_active_decompose_carbon,
@@ -391,7 +391,7 @@ def test_soil_slow_carbon_amount(slow_carbon_amount: float, plant_structural_slo
                                  slow_carbon_decomposition_amount: float) -> None:
     """Tests that total amount of slow carbon in the layer is aggregated correctly"""
     expected = slow_carbon_amount + plant_structural_slow_carbon_remaining + soil_structural_slow_carbon_remaining + \
-               active_carbon_to_slow_amount - slow_carbon_decomposition_amount
+        active_carbon_to_slow_amount - slow_carbon_decomposition_amount
     assert expected == PoolGasPartition._determine_soil_slow_carbon_amount(slow_carbon_amount,
                                                                            plant_structural_slow_carbon_remaining,
                                                                            soil_structural_slow_carbon_remaining,
@@ -410,7 +410,7 @@ def test_soil_passive_carbon_amount(passive_carbon_amount: float, slow_to_passiv
                                     passive_carbon_decomposition_amount: float) -> None:
     """Tests that total amount of passive carbon in the layer is aggregated correctly"""
     expected = passive_carbon_amount + slow_to_passive_carbon_amount + active_carbon_to_passive_amount - \
-               passive_carbon_decomposition_amount
+        passive_carbon_decomposition_amount
     assert expected == PoolGasPartition._determine_soil_passive_carbon_amount(passive_carbon_amount,
                                                                               slow_to_passive_carbon_amount,
                                                                               active_carbon_to_passive_amount,


### PR DESCRIPTION
This PR removes the second `flake8` run that happens when checking code before approving it to merge into `SC_redesign`. 

It also fixes the handful of linter errors that were present in `SC_redesign` when this reconfiguration was done.