### PR TITLE
Override user input to create new top layer of soil (2 / 2, refactor `Soil` modules)

### DIFF
--- a/SC_redesign/Crop_and_Soil/soil/infiltration.py
+++ b/SC_redesign/Crop_and_Soil/soil/infiltration.py
@@ -18,6 +18,15 @@ class Infiltration:
         weighting_coefficient: weighting coefficient used to calculate retention coefficient for daily curve number
             calculations dependent on plant evapotranspiration (unitless)
 
+        Notes
+        -----
+        This module, in part, relies on the temperature of the top soil layer to determine infiltration. Because RuFaS
+        overrides the user-defined soil profile to maintain a top soil layer that is 20 mm thick for the purpose of
+        tracking phosphorus more accurately, this module distributes the water infiltrated between the two top layers of
+        proportionately by thickness. It also assumes that the top two layers of soil will have the same temperature
+        every day, which will be true for every day of the simulation as long as daily routine in `soil_temp.py` is run
+        prior to this routine.
+
         """
         third_moisture_condition_parameter = self._determine_third_moisture_condition_parameter(
                                                                         self.data.second_moisture_condition_parameter)
@@ -65,6 +74,11 @@ class Infiltration:
         # --------------------------------------------------------------------------------------------------------------
 
         self.data.accumulated_runoff = self._determine_accumulated_runoff(rainfall, retention_parameter)
+        infiltrated_water = max(0, rainfall - self.data.accumulated_runoff)
+        top_layer_water_portion = self.data.soil_layers[0].layer_thickness / self.data.soil_layers[1].bottom_depth
+        bottom_layer_water_portion = (1.0 - top_layer_water_portion)
+        self.data.soil_layers[0].water_content += infiltrated_water * top_layer_water_portion
+        self.data.soil_layers[1].water_content += infiltrated_water * bottom_layer_water_portion
 
         # --- Update previous retention parameter ----------------------------------------------------------------------
         if self.data.previous_retention_parameter is None:

--- a/SC_redesign/Crop_and_Soil/soil/infiltration.py
+++ b/SC_redesign/Crop_and_Soil/soil/infiltration.py
@@ -75,10 +75,7 @@ class Infiltration:
 
         self.data.accumulated_runoff = self._determine_accumulated_runoff(rainfall, retention_parameter)
         infiltrated_water = max(0.0, rainfall - self.data.accumulated_runoff)
-        top_layer_water_portion = self.data.soil_layers[0].layer_thickness / self.data.soil_layers[1].bottom_depth
-        bottom_layer_water_portion = (1.0 - top_layer_water_portion)
-        self.data.soil_layers[0].water_content += infiltrated_water * top_layer_water_portion
-        self.data.soil_layers[1].water_content += infiltrated_water * bottom_layer_water_portion
+        self.data.soil_layers[0].water_content += infiltrated_water
 
         # --- Update previous retention parameter ----------------------------------------------------------------------
         if self.data.previous_retention_parameter is None:

--- a/SC_redesign/Crop_and_Soil/soil/infiltration.py
+++ b/SC_redesign/Crop_and_Soil/soil/infiltration.py
@@ -74,7 +74,7 @@ class Infiltration:
         # --------------------------------------------------------------------------------------------------------------
 
         self.data.accumulated_runoff = self._determine_accumulated_runoff(rainfall, retention_parameter)
-        infiltrated_water = max(0, rainfall - self.data.accumulated_runoff)
+        infiltrated_water = max(0.0, rainfall - self.data.accumulated_runoff)
         top_layer_water_portion = self.data.soil_layers[0].layer_thickness / self.data.soil_layers[1].bottom_depth
         bottom_layer_water_portion = (1.0 - top_layer_water_portion)
         self.data.soil_layers[0].water_content += infiltrated_water * top_layer_water_portion

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -43,7 +43,7 @@ class SoilData:
     """Cumulative total of volume of surface runoff that occurred in a year (mm per hectare)"""
 
     # Track annual nutrient activity
-    annual_runoff_fertilizer_phosphorus: float = 0  # TODO: add this to annual reset method
+    annual_runoff_fertilizer_phosphorus: float = 0
     """Cumulative total of phosphorus from surface-applied fertilizer that was carried off the field by runoff"""
 
     # ---- evapotranspiration

--- a/SC_redesign/Crop_and_Soil/soil/soil_temp.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_temp.py
@@ -33,6 +33,12 @@ class SoilTemp:
             is fairly reasonable due to temporal auto-correlation, but does not account for the random fluctuations
             that can occur throughout the year.
 
+            Because this model now simulates the top 20 mm of the soil profile as its own layer for the purpose of
+            tracking phosphorus runoff, this module first performs operations specifically on the top 2 layers of soil.
+            The result is that this module treats the top two layers of soil as if they were 1, i.e. both layers are set
+            to be the same temperature every day. For every day of the of simulation besides potentially the first, the
+            top two layers of soil will have the same temperature.
+
         SWAT Reference: section 1:1.3.3
         """
         max_damping_depth = self._determine_maximum_damping_depth(self.data.profile_bulk_density)

