### PR TITLE
Override user input to create new top layer of soil (1 / 2)

### DIFF
--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -161,13 +161,23 @@ class SoilData:
 
     def __post_init__(self):
         """This method initializes attributes that either cannot be set to a default above or depend on other
-            attributes in the object to be set before they can be set"""
+            attributes in the object to be set before they can be set
+
+        Raises
+        ------
+        ValueError
+            If the bottom depth of the top layer of soil is < 20
+
+        """
         if self.soil_layers is None:
             self.soil_layers = [LayerData(top_depth=0, bottom_depth=20, nitrate=0.3),
                                 LayerData(top_depth=20, bottom_depth=50, nitrate=0.5),
                                 LayerData(top_depth=50, bottom_depth=80, nitrate=1),
                                 LayerData(top_depth=80, bottom_depth=200, nitrate=5)]
-        else:
+        elif self.soil_layers[0].bottom_depth < 20:
+            raise ValueError(f"Expected bottom depth of top soil layer must be 20 mm or greater, received "
+                             f"'{self.soil_layers[0].bottom_depth}'.")
+        elif self.soil_layers[0].bottom_depth > 20:
             self._subdivide_top_layer()
 
         if self.vadose_zone_layer is None:

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import List, Optional
 from math import inf
+from copy import deepcopy
 from SC_redesign.Crop_and_Soil.soil.layer_data import LayerData
 
 """
@@ -162,10 +163,12 @@ class SoilData:
         """This method initializes attributes that either cannot be set to a default above or depend on other
             attributes in the object to be set before they can be set"""
         if self.soil_layers is None:
