### PR TITLE
OM Variable Tracker

### DIFF
--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -324,15 +324,20 @@ class OutputManager(object):
         file_path = os.path.join(path, self._generate_file_name("variable_names", "txt"))
         var_dict = {}
         with open(file_path, 'w') as var_names_file:
-            for k1, v1 in vars_pool.items():
-                for v2 in v1.values():
-                    for v3 in v2:
-                        if isinstance(v3, dict):
-                            for variable_name in v3.keys():
-                                variable_name_to_write = f"{key}: {variable_name}"
-                                if variable_name_to_write not in var_dict.keys():
-                                    var_dict[variable_name_to_write] = 1
-                                    var_names_file.write(variable_name_to_write + '\n')
+            for key, value in vars_pool.items():
+                if isinstance(value, dict) or isinstance(value, list):
+                    for v2 in value.values():
+                        for variable_dict in v2:
+                            if isinstance(variable_dict, dict):
+                                for variable_name in variable_dict.keys():
+                                    variable_name_to_write = f"{key}: {variable_name}"
+                                    if variable_name_to_write not in var_dict.keys():
+                                        var_dict[variable_name_to_write] = 1
+                                        var_names_file.write(variable_name_to_write + '\n')
+                            else:
+                                if key not in var_dict.keys():
+                                    var_dict[key] = 1
+                                    var_names_file.write(key + '\n')
 
     def save_all_pools(self, path: str, exclude_info_maps: bool = False) -> None:
         """

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -278,7 +278,7 @@ class OutputManager(object):
         Parameters
         ----------
         data_list : List[str]
-            The list to be saved
+            The list of variable names to be saved
         path : str
             The path to the file to be saved
 
@@ -290,8 +290,8 @@ class OutputManager(object):
         """
         try:
             with open(path, 'w') as var_names_file:
-                for item in data_list:
-                    var_names_file.write(item + '\n')
+                for variable_name in data_list:
+                    var_names_file.write(variable_name + '\n')
         except Exception as e:
             raise e
 
@@ -350,8 +350,7 @@ class OutputManager(object):
                 var_set.add(key)
                 var_set.update(f"{key}: {variable_name}" for values_list in value.values() for variable_dict in
                                values_list if isinstance(variable_dict, dict) for variable_name in variable_dict.keys())
-        var_set = sorted(var_set)
-        var_list = list(var_set)
+        var_list = sorted(var_set)  # sorted(set) converts set into a sorted list
 
         self._list_to_file_txt(var_list, file_path)
 

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -313,11 +313,33 @@ class OutputManager(object):
         file_path = os.path.join(path, self._generate_file_name("errors", "json"))
         self._dict_to_file_json(self.errors_pool, file_path)
 
+    def save_variable_names(self, path: str) -> None:
+        """
+        Saves names of all variables added to variables_pool into a json file in the give path to a directory.
+        """
+        vars_pool = self.variables_pool.copy()
+        for key, value in vars_pool.items():
+            if isinstance(value, dict) and "info_maps" in value:
+                value.pop("info_maps")
+        file_path = os.path.join(path, self._generate_file_name("variable_names", "txt"))
+        var_dict = {}
+        with open(file_path, 'w') as var_names_file:
+            for k1, v1 in vars_pool.items():
+                for v2 in v1.values():
+                    for v3 in v2:
+                        if isinstance(v3, dict):
+                            for variable_name in v3.keys():
+                                variable_name_to_write = f"{key}: {variable_name}"
+                                if variable_name_to_write not in var_dict.keys():
+                                    var_dict[variable_name_to_write] = 1
+                                    var_names_file.write(variable_name_to_write + '\n')
+
     def save_all_pools(self, path: str, exclude_info_maps: bool = False) -> None:
         """
         Saves all pool into the given path to a directory.
         """
         self.save_variables(path, exclude_info_maps=exclude_info_maps)
+        self.save_variable_names(path)
         self.save_errors(path)
         self.save_logs(path)
         self.save_warnings(path)
@@ -330,3 +352,5 @@ class OutputManager(object):
         self.warnings_pool: Dict[str, OutputManager.pool_element_type] = {}
         self.errors_pool: Dict[str, OutputManager.pool_element_type] = {}
         self.logs_pool: Dict[str, OutputManager.pool_element_type] = {}
