### PR TITLE
Implement, integrate, and test manure in soil.phosphorus_cycling module (4/6, `Manure`)

### DIFF
--- a/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
+++ b/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
@@ -41,12 +41,72 @@ class Manure:
         # Leach phosphorus from manure to surface runoff and to soil profile
         if rainfall > 0:
             if self.data.machine_manure_dry_mass > 0 and self.data.machine_manure_field_coverage > 0:
-                self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, True, True)
-                self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, True, False)
-            if self.data.grazing_manure_dry_mass > 0 and self.data.grazing_manure_field_coverage > 0:
-                self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, False, True)
-                self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, False, False)
+                machine_organic_results = \
+                    self._leach_phosphorus_to_runoff(rainfall, runoff, field_size,
+                                                     self.data.machine_manure_dry_mass,
+                                                     self.data.machine_manure_field_coverage,
+                                                     self.data.machine_water_extractable_organic_phosphorus,
+                                                     True)
+                self.data.machine_water_extractable_organic_phosphorus = \
+                    machine_organic_results["new_phosphorus_pool_amount"]
+                self.data.annual_runoff_machine_manure_organic_phosphorus += \
+                    machine_organic_results["runoff_phosphorus"]
+                self._add_infiltrated_phosphorus_to_soil(machine_organic_results["infiltrated_phosphorus"], field_size)
 
+                machine_inorganic_results = \
+                    self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, self.data.machine_manure_dry_mass,
+                                                     self.data.machine_manure_field_coverage,
+                                                     self.data.machine_water_extractable_inorganic_phosphorus, False)
+                self.data.machine_water_extractable_inorganic_phosphorus = \
+                    machine_inorganic_results["new_phosphorus_pool_amount"]
+                self.data.annual_runoff_machine_manure_inorganic_phosphorus += \
+                    machine_inorganic_results["runoff_phosphorus"]
+                self._add_infiltrated_phosphorus_to_soil(machine_inorganic_results["infiltrated_phosphorus"],
+                                                         field_size)
+
+            if self.data.grazing_manure_dry_mass > 0 and self.data.grazing_manure_field_coverage > 0:
+                grazer_organic_results = \
+                    self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, self.data.grazing_manure_dry_mass,
+                                                     self.data.grazing_manure_field_coverage,
+                                                     self.data.grazing_water_extractable_organic_phosphorus, True)
+                self.data.grazing_water_extractable_organic_phosphorus = \
+                    grazer_organic_results["new_phosphorus_pool_amount"]
+                self.data.annual_runoff_grazing_manure_organic_phosphorus += grazer_organic_results["runoff_phosphorus"]
+                self._add_infiltrated_phosphorus_to_soil(grazer_organic_results["infiltrated_phosphorus"], field_size)
+
+                grazer_inorganic_results = \
+                    self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, self.data.grazing_manure_dry_mass,
+                                                     self.data.grazing_manure_field_coverage,
+                                                     self.data.grazing_water_extractable_organic_phosphorus, False)
+                self.data.grazing_water_extractable_inorganic_phosphorus = \
+                    grazer_inorganic_results["new_phosphorus_pool_amount"]
+                self.data.annual_runoff_grazing_manure_inorganic_phosphorus += \
+                    grazer_inorganic_results["runoff_phosphorus"]
+                self._add_infiltrated_phosphorus_to_soil(grazer_inorganic_results["infiltrated_phosphorus"], field_size)
+
+    def _add_infiltrated_phosphorus_to_soil(self, infiltrated_phosphorus_amount: float, field_size: float) -> None:
+        """This method adds phosphorus that was dissolved in rainfall to the soil profile as outlined in SurPhos.
+
+        Parameters
+        ----------
+        infiltrated_phosphorus_amount : float
+            The amount of phosphorus to be added to the soil profile (kg)
+        field_size : float
+            The size of the field (ha)
+
+        Notes
+        -----
+        This method follows what is outlined in SurPhos (theoretical documentation, page 8, paragraph just below eqn.
+        [13]), which is that 80% of infiltrated phosphorus stays in the top 20 mm of soil, and the rest infiltrates
+        deeper.
+        TODO: implement distribution mechanism for the 20% of phosphorus that infiltrates deeper after talking with Pete
+            about how that mechanism works.
+
+        """
+        self.data.soil_layers[0].add_to_labile_phosphorus(0.8 * infiltrated_phosphorus_amount, field_size)
+        self.data.soil_layers[0].add_to_labile_phosphorus(0.2 * infiltrated_phosphorus_amount, field_size)
+
+    # --- Static Methods ---
     @staticmethod
     def _leach_phosphorus_to_runoff(rainfall: float, runoff: float, field_size: float, manure_dry_mass: float,
                                     field_coverage: float, water_extractable_phosphorus: float,
@@ -102,29 +162,6 @@ class Manure:
                        "runoff_phosphorus": phosphorus_lost_to_runoff_in_kg}
         return return_dict
 
-    def _add_infiltrated_phosphorus_to_soil(self, infiltrated_phosphorus_amount: float, field_size: float) -> None:
-        """This method adds phosphorus that was dissolved in rainfall to the soil profile as outlined in SurPhos.
-
-        Parameters
-        ----------
-        infiltrated_phosphorus_amount : float
-            The amount of phosphorus to be added to the soil profile (kg)
-        field_size : float
-            The size of the field (ha)
-
-        Notes
-        -----
-        This method follows what is outlined in SurPhos (theoretical documentation, page 8, paragraph just below eqn.
-        [13]), which is that 80% of infiltrated phosphorus stays in the top 20 mm of soil, and the rest infiltrates
-        deeper.
-        TODO: implement distribution mechanism for the 20% of phosphorus that infiltrates deeper after talking with Pete
-            about how that mechanism works.
-
-        """
-        self.data.soil_layers[0].add_to_labile_phosphorus(0.8 * infiltrated_phosphorus_amount, field_size)
-        self.data.soil_layers[0].add_to_labile_phosphorus(0.2 * infiltrated_phosphorus_amount, field_size)
-
-    # --- Static Methods ---
     @staticmethod
     def _determine_temperature_factor(mean_air_temperature: float) -> float:
         """Calculates the temperature factor for the current day

--- a/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
+++ b/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
@@ -345,6 +345,7 @@ class Manure:
         is why the is_from_cow parameter is necessary.
 
         """
+        # TODO: combine this method with _determine_water_extractable_organic_phosphorus_leached() - GitHub issue #423
         if is_from_cow:
             first_term = (1.2 * rainfall_to_dry_manure_ratio) / (rainfall_to_dry_manure_ratio + 73.1)
         else:
@@ -379,6 +380,7 @@ class Manure:
         SurPhos [9, 10], pseudocode_soil [S.5.D.I.3, II.1]
 
         """
+        # TODO: combine this method with _determine_water_extractable_organic_phosphorus_leached() - GitHub issue #423
         result = Manure._determine_water_extractable_inorganic_phosphorus_leached(
             manure_water_extractable_organic_phosphorus, rainfall_to_dry_manure_ratio, is_from_cow)
         return result / 0.6

--- a/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
+++ b/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
@@ -3,7 +3,8 @@ from math import exp, sqrt
 
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 from SC_redesign.Crop_and_Soil.crop_and_soil_constants import MILLIMETERS_TO_CENTIMETERS, KILOGRAMS_TO_GRAMS, \
-    KILOGRAMS_TO_MILLIGRAMS, HECTARES_TO_SQUARE_CENTIMETERS, HECTARES_TO_SQUARE_MILLIMETERS, CUBIC_MILLIMETERS_TO_LITERS
+    KILOGRAMS_TO_MILLIGRAMS, HECTARES_TO_SQUARE_CENTIMETERS, HECTARES_TO_SQUARE_MILLIMETERS, \
+    CUBIC_MILLIMETERS_TO_LITERS, MILLIGRAMS_TO_KILOGRAMS
 
 """
 This module adds and tracks manure phosphorus dynamics based on the SurPhos model.
