### PR TITLE
Pen Feed Data Added to OM

### DIFF
--- a/RUFAS/routines/animal/animal_management.py
+++ b/RUFAS/routines/animal/animal_management.py
@@ -23,7 +23,6 @@ from typing import Any, Dict, Tuple, List
 from RUFAS.general_constants import GeneralConstants
 from RUFAS.output_manager import OutputManager
 from RUFAS.routines.animal.animal_module_constants import AnimalModuleConstants
-from RUFAS.routines.animal.clustering_pen_grouping import grouping
 from RUFAS.routines.animal.life_cycle.animal_base import AnimalBase
 from RUFAS.routines.animal.life_cycle.cow import Cow
 from RUFAS.routines.animal.life_cycle.life_cycle import LifeCycleManager
@@ -384,12 +383,12 @@ class AnimalManagement:
             feed: an instance of the Feed class defined in feed.py
             temp: the temperature on the current day
         """
-
+        calf_id_list = [calf.id for calf in calves_born]
         info_map = {"class": self.__class__.__name__,
                     "function": self.daily_update_id_pen.__name__,
                     "animals_added": animals_added,
                     "ids_removed": ids_removed,
-                    "calves_born": calves_born,
+                    "calves_born_id_list": calf_id_list,
                     "temp": temp,
                     }
 
@@ -468,7 +467,7 @@ class AnimalManagement:
 
         for i in range(len(self.all_pens)):
             if self.all_pens[i].ration == {}:
-                if len(self.all_pens[i].animals_in_pen) > 0:            
+                if len(self.all_pens[i].animals_in_pen) > 0:
                     available_feeds = ration_driver.AvailableFeeds()
                     available_feeds.feed_nutrients(feed)
                     self.all_pens[i].allocated_feeds = feed.input_feed_combinations[self.all_pens[i].animal_combination]

--- a/RUFAS/routines/animal/animal_management.py
+++ b/RUFAS/routines/animal/animal_management.py
@@ -373,6 +373,14 @@ class AnimalManagement:
             temp: the temperature on the current day
         """
 
+        info_map = {"class": self.__class__.__name__,
+                    "function": self.daily_update_id_pen.__name__,
+                    "animals_added": animals_added,
+                    "ids_removed": ids_removed,
+                    "calves_born": calves_born,
+                    "temp": temp,
+                    }
+
         # stratifying the pens that lost animals by animal group
         # (values are dictionaries of pen IDs, with values being the number of animals removed)
         grouped_pens_short = {Pen.AnimalCombination.CALF: {}, Pen.AnimalCombination.GROWING: {},
@@ -447,14 +455,19 @@ class AnimalManagement:
                                                     feed, temp, pen_population_before_additions[pen.id])
 
         for i in range(len(self.all_pens)):
-            if len(self.all_pens[i].animals_in_pen) > 0:
-                if self.all_pens[i].ration == {}:
+            if self.all_pens[i].ration == {}:
+                if len(self.all_pens[i].animals_in_pen) > 0:            
                     available_feeds = ration_driver.AvailableFeeds()
                     available_feeds.feed_nutrients(feed)
                     self.all_pens[i].allocated_feeds = feed.input_feed_combinations[self.all_pens[i].animal_combination]
                     pen_specific_feed_data = available_feeds.get_feed_data_from_feed_ids(
                         self.all_pens[i].allocated_feeds)
                     self.all_pens[i].ration = self.all_pens[i].calc_ration(feed, pen_specific_feed_data)
+                    pen_specific_feed_data_pen_num = f"pen_specific_feed_data_pen_{i}"
+                    om.add_variable(pen_specific_feed_data_pen_num, pen_specific_feed_data, info_map)
+                    pen_ration_data = self.all_pens[i].ration
+                    pen_ration_data_pen_num = f"pen_ration_data_pen_{i}"
+                    om.add_variable(pen_ration_data_pen_num, pen_ration_data, info_map)
             else:
                 if len(self.all_pens[i].animals_in_pen) > 0:
                     # Need to adjust the ration totals for the pen attributes now
@@ -465,6 +478,9 @@ class AnimalManagement:
                                 (self.all_pens[i].ration[key] /
                                  pen_population_before_additions[i]) * len(
                                     self.all_pens[i].animals_in_pen)
+                            pen_ration_data = self.all_pens[i].ration
+                            pen_ration_data_pen_num = f"pen_ration_data_pen_{i}"
+                            om.add_variable(pen_ration_data_pen_num, pen_ration_data, info_map)
 
         for calf in calves_born:
             # getting valid pen to place calves in

--- a/RUFAS/routines/animal/animal_management.py
+++ b/RUFAS/routines/animal/animal_management.py
@@ -377,16 +377,17 @@ class AnimalManagement:
         they were assigned.
 
         Args:
