### PR TITLE
Refactor and test `nitrification_volatilization.py`

### DIFF
--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -630,3 +630,4 @@ class LayerData:
     def do_annual_reset(self):
         self.annual_carbon_CO2_lost = 0
         self.annual_decomposition_carbon_CO2_lost = 0
+        self.annual_volatilized_ammonium_total = 0

--- a/SC_redesign/Crop_and_Soil/soil/layer_data.py
+++ b/SC_redesign/Crop_and_Soil/soil/layer_data.py
@@ -250,6 +250,12 @@ class LayerData:
     humus_mineralization_rate_factor: float = 0.0003
     """Rate factor for humus mineralization of active organic nutrients (nitrogen and phosphorus) (unitless)
         Reference: SWAT Input .BSN file, see "CMN" on page 101."""
+    ammonium_volatilization_cation_exchange_factor: float = 0.15
+    """Exchange factor that accounts for the soil's cation exchange capacity, default = 0.15 (unitless)
+        Reference: SWAT Theoretical documentation eqn. 3:1.3.5"""
+
+    annual_volatilized_ammonium_total: float = 0
+    """Cumulative total of ammonium volatilized in this year (kg / ha)"""
 
     # --- Carbon cycling
     soil_overall_carbon_fraction: Optional[float] = None

--- a/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/nitrification_volatilization.py
+++ b/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/nitrification_volatilization.py
@@ -11,7 +11,8 @@ This module handles the nitrification and volatilization operations for the ammo
 class NitrificationVolatilization:
 
     def __init__(self, soil_data: Optional[SoilData] = None, field_size: Optional[float] = None):
-        """This method initializes the SoilData object that this module will work with, or creates one if one is not provided.
+        """This method initializes the SoilData object that this module will work with, or creates one if one is not
+            provided.
 
         Parameters
         ----------

--- a/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/nitrification_volatilization.py
+++ b/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/nitrification_volatilization.py
@@ -93,7 +93,7 @@ class NitrificationVolatilization:
         Returns
         -------
         float
-            The volatilization depth factor (mm)
+            The volatilization depth factor (unitless)
 
         References
         ----------