@@ -23,6 +24,126 @@ class Manure:
 
         """
         self.data = soil_data or SoilData()
+
+    def daily_manure_update(self, rainfall: float, runoff: float, field_size: float) -> None:
+        """This method conducts daily operations on manure including decomposition, assimilation into soil, etc.
+
+        Parameters
+        ----------
+        rainfall: float
+            The amount of rainfall on the current day (mm)
+        runoff : float
+            The amount of runoff on the current day (mm)
+        field_size : float
+            The size of the field (ha)
+
+        """
+        # Leach phosphorus from manure to surface runoff
+        if runoff > 0:
+            if self.data.machine_manure_dry_mass > 0 and self.data.machine_manure_field_coverage > 0:
+                self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, True, True)
+                self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, True, False)
+            if self.data.grazing_manure_dry_mass > 0 and self.data.grazing_manure_field_coverage > 0:
+                self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, False, True)
+                self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, False, False)
+
+    def _leach_phosphorus_to_runoff(self, rainfall: float, runoff: float, field_size: float, from_machine: bool,
+                                    is_organic: bool) -> None:
+        """This method leaches and transfers phosphorus from the manure phosphorus pools.
+
+        Parameters
+        ----------
+        rainfall : float
+            The amount of rainfall on the current day (mm)
+        runoff : float
+            The amount of runoff on the current day (mm)
+        field_size : float
+            Area of the field (ha)
+        from_machine : bool
+            Is the phosphorus being leached from the machine-applied manure pools (True / False)
+        is_organic : bool
+            Is the phosphorus being leached organic (True / False)
+
+        """
+        organic_machine, inorganic_machine, organic_grazer = False
+        if from_machine:
+            manure_dry_mass = self.data.machine_manure_dry_mass
+            field_coverage = self.data.machine_manure_field_coverage
+            if is_organic:
+                organic_machine = True
+                water_extractable_phosphorus = self.data.machine_water_extractable_organic_phosphorus
+            else:
+                inorganic_machine = True
+                water_extractable_phosphorus = self.data.machine_water_extractable_inorganic_phosphorus
+        else:
+            manure_dry_mass = self.data.grazing_manure_dry_mass
+            field_coverage = self.data.grazing_manure_field_coverage
+            if is_organic:
+                organic_grazer = True
+                water_extractable_phosphorus = self.data.grazing_water_extractable_organic_phosphorus
+            else:
+                water_extractable_phosphorus = self.data.grazing_water_extractable_inorganic_phosphorus
+
+        rain_manure_dry_matter_ratio = self._determine_rain_manure_dry_matter_ratio(rainfall, manure_dry_mass,
+                                                                                    field_coverage)
+
+        distribution_factor = self._determine_phosphorus_distribution_factor(rainfall, runoff)
+
+        # P leached in kg
+        if is_organic:
+            water_extractable_phosphorus_leached = self._determine_water_extractable_organic_phosphorus_leached(
+                water_extractable_phosphorus, rain_manure_dry_matter_ratio, True)
+        else:
+            water_extractable_phosphorus_leached = self._determine_water_extractable_inorganic_phosphorus_leached(
+                water_extractable_phosphorus, rain_manure_dry_matter_ratio, True)
+
+        # mg phosphorus / Liter of runoff
+        runoff_dissolved_phosphorus_concentration = self._determine_water_extractable_phosphorus_runoff_concentration(
+            water_extractable_phosphorus_leached, rainfall, field_size, distribution_factor)
+
+        runoff_in_liters = runoff * (field_size * HECTARES_TO_SQUARE_MILLIMETERS) * CUBIC_MILLIMETERS_TO_LITERS
+
+        phosphorus_lost_to_runoff_in_kg = (runoff_dissolved_phosphorus_concentration * runoff_in_liters) * \
+            MILLIGRAMS_TO_KILOGRAMS
+
+        infiltrated_phosphorus = max(0, water_extractable_phosphorus_leached - phosphorus_lost_to_runoff_in_kg)
+
+        if organic_machine:
+            self.data.machine_water_extractable_organic_phosphorus -= water_extractable_phosphorus_leached
+            self.data.annual_runoff_machine_manure_organic_phosphorus += phosphorus_lost_to_runoff_in_kg
+        elif inorganic_machine:
+            self.data.machine_water_extractable_inorganic_phosphorus -= water_extractable_phosphorus_leached
+            self.data.annual_runoff_machine_manure_inorganic_phosphorus += phosphorus_lost_to_runoff_in_kg
+        elif organic_grazer:
+            self.data.grazing_water_extractable_organic_phosphorus -= water_extractable_phosphorus_leached
+            self.data.annual_runoff_grazing_manure_organic_phosphorus += phosphorus_lost_to_runoff_in_kg
+        else:
+            self.data.grazing_water_extractable_inorganic_phosphorus -= water_extractable_phosphorus_leached
+            self.data.annual_runoff_grazing_manure_inorganic_phosphorus += phosphorus_lost_to_runoff_in_kg
+
+        self._add_infiltrated_phosphorus_to_soil(infiltrated_phosphorus, field_size)
+
+    def _add_infiltrated_phosphorus_to_soil(self, infiltrated_phosphorus_amount: float, field_size: float) -> None:
+        """This method adds phosphorus that was dissolved in rainfall to the soil profile as outlined in SurPhos.
+
+        Parameters
+        ----------
+        infiltrated_phosphorus_amount : float
+            The amount of phosphorus to be added to the soil profile (kg)
+        field_size : float
+            The size of the field (ha)
+
+        Notes
+        -----
+        This method follows what is outlined in SurPhos (theoretical documentation, page 8, paragraph just below eqn.
+        [13]), which is that 80% of infiltrated phosphorus stays in the top 20 mm of soil, and the rest infiltrates
+        deeper.
+        TODO: implement distribution mechanism for the 20% of phosphorus that infiltrates deeper after talking with Pete
+            about how that mechanism works.
+
+        """
+        self.data.soil_layers[0].add_to_labile_phosphorus(0.8 * infiltrated_phosphorus_amount, field_size)
+        self.data.soil_layers[0].add_to_active_phosphorus(0.2 * infiltrated_phosphorus_amount, field_size)
 
     # --- Static Methods ---
     @staticmethod

--- a/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
+++ b/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
@@ -89,7 +89,6 @@ class Manure:
 
         distribution_factor = self._determine_phosphorus_distribution_factor(rainfall, runoff)
 
-        # P leached in kg
         if is_organic:
             water_extractable_phosphorus_leached = self._determine_water_extractable_organic_phosphorus_leached(
                 water_extractable_phosphorus, rain_manure_dry_matter_ratio, True)
@@ -97,7 +96,6 @@ class Manure:
             water_extractable_phosphorus_leached = self._determine_water_extractable_inorganic_phosphorus_leached(
                 water_extractable_phosphorus, rain_manure_dry_matter_ratio, True)
 
-        # mg phosphorus / Liter of runoff
         runoff_dissolved_phosphorus_concentration = self._determine_water_extractable_phosphorus_runoff_concentration(
             water_extractable_phosphorus_leached, rainfall, field_size, distribution_factor)
 
@@ -143,7 +141,7 @@ class Manure:
 
         """
         self.data.soil_layers[0].add_to_labile_phosphorus(0.8 * infiltrated_phosphorus_amount, field_size)
-        self.data.soil_layers[0].add_to_active_phosphorus(0.2 * infiltrated_phosphorus_amount, field_size)
+        self.data.soil_layers[0].add_to_labile_phosphorus(0.2 * infiltrated_phosphorus_amount, field_size)
 
     # --- Static Methods ---
     @staticmethod

--- a/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
+++ b/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
@@ -33,7 +33,7 @@ class Manure:
         rainfall : float
             The amount of rainfall on the current day (mm)
         runoff : float
-            The amount of runoff on the current day (mm)
+            The amount of runoff from rainfall on the current day (mm)
         field_size : float
             The size of the field (ha)
 
@@ -50,7 +50,7 @@ class Manure:
         rainfall : float
             The amount of rainfall on the current day (mm)
         runoff : float
-            The amount of runoff on the current day (mm)
+            The amount of runoff from rainfall on the current day (mm)
         field_size : float
             The size of the field (ha)
 
@@ -139,7 +139,7 @@ class Manure:
         rainfall : float
             The amount of rainfall on the current day (mm)
         runoff : float
-            The amount of runoff on the current day (mm)
+            The amount of runoff from rainfall on the current day (mm)
         field_size : float
             Area of the field (ha)
         manure_dry_mass : float
@@ -150,6 +150,13 @@ class Manure:
             The mass of the water extractable phosphorus pool that is being leached from (kg)
         is_organic : bool
             Is the phosphorus being leached organic (True / False)
+
+        Returns
+        -------
+        Dict
+            new_phosphorus_pool_amount: amount of phosphorus in the pool after leaching from it (kg)
+            infiltrated_phosphorus: amount of phosphorus that infiltrates into the soil profile (kg)
+            runoff_phosphorus: amount of phosphorus that leaves the field dissolved in runoff (kg)
 
         Notes
         -----
@@ -444,7 +451,7 @@ class Manure:
         rainfall : float
             Amount of rainfall on the current day (mm)
         runoff : float
-            Amount of runoff on the current day (mm)
+            The amount of runoff from rainfall on the current day (mm)
 
         Returns
         -------

--- a/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
+++ b/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
@@ -110,6 +110,10 @@ class Manure:
         field_size : float
             The size of the field (ha)
 