--- a/SC_redesign/Crop_and_Soil/soil/soil_temp.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_temp.py
@@ -26,7 +26,8 @@ class SoilTemp:
             snow_cover: water content of the snow cover on the current day (mm)
             avg_annual_air_temp: average annual air temperature (degrees C)
 
-        Important: SWAT does not specify how to start the simulation i.e. it does not specify what to do on day 0, when
+        Notes:
+            SWAT does not specify how to start the simulation i.e. it does not specify what to do on day 0, when
             there is no previous day's temperature. Currently, the implementation just uses the temperature that the
             soil starts (it sets the previous days temperature equal to the current day's temperature). This assumption
             is fairly reasonable due to temporal auto-correlation, but does not account for the random fluctuations
@@ -77,32 +78,6 @@ class SoilTemp:
             layer.previous_day_temperature = new_previous_temperature
 
     # --- Static methods ---
-    @staticmethod
-    def _determine_weighted_average_temperature(first_layer_temp: float, first_layer_thickness: float,
-                                                second_layer_temp: float, second_layer_thickness: float) -> float:
-        """This method determines a weighted average temperature of two soil layers based on their thicknesses.
-
-        Parameters
-        ----------
-        first_layer_temp : float
-            Temperature of the first layer (degrees C)
-        first_layer_thickness : float
-            Thickness of the first layer (mm)
-        second_layer_temp : float
-            Temperature of the second layer (degrees C)
-        second_layer_thickness : float
-            Thickness of the second layer (mm)
-
-        Returns
-        -------
-        float
-            The weighted average temperature of the two soil layers passed (degrees C)
-
-        """
-        weighted_top_temp = first_layer_temp * first_layer_thickness
-        weighted_bottom_temp = second_layer_temp * second_layer_thickness
-        return (weighted_top_temp + weighted_bottom_temp) / (first_layer_thickness + second_layer_thickness)
-
     @staticmethod
     def _determine_maximum_damping_depth(bulk_density: float) -> float:
         """calculates maximum damping depth of a soil profile based on bulk density
@@ -219,6 +194,32 @@ class SoilTemp:
         plant_factor = plant_cover / (plant_cover + exp(7.563 - ((1.297 * 10 ** (-4)) * plant_cover)))
         snow_factor = snow_cover / (snow_cover + exp(6.055 - (0.3002 * snow_cover)))
         return max(plant_factor, snow_factor)
+
+    @staticmethod
+    def _determine_weighted_average_temperature(first_layer_temp: float, first_layer_thickness: float,
+                                                second_layer_temp: float, second_layer_thickness: float) -> float:
+        """This method determines a weighted average temperature of two soil layers based on their thicknesses.
+
+        Parameters
+        ----------
+        first_layer_temp : float
+            Temperature of the first layer (degrees C)
+        first_layer_thickness : float
+            Thickness of the first layer (mm)
+        second_layer_temp : float
+            Temperature of the second layer (degrees C)
+        second_layer_thickness : float
+            Thickness of the second layer (mm)
+
+        Returns
+        -------
+        float
+            The weighted average temperature of the two soil layers passed (degrees C)
+
+        """
+        weighted_top_temp = first_layer_temp * first_layer_thickness
+        weighted_bottom_temp = second_layer_temp * second_layer_thickness
+        return (weighted_top_temp + weighted_bottom_temp) / (first_layer_thickness + second_layer_thickness)
 
     @staticmethod
     def _determine_soil_surface_temp(cover_weighting_factor: float, previous_top_soil_layer_temp: float,

--- a/SC_redesign/Crop_and_Soil/soil/soil_temp.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_temp.py
@@ -44,10 +44,28 @@ class SoilTemp:
         cover_factor = self._determine_cover_weighting_factor(plant_cover, snow_cover)
         if self.data.soil_layers[0].previous_day_temperature is None:
             self.data.soil_layers[0].previous_day_temperature = self.data.soil_layers[0].temperature
+            self.data.soil_layers[1].previous_day_temperature = self.data.soil_layers[1].temperature
+        combined_previous_top_soil_layer_temp = self._determine_weighted_average_temperature(
+            self.data.soil_layers[0].previous_day_temperature, self.data.soil_layers[0].layer_thickness,
+            self.data.soil_layers[1].previous_day_temperature, self.data.soil_layers[1].layer_thickness)
         actual_soil_surface_temp = self._determine_soil_surface_temp(cover_factor,
-                                                                     self.data.soil_layers[0].previous_day_temperature,
+                                                                     combined_previous_top_soil_layer_temp,
                                                                      bare_soil_surface_temp)
-        for layer in self.data.soil_layers:
+
+        new_combined_previous_top_soil_temperature = self._determine_weighted_average_temperature(
+            self.data.soil_layers[0].temperature, self.data.soil_layers[0].layer_thickness,
+            self.data.soil_layers[1].temperature, self.data.soil_layers[1].layer_thickness
+        )
+        combined_top_layer_center_depth = self.data.soil_layers[1].bottom_depth / 2
+        depth_factor = self._determine_depth_factor(combined_top_layer_center_depth, damping_depth)
+        new_combined_top_soil_temperature = self._determine_average_soil_temperature(
+            self.data.previous_temperature_effect, new_combined_previous_top_soil_temperature, depth_factor,
+            avg_annual_air_temp, actual_soil_surface_temp)
+        for layer in self.data.soil_layers[:2]:
+            layer.previous_day_temperature = combined_previous_top_soil_layer_temp
+            layer.temperature = new_combined_top_soil_temperature
+
+        for layer in self.data.soil_layers[2:]:
             new_previous_temperature = layer.temperature
             layer_depth_factor = self._determine_depth_factor(layer.depth_of_layer_center, damping_depth)
             if layer.previous_day_temperature is None:
@@ -59,6 +77,32 @@ class SoilTemp:
             layer.previous_day_temperature = new_previous_temperature
 
     # --- Static methods ---
+    @staticmethod
+    def _determine_weighted_average_temperature(first_layer_temp: float, first_layer_thickness: float,
+                                                second_layer_temp: float, second_layer_thickness: float) -> float:
+        """This method determines a weighted average temperature of two soil layers based on their thicknesses.
+
+        Parameters
+        ----------
+        first_layer_temp : float
+            Temperature of the first layer (degrees C)
+        first_layer_thickness : float
+            Thickness of the first layer (mm)
+        second_layer_temp : float
+            Temperature of the second layer (degrees C)
+        second_layer_thickness : float
+            Thickness of the second layer (mm)
+
+        Returns
+        -------
+        float
+            The weighted average temperature of the two soil layers passed (degrees C)
+
+        """
+        weighted_top_temp = first_layer_temp * first_layer_thickness
+        weighted_bottom_temp = second_layer_temp * second_layer_thickness
+        return (weighted_top_temp + weighted_bottom_temp) / (first_layer_thickness + second_layer_thickness)
+
     @staticmethod
     def _determine_maximum_damping_depth(bulk_density: float) -> float:
         """calculates maximum damping depth of a soil profile based on bulk density

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_infiltration.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_infiltration.py
@@ -1,7 +1,6 @@
 import pytest
 from math import log, exp
 from unittest.mock import MagicMock
-from typing import Tuple
 
 from SC_redesign.Crop_and_Soil.soil.infiltration import Infiltration
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
@@ -245,12 +244,3 @@ def test_infiltrate(rainfall, is_top_frozen, coefficient):
     assert incorp.data.accumulated_runoff == 0.95
     assert incorp.data.soil_layers[0].water_content == expected_infiltrated_water
     assert incorp.data.annual_runoff_total == 0.95
-
-
-def _calculate_infiltrated_water(rainfall: float, runoff: float, first_layer_thickness: float,
-                                 bottom_depth: float) -> Tuple[float, float]:
-    """Method that calculates the amount of water that infiltrates into the top two layers of soil."""
-    top_proportion = first_layer_thickness / bottom_depth
-    bottom_proportion = 1.0 - top_proportion
-    infiltrated_water = max(0.0, rainfall - runoff)
-    return infiltrated_water * top_proportion, infiltrated_water * bottom_proportion

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_infiltration.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_infiltration.py
@@ -223,7 +223,7 @@ def test_infiltrate(rainfall, is_top_frozen, coefficient):
 
     # run main method
     incorp.infiltrate(rainfall, coefficient)
-    expected_top_water, expected_bottom_water = _calculate_infiltrated_water(rainfall, 0.95, 20, 50)
+    expected_infiltrated_water = max(0.0, rainfall - 0.95)
 
     # assertions
     assert incorp._determine_third_moisture_condition_parameter.call_count == 2
@@ -243,8 +243,7 @@ def test_infiltrate(rainfall, is_top_frozen, coefficient):
     assert incorp.data.previous_retention_parameter == 21.34
     assert incorp.data.moisture_condition_parameter == 50
     assert incorp.data.accumulated_runoff == 0.95
-    assert incorp.data.soil_layers[0].water_content == expected_top_water
-    assert incorp.data.soil_layers[1].water_content == expected_bottom_water
+    assert incorp.data.soil_layers[0].water_content == expected_infiltrated_water
     assert incorp.data.annual_runoff_total == 0.95
 
 

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_infiltration.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_infiltration.py
@@ -1,11 +1,11 @@
 import pytest
-from math import log
+from math import log, exp
 from unittest.mock import MagicMock
+from typing import Tuple
 
 from SC_redesign.Crop_and_Soil.soil.infiltration import Infiltration
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 from SC_redesign.Crop_and_Soil.soil.layer_data import LayerData
-from math import exp
 
 
 # --- static function tests ---
@@ -195,10 +195,14 @@ def test_infiltrate(rainfall, is_top_frozen, coefficient):
     # initialize objects
     if is_top_frozen:
         data = SoilData(potential_evapotranspiration=1.5, average_subbasin_slope=0.07, previous_retention_parameter=27,
-                        soil_layers=[LayerData(top_depth=0, bottom_depth=100, temperature=-1)])
+                        soil_layers=[LayerData(top_depth=0, bottom_depth=20, nitrate=0.5, temperature=-1,
+                                               soil_water_concentration=0),
+                                     LayerData(top_depth=20, bottom_depth=50, nitrate=0.5, temperature=-1,
+                                               soil_water_concentration=0)])
     else:
         data = SoilData(potential_evapotranspiration=1.5, average_subbasin_slope=0.07, previous_retention_parameter=27,
-                        soil_layers=[LayerData(top_depth=0, bottom_depth=100, temperature=14)])
+                        soil_layers=[LayerData(top_depth=0, bottom_depth=20, nitrate=0.5, soil_water_concentration=0),
+                                     LayerData(top_depth=20, bottom_depth=50, nitrate=0.5, soil_water_concentration=0)])
     incorp = Infiltration(data)
     assert incorp.data.potential_evapotranspiration == 1.5
     assert incorp.data.average_subbasin_slope == 0.07