-            # sets the soil layers to a default set if user does not provide any
-            self.soil_layers = [LayerData(top_depth=0, bottom_depth=50, nitrate=0.5),
+            self.soil_layers = [LayerData(top_depth=0, bottom_depth=20, nitrate=0.3),
+                                LayerData(top_depth=20, bottom_depth=50, nitrate=0.5),
                                 LayerData(top_depth=50, bottom_depth=80, nitrate=1),
                                 LayerData(top_depth=80, bottom_depth=200, nitrate=5)]
+        else:
+            self._subdivide_top_layer()
 
         if self.vadose_zone_layer is None:
             # configures the vadose zone LayerData object based on where the soil profile ends
@@ -177,6 +180,25 @@ class SoilData:
         # Set the initial water content for the first year of the simulation
         self.initial_water_content = self.profile_soil_water_content
         self.initial_nitrates_total = self.profile_nitrates_total
+
+    def _subdivide_top_layer(self) -> None:
+        """This method ensures that the soil profile has a top layer that is 20 mm deep.
+
+        Notes
+        -----
+        The presence of a top layer of soil that is 20 mm deep is a necessity to properly simulate SurPhos. This top 20
+        mm of soil is where most of the phosphorus that is applied stays in the soil profile, and keeping it in the top
+        20 mm of soil makes it more available to be eroded off the field by runoff.
+
+        This method assumes that the top layer of soil defined by the user is greater than 20 mm thick.
+
+        """
+        new_top_layer = deepcopy(self.soil_layers[0])
+        new_top_layer.bottom_depth = 20
+        new_top_layer.__post_init__()
+        self.soil_layers[0].top_depth = 20
+        self.soil_layers[0].__post_init__()
+        self.soil_layers.insert(0, new_top_layer)
 
     def do_annual_reset(self) -> None:
         """This method resets all annual totals to zero at the end of the year/beginning of a new year"""

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -170,7 +170,7 @@ class SoilData:
 
         """
         if self.soil_layers is None:
-            self.soil_layers = [LayerData(top_depth=0, bottom_depth=20, nitrate=0.3),
+            self.soil_layers = [LayerData(top_depth=0, bottom_depth=20, nitrate=0.5),
                                 LayerData(top_depth=20, bottom_depth=50, nitrate=0.5),
                                 LayerData(top_depth=50, bottom_depth=80, nitrate=1),
                                 LayerData(top_depth=80, bottom_depth=200, nitrate=5)]

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_decomposition.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_decomposition.py
@@ -39,25 +39,24 @@ def test_calc_moisture_factor(water_factor, a_term: float = 0.55, b_term: float 
 
 
 @pytest.mark.parametrize("temp_average, layers", [
-    (70, [LayerData(top_depth=0, bottom_depth=4, soil_water_concentration=1.8, field_capacity_water_concentration=1.6,
+    (70, [LayerData(top_depth=0, bottom_depth=40, soil_water_concentration=1.8, field_capacity_water_concentration=1.6,
                     wilting_point_water_concentration=0.9),
-          LayerData(top_depth=4, bottom_depth=12, soil_water_concentration=0.9, field_capacity_water_concentration=1.2,
-                    wilting_point_water_concentration=0.8),
-          LayerData(top_depth=12, bottom_depth=20, soil_water_concentration=0.8, field_capacity_water_concentration=0.8,
-                    wilting_point_water_concentration=0.3)]),  # lower values
-    (150, [LayerData(top_depth=0, bottom_depth=3, soil_water_concentration=2.8, field_capacity_water_concentration=2.3,
+          LayerData(top_depth=40, bottom_depth=120, soil_water_concentration=0.9,
+                    field_capacity_water_concentration=1.2, wilting_point_water_concentration=0.8),
+          LayerData(top_depth=120, bottom_depth=200, soil_water_concentration=0.8,
+                    field_capacity_water_concentration=0.8, wilting_point_water_concentration=0.3)]),  # lower values
+    (150, [LayerData(top_depth=0, bottom_depth=30, soil_water_concentration=2.8, field_capacity_water_concentration=2.3,
                      wilting_point_water_concentration=1.8),
-           LayerData(top_depth=3, bottom_depth=15, soil_water_concentration=1.9, field_capacity_water_concentration=1.8,
-                     wilting_point_water_concentration=0.8),
-           LayerData(top_depth=15, bottom_depth=22, soil_water_concentration=0.8, field_capacity_water_concentration=1,
-                     wilting_point_water_concentration=0.2)]),  # higher values
-    (88.8, [LayerData(top_depth=0, bottom_depth=8, soil_water_concentration=2.3, field_capacity_water_concentration=2.9,
-                      wilting_point_water_concentration=1.8),
-            LayerData(top_depth=8, bottom_depth=20, soil_water_concentration=1.4,
-                      field_capacity_water_concentration=1.8,
-                      wilting_point_water_concentration=0.8),
-            LayerData(top_depth=20, bottom_depth=22, soil_water_concentration=0.8, field_capacity_water_concentration=1,
-                      wilting_point_water_concentration=0.6)])  # arbitrary
+           LayerData(top_depth=30, bottom_depth=150, soil_water_concentration=1.9,
+                     field_capacity_water_concentration=1.8, wilting_point_water_concentration=0.8),
+           LayerData(top_depth=150, bottom_depth=220, soil_water_concentration=0.8,
+                     field_capacity_water_concentration=1, wilting_point_water_concentration=0.2)]),  # higher values
+    (88.8, [LayerData(top_depth=0, bottom_depth=80, soil_water_concentration=2.3,
+                      field_capacity_water_concentration=2.9, wilting_point_water_concentration=1.8),
+            LayerData(top_depth=80, bottom_depth=200, soil_water_concentration=1.4,
+                      field_capacity_water_concentration=1.8, wilting_point_water_concentration=0.8),
+            LayerData(top_depth=200, bottom_depth=220, soil_water_concentration=0.8,
+                      field_capacity_water_concentration=1, wilting_point_water_concentration=0.6)])  # arbitrary
 ])
 def test_decompose(temp_average, layers):
     """ensures that all SoilData attributes were correctly updated"""
@@ -71,7 +70,7 @@ def test_decompose(temp_average, layers):
 
     # making sure functions were called properly
     Decomposition._calc_temp_factor.assert_called_once()
-    assert Decomposition._calc_moisture_factor.call_count == 3
+    assert Decomposition._calc_moisture_factor.call_count == len(layers)
 
     assert data.decomposition_temperature_effect == 3.99
     for layer in data.soil_layers:

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_evapotranspiration.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_evapotranspiration.py
@@ -212,9 +212,9 @@ def test_determine_potential_evapotranspiration_adjusted(initial_canopy_water):
 def test_evapotranspirate(extraterrestrial_radiation, max_temp, min_temp, avg_temp, above_ground_mass, residue,
                           snow_water, initial_canopy_water):
     # initialize objects
-    data = SoilData(transpiration=0.4325, soil_layers=[LayerData(top_depth=0, bottom_depth=5, nitrate=0.5),
-                                                       LayerData(top_depth=5, bottom_depth=8, nitrate=1),
-                                                       LayerData(top_depth=8, bottom_depth=20, nitrate=5)])
+    data = SoilData(transpiration=0.4325, soil_layers=[LayerData(top_depth=0, bottom_depth=50, nitrate=0.5),
+                                                       LayerData(top_depth=50, bottom_depth=80, nitrate=1),
+                                                       LayerData(top_depth=80, bottom_depth=200, nitrate=5)])
     assert data.transpiration == 0.4325
     incorp = Evapotranspiration(data)
 
@@ -244,23 +244,23 @@ def test_evapotranspirate(extraterrestrial_radiation, max_temp, min_temp, avg_te
 
 
 @pytest.mark.parametrize("layers", [
-    [LayerData(top_depth=0, bottom_depth=4, soil_water_concentration=1.8, field_capacity_water_concentration=1.6,
+    [LayerData(top_depth=0, bottom_depth=40, soil_water_concentration=1.8, field_capacity_water_concentration=1.6,
                wilting_point_water_concentration=0.9),
-     LayerData(top_depth=4, bottom_depth=12, soil_water_concentration=0.9, field_capacity_water_concentration=1.2,
+     LayerData(top_depth=40, bottom_depth=120, soil_water_concentration=0.9, field_capacity_water_concentration=1.2,
                wilting_point_water_concentration=0.8),
-     LayerData(top_depth=12, bottom_depth=20, soil_water_concentration=0.8, field_capacity_water_concentration=0.8,
+     LayerData(top_depth=120, bottom_depth=200, soil_water_concentration=0.8, field_capacity_water_concentration=0.8,
                wilting_point_water_concentration=0.3)],
-    [LayerData(top_depth=0, bottom_depth=3, soil_water_concentration=2.8, field_capacity_water_concentration=2.3,
+    [LayerData(top_depth=0, bottom_depth=30, soil_water_concentration=2.8, field_capacity_water_concentration=2.3,
                wilting_point_water_concentration=1.8),
-     LayerData(top_depth=3, bottom_depth=15, soil_water_concentration=1.9, field_capacity_water_concentration=1.8,
+     LayerData(top_depth=30, bottom_depth=150, soil_water_concentration=1.9, field_capacity_water_concentration=1.8,
                wilting_point_water_concentration=0.8),
-     LayerData(top_depth=15, bottom_depth=22, soil_water_concentration=0.8, field_capacity_water_concentration=1,
+     LayerData(top_depth=150, bottom_depth=220, soil_water_concentration=0.8, field_capacity_water_concentration=1,
                wilting_point_water_concentration=0.2)],
-    [LayerData(top_depth=0, bottom_depth=8, soil_water_concentration=2.3, field_capacity_water_concentration=2.9,
+    [LayerData(top_depth=0, bottom_depth=80, soil_water_concentration=2.3, field_capacity_water_concentration=2.9,
                wilting_point_water_concentration=1.8),
-     LayerData(top_depth=8, bottom_depth=20, soil_water_concentration=1.4, field_capacity_water_concentration=1.8,
+     LayerData(top_depth=80, bottom_depth=200, soil_water_concentration=1.4, field_capacity_water_concentration=1.8,
                wilting_point_water_concentration=0.8),
-     LayerData(top_depth=20, bottom_depth=22, soil_water_concentration=0.8, field_capacity_water_concentration=1,
+     LayerData(top_depth=200, bottom_depth=220, soil_water_concentration=0.8, field_capacity_water_concentration=1,
                wilting_point_water_concentration=0.6)],
 ])
 def test_evaporate_from_soil(layers):

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_infiltration.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_infiltration.py
@@ -195,10 +195,10 @@ def test_infiltrate(rainfall, is_top_frozen, coefficient):
     # initialize objects
     if is_top_frozen:
         data = SoilData(potential_evapotranspiration=1.5, average_subbasin_slope=0.07, previous_retention_parameter=27,
-                        soil_layers=[LayerData(top_depth=0, bottom_depth=10, temperature=-1)])
+                        soil_layers=[LayerData(top_depth=0, bottom_depth=100, temperature=-1)])
     else:
         data = SoilData(potential_evapotranspiration=1.5, average_subbasin_slope=0.07, previous_retention_parameter=27,
-                        soil_layers=[LayerData(top_depth=0, bottom_depth=10, temperature=14)])
+                        soil_layers=[LayerData(top_depth=0, bottom_depth=100, temperature=14)])
     incorp = Infiltration(data)
     assert incorp.data.potential_evapotranspiration == 1.5
     assert incorp.data.average_subbasin_slope == 0.07

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_percolation.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_percolation.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch, PropertyMock
 from SC_redesign.Crop_and_Soil.soil.percolation import Percolation
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 from SC_redesign.Crop_and_Soil.soil.layer_data import LayerData
@@ -80,8 +80,8 @@ def test_percolate_between_layers():
     """
     # Case 1: amount to percolate is greater than amount that can be accepted by lower layer
     # Initialize objects
-    layers1 = [LayerData(top_depth=0, bottom_depth=39),
-               LayerData(top_depth=39, bottom_depth=87, saturation_point_water_concentration=0.1)]
+    layers1 = [LayerData(top_depth=0, bottom_depth=20),
+               LayerData(top_depth=20, bottom_depth=87, saturation_point_water_concentration=0.1)]
     layers1[0].water_content = 15
     layers1[1].water_content = 3.8
     data1 = SoilData(soil_layers=layers1)
@@ -112,8 +112,8 @@ def test_percolate_between_layers():
 
     # Case 2: amount to percolate is less than amount that can be accepted by lower layer
     # Initialize objects
-    layers2 = [LayerData(top_depth=0, bottom_depth=39),
-               LayerData(top_depth=39, bottom_depth=87, saturation_point_water_concentration=0.1)]
+    layers2 = [LayerData(top_depth=0, bottom_depth=20),
+               LayerData(top_depth=20, bottom_depth=87, saturation_point_water_concentration=0.1)]
     layers2[0].water_content = 15
     layers2[1].water_content = 3.8
     data2 = SoilData(soil_layers=layers2)
@@ -143,29 +143,32 @@ def test_percolate_between_layers():
 
     # Case 3: amount to percolate is greater excess water available in upper layer
     # Initialize objects
-    layers3 = [LayerData(top_depth=0, bottom_depth=39),
-               LayerData(top_depth=39, bottom_depth=87, saturation_point_water_concentration=0.1)]
-    layers3[0].water_content = 8.9
-    layers3[1].water_content = 3.8
-    data3 = SoilData(soil_layers=layers3)
-    incorp3 = Percolation(data3)
+    with patch("SC_redesign.Crop_and_Soil.soil.layer_data.LayerData.excess_water_available", new_callable=PropertyMock,
+               return_value=0):
+        layers3 = [LayerData(top_depth=0, bottom_depth=20),
+                   LayerData(top_depth=20, bottom_depth=87, saturation_point_water_concentration=0.1)]
+        layers3[0].water_content = 8.9
+        layers3[1].water_content = 3.8
+        data3 = SoilData(soil_layers=layers3)
+        incorp3 = Percolation(data3)
 
-    # Neither intermediate functions need to be re-mocked
+        # Neither intermediate functions need to be re-mocked
 
-    # Determine expected return value
-    expect = helper_percolate_between_layers(incorp3.data.soil_layers[0].excess_water_available, 0.85,
-                                             incorp3.data.soil_layers[1].acceptable_percolation_amount)
+        # Determine expected return value
+        expect = helper_percolate_between_layers(incorp3.data.soil_layers[0].excess_water_available, 0.85,
+                                                 incorp3.data.soil_layers[1].acceptable_percolation_amount)
 
-    # Run method
-    observe = incorp3._percolate_between_layers(incorp3.data.time_step, incorp3.data.soil_layers[0],
-                                                incorp3.data.soil_layers[1])
+        # Run method
+        observe = incorp3._percolate_between_layers(incorp3.data.time_step, incorp3.data.soil_layers[0],
+                                                    incorp3.data.soil_layers[1])
 
-    # Assertions
-    assert observe == expect
-    assert Percolation._determine_percolation_travel_time.call_count == 2
-    # Should only be called in the first two cases, not this one
-    assert Percolation._determine_percolation_to_next_layer.call_count == 1
-    # This method is not called in this test case, and is only called once after being re-mocked in the last test case
+        # Assertions
+        assert observe == expect
+        assert Percolation._determine_percolation_travel_time.call_count == 2
+        # Should only be called in the first two cases, not this one
+        assert Percolation._determine_percolation_to_next_layer.call_count == 1
+        # This method is not called in this test case, and is only called once after being re-mocked in the last test
+        # case
 
 
 def helper_percolate_between_layers(excess_water, amount_to_percolate, acceptable_percolation_amount):
@@ -218,5 +221,5 @@ def test_percolate(high_seasonal_water_table):
 
     # Assertions
     assert observe == expect
-    assert Percolation._determine_if_percolation_allowed.call_count == 3
-    assert Percolation._percolate_between_layers.call_count == 3
+    assert Percolation._determine_if_percolation_allowed.call_count == len(data.soil_layers)
+    assert Percolation._percolate_between_layers.call_count == len(data.soil_layers)

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_percolation.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_percolation.py
@@ -141,7 +141,7 @@ def test_percolate_between_layers():
         incorp2.data.soil_layers[0].excess_water_available,
         incorp2.data.time_step, 0.245)
 