+    
+    

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -341,16 +341,16 @@ class OutputManager(object):
         Saves names of all variables added to variables_pool into a json file in the given path to a directory.
         """
         vars_pool = self.variables_pool.copy()
-        file_path = os.path.join(path, self._generate_file_name("variable_names", "txt"))
-        var_set = set()
         for key, value in vars_pool.items():
             if isinstance(value, dict) and "info_maps" in value:
                 value.pop("info_maps")
-            else:
-                var_set.add(key)
-                var_set.update(f"{key}: {variable_name}" for values_list in value.values() for variable_dict in
-                               values_list if isinstance(variable_dict, dict) for variable_name in variable_dict.keys())
-        var_list = sorted(var_set)  # sorted(set) converts set into a sorted list
+        file_path = os.path.join(path, self._generate_file_name("variable_names", "txt"))
+        var_set = set()
+        for key, value in vars_pool.items():
+            var_set.add(key)
+            var_set.update(f"{key}: {variable_name}" for values_list in value.values() for variable_dict in values_list
+                           if isinstance(variable_dict, dict) for variable_name in variable_dict.keys())
+        var_list = sorted(var_set)  # sorted(set) sorts and then converts set into a list
 
         self._list_to_file_txt(var_list, file_path)
 

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -272,6 +272,29 @@ class OutputManager(object):
         except Exception as e:
             raise e
 
+    def _list_to_file_txt(self, data_list: List[str], path: str) -> None:
+        """Saves a list into a text file
+
+        Parameters
+        ----------
+        data_list : List[str]
+            The list to be saved
+        path : str
+            The path to the file to be saved
+
+        Raises
+        ------
+        Exception
+            If an error occurs while saving the file
+        
+        """
+        try:
+            with open(path, 'w') as var_names_file:
+                for item in data_list:
+                    var_names_file.write(item + '\n')
+        except Exception as e:
+            raise e
+
     def _generate_file_name(self, base_name: str, extension: str = "json") -> str:
         """
         Returns a file name using the given base_name and timestamp.
@@ -315,28 +338,27 @@ class OutputManager(object):
 
     def save_variable_names(self, path: str) -> None:
         """
-        Saves names of all variables added to variables_pool into a json file in the give path to a directory.
+        Saves names of all variables added to variables_pool into a json file in the given path to a directory.
         """
         vars_pool = self.variables_pool.copy()
         for key, value in vars_pool.items():
             if isinstance(value, dict) and "info_maps" in value:
                 value.pop("info_maps")
         file_path = os.path.join(path, self._generate_file_name("variable_names", "txt"))
-        var_dict = {}
-        with open(file_path, 'w') as var_names_file:
-            for key, value in vars_pool.items():
-                for values_list in value.values():
-                    for variable_dict in values_list:
-                        if isinstance(variable_dict, dict):
-                            for variable_name in variable_dict.keys():
-                                variable_name_to_write = f"{key}: {variable_name}"
-                                if variable_name_to_write not in var_dict.keys():
-                                    var_dict[variable_name_to_write] = 1
-                                    var_names_file.write(variable_name_to_write + '\n')
-                        else:
-                            if key not in var_dict.keys():
-                                var_dict[key] = 1
-                                var_names_file.write(key + '\n')
+        var_list = []
+        for key, value in vars_pool.items():
+            for values_list in value.values():
+                for variable_dict in values_list:
+                    if isinstance(variable_dict, dict):
+                        for variable_name in variable_dict.keys():
+                            variable_name_to_write = f"{key}: {variable_name}"
+                            if variable_name_to_write not in var_list:
+                                var_list.append(variable_name_to_write)
+                    else:
+                        if key not in var_list:
+                            var_list.append(key)
+                            
+        self._list_to_file_txt(var_list, file_path)
 
     def save_all_pools(self, path: str, exclude_info_maps: bool = False) -> None:
         """

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -341,23 +341,18 @@ class OutputManager(object):
         Saves names of all variables added to variables_pool into a json file in the given path to a directory.
         """
         vars_pool = self.variables_pool.copy()
+        file_path = os.path.join(path, self._generate_file_name("variable_names", "txt"))
+        var_set = set()
         for key, value in vars_pool.items():
             if isinstance(value, dict) and "info_maps" in value:
                 value.pop("info_maps")
-        file_path = os.path.join(path, self._generate_file_name("variable_names", "txt"))
-        var_list = []
-        for key, value in vars_pool.items():
-            for values_list in value.values():
-                for variable_dict in values_list:
-                    if isinstance(variable_dict, dict):
-                        for variable_name in variable_dict.keys():
-                            variable_name_to_write = f"{key}: {variable_name}"
-                            if variable_name_to_write not in var_list:
-                                var_list.append(variable_name_to_write)
-                    else:
-                        if key not in var_list:
-                            var_list.append(key)
-                            
+            else:
+                var_set.add(key)
+                var_set.update(f"{key}: {variable_name}" for values_list in value.values() for variable_dict in
+                               values_list if isinstance(variable_dict, dict) for variable_name in variable_dict.keys())
+        var_set = sorted(var_set)
+        var_list = list(var_set)
+
         self._list_to_file_txt(var_list, file_path)
 
     def save_all_pools(self, path: str, exclude_info_maps: bool = False) -> None:

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -325,19 +325,18 @@ class OutputManager(object):
         var_dict = {}
         with open(file_path, 'w') as var_names_file:
             for key, value in vars_pool.items():