@@ -219,6 +223,7 @@ def test_infiltrate(rainfall, is_top_frozen, coefficient):
 
     # run main method
     incorp.infiltrate(rainfall, coefficient)
+    expected_top_water, expected_bottom_water = _calculate_infiltrated_water(rainfall, 0.95, 20, 50)
 
     # assertions
     assert incorp._determine_third_moisture_condition_parameter.call_count == 2
@@ -238,4 +243,15 @@ def test_infiltrate(rainfall, is_top_frozen, coefficient):
     assert incorp.data.previous_retention_parameter == 21.34
     assert incorp.data.moisture_condition_parameter == 50
     assert incorp.data.accumulated_runoff == 0.95
+    assert incorp.data.soil_layers[0].water_content == expected_top_water
+    assert incorp.data.soil_layers[1].water_content == expected_bottom_water
     assert incorp.data.annual_runoff_total == 0.95
+
+
+def _calculate_infiltrated_water(rainfall: float, runoff: float, first_layer_thickness: float,
+                                 bottom_depth: float) -> Tuple[float, float]:
+    """Method that calculates the amount of water that infiltrates into the top two layers of soil."""
+    top_proportion = first_layer_thickness / bottom_depth
+    bottom_proportion = 1.0 - top_proportion
+    infiltrated_water = max(0.0, rainfall - runoff)
+    return infiltrated_water * top_proportion, infiltrated_water * bottom_proportion

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_temp.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_temp.py
@@ -6,6 +6,19 @@ from math import exp, log
 
 
 # --- Static function tests ---