-            animals_added: list of animal IDs that have been added to the herd
+            animals_added: list of animal (cow) objects that have been added to the herd
             ids_removed: list of animal IDs that have been removed from the herd
             calves_born: list of Calf objects that have been added to the herd
             feed: an instance of the Feed class defined in feed.py
             temp: the temperature on the current day
         """
+        animals_added_id_list = [cow.id for cow in animals_added]
         calf_id_list = [calf.id for calf in calves_born]
         info_map = {"class": self.__class__.__name__,
                     "function": self.daily_update_id_pen.__name__,
-                    "animals_added": animals_added,
+                    "animals_added_id_list": animals_added_id_list,
                     "ids_removed": ids_removed,
                     "calves_born_id_list": calf_id_list,
                     "temp": temp,

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -452,12 +452,6 @@ class Pen:
             else:  # feeds and price
                 ration[key] = ration_per_animal[key] * num_animals
 
-        info_map = {"class": self.__class__.__name__,
-                    "function": self.calc_ration.__name__,
-                    "feed": vars(feed),
-                    "available_feeds": available_feeds, }
-        om.add_variable("pen_ration_data", ration, info_map)
-
         return ration
 
     def calc_manure(self, feed, methane_model):

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -22,13 +22,7 @@ from RUFAS.routines.animal.ration.calf_ration import optimize as calf_optimize
 from RUFAS.routines.animal.ration import ration_driver as ration_driver
 import copy
 from RUFAS.routines.animal.ration import animal_requirements as req
-from RUFAS.routines.animal.life_cycle.calf import Calf
-from RUFAS.routines.animal.life_cycle.cow import Cow
-from RUFAS.routines.animal.life_cycle.heiferI import HeiferI
-from RUFAS.routines.animal.life_cycle.heiferII import HeiferII
-from RUFAS.routines.animal.life_cycle.heiferIII import HeiferIII
 
-from RUFAS import util, errors
 from enum import Enum
 
 om = OutputManager()
@@ -440,7 +434,6 @@ class Pen:
 
         info_map = {"class": self.__class__.__name__,
                     "function": self.calc_ration.__name__,
-                    "feed": vars(feed),
                     "available_feeds": available_feeds, }
         om.add_variable("ration_nutrient_amount", nutrient_amount, info_map)
         om.add_variable("ration_nutrient_conc", nutrient_conc, info_map)
@@ -522,9 +515,12 @@ class Pen:
         self.heifer_total = heifer_total
         self.dry_total = dry_total
         self.lactating_total = lactating_total
+
         info_map = {"class": self.__class__.__name__,
                     "function": self.calc_manure.__name__,
-                    "feed": vars(feed)}
+                    "pen_id": self.id,
+                    "pen_animal_combination": self.animal_combination,
+                    }
         om.add_variable("pen_manure_data", self.manure, info_map)
 
     def _copy_manure_template(self):
@@ -614,7 +610,7 @@ class Pen:
 
         if class_name == 'Cow':
             requirements = req.calc_rqmts(body_weight=animal.body_weight, mature_body_weight=animal.mature_body_weight,
-                                          day_of_pregnancy=animal.days_in_preg, animal_type='cow', 
+                                          day_of_pregnancy=animal.days_in_preg, animal_type='cow',
                                           parity=animal.calves, calving_interval=animal.CI,
                                           milk_true_protein=animal.mPrt, milk_fat=animal.fat_percent,
                                           milk_lactose=animal.lactose_milk,

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -437,6 +437,15 @@ class Pen:
         self.MEdiet = ration_vals['ME_tot']
         self.dry_matter_intake = nutrient_amount['dm']
 
+        info_map = {"class": self.__class__.__name__,
+                    "function": self.calc_ration.__name__,
+                    "feed": vars(feed),
+                    "available_feeds": available_feeds, }
+        om.add_variable("ration_nutrient_amount", nutrient_amount, info_map)
+        om.add_variable("ration_nutrient_conc", nutrient_conc, info_map)
+        om.add_variable("MEdiet", self.MEdiet, info_map)
+        om.add_variable("dry_matter_intake", self.dry_matter_intake, info_map)
+
         for animal in self.animals_in_pen:
             animal.set_ration(ration_per_animal, nutrient_amount['dm'])
             animal.set_p_intake(nutrient_amount['phosphorus'],

--- a/RUFAS/routines/manure/reception_pits/reception_pit.py
+++ b/RUFAS/routines/manure/reception_pits/reception_pit.py
@@ -34,7 +34,6 @@ class ReceptionPit:
         info_map = {"class": cls.__name__,
                     "function": cls.daily_update.__name__,
                     "manure_handler_daily_output": vars(manure_handler_daily_output),
-                    "pen": vars(pen),
                     "bedding": vars(bedding),
                     }
 


### PR DESCRIPTION
This PR adds some requested data on rations and feed by individual pen to the Output Manager.

It adds: 
- the daily ration data (animalmanagement.daily_update_id_pen.pen_ration_data_pen_num) by pen

- the ration formula at each ration formulation (animalmanagement.daily_update_id_pen.pen_specific_feed_data_pen_num) by pen

- several pieces of ration nutrition data at the point of ration formulation:
1. ration_nutrient_amount
2. ration_nutrient_conc
3. MEdiet (metabolizable energy concentration of the diet fed to the pen)
4. dry_matter_intake

To make this work, I had to slightly tweak the logic in a part of the daily_update_id_pen function to ensure pens with a ration set are being updated with ration amounts daily.