@@ -102,3 +102,137 @@ class NitrificationVolatilization:
         """
         exponential_term = exp(4.706 - 0.0305 * depth)
         return 1 - (depth / (depth + exponential_term))
+
+    @staticmethod
+    def _calculate_nitrification_regulator(temp_factor: float, water_factor: float) -> float:
+        """Calculates the nitrification regulator for this layer of soil.
+
+        Parameters
+        ----------
+        temp_factor : float
+            The nitrification/volatilization temperature factor of the current layer of soil (unitless)
+        water_factor : float
+            The nitrification soil water factor of the current soil layer (unitless)
+
+        Returns
+        -------
+        float
+            The nitrification regulator for this layer of soil (unitless)
+
+        References
+        ----------
+        SWAT Theoretical documentation eqn. 3:1.3.6
+
+        """
+        return temp_factor * water_factor
+
+    @staticmethod
+    def _calculate_volatilization_regulator(temp_factor: float, depth_factor: float,
+                                            cation_exchange_factor: float) -> float:
+        """Calculates the volatilization regulator for this layer of soil.
+
+        Parameters
+        ----------
+        temp_factor : float
+            The nitrification/volatilization temperature factor of the current layer of soil (unitless)
+        depth_factor : float
+            The volatilization depth factor (unitless)
+        cation_exchange_factor : float
+            The volatilization cation exchange factor (unitless)
+
+        Returns
+        -------
+        float
+            The volatilization regulator for this layer of soil (unitless)
+
+        References
+        ----------
+        SWAT Theoretical documentation eqn. 3:1.3.7
+
+        """
+        return temp_factor * depth_factor * cation_exchange_factor
+
+    @staticmethod
+    def _calculate_total_ammonium_lost(ammonium_content: float, nitrification_regulator: float,
+                                       volatilization_regulator: float) -> float:
+        """Calculates the amount of ammonium lost to nitrification and volatilization.
+
+        Parameters
+        ----------
+        ammonium_content : float
+            The ammonium content of this soil layer (kg / ha)
+        nitrification_regulator : float
+            The nitrification regulator for this layer of soil (unitless)
+        volatilization_regulator : float
+            The volatilization regulator for this layer of soil (unitless)
+
+        Returns
+        -------
+        float
+            The amount of ammonium lost to nitrification and volatilization (kg / ha)
+
+        References
+        ----------
+        SWAT Theoretical documentation eqn. 3:1.3.8
+
+        """
+        exponential_term = exp(-1 * nitrification_regulator - volatilization_regulator)
+        return ammonium_content * (1 - exponential_term)
+
+    @staticmethod
+    def _calculate_ammonium_loss_fraction(regulator: float) -> float:
+        """Calculates the fraction of lost ammonium that is lost to the specified process.
+
+        Parameters
+        ----------
+        regulator : float
+            The regulator for the process that ammonium is being lost to (unitless)
+
+        Returns
+        -------
+        float
+            Fraction of lost ammonium that is lost due to the given process (unitless)
+
+        References
+        ----------
+        SWAT Theoretical documentation eqn. 3:1.3.9, 10
+
+        Notes
+        -----
+        This method is used to calculate the fraction of ammonium lost to both nitrification and volatilization.
+
+        """
+        return 1 - exp(-1 * regulator)
+
+    @staticmethod
+    def _calculate_ammonium_lost_to_process(total_lost_ammonium: float, actual_loss_fraction: float,
+                                            other_loss_fraction: float) -> float:
+        """Calculates the amount of ammonium lost to the specified process.
+
+        Parameters
+        ----------
+        total_lost_ammonium : float
+            The total ammonium content lost to nitrification and volatilization (kg / ha)
+        actual_loss_fraction : float
+            The loss fraction for the specified process that ammonium is being lost to (unitless)
+        other_loss_fraction : float
+            The loss fraction for the other process that ammonium is lost to (unitless)
+
+        Returns
+        -------
+        float
+            The amount of ammonium that is lost to the specified process (kg / ha)
+
+        References
+        ----------
+        SWAT Theoretical documentation eqn. 3:1.3.11, 12
+
+        Notes
+        -----
+        This method is intended to be used to calculate both the amount of ammonium lost to nitrification and to
+        volatilization. To calculate the amount lost to nitrification, pass the nitrification loss fraction as the
+        `actual_loss_fraction` and the volatilization loss fraction as the `other_loss_fraction`, and vice versa for
+        calculating the amount lost to volatilization.
+
+        """
+        return (actual_loss_fraction / (actual_loss_fraction + other_loss_fraction)) * total_lost_ammonium

--- a/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/nitrification_volatilization.py
+++ b/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/nitrification_volatilization.py
@@ -29,6 +29,45 @@ class NitrificationVolatilization:
         """
         self.data = soil_data or SoilData(field_size=field_size)
 