-    # Case 3: amount to percolate is greater excess water available in upper layer
+    # Case 3: amount to percolate is greater than excess water available in upper layer
     # Initialize objects
     with patch("SC_redesign.Crop_and_Soil.soil.layer_data.LayerData.excess_water_available", new_callable=PropertyMock,
                return_value=0):

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_pool_gas_partition.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_pool_gas_partition.py
@@ -418,24 +418,24 @@ def test_soil_passive_carbon_amount(passive_carbon_amount: float, slow_to_passiv
 
 
 @pytest.mark.parametrize("layers", [
-    ([LayerData(top_depth=0, bottom_depth=4, soil_water_concentration=1.8, field_capacity_water_concentration=1.6,
+    ([LayerData(top_depth=0, bottom_depth=40, soil_water_concentration=1.8, field_capacity_water_concentration=1.6,
                 wilting_point_water_concentration=0.9),
-      LayerData(top_depth=4, bottom_depth=12, soil_water_concentration=0.9, field_capacity_water_concentration=1.2,
+      LayerData(top_depth=40, bottom_depth=120, soil_water_concentration=0.9, field_capacity_water_concentration=1.2,
                 wilting_point_water_concentration=0.8),
-      LayerData(top_depth=12, bottom_depth=20, soil_water_concentration=0.8, field_capacity_water_concentration=0.8,
+      LayerData(top_depth=120, bottom_depth=200, soil_water_concentration=0.8, field_capacity_water_concentration=0.8,
                 wilting_point_water_concentration=0.3)]),
-    ([LayerData(top_depth=0, bottom_depth=3, soil_water_concentration=2.8, field_capacity_water_concentration=2.3,
+    ([LayerData(top_depth=0, bottom_depth=30, soil_water_concentration=2.8, field_capacity_water_concentration=2.3,
                 wilting_point_water_concentration=1.8),
-      LayerData(top_depth=3, bottom_depth=15, soil_water_concentration=1.9, field_capacity_water_concentration=1.8,
+      LayerData(top_depth=30, bottom_depth=150, soil_water_concentration=1.9, field_capacity_water_concentration=1.8,
                 wilting_point_water_concentration=0.8),
-      LayerData(top_depth=15, bottom_depth=22, soil_water_concentration=0.8, field_capacity_water_concentration=1,
+      LayerData(top_depth=150, bottom_depth=220, soil_water_concentration=0.8, field_capacity_water_concentration=1,
                 wilting_point_water_concentration=0.2)]),
-    ([LayerData(top_depth=0, bottom_depth=8, soil_water_concentration=2.3, field_capacity_water_concentration=2.9,
+    ([LayerData(top_depth=0, bottom_depth=80, soil_water_concentration=2.3, field_capacity_water_concentration=2.9,
                 wilting_point_water_concentration=1.8),
-      LayerData(top_depth=8, bottom_depth=20, soil_water_concentration=1.4,
+      LayerData(top_depth=80, bottom_depth=200, soil_water_concentration=1.4,
                 field_capacity_water_concentration=1.8,
                 wilting_point_water_concentration=0.8),
-      LayerData(top_depth=20, bottom_depth=22, soil_water_concentration=0.8, field_capacity_water_concentration=1,
+      LayerData(top_depth=200, bottom_depth=220, soil_water_concentration=0.8, field_capacity_water_concentration=1,
                 wilting_point_water_concentration=0.6)])
 ])
 def test_partition_pool_gas(layers: list) -> None:
@@ -489,46 +489,46 @@ def test_partition_pool_gas(layers: list) -> None:
     partition.partition_pool_gas()
 
     # Checking if methods are called correct number of times
-    assert PoolGasPartition._determine_plant_metabolic_active_carbon_loss.call_count == 3
-    assert PoolGasPartition._determine_plant_metabolic_active_carbon_remaining.call_count == 3
-    assert PoolGasPartition._determine_plant_structural_active_carbon_loss.call_count == 3
-    assert PoolGasPartition._determine_plant_structural_active_carbon_remaining.call_count == 3
-    assert PoolGasPartition._determine_plant_structural_slow_carbon_loss.call_count == 3
-    assert PoolGasPartition._determine_plant_structural_slow_carbon_remaining.call_count == 3
-    assert PoolGasPartition._determine_soil_metabolic_active_carbon_loss.call_count == 3
-    assert PoolGasPartition._determine_soil_metabolic_active_carbon_remaining.call_count == 3
-    assert PoolGasPartition._determine_soil_structural_active_carbon_loss.call_count == 3
-    assert PoolGasPartition._determine_soil_structural_active_carbon_remaining.call_count == 3
-    assert PoolGasPartition._determine_soil_structural_slow_carbon_loss.call_count == 3
-    assert PoolGasPartition._determine_soil_structural_slow_carbon_remaining.call_count == 3
+    assert PoolGasPartition._determine_plant_metabolic_active_carbon_loss.call_count == len(layers)
+    assert PoolGasPartition._determine_plant_metabolic_active_carbon_remaining.call_count == len(layers)
+    assert PoolGasPartition._determine_plant_structural_active_carbon_loss.call_count == len(layers)
+    assert PoolGasPartition._determine_plant_structural_active_carbon_remaining.call_count == len(layers)
+    assert PoolGasPartition._determine_plant_structural_slow_carbon_loss.call_count == len(layers)
+    assert PoolGasPartition._determine_plant_structural_slow_carbon_remaining.call_count == len(layers)
+    assert PoolGasPartition._determine_soil_metabolic_active_carbon_loss.call_count == len(layers)
+    assert PoolGasPartition._determine_soil_metabolic_active_carbon_remaining.call_count == len(layers)
+    assert PoolGasPartition._determine_soil_structural_active_carbon_loss.call_count == len(layers)
+    assert PoolGasPartition._determine_soil_structural_active_carbon_remaining.call_count == len(layers)
+    assert PoolGasPartition._determine_soil_structural_slow_carbon_loss.call_count == len(layers)
+    assert PoolGasPartition._determine_soil_structural_slow_carbon_remaining.call_count == len(layers)
 
-    assert PoolGasPartition._determine_active_carbon_decomposition_rate.call_count == 3
+    assert PoolGasPartition._determine_active_carbon_decomposition_rate.call_count == len(layers)
 
-    assert PoolGasPartition._determine_active_carbon_decomposition_amount.call_count == 3
+    assert PoolGasPartition._determine_active_carbon_decomposition_amount.call_count == len(layers)
 
-    assert PoolGasPartition._determine_slow_carbon_decomposition_amount.call_count == 3
+    assert PoolGasPartition._determine_slow_carbon_decomposition_amount.call_count == len(layers)
 
-    assert PoolGasPartition._determine_passive_carbon_decomposition_amount.call_count == 3
+    assert PoolGasPartition._determine_passive_carbon_decomposition_amount.call_count == len(layers)
 
-    assert PoolGasPartition._determine_carbon_lost_adjusted_factor.call_count == 3
+    assert PoolGasPartition._determine_carbon_lost_adjusted_factor.call_count == len(layers)
 
-    assert PoolGasPartition._determine_active_carbon_to_slow_amount.call_count == 3
-    assert PoolGasPartition._determine_active_carbon_to_slow_loss.call_count == 3
+    assert PoolGasPartition._determine_active_carbon_to_slow_amount.call_count == len(layers)
+    assert PoolGasPartition._determine_active_carbon_to_slow_loss.call_count == len(layers)
 
-    assert PoolGasPartition._determine_slow_to_active_carbon_amount.call_count == 3
-    assert PoolGasPartition._determine_slow_carbon_co2_lost_amount.call_count == 3
-    assert PoolGasPartition._determine_slow_to_passive_carbon_amount.call_count == 3
+    assert PoolGasPartition._determine_slow_to_active_carbon_amount.call_count == len(layers)
+    assert PoolGasPartition._determine_slow_carbon_co2_lost_amount.call_count == len(layers)
+    assert PoolGasPartition._determine_slow_to_passive_carbon_amount.call_count == len(layers)
 
-    assert PoolGasPartition._determine_passive_to_active_carbon_amount.call_count == 3
-    assert PoolGasPartition._determine_passive_carbon_co2_lost_amount.call_count == 3
+    assert PoolGasPartition._determine_passive_to_active_carbon_amount.call_count == len(layers)
+    assert PoolGasPartition._determine_passive_carbon_co2_lost_amount.call_count == len(layers)
 
-    assert PoolGasPartition._determine_plant_active_decompose_carbon.call_count == 3
-    assert PoolGasPartition._determine_soil_active_decompose_carbon.call_count == 3
-    assert PoolGasPartition._determine_soil_active_carbon_amount.call_count == 3
+    assert PoolGasPartition._determine_plant_active_decompose_carbon.call_count == len(layers)
+    assert PoolGasPartition._determine_soil_active_decompose_carbon.call_count == len(layers)
+    assert PoolGasPartition._determine_soil_active_carbon_amount.call_count == len(layers)
 
-    assert PoolGasPartition._determine_soil_slow_carbon_amount.call_count == 3
+    assert PoolGasPartition._determine_soil_slow_carbon_amount.call_count == len(layers)
 
-    assert PoolGasPartition._determine_soil_passive_carbon_amount.call_count == 3
+    assert PoolGasPartition._determine_soil_passive_carbon_amount.call_count == len(layers)
 
     # Checking values were set correctly by the main routine
     for layer in data.soil_layers:

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_data_and_config_factory.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_data_and_config_factory.py
@@ -101,13 +101,10 @@ def test_soil_factory_alteration_error(config: str, args_dict: Dict) -> None:
 # --- Tests to verify correct behavior of SoilData module
 def test_manual_soil_data_configuration() -> None:
     """Test that creating a custom SoilData object actually has all the correct values in its fields"""
-    # with patch("SC_redesign.Crop_and_Soil.soil.soil_data.SoilData._subdivide_top_layer", new_callable=MagicMock) as \
-    #         mocked_subdivide_top_layer:
     mollisols = SoilData(name="mollisols", soil_layers=[LayerData(top_depth=0, bottom_depth=80, nitrate=1.8),
                                                         LayerData(top_depth=80, bottom_depth=150, nitrate=2.6),
                                                         LayerData(top_depth=150, bottom_depth=300, nitrate=5)])
 
-    # assert mocked_subdivide_top_layer.call_count == 1
     assert mollisols.name == "mollisols"
     assert mollisols.soil_layers[0] == LayerData(top_depth=0, bottom_depth=20, nitrate=1.8)
     assert mollisols.soil_layers[1] == LayerData(top_depth=20, bottom_depth=80, nitrate=1.8)
@@ -116,6 +113,15 @@ def test_manual_soil_data_configuration() -> None:
     assert mollisols.vadose_zone_layer == LayerData(top_depth=300, bottom_depth=10000000,
                                                     soil_water_concentration=0,
                                                     saturation_point_water_concentration=inf)
+
+
+def test_error_manual_soil_data_configuration() -> None:
+    """Test that an error is correctly raised when an invalid input is used to create SoilData object."""
+    with pytest.raises(ValueError) as e:
+        SoilData(soil_layers=[LayerData(top_depth=0, bottom_depth=19, nitrate=1.8),
+                              LayerData(top_depth=19, bottom_depth=150, nitrate=2.6),
+                              LayerData(top_depth=150, bottom_depth=300, nitrate=5)])
+    assert str(e.value) == "Expected bottom depth of top soil layer must be 20 mm or greater, received '19'."
 
 
 def test_annual_reset() -> None:

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_data_and_config_factory.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_data_and_config_factory.py
@@ -39,7 +39,7 @@ def test_config_factory_defaults():
         defaults"""
     generic = SoilConfigFactory.create_soil_data()
     assert generic.name == "generic soil configuration"
-    assert generic.soil_layers == [LayerData(top_depth=0, bottom_depth=20, nitrate=0.3),
+    assert generic.soil_layers == [LayerData(top_depth=0, bottom_depth=20, nitrate=0.5),
                                    LayerData(top_depth=20, bottom_depth=50, nitrate=0.5),
                                    LayerData(top_depth=50, bottom_depth=80, nitrate=1),
                                    LayerData(top_depth=80, bottom_depth=200, nitrate=5)]

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_data_and_config_factory.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_data_and_config_factory.py
@@ -39,7 +39,8 @@ def test_config_factory_defaults():
         defaults"""
     generic = SoilConfigFactory.create_soil_data()
     assert generic.name == "generic soil configuration"
-    assert generic.soil_layers == [LayerData(top_depth=0, bottom_depth=50, nitrate=0.5),
+    assert generic.soil_layers == [LayerData(top_depth=0, bottom_depth=20, nitrate=0.3),
+                                   LayerData(top_depth=20, bottom_depth=50, nitrate=0.5),
                                    LayerData(top_depth=50, bottom_depth=80, nitrate=1),
                                    LayerData(top_depth=80, bottom_depth=200, nitrate=5)]
     assert generic.potential_evapotranspiration is None
@@ -100,17 +101,20 @@ def test_soil_factory_alteration_error(config: str, args_dict: Dict) -> None:
 # --- Tests to verify correct behavior of SoilData module
 def test_manual_soil_data_configuration() -> None:
     """Test that creating a custom SoilData object actually has all the correct values in its fields"""
-    # Create custom soil configuration
+    # with patch("SC_redesign.Crop_and_Soil.soil.soil_data.SoilData._subdivide_top_layer", new_callable=MagicMock) as \
+    #         mocked_subdivide_top_layer:
     mollisols = SoilData(name="mollisols", soil_layers=[LayerData(top_depth=0, bottom_depth=80, nitrate=1.8),
                                                         LayerData(top_depth=80, bottom_depth=150, nitrate=2.6),
                                                         LayerData(top_depth=150, bottom_depth=300, nitrate=5)])
-    # Check that attributes were properly set
+
+    # assert mocked_subdivide_top_layer.call_count == 1
     assert mollisols.name == "mollisols"
-    assert mollisols.soil_layers[0] == LayerData(top_depth=0, bottom_depth=80, nitrate=1.8)
-    assert mollisols.soil_layers[1] == LayerData(top_depth=80, bottom_depth=150, nitrate=2.6)
-    assert mollisols.soil_layers[2] == LayerData(top_depth=150, bottom_depth=300, nitrate=5)
-    # Vadose zone layer gets initialized based on the bottom soil layer, so check that too
-    assert mollisols.vadose_zone_layer == LayerData(top_depth=300, bottom_depth=10000000, soil_water_concentration=0,
+    assert mollisols.soil_layers[0] == LayerData(top_depth=0, bottom_depth=20, nitrate=1.8)
+    assert mollisols.soil_layers[1] == LayerData(top_depth=20, bottom_depth=80, nitrate=1.8)
+    assert mollisols.soil_layers[2] == LayerData(top_depth=80, bottom_depth=150, nitrate=2.6)
+    assert mollisols.soil_layers[3] == LayerData(top_depth=150, bottom_depth=300, nitrate=5)
+    assert mollisols.vadose_zone_layer == LayerData(top_depth=300, bottom_depth=10000000,
+                                                    soil_water_concentration=0,
                                                     saturation_point_water_concentration=inf)
 
 
@@ -171,7 +175,7 @@ def test_profile_soil_water_content() -> None:
                         wilting_point_content=PropertyMock(return_value=0.32)):
         soil_data = SoilData()
         observe = soil_data.profile_soil_water_content
-        expect = 3 * (0.87 - 0.32)
+        expect = len(soil_data.soil_layers) * (0.87 - 0.32)
         assert observe == expect
 
 
@@ -181,7 +185,7 @@ def test_profile_saturation() -> None:
                return_value=0.98):
         soil_data = SoilData()
         observe = soil_data.profile_saturation
-        expect = 3 * 0.98
+        expect = len(soil_data.soil_layers) * 0.98
         assert observe == expect
 
 
@@ -191,7 +195,7 @@ def test_profile_field_capacity() -> None:
                return_value=0.67):
         soil_data = SoilData()
         observe = soil_data.profile_field_capacity
-        expect = 3 * 0.67
+        expect = len(soil_data.soil_layers) * 0.67
         assert observe == expect
 
 

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_temp.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_temp.py
@@ -185,10 +185,8 @@ def test_daily_soil_temperature_update(radiation, avg_temp, min_temp, max_temp, 
     incorp._determine_soil_surface_temp.assert_called_with(0.5, incorp.data.soil_layers[0].previous_day_temperature,
                                                            20)
 
-    # TODO: the hardcoded values below based off the number of layers in the default configuration for soil_layers,
-    #  should they be made dynamic that that the tests won't fail if the default soil profile is changed?
-    assert incorp._determine_depth_factor.call_count == 3
-    assert incorp._determine_average_soil_temperature.call_count == 3
+    assert incorp._determine_depth_factor.call_count == len(data.soil_layers)
+    assert incorp._determine_average_soil_temperature.call_count == len(data.soil_layers)
     for layer_index in range(len(incorp.data.soil_layers)):
         assert 14 == incorp.data.soil_layers[layer_index].temperature
         assert expect_prev_temps[layer_index] == incorp.data.soil_layers[layer_index].previous_day_temperature
@@ -207,8 +205,8 @@ def test_daily_soil_temperature_update(radiation, avg_temp, min_temp, max_temp, 
     incorp._determine_bare_soil_surface_temp.assert_called_with(0.5, avg_temp, min_temp, max_temp)
     incorp._determine_cover_weighting_factor.assert_called_with(plant_cover, snow_cover)
     incorp._determine_soil_surface_temp.assert_called_with(0.5, expect_prev_temps[0], 20)
-    assert incorp._determine_depth_factor.call_count == 6
-    assert incorp._determine_average_soil_temperature.call_count == 6
+    assert incorp._determine_depth_factor.call_count == 2 * len(data.soil_layers)
+    assert incorp._determine_average_soil_temperature.call_count == 2 * len(data.soil_layers)
     for layer in incorp.data.soil_layers:
         assert 14 == layer.temperature
         assert 14 == layer.previous_day_temperature


### PR DESCRIPTION
# Summary

This is the first PR in a series that overrides user-defined the soil profile by adding a 20 mm thick top layer, and refactors the other modules in `soil/` (outside of `phosphorus_cycling/`) to account for this new top layer. The need for this top layer comes from SurPhos, which tracks phosphorus content specifically in the top 20 mm of soil because that is where most phosphorus that comes from manure and fertilizer stays, and tracking the concentrated part near the soil surface is crucial to accurately predicting phosphorus runoff.

# Outline for this PR series

1. (this PR) implements the overriding of user-given soil specification so that there is always a top layer of soil that is 20 mm thick. Also refactors all old tests that deal with the soil profile so they don't fail. 
2. Refactor modules (hopefully just 1-2) so that they treat the top two layers in the soil profile as one to ensure the integrity of non-SurPhos modules.
3. Refactor additional modules that were not covered in second PR of this series. This one may not happen, depends on how many modules end up being refactored.

# Main Changes:

- `soil_data.py`:
  - Change defaults so default soil profile has the top 20 mm soil layer.
  - Added `_subdivide_top_layer()`, is called in `post_init()` when user defines a soil profile.
  - **PLEASE CRITIQUE** specifically how `_subdivide_top_layer()` is implemented and the bounds used by `post_init()` to decide whether or not to call it .
- Test files for `Evapotranspiration`, `Infiltration`, `PoolGasPartition`, `Decomposition`, and `SoilTemperature`
  - These test files now have much thicker, more realistic (I think) soil layers.
  - The number of times subroutines are assumed to have been called is now a function of how many layers of soil are in the profile being tested, instead of being hardcoded. 
- `test_soil_data_and_config_factory.py`
  - Tests that new default soil profile is properly created.
  - Tests that user-defined soil profile is properly overridden, and error is raised when inappropriate profile is passed.
  - Same changes as in test files listed above.
- `test_percolation.py` 
  - Last test case in `test_percolate_between_layers()` now has a `LayerData` method patched so it correctly follows that control branch is supposed to be tested in this case
  - Same changes as in the changes to the long list of test files above.