+        References
+        ----------
+        SurPhos Theoretical, page 8, paragraph below [13]
+
         Notes
         -----
         This method follows what is outlined in SurPhos (theoretical documentation, page 8, paragraph just below eqn.
@@ -146,6 +150,17 @@ class Manure:
             The mass of the water extractable phosphorus pool that is being leached from (kg)
         is_organic : bool
             Is the phosphorus being leached organic (True / False)
+
+        Notes
+        -----
+        This method follows the steps outlined for how to calculate phosphorus lost from a field's surface as outlined
+        by the section with the header "Phosphorus Leaching from Manure by Rain" (page 8). Generally, the steps are
+            - Calculate the ratios of rainfall to manure mass and rainfall to runoff on the given day.
+            - Calculate the amounts of water extractable phosphorus lost by the surface manure pools on a given day.
+            - Calculate how much of the leached phosphorus runs off the field and how much infiltrates the soil based on
+                the ratios calculated above.
+            - Determine how much phosphorus is remains in the surface pool after leaching.
+            - Return all the above amounts of phosphorus (lost to runoff, infiltrated soil, still on field surface).
 
         """
         rain_manure_dry_matter_ratio = Manure._determine_rain_manure_dry_matter_ratio(rainfall, manure_dry_mass,

--- a/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
+++ b/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
@@ -96,6 +96,8 @@ class Manure:
             water_extractable_phosphorus_leached = self._determine_water_extractable_inorganic_phosphorus_leached(
                 water_extractable_phosphorus, rain_manure_dry_matter_ratio, True)
 
+        water_extractable_phosphorus_leached = min(water_extractable_phosphorus, water_extractable_phosphorus_leached)
+
         runoff_dissolved_phosphorus_concentration = self._determine_water_extractable_phosphorus_runoff_concentration(
             water_extractable_phosphorus_leached, rainfall, field_size, distribution_factor)
 

--- a/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
+++ b/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
@@ -114,7 +114,7 @@ class Manure:
 
         """
         self.data.soil_layers[0].add_to_labile_phosphorus(0.8 * infiltrated_phosphorus_amount, field_size)
-        self.data.soil_layers[0].add_to_labile_phosphorus(0.2 * infiltrated_phosphorus_amount, field_size)
+        self.data.soil_layers[1].add_to_labile_phosphorus(0.2 * infiltrated_phosphorus_amount, field_size)
 
     # --- Static Methods ---
     @staticmethod

--- a/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
+++ b/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Dict
 from math import exp, sqrt
 
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
@@ -38,8 +38,8 @@ class Manure:
             The size of the field (ha)
 
         """
-        # Leach phosphorus from manure to surface runoff
-        if runoff > 0:
+        # Leach phosphorus from manure to surface runoff and to soil profile
+        if rainfall > 0:
             if self.data.machine_manure_dry_mass > 0 and self.data.machine_manure_field_coverage > 0:
                 self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, True, True)
                 self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, True, False)
@@ -47,9 +47,12 @@ class Manure:
                 self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, False, True)
                 self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, False, False)
 
-    def _leach_phosphorus_to_runoff(self, rainfall: float, runoff: float, field_size: float, from_machine: bool,
-                                    is_organic: bool) -> None:
-        """This method leaches and transfers phosphorus from the manure phosphorus pools.
+    @staticmethod
+    def _leach_phosphorus_to_runoff(rainfall: float, runoff: float, field_size: float, manure_dry_mass: float,
+                                    field_coverage: float, water_extractable_phosphorus: float,
+                                    is_organic: bool) -> Dict:
+        """This method determines how much phosphorus is leached from the given pool, how that phosphorus is distributed
+            between runoff and soil infiltration, and how much phosphorus remains in the given pool.
 
         Parameters
         ----------
@@ -59,46 +62,31 @@ class Manure:
             The amount of runoff on the current day (mm)
         field_size : float
             Area of the field (ha)
-        from_machine : bool
-            Is the phosphorus being leached from the machine-applied manure pools (True / False)
+        manure_dry_mass : float
+            Dry-weight equivalent of manure on the field (kg)
+        field_coverage : float
+            Percent of the field covered by manure, in range [0.0, 1.0]
+        water_extractable_phosphorus : float
+            The mass of the water extractable phosphorus pool that is being leached from (kg)
         is_organic : bool
             Is the phosphorus being leached organic (True / False)
 
         """
-        organic_machine = inorganic_machine = organic_grazer = False
-        if from_machine:
-            manure_dry_mass = self.data.machine_manure_dry_mass
-            field_coverage = self.data.machine_manure_field_coverage
-            if is_organic:
-                organic_machine = True
-                water_extractable_phosphorus = self.data.machine_water_extractable_organic_phosphorus
-            else:
-                inorganic_machine = True
-                water_extractable_phosphorus = self.data.machine_water_extractable_inorganic_phosphorus
-        else:
-            manure_dry_mass = self.data.grazing_manure_dry_mass
-            field_coverage = self.data.grazing_manure_field_coverage
-            if is_organic:
-                organic_grazer = True
-                water_extractable_phosphorus = self.data.grazing_water_extractable_organic_phosphorus
-            else:
-                water_extractable_phosphorus = self.data.grazing_water_extractable_inorganic_phosphorus
+        rain_manure_dry_matter_ratio = Manure._determine_rain_manure_dry_matter_ratio(rainfall, manure_dry_mass,
+                                                                                      field_coverage)
 
-        rain_manure_dry_matter_ratio = self._determine_rain_manure_dry_matter_ratio(rainfall, manure_dry_mass,
-                                                                                    field_coverage)
-
-        distribution_factor = self._determine_phosphorus_distribution_factor(rainfall, runoff)
+        distribution_factor = Manure._determine_phosphorus_distribution_factor(rainfall, runoff)
 
         if is_organic:
-            water_extractable_phosphorus_leached = self._determine_water_extractable_organic_phosphorus_leached(
+            water_extractable_phosphorus_leached = Manure._determine_water_extractable_organic_phosphorus_leached(
                 water_extractable_phosphorus, rain_manure_dry_matter_ratio, True)
         else:
-            water_extractable_phosphorus_leached = self._determine_water_extractable_inorganic_phosphorus_leached(
+            water_extractable_phosphorus_leached = Manure._determine_water_extractable_inorganic_phosphorus_leached(
                 water_extractable_phosphorus, rain_manure_dry_matter_ratio, True)
 
         water_extractable_phosphorus_leached = min(water_extractable_phosphorus, water_extractable_phosphorus_leached)
 
-        runoff_dissolved_phosphorus_concentration = self._determine_water_extractable_phosphorus_runoff_concentration(
+        runoff_dissolved_phosphorus_concentration = Manure._determine_water_extractable_phosphorus_runoff_concentration(
             water_extractable_phosphorus_leached, rainfall, field_size, distribution_factor)
 
         runoff_in_liters = runoff * (field_size * HECTARES_TO_SQUARE_MILLIMETERS) * CUBIC_MILLIMETERS_TO_LITERS
@@ -108,20 +96,11 @@ class Manure:
 
         infiltrated_phosphorus = max(0, water_extractable_phosphorus_leached - phosphorus_lost_to_runoff_in_kg)
 
-        if organic_machine:
-            self.data.machine_water_extractable_organic_phosphorus -= water_extractable_phosphorus_leached
-            self.data.annual_runoff_machine_manure_organic_phosphorus += phosphorus_lost_to_runoff_in_kg
-        elif inorganic_machine:
-            self.data.machine_water_extractable_inorganic_phosphorus -= water_extractable_phosphorus_leached
-            self.data.annual_runoff_machine_manure_inorganic_phosphorus += phosphorus_lost_to_runoff_in_kg
-        elif organic_grazer:
-            self.data.grazing_water_extractable_organic_phosphorus -= water_extractable_phosphorus_leached
-            self.data.annual_runoff_grazing_manure_organic_phosphorus += phosphorus_lost_to_runoff_in_kg
-        else:
-            self.data.grazing_water_extractable_inorganic_phosphorus -= water_extractable_phosphorus_leached
-            self.data.annual_runoff_grazing_manure_inorganic_phosphorus += phosphorus_lost_to_runoff_in_kg
-
-        self._add_infiltrated_phosphorus_to_soil(infiltrated_phosphorus, field_size)
+        new_phosphorus_pool_amount = water_extractable_phosphorus - water_extractable_phosphorus_leached
+        return_dict = {"new_phosphorus_pool_amount": new_phosphorus_pool_amount,
+                       "infiltrated_phosphorus": infiltrated_phosphorus,
+                       "runoff_phosphorus": phosphorus_lost_to_runoff_in_kg}
+        return return_dict
 
     def _add_infiltrated_phosphorus_to_soil(self, infiltrated_phosphorus_amount: float, field_size: float) -> None:
         """This method adds phosphorus that was dissolved in rainfall to the soil profile as outlined in SurPhos.

--- a/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
+++ b/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
@@ -30,7 +30,7 @@ class Manure:
 
         Parameters
         ----------
-        rainfall: float
+        rainfall : float
             The amount of rainfall on the current day (mm)
         runoff : float
             The amount of runoff on the current day (mm)
@@ -38,51 +38,61 @@ class Manure:
             The size of the field (ha)
 
         """
-        # Leach phosphorus from manure to surface runoff and to soil profile
         if rainfall > 0:
-            if self.data.machine_manure_dry_mass > 0 and self.data.machine_manure_field_coverage > 0:
-                machine_organic_results = \
-                    self._leach_phosphorus_to_runoff(rainfall, runoff, field_size,
-                                                     self.data.machine_manure_dry_mass,
-                                                     self.data.machine_manure_field_coverage,
-                                                     self.data.machine_water_extractable_organic_phosphorus,
-                                                     True)
-                self.data.machine_water_extractable_organic_phosphorus = \
-                    machine_organic_results["new_phosphorus_pool_amount"]
-                self.data.annual_runoff_machine_manure_organic_phosphorus += \
-                    machine_organic_results["runoff_phosphorus"]
-                self._add_infiltrated_phosphorus_to_soil(machine_organic_results["infiltrated_phosphorus"], field_size)
+            self._leach_and_update_phosphorus_pools(rainfall, runoff, field_size)
 
-                machine_inorganic_results = \
-                    self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, self.data.machine_manure_dry_mass,
-                                                     self.data.machine_manure_field_coverage,
-                                                     self.data.machine_water_extractable_inorganic_phosphorus, False)
-                self.data.machine_water_extractable_inorganic_phosphorus = \
-                    machine_inorganic_results["new_phosphorus_pool_amount"]
-                self.data.annual_runoff_machine_manure_inorganic_phosphorus += \
-                    machine_inorganic_results["runoff_phosphorus"]
-                self._add_infiltrated_phosphorus_to_soil(machine_inorganic_results["infiltrated_phosphorus"],
-                                                         field_size)
+    def _leach_and_update_phosphorus_pools(self, rainfall: float, runoff: float, field_size: float) -> None:
+        """This method handles all calls to the methods that determine how much phosphorus is leached from manure, how
+            that leached phosphorus is distributed, and updates the phosphorus pools based on those values.
 
-            if self.data.grazing_manure_dry_mass > 0 and self.data.grazing_manure_field_coverage > 0:
-                grazer_organic_results = \
-                    self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, self.data.grazing_manure_dry_mass,
-                                                     self.data.grazing_manure_field_coverage,
-                                                     self.data.grazing_water_extractable_organic_phosphorus, True)
-                self.data.grazing_water_extractable_organic_phosphorus = \
-                    grazer_organic_results["new_phosphorus_pool_amount"]
-                self.data.annual_runoff_grazing_manure_organic_phosphorus += grazer_organic_results["runoff_phosphorus"]
-                self._add_infiltrated_phosphorus_to_soil(grazer_organic_results["infiltrated_phosphorus"], field_size)
+        Parameters
+        ----------
+        rainfall : float
+            The amount of rainfall on the current day (mm)
+        runoff : float
+            The amount of runoff on the current day (mm)
+        field_size : float
+            The size of the field (ha)
 
-                grazer_inorganic_results = \
-                    self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, self.data.grazing_manure_dry_mass,
-                                                     self.data.grazing_manure_field_coverage,
-                                                     self.data.grazing_water_extractable_organic_phosphorus, False)
-                self.data.grazing_water_extractable_inorganic_phosphorus = \
-                    grazer_inorganic_results["new_phosphorus_pool_amount"]
-                self.data.annual_runoff_grazing_manure_inorganic_phosphorus += \
-                    grazer_inorganic_results["runoff_phosphorus"]
-                self._add_infiltrated_phosphorus_to_soil(grazer_inorganic_results["infiltrated_phosphorus"], field_size)
+        """
+        if self.data.machine_manure_dry_mass > 0 and self.data.machine_manure_field_coverage > 0:
+            machine_organic_results = \
+                self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, self.data.machine_manure_dry_mass,
+                                                 self.data.machine_manure_field_coverage,
+                                                 self.data.machine_water_extractable_organic_phosphorus, True)
+            self.data.machine_water_extractable_organic_phosphorus = \
+                machine_organic_results["new_phosphorus_pool_amount"]
+            self.data.annual_runoff_machine_manure_organic_phosphorus += machine_organic_results["runoff_phosphorus"]
+            self._add_infiltrated_phosphorus_to_soil(machine_organic_results["infiltrated_phosphorus"], field_size)
+
+            machine_inorganic_results = \
+                self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, self.data.machine_manure_dry_mass,
+                                                 self.data.machine_manure_field_coverage,
+                                                 self.data.machine_water_extractable_inorganic_phosphorus, False)
+            self.data.machine_water_extractable_inorganic_phosphorus = \
+                machine_inorganic_results["new_phosphorus_pool_amount"]
+            self.data.annual_runoff_machine_manure_inorganic_phosphorus += \
+                machine_inorganic_results["runoff_phosphorus"]
+            self._add_infiltrated_phosphorus_to_soil(machine_inorganic_results["infiltrated_phosphorus"], field_size)
+
+        if self.data.grazing_manure_dry_mass > 0 and self.data.grazing_manure_field_coverage > 0:
+            grazer_organic_results = \
+                self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, self.data.grazing_manure_dry_mass,
+                                                 self.data.grazing_manure_field_coverage,
+                                                 self.data.grazing_water_extractable_organic_phosphorus, True)
+            self.data.grazing_water_extractable_organic_phosphorus = \
+                grazer_organic_results["new_phosphorus_pool_amount"]
+            self.data.annual_runoff_grazing_manure_organic_phosphorus += grazer_organic_results["runoff_phosphorus"]
+            self._add_infiltrated_phosphorus_to_soil(grazer_organic_results["infiltrated_phosphorus"], field_size)
+
+            grazer_inorganic_results = \
+                self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, self.data.grazing_manure_dry_mass,
+                                                 self.data.grazing_manure_field_coverage,
+                                                 self.data.grazing_water_extractable_inorganic_phosphorus, False)
+            self.data.grazing_water_extractable_inorganic_phosphorus = \
+                grazer_inorganic_results["new_phosphorus_pool_amount"]
+            self.data.annual_runoff_grazing_manure_inorganic_phosphorus += grazer_inorganic_results["runoff_phosphorus"]
+            self._add_infiltrated_phosphorus_to_soil(grazer_inorganic_results["infiltrated_phosphorus"], field_size)
 
     def _add_infiltrated_phosphorus_to_soil(self, infiltrated_phosphorus_amount: float, field_size: float) -> None:
         """This method adds phosphorus that was dissolved in rainfall to the soil profile as outlined in SurPhos.

--- a/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
+++ b/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
@@ -57,18 +57,21 @@ class Manure:
         """
         if self.data.machine_manure_dry_mass > 0 and self.data.machine_manure_field_coverage > 0:
             machine_organic_results = \