+    def do_daily_nitrification_and_volatilization(self) -> None:
+        """Conducts the nitrification and volatilization of ammonium within the soil profile on a daily basis.
+
+        References
+        ----------
+        SWAT Theoretical documentation section 3:1.3
+
+        """
+        for layer in self.data.soil_layers:
+            if layer.temperature <= 5:
+                continue
+
+            temp_factor = self._calculate_nitrification_volatilization_temp_factor(layer.temperature)
+            water_factor = self._calculate_nitrification_soil_water_factor(layer.water_content,
+                                                                           layer.wilting_point_content,
+                                                                           layer.field_capacity_content)
+            depth_factor = self._calculate_volatilization_depth_factor(layer.depth_of_layer_center)
+
+            nitrification_regulator = self._calculate_nitrification_regulator(temp_factor, water_factor)
+            volatilization_regulator = self._calculate_volatilization_regulator(
+                temp_factor, depth_factor, layer.ammonium_volatilization_cation_exchange_factor)
+
+            nitrification_loss_fraction = self._calculate_ammonium_loss_fraction(nitrification_regulator)
+            volatilization_loss_fraction = self._calculate_ammonium_loss_fraction(volatilization_regulator)
+
+            total_ammonium_lost = self._calculate_total_ammonium_lost(layer.ammonium_content, nitrification_regulator,
+                                                                      volatilization_regulator)
+
+            nitrified_ammonium = self._calculate_ammonium_lost_to_process(total_ammonium_lost,
+                                                                          nitrification_loss_fraction,
+                                                                          volatilization_loss_fraction)
+            volatilized_ammonium = self._calculate_ammonium_lost_to_process(total_ammonium_lost,
+                                                                            volatilization_loss_fraction,
+                                                                            nitrification_loss_fraction)
+
+            layer.ammonium_content -= total_ammonium_lost
+            layer.nitrate_content += nitrified_ammonium
+            layer.annual_volatilized_ammonium_total += volatilized_ammonium
+
     # --- Static methods ---
     @staticmethod
     def _calculate_nitrification_volatilization_temp_factor(temperature: float) -> float:

--- a/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/nitrification_volatilization.py
+++ b/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/nitrification_volatilization.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from math import exp
 
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 
@@ -71,12 +72,33 @@ class NitrificationVolatilization:
 
         References
         ----------
-        SWAT Theoretical documentation 3:1.3.2, 3
+        SWAT Theoretical documentation eqn. 3:1.3.2, 3
 
         """
         if water_content >= 0.25 * field_capacity - 0.75 * wilting_point:
             return 1.0
-
         upper_term = water_content - wilting_point
         bottom_term = 0.25 * (field_capacity - wilting_point)
         return upper_term / bottom_term
+
+    @staticmethod
+    def _calculate_volatilization_depth_factor(depth: float) -> float:
+        """Calculates the depth factor for use in determining volatilization.
+
+        Parameters
+        ----------
+        depth : float
+            The depth of the center of this soil layer (mm)
+
+        Returns
+        -------
+        float
+            The volatilization depth factor (mm)
+
+        References
+        ----------
+        SWAT Theoretical documentation eqn. 3:1.3.4
+
+        """
+        exponential_term = exp(4.706 - 0.0305 * depth)
+        return 1 - (depth / (depth + exponential_term))

--- a/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/nitrification_volatilization.py
+++ b/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/nitrification_volatilization.py
@@ -11,7 +11,7 @@ This module handles the nitrification and volatilization operations for the ammo
 class NitrificationVolatilization:
 
     def __init__(self, soil_data: Optional[SoilData] = None, field_size: Optional[float] = None):
-        """This method initializes the SoilData object that this module will work with, or create one if none provided.
+        """This method initializes the SoilData object that this module will work with, or creates one if one is not provided.
 
         Parameters
         ----------

--- a/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/nitrification_volatilization.py
+++ b/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/nitrification_volatilization.py
@@ -49,3 +49,34 @@ class NitrificationVolatilization:
 
         """
         return 0.41 * ((temperature - 5) / 10)
+
+    @staticmethod
+    def _calculate_nitrification_soil_water_factor(water_content: float, wilting_point: float,
+                                                   field_capacity: float) -> float:
+        """Calculates the soil water factor for nitrification.
+
+        Parameters
+        ----------
+        water_content : float
+            Water present in this soil layer (mm)
+        wilting_point : float
+            Amount of water in this soil layer when at wilting point (mm)
+        field_capacity : float
+            Amount of water in this soil layer when at field capacity (mm)
+
+        Returns
+        -------
+        float
+            The nitrification soil water factor (unitless)
+
+        References
+        ----------
+        SWAT Theoretical documentation 3:1.3.2, 3
+
+        """
+        if water_content >= 0.25 * field_capacity - 0.75 * wilting_point:
+            return 1.0
+
+        upper_term = water_content - wilting_point
+        bottom_term = 0.25 * (field_capacity - wilting_point)
+        return upper_term / bottom_term