-                if isinstance(value, dict) or isinstance(value, list):
-                    for v2 in value.values():
-                        for variable_dict in v2:
-                            if isinstance(variable_dict, dict):
-                                for variable_name in variable_dict.keys():
-                                    variable_name_to_write = f"{key}: {variable_name}"
-                                    if variable_name_to_write not in var_dict.keys():
-                                        var_dict[variable_name_to_write] = 1
-                                        var_names_file.write(variable_name_to_write + '\n')
-                            else:
-                                if key not in var_dict.keys():
-                                    var_dict[key] = 1
-                                    var_names_file.write(key + '\n')
+                for values_list in value.values():
+                    for variable_dict in values_list:
+                        if isinstance(variable_dict, dict):
+                            for variable_name in variable_dict.keys():
+                                variable_name_to_write = f"{key}: {variable_name}"
+                                if variable_name_to_write not in var_dict.keys():
+                                    var_dict[variable_name_to_write] = 1
+                                    var_names_file.write(variable_name_to_write + '\n')
+                        else:
+                            if key not in var_dict.keys():
+                                var_dict[key] = 1
+                                var_names_file.write(key + '\n')
 
     def save_all_pools(self, path: str, exclude_info_maps: bool = False) -> None:
         """
@@ -357,5 +356,3 @@ class OutputManager(object):
         self.warnings_pool: Dict[str, OutputManager.pool_element_type] = {}
         self.errors_pool: Dict[str, OutputManager.pool_element_type] = {}
         self.logs_pool: Dict[str, OutputManager.pool_element_type] = {}
-    
-    

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -527,6 +527,7 @@ def output_manager_original_method_states(
         "_generate_file_name": mock_output_manager._generate_file_name,
         "_generate_key": mock_output_manager._generate_key,
         "_dict_to_file_json": mock_output_manager._dict_to_file_json,
+        "_list_to_file_txt": mock_output_manager._list_to_file_txt,
         "_add_to_pool": mock_output_manager._add_to_pool,
         "add_variable": mock_output_manager.add_variable,
         "add_error": mock_output_manager.add_error,
@@ -536,6 +537,7 @@ def output_manager_original_method_states(
         "save_logs": mock_output_manager.save_logs,
         "save_warnings": mock_output_manager.save_warnings,
         "save_errors": mock_output_manager.save_errors,
+        "save_variable_names": mock_output_manager.save_variable_names,
     }
 
 
@@ -549,6 +551,7 @@ def test_save_all_pools(
     mock_output_manager.save_warnings = MagicMock()
     mock_output_manager.save_logs = MagicMock()
     mock_output_manager.save_variables = MagicMock()
+    mock_output_manager.save_variable_names = MagicMock()
 
     mock_output_manager.save_all_pools(path, exclude_info_maps=False)
 
@@ -558,6 +561,7 @@ def test_save_all_pools(
     mock_output_manager.save_variables.assert_called_once_with(
         path, exclude_info_maps=False
     )
+    mock_output_manager.save_variable_names.assert_called_once_with(path)
 
     mock_output_manager.save_all_pools(path, exclude_info_maps=True)
     mock_output_manager.save_variables.assert_called_with(path, exclude_info_maps=True)
@@ -575,6 +579,9 @@ def test_save_all_pools(
     ]
     mock_output_manager.save_errors = output_manager_original_method_states[
         "save_errors"
+    ]
+    mock_output_manager.save_variable_names = output_manager_original_method_states[
+        "save_variable_names"
     ]
 
 
@@ -684,6 +691,31 @@ def test_save_errors(
     ]
     mock_output_manager._dict_to_file_json = output_manager_original_method_states[
         "_dict_to_file_json"
+    ]
+
+
+def test_save_variable_names(
+    mock_output_manager: OutputManager,
+    output_manager_original_method_states: Dict[str, Callable],
+) -> None:
+    """Test case for function save_variable_names in output_manager.py"""
+    dummy_list = []
+    mock_output_manager._generate_file_name = MagicMock(return_value="dummy_name")
+    mock_output_manager._list_to_file_txt = MagicMock()
+
+    mock_output_manager.save_variable_names("dummy_path")
+
+    mock_output_manager._generate_file_name.assert_called_once_with("variable_names", "txt")
+    mock_output_manager._list_to_file_txt.assert_called_once_with(
+        dummy_list, os.path.join("dummy_path", "dummy_name")
+    )
+
+    # Restore original methods
+    mock_output_manager._generate_file_name = output_manager_original_method_states[
+        "_generate_file_name"
+    ]
+    mock_output_manager._dict_to_file_json = output_manager_original_method_states[
+        "_list_to_file_txt"
     ]
 
 


### PR DESCRIPTION
This PR adds 2 methods to the Output Manager that look through the variables_pool after the simulation runs and pull out the names of all the variables tracked during a simulation and add them, alphabetized, to a .txt file for easy viewing.

This feature was requested as a way to continually be able to easily track what variables are collected by the Output Manager.

To test, run a simulation (try with and without info_maps to ensure both options work) and look at the newly-generated variable names tracking txt file:
<img width="353" alt="Screenshot 2023-04-25 at 8 13 36 AM" src="https://user-images.githubusercontent.com/70217952/234273161-99d82128-e744-4d3f-b4fe-feafaade2e61.png">

It should generate a list of all the variables added to the OM variables pool including the class and function from which they were added:
<img width="815" alt="Screenshot 2023-04-25 at 8 14 11 AM" src="https://user-images.githubusercontent.com/70217952/234273454-dfdbc5f6-5e41-45f7-9188-080391646064.png">

Unit testing was added and was running successfully for me.