-                self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, self.data.machine_manure_dry_mass,
-                                                 self.data.machine_manure_field_coverage,
-                                                 self.data.machine_water_extractable_organic_phosphorus, True)
+                self._determine_phosphorus_leached_from_surface(rainfall, runoff, field_size,
+                                                                self.data.machine_manure_dry_mass,
+                                                                self.data.machine_manure_field_coverage,
+                                                                self.data.machine_water_extractable_organic_phosphorus,
+                                                                True)
             self.data.machine_water_extractable_organic_phosphorus = \
                 machine_organic_results["new_phosphorus_pool_amount"]
             self.data.annual_runoff_machine_manure_organic_phosphorus += machine_organic_results["runoff_phosphorus"]
             self._add_infiltrated_phosphorus_to_soil(machine_organic_results["infiltrated_phosphorus"], field_size)
 
             machine_inorganic_results = \
-                self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, self.data.machine_manure_dry_mass,
-                                                 self.data.machine_manure_field_coverage,
-                                                 self.data.machine_water_extractable_inorganic_phosphorus, False)
+                self._determine_phosphorus_leached_from_surface(
+                    rainfall, runoff, field_size, self.data.machine_manure_dry_mass,
+                    self.data.machine_manure_field_coverage, self.data.machine_water_extractable_inorganic_phosphorus,
+                    False)
             self.data.machine_water_extractable_inorganic_phosphorus = \
                 machine_inorganic_results["new_phosphorus_pool_amount"]
             self.data.annual_runoff_machine_manure_inorganic_phosphorus += \
@@ -77,18 +80,21 @@ class Manure:
 
         if self.data.grazing_manure_dry_mass > 0 and self.data.grazing_manure_field_coverage > 0:
             grazer_organic_results = \
-                self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, self.data.grazing_manure_dry_mass,
-                                                 self.data.grazing_manure_field_coverage,
-                                                 self.data.grazing_water_extractable_organic_phosphorus, True)
+                self._determine_phosphorus_leached_from_surface(rainfall, runoff, field_size,
+                                                                self.data.grazing_manure_dry_mass,
+                                                                self.data.grazing_manure_field_coverage,
+                                                                self.data.grazing_water_extractable_organic_phosphorus,
+                                                                True)
             self.data.grazing_water_extractable_organic_phosphorus = \
                 grazer_organic_results["new_phosphorus_pool_amount"]
             self.data.annual_runoff_grazing_manure_organic_phosphorus += grazer_organic_results["runoff_phosphorus"]
             self._add_infiltrated_phosphorus_to_soil(grazer_organic_results["infiltrated_phosphorus"], field_size)
 
             grazer_inorganic_results = \
-                self._leach_phosphorus_to_runoff(rainfall, runoff, field_size, self.data.grazing_manure_dry_mass,
-                                                 self.data.grazing_manure_field_coverage,
-                                                 self.data.grazing_water_extractable_inorganic_phosphorus, False)
+                self._determine_phosphorus_leached_from_surface(
+                    rainfall, runoff, field_size, self.data.grazing_manure_dry_mass,
+                    self.data.grazing_manure_field_coverage, self.data.grazing_water_extractable_inorganic_phosphorus,
+                    False)
             self.data.grazing_water_extractable_inorganic_phosphorus = \
                 grazer_inorganic_results["new_phosphorus_pool_amount"]
             self.data.annual_runoff_grazing_manure_inorganic_phosphorus += grazer_inorganic_results["runoff_phosphorus"]
@@ -118,9 +124,9 @@ class Manure:
 
     # --- Static Methods ---
     @staticmethod
-    def _leach_phosphorus_to_runoff(rainfall: float, runoff: float, field_size: float, manure_dry_mass: float,
-                                    field_coverage: float, water_extractable_phosphorus: float,
-                                    is_organic: bool) -> Dict:
+    def _determine_phosphorus_leached_from_surface(rainfall: float, runoff: float, field_size: float,
+                                                   manure_dry_mass: float, field_coverage: float,
+                                                   water_extractable_phosphorus: float, is_organic: bool) -> Dict:
         """This method determines how much phosphorus is leached from the given pool, how that phosphorus is distributed
             between runoff and soil infiltration, and how much phosphorus remains in the given pool.
 

--- a/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
+++ b/SC_redesign/Crop_and_Soil/soil/phosphorus_cycling/manure.py
@@ -65,7 +65,7 @@ class Manure:
             Is the phosphorus being leached organic (True / False)
 
         """
-        organic_machine, inorganic_machine, organic_grazer = False
+        organic_machine = inorganic_machine = organic_grazer = False
         if from_machine:
             manure_dry_mass = self.data.machine_manure_dry_mass
             field_coverage = self.data.machine_manure_field_coverage

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -45,16 +45,16 @@ class SoilData:
     annual_runoff_fertilizer_phosphorus: float = 0
     """Cumulative total of phosphorus from surface-applied fertilizer that was carried off the field by runoff (kg)"""
     annual_runoff_machine_manure_inorganic_phosphorus: float = 0