--- a/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/nitrification_volatilization.py
+++ b/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/nitrification_volatilization.py
@@ -1,0 +1,51 @@
+from typing import Optional
+
+from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
+
+"""
+This module handles the nitrification and volatilization operations for the ammonium pool, based on SWAT section 3:1.3.
+"""
+
+
+class NitrificationVolatilization:
+
+    def __init__(self, soil_data: Optional[SoilData] = None, field_size: Optional[float] = None):
+        """This method initializes the SoilData object that this module will work with, or create one if none provided.
+
+        Parameters
+        ----------
+        soil_data : SoilData, optional
+            The SoilData object used by this module to track the nitrification and volatilization of ammonium, creates
+            new one if one is not provided.
+        field_size : float, optional
+            Size of the field (ha)
+
+        Notes
+        -----
+        The field size is used to initialize a SoilData object for this module to work with, if a pre-configured
+        SoilData object is not provided.
+
+        """
+        self.data = soil_data or SoilData(field_size=field_size)
+
+    # --- Static methods ---
+    @staticmethod
+    def _calculate_nitrification_volatilization_temp_factor(temperature: float) -> float:
+        """Calculates the nitrification/volatilization temperature factor.
+
+        Parameters
+        ----------
+        temperature : float
+            Current temperature of the soil layer (degrees C)
+
+        Returns
+        -------
+        float
+            The nitrification/volatilization temperature factor of the current layer of soil (unitless)
+
+        References
+        ----------
+        SWAT Theoretical documentation eqn. 3:1.3.1
+
+        """
+        return 0.41 * ((temperature - 5) / 10)

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/nitrogen_cycling_tests/test_nitrification_volatilization.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/nitrogen_cycling_tests/test_nitrification_volatilization.py
@@ -1,0 +1,17 @@
+import pytest
+
+from SC_redesign.Crop_and_Soil.soil.nitrogen_cycling.nitrification_volatilization import NitrificationVolatilization
+
+
+# --- Static method tests ---
+@pytest.mark.parametrize("temp", [
+    20,
+    31.493,
+    14.334,
+    5.0193
+])
+def test_calculate_nitrification_volatilization_temp_factor(temp: float) -> None:
+    """Tests that the temperature factor used by the nitrification volatilization module is calculated correctly."""
+    observed = NitrificationVolatilization._calculate_nitrification_volatilization_temp_factor(temp)
+    expected = 0.41 * (temp - 5) / 10
+    assert observed == expected

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/nitrogen_cycling_tests/test_nitrification_volatilization.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/nitrogen_cycling_tests/test_nitrification_volatilization.py
@@ -1,4 +1,5 @@
 import pytest
+from math import exp
 
 from SC_redesign.Crop_and_Soil.soil.nitrogen_cycling.nitrification_volatilization import NitrificationVolatilization
 
@@ -30,4 +31,17 @@ def test_calculate_nitrification_soil_water_factor(water: float, wilting: float,
         expected = (water - wilting) / (0.25 * (field - wilting))
     else:
         expected = 1.0
+    assert observed == expected
+
+
+@pytest.mark.parametrize("depth", [
+    12,
+    33.5,
+    94,
+    120.394,
+])
+def test_calculate_volatilization_depth_factor(depth: float) -> float:
+    """Tests that the volatilization depth factor is calculated correctly."""
+    observed = NitrificationVolatilization._calculate_volatilization_depth_factor(depth)
+    expected = 1 - depth / (depth + exp(4.706 - 0.0305 * depth))
     assert observed == expected

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/nitrogen_cycling_tests/test_nitrification_volatilization.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/nitrogen_cycling_tests/test_nitrification_volatilization.py
@@ -40,8 +40,72 @@ def test_calculate_nitrification_soil_water_factor(water: float, wilting: float,
     94,
     120.394,
 ])