+@pytest.mark.parametrize("top_temp,top_thickness,bottom_temp,bottom_thickness", [
+    (14.52, 20, 13.29, 30),
+    (16.99, 20, 16.78, 60),
+    (11, 20, 24, 66),
+])
+def test_determine_weighted_average_temperature(top_temp: float, top_thickness: float, bottom_temp: float,
+                                                bottom_thickness: float) -> None:
+    """Tests that the correct weighted average temperature is calculated for the two soil layers given."""
+    observe = SoilTemp._determine_weighted_average_temperature(top_temp, top_thickness, bottom_temp, bottom_thickness)
+    expect = (top_temp * top_thickness + bottom_temp * bottom_thickness) / (top_thickness + bottom_thickness)
+    assert observe == expect
+
+
 @pytest.mark.parametrize("bulk_density", [
     0,
     1.89,
@@ -43,7 +56,7 @@ def test_determine_scaling_factor(water_content, density, bottom_depth):
 def test_determine_damping_depth(max_damping_depth, scaling_factor):
     """tests _determine_damping_depth() in soil_temp.py"""
     observe = SoilTemp._determine_damping_depth(max_damping_depth, scaling_factor)
-    expect = max_damping_depth * exp(log(500 / max_damping_depth) * ((1 - scaling_factor) / (1 + scaling_factor))**2)
+    expect = max_damping_depth * exp(log(500 / max_damping_depth) * ((1 - scaling_factor) / (1 + scaling_factor)) ** 2)
     assert observe == expect
 
 

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_temp.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_temp.py
@@ -173,13 +173,14 @@ def test_daily_soil_temperature_update(radiation, avg_temp, min_temp, max_temp, 
     incorp._determine_radiation_factor = MagicMock(return_value=0.5)
     incorp._determine_bare_soil_surface_temp = MagicMock(return_value=20)
     incorp._determine_cover_weighting_factor = MagicMock(return_value=0.5)
+    incorp._determine_weighted_average_temperature = MagicMock(return_value=15)
     incorp._determine_soil_surface_temp = MagicMock(return_value=18.5)
     incorp._determine_depth_factor = MagicMock(return_value=0.5)
     incorp._determine_average_soil_temperature = MagicMock(return_value=14)
 
     # Record expected previous day temperature values
-    expect_prev_temps = []
-    for layer in incorp.data.soil_layers:
+    expect_prev_temps = [15, 15]
+    for layer in incorp.data.soil_layers[2:]:
         expect_prev_temps.append(layer.temperature)
 
     # Run method
@@ -198,8 +199,9 @@ def test_daily_soil_temperature_update(radiation, avg_temp, min_temp, max_temp, 
     incorp._determine_soil_surface_temp.assert_called_with(0.5, incorp.data.soil_layers[0].previous_day_temperature,
                                                            20)
 
-    assert incorp._determine_depth_factor.call_count == len(data.soil_layers)
-    assert incorp._determine_average_soil_temperature.call_count == len(data.soil_layers)
+    assert incorp._determine_weighted_average_temperature.call_count == 2
+    assert incorp._determine_depth_factor.call_count == len(data.soil_layers) - 1
+    assert incorp._determine_average_soil_temperature.call_count == len(data.soil_layers) - 1
     for layer_index in range(len(incorp.data.soil_layers)):
         assert 14 == incorp.data.soil_layers[layer_index].temperature
         assert expect_prev_temps[layer_index] == incorp.data.soil_layers[layer_index].previous_day_temperature
@@ -218,8 +220,12 @@ def test_daily_soil_temperature_update(radiation, avg_temp, min_temp, max_temp, 
     incorp._determine_bare_soil_surface_temp.assert_called_with(0.5, avg_temp, min_temp, max_temp)
     incorp._determine_cover_weighting_factor.assert_called_with(plant_cover, snow_cover)
     incorp._determine_soil_surface_temp.assert_called_with(0.5, expect_prev_temps[0], 20)
-    assert incorp._determine_depth_factor.call_count == 2 * len(data.soil_layers)
-    assert incorp._determine_average_soil_temperature.call_count == 2 * len(data.soil_layers)
-    for layer in incorp.data.soil_layers:
+    assert incorp._determine_weighted_average_temperature.call_count == 4
+    assert incorp._determine_depth_factor.call_count == 2 * (len(data.soil_layers) - 1)
+    assert incorp._determine_average_soil_temperature.call_count == 2 * (len(data.soil_layers) - 1)
+    for layer in incorp.data.soil_layers[:2]:
+        assert 14 == layer.temperature
+        assert 15 == layer.previous_day_temperature
+    for layer in incorp.data.soil_layers[2:]:
         assert 14 == layer.temperature
         assert 14 == layer.previous_day_temperature


### PR DESCRIPTION
# Summary

This is the second PR in the series to implement overriding user input so that the soil profile maintains a 20 mm thick top layer. This PR refactors the `Infiltration` and `SoilTemp` modules to account for this new top layer of soil (and tests their new functionality).

# Main Changes
- `SoilTemp`
  - Instead of passing just the temperature of the top layer of soil to the static helper methods, the top two layers have all necessary attributes either combined or averaged so that they are treated as one layer.
  - Note that because the top two layers of soil are set to the same temperature as each other every time the main routine is called, it is only possible for them to be different temperatures on the first day of the simulation, and have different previous temperatures on the first and second days of the simulation.
  - A `@staticmethod` helper has been introduced to calculate weighted average temperatures. It is tested with the rest of the helper methods.
- `Infiltration`
  - This file has had functionality added so that the soil will actually absorb the rainfall that does not runoff the field (a functionality that I did not originally implement for some reason), and this absorbed rainfall is proportionally divided between the top two layers of soil in the profile.
  - This new functionality is tested, and a helper method has been added in the test file to make this a bit cleaner.
  - A potential issue with the way water is absorbed in this module is that it is effectively skipping the percolation process for the top 20 mm of soil. This may have significant effects on the accuracy of the model, because water percolating through the top 20 mm of soil may have a significant effect on the phosphorus that is stored in that layer. It may be better to have all absorbed water stay in the top 20 mm, as this is more realistic and the amount of water absorbed is the same with either method. EDIT: this module's behavior has been changed. It now only absorbs water into the top 20 mm of soil, where it stays until the `Percolation` module causes it to move downward through the soil profile.

In both modules, please check the sections added to the docstrings for clarity and sensibility.

# Going Forward

I believe only modifying these two modules within `Soil` is sufficient. The other potential modules to refactor are `Evapotranspiration` and `SoilErosion`, which I think will retain their integrity even if they treat the top 20 mm of soil as a separate layer.