-    """Cumulative total of inorganic phosphorus from machine-applied manure that was carried off the field by runoff 
+    """Cumulative total of inorganic phosphorus from machine-applied manure that was carried off the field by runoff
         (kg)"""
     annual_runoff_machine_manure_organic_phosphorus: float = 0
-    """Cumulative total of organic phosphorus from machine-applied manure that was carried off the field by runoff 
+    """Cumulative total of organic phosphorus from machine-applied manure that was carried off the field by runoff
         (kg)"""
     annual_runoff_grazing_manure_inorganic_phosphorus: float = 0
-    """Cumulative total of inorganic phosphorus from grazer-applied manure that was carried off the field by runoff 
+    """Cumulative total of inorganic phosphorus from grazer-applied manure that was carried off the field by runoff
         (kg)"""
     annual_runoff_grazing_manure_organic_phosphorus: float = 0
-    """Cumulative total of organic phosphorus from grazer-applied manure that was carried off the field by runoff 
+    """Cumulative total of organic phosphorus from grazer-applied manure that was carried off the field by runoff
         (kg)"""
 
     # ---- evapotranspiration

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -42,8 +42,20 @@ class SoilData:
     """Cumulative total of volume of surface runoff that occurred in a year (mm per hectare)"""
 
     # Track annual nutrient activity
-    annual_runoff_fertilizer_phosphorus: float = 0  # TODO: add this to annual reset method
-    """Cumulative total of phosphorus from surface-applied fertilizer that was carried off the field by runoff"""
+    annual_runoff_fertilizer_phosphorus: float = 0
+    """Cumulative total of phosphorus from surface-applied fertilizer that was carried off the field by runoff (kg)"""
+    annual_runoff_machine_manure_inorganic_phosphorus: float = 0
+    """Cumulative total of inorganic phosphorus from machine-applied manure that was carried off the field by runoff 
+        (kg)"""
+    annual_runoff_machine_manure_organic_phosphorus: float = 0
+    """Cumulative total of organic phosphorus from machine-applied manure that was carried off the field by runoff 
+        (kg)"""
+    annual_runoff_grazing_manure_inorganic_phosphorus: float = 0
+    """Cumulative total of inorganic phosphorus from grazer-applied manure that was carried off the field by runoff 
+        (kg)"""
+    annual_runoff_grazing_manure_organic_phosphorus: float = 0
+    """Cumulative total of organic phosphorus from grazer-applied manure that was carried off the field by runoff 
+        (kg)"""
 
     # ---- evapotranspiration
     potential_evapotranspiration: Optional[float] = None

--- a/SC_redesign/Crop_and_Soil/soil/soil_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/soil_data.py
@@ -239,8 +239,12 @@ class SoilData:
         self.annual_eroded_sediment_total = 0
         self.annual_surface_runoff_total = 0
 
-        # Reset phosphorus fertilizer total
+        # Reset phosphorus totals
         self.annual_runoff_fertilizer_phosphorus = 0
+        self.annual_runoff_machine_manure_organic_phosphorus = 0
+        self.annual_runoff_machine_manure_inorganic_phosphorus = 0
+        self.annual_runoff_grazing_manure_organic_phosphorus = 0
+        self.annual_runoff_grazing_manure_inorganic_phosphorus = 0
 
     @property
     def profile_soil_water_content(self) -> float:

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_manure.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_manure.py
@@ -174,18 +174,18 @@ def test_determine_water_extractable_phosphorus_runoff_concentration(manure: flo
     (9.8, 9.1, 2, 36, 0.28, 2.1, True),
     (6.2, 0.0, 2.3, 500, 0.65, 80, False),
 ])
-def test_leach_phosphorus_to_runoff(rain: float, runoff: float, area: float, manure_mass: float, field_coverage: float,
-                                    phosphorus_mass: float, organic: bool) -> None:
-    """Test that leaching phosphorus calls all the correct functions and calculates the masses of phosphorus lost
-        correctly."""
+def test_determine_phosphorus_leached_from_surface(rain: float, runoff: float, area: float, manure_mass: float,
+                                                   field_coverage: float, phosphorus_mass: float,
+                                                   organic: bool) -> None:
+    """Test that subroutines are called correctly and that leached phosphorus amounts are calculated correctly."""
     Manure._determine_rain_manure_dry_matter_ratio = MagicMock(return_value=0.4)
     Manure._determine_phosphorus_distribution_factor = MagicMock(return_value=1.2)
     Manure._determine_water_extractable_organic_phosphorus_leached = MagicMock(return_value=25.0)
     Manure._determine_water_extractable_inorganic_phosphorus_leached = MagicMock(return_value=25.0)
     Manure._determine_water_extractable_phosphorus_runoff_concentration = MagicMock(return_value=5)
 
-    observed = Manure._leach_phosphorus_to_runoff(rain, runoff, area, manure_mass, field_coverage, phosphorus_mass,
-                                                  organic)
+    observed = Manure._determine_phosphorus_leached_from_surface(rain, runoff, area, manure_mass, field_coverage,
+                                                                 phosphorus_mass, organic)
     runoff_in_liters = runoff * area * HECTARES_TO_SQUARE_MILLIMETERS * CUBIC_MILLIMETERS_TO_LITERS
     expected_water_extractable_phosphorus_leached = min(25.0, phosphorus_mass)
     expected_runoff_phosphorus_in_kg = 5 * runoff_in_liters * MILLIGRAMS_TO_KILOGRAMS
@@ -239,7 +239,7 @@ def test_leach_and_update_phosphorus_pools(rain: float, runoff: float, area: flo
                     grazing_water_extractable_inorganic_phosphorus=125, grazing_water_extractable_organic_phosphorus=70)
     incorp = Manure(data)
 