-def test_calculate_volatilization_depth_factor(depth: float) -> float:
+def test_calculate_volatilization_depth_factor(depth: float) -> None:
     """Tests that the volatilization depth factor is calculated correctly."""
     observed = NitrificationVolatilization._calculate_volatilization_depth_factor(depth)
     expected = 1 - depth / (depth + exp(4.706 - 0.0305 * depth))
     assert observed == expected
+
+
+@pytest.mark.parametrize("temp_factor,water_factor", [
+    (0.9982, 0.7767),
+    (0.6779, 0.88657),
+    (0.144, 0.2295),
+    (0.3059, 0.2259)
+])
+def test_calculate_nitrification_regulator(temp_factor: float, water_factor: float) -> None:
+    """Tests that the nitrification factor is calculated correctly."""
+    observed = NitrificationVolatilization._calculate_nitrification_regulator(temp_factor, water_factor)
+    expected = temp_factor * water_factor
+    assert observed == expected
+
+
+@pytest.mark.parametrize("temp_factor,depth_factor,exchange_factor", [
+    (0.7795, 0.4495, 0.15),
+    (0.11439, 0.9938, 0.1245),
+    (0.8858, 0.6675, 0.22395)
+])
+def test_calculate_volatilization_regulator(temp_factor: float, depth_factor: float, exchange_factor: float) -> None:
+    """Tests that the volatilization factor is calculated correctly."""
+    observed = NitrificationVolatilization._calculate_volatilization_regulator(temp_factor, depth_factor,
+                                                                               exchange_factor)
+    expected = temp_factor * depth_factor * exchange_factor
+    assert observed == expected
+
+
+@pytest.mark.parametrize("ammonium,nitrification,volatilization", [
+    (30.12, 0.56, 0.056),
+    (21.45, 0.8895, 0.1123),
+    (40.595, 0.411894, 0.0857)
+])
+def test_calculate_total_ammonium_lost(ammonium: float, nitrification: float, volatilization: float) -> None:
+    """Tests that the amount of ammonium lost to nitrification and volatilization is calculated correctly."""
+    observed = NitrificationVolatilization._calculate_total_ammonium_lost(ammonium, nitrification, volatilization)
+    expected = ammonium * (1 - exp(-1 * nitrification - volatilization))
+    assert observed == expected
+
+
+@pytest.mark.parametrize("regulator", [
+    0.05,
+    0.11234,
+    0.781,
+    0.8894,
+    0.4459
+])
+def test_calculate_ammonium_loss_fraction(regulator: float) -> None:
+    """Tests that the fraction of ammonium lost to a given process is calculated correctly."""
+    observed = NitrificationVolatilization._calculate_ammonium_loss_fraction(regulator)
+    expected = 1 - exp(-1 * regulator)
+    assert observed == expected
+
+
+@pytest.mark.parametrize("ammonium_lost,actual,other", [
+    (12.44, 0.33, 0.132),
+    (33.4495, 0.465, 0.33184),
+    (22.592, 0.2815, 0.44568)
+])
+def test_calculate_ammonium_lost_to_process(ammonium_lost: float, actual: float, other: float) -> None:
+    """Tests that the amount of ammonium lost to a specific process is calculated correctly."""
+    observed = NitrificationVolatilization._calculate_ammonium_lost_to_process(ammonium_lost, actual, other)
+    expected = ammonium_lost * actual / (actual + other)
+    assert pytest.approx(observed) == expected

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/nitrogen_cycling_tests/test_nitrification_volatilization.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/nitrogen_cycling_tests/test_nitrification_volatilization.py
@@ -15,3 +15,19 @@ def test_calculate_nitrification_volatilization_temp_factor(temp: float) -> None
     observed = NitrificationVolatilization._calculate_nitrification_volatilization_temp_factor(temp)
     expected = 0.41 * (temp - 5) / 10
     assert observed == expected