-    incorp._leach_phosphorus_to_runoff = MagicMock(return_value={
+    incorp._determine_phosphorus_leached_from_surface = MagicMock(return_value={
         "new_phosphorus_pool_amount": 30,
         "infiltrated_phosphorus": 25,
         "runoff_phosphorus": 20,
@@ -250,7 +250,7 @@ def test_leach_and_update_phosphorus_pools(rain: float, runoff: float, area: flo
 
     leached_calls = [call(rain, runoff, area, 1000, 0.86, 90, True), call(rain, runoff, area, 1000, 0.86, 200, False),
                      call(rain, runoff, area, 800, 0.78, 70, True), call(rain, runoff, area, 800, 0.78, 125, False)]
-    incorp._leach_phosphorus_to_runoff.assert_has_calls(leached_calls)
+    incorp._determine_phosphorus_leached_from_surface.assert_has_calls(leached_calls)
     infiltrated_calls = [call(25, area), call(25, area), call(25, area), call(25, area)]
     incorp._add_infiltrated_phosphorus_to_soil.assert_has_calls(infiltrated_calls)
     assert incorp.data.machine_water_extractable_organic_phosphorus == 30

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_manure.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_manure.py
@@ -186,6 +186,8 @@ def test_add_infiltrated_phosphorus_to_soil(amount_phosphorus: float, field_size
     (14, 1.8, 3.1, True, False),        # Machine-applied inorganic manure
     (9.1, 2.7, 2.2, False, True),       # Grazer-applied organic manure
     (10.11, 4.1, 2.8, False, False),    # Grazer-applied inorganic manure
+    (14, 13, 2.0, True, False),
+    (9.8, 9.1, 2.3, False, True),
 ])
 def test_leach_phosphorus_to_runoff(rain: float, runoff: float, area: float, machine: bool, organic: bool) -> None:
     """Test that leaching phosphorus calls all the correct functions and sets right attributes to right values."""
@@ -225,21 +227,26 @@ def test_leach_phosphorus_to_runoff(rain: float, runoff: float, area: float, mac
         incorp._determine_water_extractable_organic_phosphorus_leached.assert_called_once_with(100, 0.4, True)
         assert incorp._determine_water_extractable_inorganic_phosphorus_leached.call_count == 0
         assert incorp.data.machine_water_extractable_organic_phosphorus == 75
-        assert incorp.data.annual_runoff_machine_manure_organic_phosphorus == expected_runoff_phosphorus_in_kg
+        assert pytest.approx(incorp.data.annual_runoff_machine_manure_organic_phosphorus) == \
+               expected_runoff_phosphorus_in_kg
     elif machine_inorganic:
         incorp._determine_water_extractable_inorganic_phosphorus_leached.assert_called_once_with(200, 0.4, True)
         assert incorp._determine_water_extractable_organic_phosphorus_leached.call_count == 0
         assert incorp.data.machine_water_extractable_inorganic_phosphorus == 175
-        assert incorp.data.annual_runoff_machine_manure_inorganic_phosphorus == expected_runoff_phosphorus_in_kg
+        assert pytest.approx(incorp.data.annual_runoff_machine_manure_inorganic_phosphorus) == \
+               expected_runoff_phosphorus_in_kg
     elif grazer_organic:
         incorp._determine_water_extractable_organic_phosphorus_leached.assert_called_once_with(120, 0.4, True)
         assert incorp._determine_water_extractable_inorganic_phosphorus_leached.call_count == 0
         assert incorp.data.grazing_water_extractable_organic_phosphorus == 95
-        assert incorp.data.annual_runoff_grazing_manure_organic_phosphorus == expected_runoff_phosphorus_in_kg
+        assert pytest.approx(incorp.data.annual_runoff_grazing_manure_organic_phosphorus) == \
+               expected_runoff_phosphorus_in_kg
     else:
         incorp._determine_water_extractable_inorganic_phosphorus_leached.assert_called_once_with(220, 0.4, True)
         assert incorp._determine_water_extractable_organic_phosphorus_leached.call_count == 0
         assert incorp.data.grazing_water_extractable_inorganic_phosphorus == 195
-        assert incorp.data.annual_runoff_grazing_manure_inorganic_phosphorus == expected_runoff_phosphorus_in_kg
+        assert pytest.approx(incorp.data.annual_runoff_grazing_manure_inorganic_phosphorus) == \
+               expected_runoff_phosphorus_in_kg
     incorp._determine_water_extractable_phosphorus_runoff_concentration.assert_called_once_with(25, rain, area, 1.2)
-    incorp._add_infiltrated_phosphorus_to_soil.assert_called_once_with(expected_infiltrated_phosphorus, area)
+    incorp._add_infiltrated_phosphorus_to_soil.assert_called_once_with(pytest.approx(expected_infiltrated_phosphorus),
+                                                                       area)

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_manure.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_manure.py
@@ -2,6 +2,8 @@ import pytest
 from math import exp, sqrt
 from unittest.mock import patch, MagicMock, PropertyMock
 
+from SC_redesign.Crop_and_Soil.crop_and_soil_constants import HECTARES_TO_SQUARE_MILLIMETERS, \
+    CUBIC_MILLIMETERS_TO_LITERS, MILLIGRAMS_TO_KILOGRAMS
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 from SC_redesign.Crop_and_Soil.soil.phosphorus_cycling.manure import Manure
 
@@ -177,3 +179,67 @@ def test_add_infiltrated_phosphorus_to_soil(amount_phosphorus: float, field_size
                new_callable=PropertyMock) as mocked_add_to_labile_phosphorus:
         incorp._add_infiltrated_phosphorus_to_soil(amount_phosphorus, field_size)
         assert mocked_add_to_labile_phosphorus.call_count == 2
+
+
+@pytest.mark.parametrize("rain,runoff,area,machine,organic", [
+    (11, 3, 1.8, True, True),           # Machine-applied organic manure
+    (14, 1.8, 3.1, True, False),        # Machine-applied inorganic manure
+    (9.1, 2.7, 2.2, False, True),       # Grazer-applied organic manure
+    (10.11, 4.1, 2.8, False, False),    # Grazer-applied inorganic manure
+])
+def test_leach_phosphorus_to_runoff(rain: float, runoff: float, area: float, machine: bool, organic: bool) -> None:
+    """Test that leaching phosphorus calls all the correct functions and sets right attributes to right values."""
+    machine_organic = machine and organic
+    machine_inorganic = machine and not organic
+    grazer_organic = not machine and organic
+
+    data = SoilData(machine_manure_dry_mass=800,
+                    machine_manure_field_coverage=0.8,
+                    machine_water_extractable_organic_phosphorus=100,
+                    machine_water_extractable_inorganic_phosphorus=200,
+                    grazing_manure_dry_mass=900,
+                    grazing_manure_field_coverage=0.9,
+                    grazing_water_extractable_organic_phosphorus=120,
+                    grazing_water_extractable_inorganic_phosphorus=220)
+    incorp = Manure(data)
+
+    incorp._determine_rain_manure_dry_matter_ratio = MagicMock(return_value=0.4)
+    incorp._determine_distribution_factor = MagicMock(return_value=1.1)
+    incorp._determine_phosphorus_distribution_factor = MagicMock(return_value=1.2)
+    incorp._determine_water_extractable_organic_phosphorus_leached = MagicMock(return_value=25)
+    incorp._determine_water_extractable_inorganic_phosphorus_leached = MagicMock(return_value=25)
+    incorp._determine_water_extractable_phosphorus_runoff_concentration = MagicMock(return_value=5)
+    incorp._add_infiltrated_phosphorus_to_soil = MagicMock()
+
+    incorp._leach_phosphorus_to_runoff(rain, runoff, area, machine, organic)
+    runoff_in_liters = runoff * area * HECTARES_TO_SQUARE_MILLIMETERS * CUBIC_MILLIMETERS_TO_LITERS
+    expected_runoff_phosphorus_in_kg = 5 * runoff_in_liters * MILLIGRAMS_TO_KILOGRAMS
+    expected_infiltrated_phosphorus = max(0, 25 - expected_runoff_phosphorus_in_kg)
+
+    if machine:
+        incorp._determine_rain_manure_dry_matter_ratio.assert_called_once_with(rain, 800, 0.8)
+    else:
+        incorp._determine_rain_manure_dry_matter_ratio.assert_called_once_with(rain, 900, 0.9)
+    incorp._determine_phosphorus_distribution_factor.assert_called_once_with(rain, runoff)
+    if machine_organic:
+        incorp._determine_water_extractable_organic_phosphorus_leached.assert_called_once_with(100, 0.4, True)
+        assert incorp._determine_water_extractable_inorganic_phosphorus_leached.call_count == 0
+        assert incorp.data.machine_water_extractable_organic_phosphorus == 75
+        assert incorp.data.annual_runoff_machine_manure_organic_phosphorus == expected_runoff_phosphorus_in_kg
+    elif machine_inorganic:
+        incorp._determine_water_extractable_inorganic_phosphorus_leached.assert_called_once_with(200, 0.4, True)
+        assert incorp._determine_water_extractable_organic_phosphorus_leached.call_count == 0
+        assert incorp.data.machine_water_extractable_inorganic_phosphorus == 175
+        assert incorp.data.annual_runoff_machine_manure_inorganic_phosphorus == expected_runoff_phosphorus_in_kg
+    elif grazer_organic:
+        incorp._determine_water_extractable_organic_phosphorus_leached.assert_called_once_with(120, 0.4, True)
+        assert incorp._determine_water_extractable_inorganic_phosphorus_leached.call_count == 0
+        assert incorp.data.grazing_water_extractable_organic_phosphorus == 95
+        assert incorp.data.annual_runoff_grazing_manure_organic_phosphorus == expected_runoff_phosphorus_in_kg
+    else:
+        incorp._determine_water_extractable_inorganic_phosphorus_leached.assert_called_once_with(220, 0.4, True)
+        assert incorp._determine_water_extractable_organic_phosphorus_leached.call_count == 0
+        assert incorp.data.grazing_water_extractable_inorganic_phosphorus == 195
+        assert incorp.data.annual_runoff_grazing_manure_inorganic_phosphorus == expected_runoff_phosphorus_in_kg
+    incorp._determine_water_extractable_phosphorus_runoff_concentration.assert_called_once_with(25, rain, area, 1.2)
+    incorp._add_infiltrated_phosphorus_to_soil.assert_called_once_with(expected_infiltrated_phosphorus, area)

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_manure.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_manure.py
@@ -181,72 +181,45 @@ def test_add_infiltrated_phosphorus_to_soil(amount_phosphorus: float, field_size
         assert mocked_add_to_labile_phosphorus.call_count == 2
 
 
-@pytest.mark.parametrize("rain,runoff,area,machine,organic", [
-    (11, 3, 1.8, True, True),           # Machine-applied organic manure
-    (14, 1.8, 3.1, True, False),        # Machine-applied inorganic manure
-    (9.1, 2.7, 2.2, False, True),       # Grazer-applied organic manure
-    (10.11, 4.1, 2.8, False, False),    # Grazer-applied inorganic manure
-    (14, 13, 2.0, True, False),
-    (9.8, 9.1, 2.3, False, True),
+@pytest.mark.parametrize("rain,runoff,area,manure_mass,field_coverage,phosphorus_mass,organic", [
+    (11, 3, 1.8, 800, 0.7, 120, True),
+    (14, 1.8, 3.1, 950, 0.91, 133, False),
+    (9.1, 2.7, 2.2, 993, 0.88, 86, True),
+    (10.11, 4.1, 2.8, 1234, 0.9655, 200, False),
+    (14, 13, 2.0, 20, 0.12, 1.4, False),
+    (9.8, 9.1, 2, 36, 0.28, 2.1, True),
+    (6.2, 0.0, 2.3, 500, 0.65, 80, False),
 ])
-def test_leach_phosphorus_to_runoff(rain: float, runoff: float, area: float, machine: bool, organic: bool) -> None:
-    """Test that leaching phosphorus calls all the correct functions and sets right attributes to right values."""
-    machine_organic = machine and organic
-    machine_inorganic = machine and not organic
-    grazer_organic = not machine and organic
+def test_leach_phosphorus_to_runoff(rain: float, runoff: float, area: float, manure_mass: float, field_coverage: float,
+                                    phosphorus_mass: float, organic: bool) -> None:
+    """Test that leaching phosphorus calls all the correct functions and calculates the masses of phosphorus lost
+        correctly."""
+    Manure._determine_rain_manure_dry_matter_ratio = MagicMock(return_value=0.4)
+    Manure._determine_phosphorus_distribution_factor = MagicMock(return_value=1.2)
+    Manure._determine_water_extractable_organic_phosphorus_leached = MagicMock(return_value=25)
+    Manure._determine_water_extractable_inorganic_phosphorus_leached = MagicMock(return_value=25)
+    Manure._determine_water_extractable_phosphorus_runoff_concentration = MagicMock(return_value=5)
 
-    data = SoilData(machine_manure_dry_mass=800,
-                    machine_manure_field_coverage=0.8,
-                    machine_water_extractable_organic_phosphorus=100,
-                    machine_water_extractable_inorganic_phosphorus=200,
-                    grazing_manure_dry_mass=900,
-                    grazing_manure_field_coverage=0.9,
-                    grazing_water_extractable_organic_phosphorus=120,
-                    grazing_water_extractable_inorganic_phosphorus=220)
-    incorp = Manure(data)
-
-    incorp._determine_rain_manure_dry_matter_ratio = MagicMock(return_value=0.4)
-    incorp._determine_distribution_factor = MagicMock(return_value=1.1)
-    incorp._determine_phosphorus_distribution_factor = MagicMock(return_value=1.2)
-    incorp._determine_water_extractable_organic_phosphorus_leached = MagicMock(return_value=25)
-    incorp._determine_water_extractable_inorganic_phosphorus_leached = MagicMock(return_value=25)
-    incorp._determine_water_extractable_phosphorus_runoff_concentration = MagicMock(return_value=5)
-    incorp._add_infiltrated_phosphorus_to_soil = MagicMock()
-
-    incorp._leach_phosphorus_to_runoff(rain, runoff, area, machine, organic)
+    observed = Manure._leach_phosphorus_to_runoff(rain, runoff, area, manure_mass, field_coverage, phosphorus_mass,
+                                                  organic)
     runoff_in_liters = runoff * area * HECTARES_TO_SQUARE_MILLIMETERS * CUBIC_MILLIMETERS_TO_LITERS
+    expected_water_extractable_phosphorus_leached = min(25, phosphorus_mass)
     expected_runoff_phosphorus_in_kg = 5 * runoff_in_liters * MILLIGRAMS_TO_KILOGRAMS
-    expected_infiltrated_phosphorus = max(0, 25 - expected_runoff_phosphorus_in_kg)
+    expected_infiltrated_phosphorus = max(0, expected_water_extractable_phosphorus_leached
+                                          - expected_runoff_phosphorus_in_kg)
 
-    if machine:
-        incorp._determine_rain_manure_dry_matter_ratio.assert_called_once_with(rain, 800, 0.8)
+    Manure._determine_rain_manure_dry_matter_ratio.assert_called_once_with(rain, manure_mass, field_coverage)
+    Manure._determine_phosphorus_distribution_factor.assert_called_once_with(rain, runoff)
+    if organic:
+        Manure._determine_water_extractable_organic_phosphorus_leached.assert_called_once_with(phosphorus_mass, 0.4,
+                                                                                               True)
+        Manure._determine_water_extractable_inorganic_phosphorus_leached.assert_not_called()
     else:
-        incorp._determine_rain_manure_dry_matter_ratio.assert_called_once_with(rain, 900, 0.9)
-    incorp._determine_phosphorus_distribution_factor.assert_called_once_with(rain, runoff)
-    if machine_organic:
-        incorp._determine_water_extractable_organic_phosphorus_leached.assert_called_once_with(100, 0.4, True)
-        assert incorp._determine_water_extractable_inorganic_phosphorus_leached.call_count == 0
-        assert incorp.data.machine_water_extractable_organic_phosphorus == 75
-        assert pytest.approx(incorp.data.annual_runoff_machine_manure_organic_phosphorus) == \
-               expected_runoff_phosphorus_in_kg
-    elif machine_inorganic:
-        incorp._determine_water_extractable_inorganic_phosphorus_leached.assert_called_once_with(200, 0.4, True)
-        assert incorp._determine_water_extractable_organic_phosphorus_leached.call_count == 0
-        assert incorp.data.machine_water_extractable_inorganic_phosphorus == 175
-        assert pytest.approx(incorp.data.annual_runoff_machine_manure_inorganic_phosphorus) == \
-               expected_runoff_phosphorus_in_kg
-    elif grazer_organic:
-        incorp._determine_water_extractable_organic_phosphorus_leached.assert_called_once_with(120, 0.4, True)
-        assert incorp._determine_water_extractable_inorganic_phosphorus_leached.call_count == 0
-        assert incorp.data.grazing_water_extractable_organic_phosphorus == 95
-        assert pytest.approx(incorp.data.annual_runoff_grazing_manure_organic_phosphorus) == \
-               expected_runoff_phosphorus_in_kg
-    else:
-        incorp._determine_water_extractable_inorganic_phosphorus_leached.assert_called_once_with(220, 0.4, True)
-        assert incorp._determine_water_extractable_organic_phosphorus_leached.call_count == 0
-        assert incorp.data.grazing_water_extractable_inorganic_phosphorus == 195
-        assert pytest.approx(incorp.data.annual_runoff_grazing_manure_inorganic_phosphorus) == \
-               expected_runoff_phosphorus_in_kg
-    incorp._determine_water_extractable_phosphorus_runoff_concentration.assert_called_once_with(25, rain, area, 1.2)
-    incorp._add_infiltrated_phosphorus_to_soil.assert_called_once_with(pytest.approx(expected_infiltrated_phosphorus),
-                                                                       area)
+        Manure._determine_water_extractable_organic_phosphorus_leached.assert_not_called()
+        Manure._determine_water_extractable_inorganic_phosphorus_leached.assert_called_once_with(phosphorus_mass, 0.4,
+                                                                                                 True)
+    Manure._determine_water_extractable_phosphorus_runoff_concentration.assert_called_once_with(
+        expected_water_extractable_phosphorus_leached, rain, area, 1.2)
+    assert observed["new_phosphorus_pool_amount"] == (phosphorus_mass - expected_water_extractable_phosphorus_leached)
+    assert observed["infiltrated_phosphorus"] == expected_infiltrated_phosphorus
+    assert observed["runoff_phosphorus"] == expected_runoff_phosphorus_in_kg

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_manure.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_manure.py
@@ -162,7 +162,6 @@ def test_determine_water_extractable_phosphorus_runoff_concentration(manure: flo
     observe = Manure._determine_water_extractable_phosphorus_runoff_concentration(manure, rain, field_size,
                                                                                   distribution_factor)
     expect = manure / rain * (1 / field_size) * 100 * distribution_factor
-    print(observe, expect)
     assert pytest.approx(observe) == expect
 
 

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_manure.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_manure.py
@@ -1,7 +1,8 @@
 import pytest
 from math import exp, sqrt
-from unittest.mock import MagicMock
+from unittest.mock import patch, MagicMock, PropertyMock
 
+from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 from SC_redesign.Crop_and_Soil.soil.phosphorus_cycling.manure import Manure
 
 
@@ -160,3 +161,19 @@ def test_determine_water_extractable_phosphorus_runoff_concentration(manure: flo
                                                                                   distribution_factor)
     expect = manure / rain * (1 / field_size) * 100 * distribution_factor
     assert pytest.approx(observe) == expect
+
+
+# --- Helper method tests ---
+@pytest.mark.parametrize("amount_phosphorus,field_size", [
+    (100, 3.1),
+    (25.6, 2),
+    (66.23, 1.88),
+])
+def test_add_infiltrated_phosphorus_to_soil(amount_phosphorus: float, field_size: float) -> None:
+    """Test that methods are called correctly on correct layers of soil profile."""
+    data = SoilData()
+    incorp = Manure(data)
+    with patch("SC_redesign.Crop_and_Soil.soil.layer_data.LayerData.add_to_labile_phosphorus",
+               new_callable=PropertyMock) as mocked_add_to_labile_phosphorus:
+        incorp._add_infiltrated_phosphorus_to_soil(amount_phosphorus, field_size)
+        assert mocked_add_to_labile_phosphorus.call_count == 2

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_manure.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_manure.py
@@ -1,6 +1,6 @@
 import pytest
 from math import exp, sqrt
-from unittest.mock import patch, MagicMock, PropertyMock
+from unittest.mock import patch, call, MagicMock, PropertyMock
 
 from SC_redesign.Crop_and_Soil.crop_and_soil_constants import HECTARES_TO_SQUARE_MILLIMETERS, \
     CUBIC_MILLIMETERS_TO_LITERS, MILLIGRAMS_TO_KILOGRAMS
@@ -162,23 +162,8 @@ def test_determine_water_extractable_phosphorus_runoff_concentration(manure: flo
     observe = Manure._determine_water_extractable_phosphorus_runoff_concentration(manure, rain, field_size,
                                                                                   distribution_factor)
     expect = manure / rain * (1 / field_size) * 100 * distribution_factor
+    print(observe, expect)
     assert pytest.approx(observe) == expect
-
-
-# --- Helper method tests ---
-@pytest.mark.parametrize("amount_phosphorus,field_size", [
-    (100, 3.1),
-    (25.6, 2),
-    (66.23, 1.88),
-])
-def test_add_infiltrated_phosphorus_to_soil(amount_phosphorus: float, field_size: float) -> None:
-    """Test that methods are called correctly on correct layers of soil profile."""
-    data = SoilData()
-    incorp = Manure(data)
-    with patch("SC_redesign.Crop_and_Soil.soil.layer_data.LayerData.add_to_labile_phosphorus",
-               new_callable=PropertyMock) as mocked_add_to_labile_phosphorus:
-        incorp._add_infiltrated_phosphorus_to_soil(amount_phosphorus, field_size)
-        assert mocked_add_to_labile_phosphorus.call_count == 2
 
 
 @pytest.mark.parametrize("rain,runoff,area,manure_mass,field_coverage,phosphorus_mass,organic", [
@@ -223,3 +208,77 @@ def test_leach_phosphorus_to_runoff(rain: float, runoff: float, area: float, man
     assert observed["new_phosphorus_pool_amount"] == (phosphorus_mass - expected_water_extractable_phosphorus_leached)
     assert observed["infiltrated_phosphorus"] == expected_infiltrated_phosphorus
     assert observed["runoff_phosphorus"] == expected_runoff_phosphorus_in_kg
+
+
+# --- Helper method tests ---
+@pytest.mark.parametrize("amount_phosphorus,field_size", [
+    (100, 3.1),
+    (25.6, 2),
+    (66.23, 1.88),
+])
+def test_add_infiltrated_phosphorus_to_soil(amount_phosphorus: float, field_size: float) -> None:
+    """Test that methods are called correctly on correct layers of soil profile."""
+    data = SoilData()
+    incorp = Manure(data)
+    with patch("SC_redesign.Crop_and_Soil.soil.layer_data.LayerData.add_to_labile_phosphorus",
+               new_callable=PropertyMock) as mocked_add_to_labile_phosphorus:
+        incorp._add_infiltrated_phosphorus_to_soil(amount_phosphorus, field_size)
+        assert mocked_add_to_labile_phosphorus.call_count == 2
+
+
+@pytest.mark.parametrize("rain,runoff,area", [
+    (13, 4, 1.8),
+    (12, 1.8, 2.1),
+    (14, 12.2, 3.4),
+    (4.2, 0, 2.4),
+])
+def test_leach_and_update_phosphorus_pools(rain: float, runoff: float, area: float) -> None:
+    """Tests that the update subroutine for phosphorus pools in Manure correctly calls methods and sets attributes."""
+    data = SoilData(machine_manure_dry_mass=1000, machine_manure_field_coverage=0.86,
+                    machine_water_extractable_inorganic_phosphorus=200, machine_water_extractable_organic_phosphorus=90,
+                    grazing_manure_dry_mass=800, grazing_manure_field_coverage=0.78,
+                    grazing_water_extractable_inorganic_phosphorus=125, grazing_water_extractable_organic_phosphorus=70)
+    incorp = Manure(data)
+
+    incorp._leach_phosphorus_to_runoff = MagicMock(return_value={
+        "new_phosphorus_pool_amount": 30,
+        "infiltrated_phosphorus": 25,
+        "runoff_phosphorus": 20,
+    })
+    incorp._add_infiltrated_phosphorus_to_soil = MagicMock()
+
+    incorp._leach_and_update_phosphorus_pools(rain, runoff, area)
+
+    leached_calls = [call(rain, runoff, area, 1000, 0.86, 90, True), call(rain, runoff, area, 1000, 0.86, 200, False),
+                     call(rain, runoff, area, 800, 0.78, 70, True), call(rain, runoff, area, 800, 0.78, 125, False)]
+    incorp._leach_phosphorus_to_runoff.assert_has_calls(leached_calls)
+    infiltrated_calls = [call(25, area), call(25, area), call(25, area), call(25, area)]
+    incorp._add_infiltrated_phosphorus_to_soil.assert_has_calls(infiltrated_calls)
+    assert incorp.data.machine_water_extractable_organic_phosphorus == 30
+    assert incorp.data.machine_water_extractable_inorganic_phosphorus == 30
+    assert incorp.data.annual_runoff_machine_manure_organic_phosphorus == 20
+    assert incorp.data.annual_runoff_machine_manure_inorganic_phosphorus == 20
+    assert incorp.data.grazing_water_extractable_organic_phosphorus == 30
+    assert incorp.data.grazing_water_extractable_inorganic_phosphorus == 30
+    assert incorp.data.annual_runoff_grazing_manure_organic_phosphorus == 20
+    assert incorp.data.annual_runoff_grazing_manure_inorganic_phosphorus == 20
+
+
+@pytest.mark.parametrize("rain,runoff,area", [
+    (12, 1.8, 2.1),
+    (14, 12.2, 3.4),
+    (0, 0, 2.4),
+])
+def test_daily_manure_update(rain: float, runoff: float, area: float) -> None:
+    """Tests that the main manure update method correctly calls all subroutines."""
+    data = SoilData()
+    incorp = Manure(data)
+
+    incorp._leach_and_update_phosphorus_pools = MagicMock()
+
+    incorp.daily_manure_update(rain, runoff, area)
+
+    if rain > 0.0:
+        incorp._leach_and_update_phosphorus_pools.assert_called_once_with(rain, runoff, area)
+    else:
+        incorp._leach_and_update_phosphorus_pools.assert_not_called()

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_manure.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/phosphorus_cycling_tests/test_manure.py
@@ -196,14 +196,14 @@ def test_leach_phosphorus_to_runoff(rain: float, runoff: float, area: float, man
         correctly."""
     Manure._determine_rain_manure_dry_matter_ratio = MagicMock(return_value=0.4)
     Manure._determine_phosphorus_distribution_factor = MagicMock(return_value=1.2)
-    Manure._determine_water_extractable_organic_phosphorus_leached = MagicMock(return_value=25)
-    Manure._determine_water_extractable_inorganic_phosphorus_leached = MagicMock(return_value=25)
+    Manure._determine_water_extractable_organic_phosphorus_leached = MagicMock(return_value=25.0)
+    Manure._determine_water_extractable_inorganic_phosphorus_leached = MagicMock(return_value=25.0)
     Manure._determine_water_extractable_phosphorus_runoff_concentration = MagicMock(return_value=5)
 
     observed = Manure._leach_phosphorus_to_runoff(rain, runoff, area, manure_mass, field_coverage, phosphorus_mass,
                                                   organic)
     runoff_in_liters = runoff * area * HECTARES_TO_SQUARE_MILLIMETERS * CUBIC_MILLIMETERS_TO_LITERS
-    expected_water_extractable_phosphorus_leached = min(25, phosphorus_mass)
+    expected_water_extractable_phosphorus_leached = min(25.0, phosphorus_mass)
     expected_runoff_phosphorus_in_kg = 5 * runoff_in_liters * MILLIGRAMS_TO_KILOGRAMS
     expected_infiltrated_phosphorus = max(0, expected_water_extractable_phosphorus_leached
                                           - expected_runoff_phosphorus_in_kg)

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_data_and_config_factory.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/test_soil_data_and_config_factory.py
@@ -127,7 +127,11 @@ def test_error_manual_soil_data_configuration() -> None:
 def test_annual_reset() -> None:
     """Test that annual_reset() actually resets the values it should"""
     # Initialize objects
-    soil_data = SoilData(name="test", peak_runoff_rate=0.95)
+    soil_data = SoilData(name="test", peak_runoff_rate=0.95,
+                         annual_runoff_machine_manure_organic_phosphorus=10,
+                         annual_runoff_machine_manure_inorganic_phosphorus=10,
+                         annual_runoff_grazing_manure_organic_phosphorus=10,
+                         annual_runoff_grazing_manure_inorganic_phosphorus=10)
     evapotranspirator = Evapotranspiration(soil_data)
     infiltrator = Infiltration(soil_data)
     eroder = SoilErosion(soil_data)
@@ -155,6 +159,10 @@ def test_annual_reset() -> None:
         assert soil_data.annual_eroded_sediment_total != 0
         assert soil_data.annual_surface_runoff_total != 0
         assert soil_data.annual_runoff_fertilizer_phosphorus != 0
+        assert soil_data.annual_runoff_machine_manure_organic_phosphorus != 0
+        assert soil_data.annual_runoff_machine_manure_inorganic_phosphorus != 0
+        assert soil_data.annual_runoff_grazing_manure_organic_phosphorus != 0
+        assert soil_data.annual_runoff_grazing_manure_inorganic_phosphorus != 0
 
         # Run method
         soil_data.do_annual_reset()
@@ -170,6 +178,10 @@ def test_annual_reset() -> None:
         assert soil_data.annual_eroded_sediment_total == 0
         assert soil_data.annual_surface_runoff_total == 0
         assert soil_data.annual_runoff_fertilizer_phosphorus == 0
+        assert soil_data.annual_runoff_machine_manure_organic_phosphorus == 0
+        assert soil_data.annual_runoff_machine_manure_inorganic_phosphorus == 0
+        assert soil_data.annual_runoff_grazing_manure_organic_phosphorus == 0
+        assert soil_data.annual_runoff_grazing_manure_inorganic_phosphorus == 0
 
 
 def test_profile_soil_water_content() -> None:


### PR DESCRIPTION
# Summary
This PR adds the ability in `Manure` to leach phosphorus from surface manure pools and transfer it to runoff pools and the soil profile.

# Changes
- `manure.py`
  - `daily_manure_update()`: will be the main routine used by higher level modules to update manure pools. Currently it only calls the leach and update method, but more functionality will be placed there in the next PR.
  - `_leach_and_update_phosphorus_pools()`: handles removing water-extractable phosphorus from pools and adding that phosphorus to runoff trackers, as well as calling the method that adds leached phosphorus to the soil profile.
  - `_add_infiltrated_phosphorus_to_soil()`: adds phosphorus that has infiltrated the soil profile into the top two layers of soil, with the added phosphorus distributed as dictated by the SurPhos theoretical documentation.
  - `_determine_phosphorus_leached_from_surface()`: calculates how much phosphorus is leached from surface pools, how much of that leached phosphorus infiltrates the soil profile and how much is removed from the field by runoff.
  - All of the above methods are tested individually in `test_manure.py`. NOTE: please carefully scrutinize the code coverage of the test cases for `_determine_phosphorus_leached_from_surface()`. It is a fairly complex method that has to ensure no more phosphorus can be removed from the field than there actually is on the field.
- `soil_data.py`
  - now separately tracks the phosphorus in runoff from each individual pool, and resets the trackers annually with all other annual tracker attributes in `SoilData`
  - `test_soil_data_and_config_factory.py` now tests that the new annual tracker attributes are reset correctly

# Notes 
This PR was originally meant to be the penultimate one in the series to implement `Manure`, but an extra PR will most likely be needed to implement the decomposition functionality of `Manure`.