+
+
+@pytest.mark.parametrize("water,wilting,field", [
+    (3.55, 1.85, 6.559),
+    (0.0, 1.22, 4.55712),
+    (1.33, 2.22, 5.7781),
+    (7.55, 2.314, 6.0133)
+])
+def test_calculate_nitrification_soil_water_factor(water: float, wilting: float, field: float) -> None:
+    """Tests that the water factor for nitrification is calculated correctly."""
+    observed = NitrificationVolatilization._calculate_nitrification_soil_water_factor(water, wilting, field)
+    if water < 0.25 * field - 0.75 * wilting:
+        expected = (water - wilting) / (0.25 * (field - wilting))
+    else:
+        expected = 1.0
+    assert observed == expected

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/nitrogen_cycling_tests/test_nitrification_volatilization.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/nitrogen_cycling_tests/test_nitrification_volatilization.py
@@ -1,6 +1,6 @@
 import pytest
 from math import exp
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch, PropertyMock, call
 
 from SC_redesign.Crop_and_Soil.soil.nitrogen_cycling.nitrification_volatilization import NitrificationVolatilization
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
@@ -116,31 +116,56 @@ def test_calculate_ammonium_lost_to_process(ammonium_lost: float, actual: float,
 # --- Main routine test ---
 def test_do_daily_nitrification_and_volatilization() -> None:
     """Tests that the main routine of NitrificationVolatilization correctly calculates and updates attributes."""
-    data = SoilData(field_size=1.8)
-    incorp = NitrificationVolatilization(data)
-    incorp.data.set_vectorized_layer_attribute("ammonium_content", [25, 25, 25, 25])
-    incorp.data.set_vectorized_layer_attribute("nitrate_content", [25, 25, 25, 25])
+    with patch.multiple("SC_redesign.Crop_and_Soil.soil.layer_data.LayerData",
+                        wilting_point_content=PropertyMock(return_value=2.33),
+                        field_capacity_content=PropertyMock(return_value=5.77),
+                        depth_of_layer_center=PropertyMock(return_value=57.89)):
+        data = SoilData(field_size=1.8)
+        incorp = NitrificationVolatilization(data)
+        incorp.data.set_vectorized_layer_attribute("temperature", [18, 4, 18, 18])
+        incorp.data.set_vectorized_layer_attribute("water_content", [3.67, 3.67, 3.67, 3.67])
+        incorp.data.set_vectorized_layer_attribute("ammonium_volatilization_cation_exchange_factor", [0.18, 0.18, 0.18,
+                                                                                                      0.18])
+        incorp.data.set_vectorized_layer_attribute("ammonium_content", [25, 25, 25, 25])
+        incorp.data.set_vectorized_layer_attribute("nitrate_content", [25, 25, 25, 25])
 
-    incorp._calculate_nitrification_volatilization_temp_factor = MagicMock(return_value=0.8)
-    incorp._calculate_nitrification_soil_water_factor = MagicMock(return_value=0.75)
-    incorp._calculate_volatilization_depth_factor = MagicMock(return_value=0.46)
-    incorp._calculate_nitrification_regulator = MagicMock(return_value=0.55)
-    incorp._calculate_volatilization_regulator = MagicMock(return_value=0.08)
-    incorp._calculate_ammonium_loss_fraction = MagicMock(return_value=0.35)
-    incorp._calculate_total_ammonium_lost = MagicMock(return_value=6.5)
-    incorp._calculate_ammonium_lost_to_process = MagicMock(return_value=3.25)
+        incorp._calculate_nitrification_volatilization_temp_factor = MagicMock(return_value=0.8)
+        incorp._calculate_nitrification_soil_water_factor = MagicMock(return_value=0.75)
+        incorp._calculate_volatilization_depth_factor = MagicMock(return_value=0.46)
+        incorp._calculate_nitrification_regulator = MagicMock(return_value=0.55)
+        incorp._calculate_volatilization_regulator = MagicMock(return_value=0.08)
+        incorp._calculate_ammonium_loss_fraction = MagicMock(return_value=0.35)
+        incorp._calculate_total_ammonium_lost = MagicMock(return_value=6.5)
+        incorp._calculate_ammonium_lost_to_process = MagicMock(return_value=3.25)
 
-    incorp.do_daily_nitrification_and_volatilization()
+        incorp.do_daily_nitrification_and_volatilization()
 
-    assert incorp._calculate_nitrification_volatilization_temp_factor.call_count == 4
-    assert incorp._calculate_nitrification_soil_water_factor.call_count == 4
-    assert incorp._calculate_volatilization_depth_factor.call_count == 4
-    assert incorp._calculate_nitrification_regulator.call_count == 4
-    assert incorp._calculate_volatilization_regulator.call_count == 4
-    assert incorp._calculate_ammonium_loss_fraction.call_count == 8
-    assert incorp._calculate_total_ammonium_lost.call_count == 4
-    assert incorp._calculate_ammonium_lost_to_process.call_count == 8
-    for layer in incorp.data.soil_layers:
-        assert layer.ammonium_content == 18.5
-        assert layer.nitrate_content == 28.25
-        assert layer.annual_volatilized_ammonium_total == 3.25
+        temp_factor_calls = [call(18)] * 3
+        incorp._calculate_nitrification_volatilization_temp_factor.assert_has_calls(temp_factor_calls)
+        water_factor_calls = [call(3.67, 2.33, 5.77)] * 3
+        incorp._calculate_nitrification_soil_water_factor.assert_has_calls(water_factor_calls)
+        depth_factor_calls = [call(57.89)] * 3
+        incorp._calculate_volatilization_depth_factor.assert_has_calls(depth_factor_calls)
+        nitrification_regulator_calls = [call(0.8, 0.75)] * 3
+        incorp._calculate_nitrification_regulator.assert_has_calls(nitrification_regulator_calls)
+        volatilization_regulator_calls = [call(0.8, 0.46, 0.18)] * 3
+        incorp._calculate_volatilization_regulator.assert_has_calls(volatilization_regulator_calls)
+        ammonium_loss_frac_calls = [call(0.55), call(0.08)] * 3
+        incorp._calculate_ammonium_loss_fraction.assert_has_calls(ammonium_loss_frac_calls)
+        total_ammonium_lost_calls = [call(25, 0.55, 0.08)] * 3
+        incorp._calculate_total_ammonium_lost.assert_has_calls(total_ammonium_lost_calls)
+        ammonium_lost_calls = [call(6.5, 0.35, 0.35)] * 6
+        incorp._calculate_ammonium_lost_to_process.assert_has_calls(ammonium_lost_calls)
+
+        assert incorp.data.soil_layers[0].ammonium_content == 18.5
+        assert incorp.data.soil_layers[0].nitrate_content == 28.25
+        assert incorp.data.soil_layers[0].annual_volatilized_ammonium_total == 3.25
+
+        assert incorp.data.soil_layers[1].ammonium_content == 25
+        assert incorp.data.soil_layers[1].nitrate_content == 25
+        assert incorp.data.soil_layers[1].annual_volatilized_ammonium_total == 0
+
+        for layer in incorp.data.soil_layers[2:]:
+            assert layer.ammonium_content == 18.5
+            assert layer.nitrate_content == 28.25
+            assert layer.annual_volatilized_ammonium_total == 3.25

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/nitrogen_cycling_tests/test_nitrification_volatilization.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/nitrogen_cycling_tests/test_nitrification_volatilization.py
@@ -1,7 +1,9 @@
 import pytest
 from math import exp
+from unittest.mock import MagicMock
 
 from SC_redesign.Crop_and_Soil.soil.nitrogen_cycling.nitrification_volatilization import NitrificationVolatilization
+from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 
 
 # --- Static method tests ---
@@ -109,3 +111,36 @@ def test_calculate_ammonium_lost_to_process(ammonium_lost: float, actual: float,
     observed = NitrificationVolatilization._calculate_ammonium_lost_to_process(ammonium_lost, actual, other)
     expected = ammonium_lost * actual / (actual + other)
     assert pytest.approx(observed) == expected
+
+
+# --- Main routine test ---
+def test_do_daily_nitrification_and_volatilization() -> None:
+    """Tests that the main routine of NitrificationVolatilization correctly calculates and updates attributes."""
+    data = SoilData(field_size=1.8)
+    incorp = NitrificationVolatilization(data)
+    incorp.data.set_vectorized_layer_attribute("ammonium_content", [25, 25, 25, 25])
+    incorp.data.set_vectorized_layer_attribute("nitrate_content", [25, 25, 25, 25])
+
+    incorp._calculate_nitrification_volatilization_temp_factor = MagicMock(return_value=0.8)
+    incorp._calculate_nitrification_soil_water_factor = MagicMock(return_value=0.75)
+    incorp._calculate_volatilization_depth_factor = MagicMock(return_value=0.46)
+    incorp._calculate_nitrification_regulator = MagicMock(return_value=0.55)
+    incorp._calculate_volatilization_regulator = MagicMock(return_value=0.08)
+    incorp._calculate_ammonium_loss_fraction = MagicMock(return_value=0.35)
+    incorp._calculate_total_ammonium_lost = MagicMock(return_value=6.5)
+    incorp._calculate_ammonium_lost_to_process = MagicMock(return_value=3.25)
+
+    incorp.do_daily_nitrification_and_volatilization()
+
+    assert incorp._calculate_nitrification_volatilization_temp_factor.call_count == 4
+    assert incorp._calculate_nitrification_soil_water_factor.call_count == 4
+    assert incorp._calculate_volatilization_depth_factor.call_count == 4
+    assert incorp._calculate_nitrification_regulator.call_count == 4
+    assert incorp._calculate_volatilization_regulator.call_count == 4
+    assert incorp._calculate_ammonium_loss_fraction.call_count == 8
+    assert incorp._calculate_total_ammonium_lost.call_count == 4
+    assert incorp._calculate_ammonium_lost_to_process.call_count == 8
+    for layer in incorp.data.soil_layers:
+        assert layer.ammonium_content == 18.5
+        assert layer.nitrate_content == 28.25
+        assert layer.annual_volatilized_ammonium_total == 3.25


### PR DESCRIPTION
# Summary
This PR refactors and tests the `nitrification_volatilization.py` file, which handles the nitrification and volatilization of ammonium within the soil profile. The `NitrificationVolatilization` file closely follows the SWAT section 3:1.3, Nitrification and Ammonia Volatilization.

# Main Changes  
- `nitrification_volatilization.py`:
  - This file consists of one main method (`do_daily_nitrification_and_volatilization()`) to be called by higher-level modules, and 8 `@staticmethod`s
  - All methods in this module are tested in `test_nitrification_volatilization.py`
- `layer_data.py`:
  - Two attributes have been added to use in `NitrificationVolatilization` 
    1) `ammonium_volatilization_cation_exchange_factor` is used to determine the volatilization regulator, and has been included in `LayerData` so that it may be modified by the user. This differs from SWAT, which does not allow users to modify it from the default 0.15.
    2) `annual_volatilized_ammonium_total` tracks the total amount of ammonium volatilized from that soil layer in a given year, and is reset by the `do_annual_reset()` method.

Closes #484 