### PR TITLE
Refactor and test `leaching_runoff_erosion.py` 3/3

### DIFF
--- a/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/leaching_runoff_erosion.py
+++ b/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/leaching_runoff_erosion.py
@@ -1,6 +1,14 @@
 from typing import Optional
 from math import exp, log
+
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
+from SC_redesign.Crop_and_Soil.soil.layer_data import LayerData
+
+
+"""
+This module handles the movement and loss of nitrogen due to erosion and leaching within the soil profile, and is based
+on SWAT sections 4:2.1, 2
+"""
 
 
 class LeachingRunoffErosion:
@@ -20,26 +28,154 @@ class LeachingRunoffErosion:
         """
         self.data = soil_data or SoilData(field_size=field_size)
 
+    def leach_runoff_and_erode_nitrogen(self, field_size: float) -> None:
+        """This is the main routine for updating nitrogen leaching, runoff, and erosion within the soil profile.
+
+        Parameters
+        ----------
+        field_size : float
+            Size of the field (ha)
+
+        Notes
+        -----
+        This equation simply calls two helper methods, one executes runoff and erosion operations and the second
+        executes leaching operations.
+
+        """
+        self._erode_nitrogen(field_size)
+        self._leach_nitrogen()
+
+    def _erode_nitrogen(self, field_size: float) -> None:
+        """This method handles the erosion of nitrogen and updating the soil profile accordingly.
+
+        Parameters
+        ----------
+        field_size : float
+            Size of the field (ha)
+
+        References
+        ----------
+        pseudocode_soil [S.4.C.2] (determines what the runoff extraction coefficient will be for nitrates and ammonium)
+        TODO: find literature source for these values, issue #495
+
+        Notes
+        -----
+        This method only removes nitrogen from the top soil layer. Inorganic nitrogen is removed by runoff, while
+        organic nitrogen is removed by sediment erosion.
+
+        """
+        if self.data.accumulated_runoff > 0.0:
+            nitrates_lost_to_runoff = self._calculate_inorganic_nitrogen_loss(
+                self.data.soil_layers[0].nitrate_content, self.data.soil_layers[0].water_content,
+                self.data.soil_layers[0].saturation_content, self.data.accumulated_runoff, 0.1)
+            ammonium_lost_to_runoff = self._calculate_inorganic_nitrogen_loss(
+                self.data.soil_layers[0].ammonium_content, self.data.soil_layers[0].water_content,
+                self.data.soil_layers[0].saturation_content, self.data.accumulated_runoff, 1.0)
+
+            self.data.soil_layers[0].nitrate_content -= nitrates_lost_to_runoff
+            self.data.annual_runoff_nitrates_total += nitrates_lost_to_runoff * field_size
+
+            self.data.soil_layers[0].ammonium_content -= ammonium_lost_to_runoff
+            self.data.annual_runoff_ammonium_total += ammonium_lost_to_runoff * field_size
+
+        if self.data.eroded_sediment > 0.0:
+            fresh_organic_nitrogen_lost = self._calculate_eroded_organic_nitrogen(
+                self.data.soil_layers[0].fresh_organic_nitrogen_content, self.data.soil_layers[0].bulk_density,
+                self.data.soil_layers[0].layer_thickness, field_size, self.data.eroded_sediment)
+            stable_organic_nitrogen_lost = self._calculate_eroded_organic_nitrogen(
+                self.data.soil_layers[0].stable_organic_nitrogen_content, self.data.soil_layers[0].bulk_density,
+                self.data.soil_layers[0].layer_thickness, field_size, self.data.eroded_sediment)
+            active_organic_nitrogen_lost = self._calculate_eroded_organic_nitrogen(
+                self.data.soil_layers[0].active_organic_nitrogen_content, self.data.soil_layers[0].bulk_density,
+                self.data.soil_layers[0].layer_thickness, field_size, self.data.eroded_sediment)
+
+            self.data.soil_layers[0].fresh_organic_nitrogen_content -= fresh_organic_nitrogen_lost
+            self.data.annual_eroded_fresh_organic_nitrogen_total += fresh_organic_nitrogen_lost * field_size
+
+            self.data.soil_layers[0].stable_organic_nitrogen_content -= stable_organic_nitrogen_lost
+            self.data.annual_eroded_stable_organic_nitrogen_total += stable_organic_nitrogen_lost * field_size
+
+            self.data.soil_layers[0].active_organic_nitrogen_content -= active_organic_nitrogen_lost
+            self.data.annual_eroded_active_organic_nitrogen_total += active_organic_nitrogen_lost * field_size
+
+    def _leach_nitrogen(self) -> None:
+        """Removes leached nitrogen from each soil layer, then adds the leached nitrogen to the next layer.
+
+        References
+        ----------
+        pseudocode_soil [S.4.C.8] (determines what the leaching extraction coefficient will be for each pool/layer)
+        TODO: find literature source for these values, issue #495
+
+        Notes
+        -----
+        This method determines how much nitrogen will be leached out of each layer without being influenced at all by
+        the amount of nitrogen leaching into that layer. It achieves this by calculating the amounts leached out of each
+        layer, storing those amounts in a dictionary, appending that dictionary to a list (`percolated_nitrogen`), then
+        iterating through the soil profile a second time and adding the leached nitrogen into the appropriate layer. The
+        bottom soil layer leaches into the vadose zone.
+
+        """
+        percolated_nitrogen = []
+        for layer in self.data.soil_layers:
+            if layer.percolated_water == 0.0:
+                nitrogen_percolated_to_next_layer = {
+                    "nitrates": 0,
+                    "ammonium": 0,
+                    "active_organic": 0
+                }
+                percolated_nitrogen.append(nitrogen_percolated_to_next_layer)
+                continue
+
+            nitrate_extraction_coefficient = 1.0 if layer.top_depth == 0 else 2.5
+
+            nitrates_lost = self._calculate_nitrogen_lost_to_leaching(
+                layer.nitrate_content, layer.field_capacity_content, layer.percolated_water,
+                nitrate_extraction_coefficient, False)
+            ammonium_lost = self._calculate_nitrogen_lost_to_leaching(
+                layer.ammonium_content, layer.field_capacity_content, layer.percolated_water, 1.0, False)
+            active_organic_nitrogen_lost = self._calculate_nitrogen_lost_to_leaching(
+                layer.active_organic_nitrogen_content, layer.field_capacity_content, layer.percolated_water, 1.0, True)
+
+            layer.nitrate_content -= nitrates_lost
+            layer.ammonium_content -= ammonium_lost
+            layer.active_organic_nitrogen_content -= active_organic_nitrogen_lost
+
+            nitrogen_percolated_to_next_layer = {
+                "nitrates": nitrates_lost,
+                "ammonium": ammonium_lost,
+                "active_organic": active_organic_nitrogen_lost
+            }
+            percolated_nitrogen.append(nitrogen_percolated_to_next_layer)
+
+        layers_leached_into = self.data.soil_layers[1:] + [self.data.vadose_zone_layer]
+        for index in range(len(layers_leached_into)):
+            current_layer = layers_leached_into[index]
+            amounts_leached_into_layer = percolated_nitrogen[index]
+
+            current_layer.nitrate_content += amounts_leached_into_layer.get("nitrates")
+            current_layer.ammonium_content += amounts_leached_into_layer.get("ammonium")
+            current_layer.active_organic_nitrogen_content += amounts_leached_into_layer.get("active_organic")
+
     # --- Static methods ---
     @staticmethod
     def _determine_nitrogen_concentration(soluble_nitrogen_amount: float,
                                           soil_water_runoff_sum: float,
                                           saturation_content: float) -> float:
-        """This method determines the concentration of the inorganic pools NO3/NH4 in the top soil layer
+        """This method determines the concentration of the inorganic pools NO3/NH4 in the top soil layer.
 
         Parameters
         ----------
         soluble_nitrogen_amount: float
-            amount of soluble nitrogen (kg /mm H20)
+            Amount of soluble nitrogen (kg / ha)
         soil_water_runoff_sum: float
             Sum of runoff and soil water for layer (mm H2O)
         saturation_content: float
-            volume of water in layer when saturated (mm)
+            Volume of water in layer when saturated (mm)
 
         Returns
         -------
         float
-            the concentration of the inorganic pools NO3/NH4 in the top soil layer (kg /mm H20)
+            The concentration of the inorganic pools NO3/NH4 in the top soil layer (kg / mm H20)
 
         References
         ----------
@@ -176,6 +312,44 @@ class LeachingRunoffErosion:
         return exp(1.21 - 0.16 * log(daily_soil_lost * 1000))
 
     @staticmethod
+    def _calculate_eroded_organic_nitrogen(nitrogen_content: float, bulk_density: float, layer_thickness: float,
+                                           field_size: float, eroded_sediment: float) -> float:
+        """This method calculates how much organic nitrogen is lost from the field via eroded sediment.
+
+        Parameters
+        ----------
+        nitrogen_content : float
+            Nitrogen content of the given pool of the top soil layer (kg / ha)
+        bulk_density : float
+            The density of the top soil layer (Megagrams / cubic meter)
+        layer_thickness : float
+            The thickness of the top layer of soil (mm)
+        field_size : float
+            Size of the field (ha)
+        eroded_sediment : float
+            Amount of sediment that was eroded from the field on the current day (metric tons)
+
+        Returns
+        -------
+        float
+            Amount of nitrogen lost to erosion from the given organic pool in the top soil layer (kg / ha)
+
+        Notes
+        -----
+        Nitrogen can only be removed from the field by erosion from the top layer of soil, so this method should not be
+        used on any other layers of soil.
+
+        """
+        nitrogen_concentration = LayerData.determine_soil_nutrient_concentration(nitrogen_content, bulk_density,
+                                                                                 layer_thickness, field_size)
+        sediment_content_loss = eroded_sediment / field_size
+        enrichment_ratio = LeachingRunoffErosion._determine_enrichment_ratio(sediment_content_loss)
+        nitrogen_lost = LeachingRunoffErosion._determine_erosion_nitrogen_loss_content(nitrogen_concentration,
+                                                                                       sediment_content_loss,
+                                                                                       enrichment_ratio)
+        return min(nitrogen_content, nitrogen_lost)
+
+    @staticmethod
     def _determine_nitrogen_percolation_water_concentration(nitrogen_content: float,
                                                             field_capacity_content: float,
                                                             percolation_amount: float) -> float:
@@ -271,3 +445,46 @@ class LeachingRunoffErosion:
         """
         adjusted_concentration = nitrogen_concentration / leaching_extraction_coefficient
         return adjusted_concentration * percolation_amount
+
+    @staticmethod
+    def _calculate_nitrogen_lost_to_leaching(nitrogen_content: float, field_capacity_content: float,
+                                             percolation_amount: float, leaching_extraction_coefficient: float,
+                                             is_active_organic_nitrogen: bool) -> float:
+        """Calculates how much nitrogen is lost from the given pool on the current day.
+
+        Parameters
+        ----------
+        nitrogen_content : float
+            The content of nitrogen in the given pool in the current layer of soil (kg / ha)
+        field_capacity_content : float
+            Amount of water in this soil layer when at field capacity (mm)
+        percolation_amount : float
+            Amount of water that percolated out of the current soil layer on this day (mm)
+        leaching_extraction_coefficient : float
+            Coefficient for adjusting the amount leached based on depth (unitless)
+        is_active_organic_nitrogen
+            Status indicating whether the pool being leached from is the active organic nitrogen pool or not
+            (True / False)
+
+        Returns
+        -------
+        float
+            The amount of nitrogen that leaches out of the current pool and into the next lowest layer on the current
+            day (kg / ha)
+
+        Notes
+        -----
+        Only the concentration of active organic nitrogen gets adjusted, which necessitates the need for the parameter
+        indicating whether the pool being leached from is the active organic pool.
+
+        """
+        nitrogen_concentration = LeachingRunoffErosion._determine_nitrogen_percolation_water_concentration(
+            nitrogen_content, field_capacity_content, percolation_amount)
+
+        if is_active_organic_nitrogen:
+            nitrogen_concentration = LeachingRunoffErosion._adjust_active_organic_nitrogen_concentration(
+                nitrogen_concentration)
+
+        nitrogen_lost = LeachingRunoffErosion._determine_leached_nitrogen(nitrogen_concentration, percolation_amount,
+                                                                          leaching_extraction_coefficient)
+        return min(nitrogen_content, nitrogen_lost)

--- a/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/leaching_runoff_erosion.py
+++ b/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/leaching_runoff_erosion.py
@@ -61,7 +61,8 @@ class LeachingRunoffErosion:
         Notes
         -----
         This method only removes nitrogen from the top soil layer. Inorganic nitrogen is removed by runoff, while
-        organic nitrogen is removed by sediment erosion.
+        organic nitrogen is removed by sediment erosion. When determining the amounts of nitrates and ammonium lost to
+        runoff, 0.1 is used as the runoff extraction coefficient for nitrates and 1.0 for ammonium.
 
         """
         if self.data.accumulated_runoff > 0.0:
@@ -114,6 +115,9 @@ class LeachingRunoffErosion:
         iterating through the soil profile a second time and adding the leached nitrogen into the appropriate layer. The
         bottom soil layer leaches into the vadose zone.
 
+        The leaching extraction coefficient is 1.0 except when leaching from the nitrate pool in all non-top soil
+        layers, in which case it is 2.5.
+
         """
         percolated_nitrogen = []
         for layer in self.data.soil_layers:
@@ -156,7 +160,6 @@ class LeachingRunoffErosion:
             current_layer.ammonium_content += amounts_leached_into_layer.get("ammonium")
             current_layer.active_organic_nitrogen_content += amounts_leached_into_layer.get("active_organic")
 
-    # --- Static methods ---
     @staticmethod
     def _determine_nitrogen_concentration(soluble_nitrogen_amount: float,
                                           soil_water_runoff_sum: float,

--- a/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/leaching_runoff_erosion.py
+++ b/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/leaching_runoff_erosion.py
@@ -123,35 +123,6 @@ class LeachingRunoffErosion:
         return min(nitrogen_content, nitrogen_lost_to_runoff)
 
     @staticmethod
-    def _determine_nitrogen_erosion_concentration(nitrogen_amount: float,
-                                                  layer_thickness: float,
-                                                  bulk_density: float) -> float:
-        """This method calculates the soil nitrogen concentrations for the Fresh, Active, and Stable pools
-
-        Parameters
-        ----------
-        nitrogen_amount: float
-            amount of Fresh, Active, and Stable nitrogen (kg/ha)
-        bulk_density: float
-    `       bulk density of the soil layer (Mg per cubic meter)
-
-        Returns
-        -------
-        float
-            the soil nitrogen concentrations for the Fresh, Active, and Stable pools in soil(mg/kg)
-
-        References
-        ----------
-        SWAT Theoretical documentation eqn. 4:2.2.2
-
-        Notes
-        -----
-        This unit conversion is already implemented in LayerData, this method will be eliminated in the next PR.
-
-        """
-        return (100 * nitrogen_amount) / (bulk_density * layer_thickness)
-
-    @staticmethod
     def _determine_erosion_nitrogen_loss_content(nitrogen_erosion_concentration: float,
                                                  daily_soil_lost: float,
                                                  enrichment_ratio: float) -> float:

--- a/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/leaching_runoff_erosion.py
+++ b/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/leaching_runoff_erosion.py
@@ -54,24 +54,24 @@ class LeachingRunoffErosion:
         return soluble_nitrogen_amount * (1 - (exp(-soil_water_runoff_sum/saturation_content))/soil_water_runoff_sum)
 
     @staticmethod
-    def _determine_nitrate_runoff_amount(nitrogen_concentration: float,
-                                         runoff: float,
-                                         runoff_extraction_coef: float) -> float:
-        """This method determines the amount of nitrate runoff for the first layer
+    def _determine_nitrogen_runoff_amount(nitrogen_concentration: float,
+                                          runoff: float,
+                                          runoff_extraction_coef: float) -> float:
+        """This method determines the amount of nitrate runoff for the first layer.
 
         Parameters
         ----------
         nitrogen_concentration: float
-            the content of inorganic (nitrate or ammonium) nitrogen in the top soil layer (kg N/mm H20)
+            The content of inorganic (nitrate or ammonium) nitrogen in the top soil layer (kg N/mm H20)
         runoff_extraction_coef: float
-            coefficient of extraction for runoff (unitless)
+            Coefficient of extraction for runoff (unitless)
         runoff: float
-            daily runoff of H2O (mm)
+            Daily runoff of H2O (mm)
 
         Returns
         -------
         float:
-            the amount of nitrate runoff from the first layer (kg/ha)
+            The amount of nitrate runoff from the first layer (kg/ha)
 
         References
         ----------
@@ -84,6 +84,43 @@ class LeachingRunoffErosion:
         1.0 for ammonium runoff.
         """
         return nitrogen_concentration * runoff * runoff_extraction_coef
+
+    @staticmethod
+    def _calculate_inorganic_nitrogen_loss(nitrogen_content: float, water_content: float, saturation_content: float,
+                                           runoff: float, runoff_extraction_coefficient: float) -> float:
+        """Calculates the amount of nitrogen lost from the given pool due to runoff.
+
+        Parameters
+        ----------
+        nitrogen_content : float
+            Amount of inorganic nitrogen in the top soil layer (kg / ha)
+        water_content : float
+            Water content of the top soil layer (mm)
+        saturation_content : float
+            Amount of water in the top soil layer when saturated (mm)
+        runoff : float
+            Amount of precipitation than left the field through runoff on the current day (mm)
+        runoff_extraction_coefficient : float
+            Coefficient of extraction for runoff (unitless)
+
+        Returns
+        -------
+        float
+            The amount of inorganic nitrogen lost from the top layer of soil on the current day (kg / ha)
+
+        Notes
+        -----
+        Precipitation that runs off the field only effects the top soil layer, so this method should only ever be used
+        to calculate nitrogen lost from the top soil layer.
+
+        """
+        water_sum = water_content + runoff
+        nitrogen_concentration = LeachingRunoffErosion._determine_nitrogen_concentration(nitrogen_content, water_sum,
+                                                                                         saturation_content)
+        nitrogen_lost_to_runoff = LeachingRunoffErosion._determine_nitrogen_runoff_amount(nitrogen_concentration,
+                                                                                          runoff,
+                                                                                          runoff_extraction_coefficient)
+        return min(nitrogen_content, nitrogen_lost_to_runoff)
 
     @staticmethod
     def _determine_nitrogen_erosion_concentration(nitrogen_amount: float,

--- a/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/leaching_runoff_erosion.py
+++ b/SC_redesign/Crop_and_Soil/soil/nitrogen_cycling/leaching_runoff_erosion.py
@@ -465,9 +465,8 @@ class LeachingRunoffErosion:
             Amount of water that percolated out of the current soil layer on this day (mm)
         leaching_extraction_coefficient : float
             Coefficient for adjusting the amount leached based on depth (unitless)
-        is_active_organic_nitrogen
+        is_active_organic_nitrogen  : bool
             Status indicating whether the pool being leached from is the active organic nitrogen pool or not
-            (True / False)
 
         Returns
         -------

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/nitrogen_cycling_tests/test_leaching_runoff_erosion.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/nitrogen_cycling_tests/test_leaching_runoff_erosion.py
@@ -7,7 +7,6 @@ from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 from SC_redesign.Crop_and_Soil.soil.layer_data import LayerData
 
 
-# --- Static method tests ---
 @pytest.mark.parametrize("soluble_nitrogen_amount, soil_water_runoff_sum,saturation_content", [
     (102, 100, 99),
     (0.5, 1.8, 2.3),
@@ -167,7 +166,6 @@ def test_calculate_nitrogen_lost_to_leaching(nitrogen_content: float, field_capa
     assert observed == min(nitrogen_content, 18)
 
 
-# --- Integration tests ---
 @pytest.mark.parametrize("nitrates,ammonium,fresh,active,stable,field_size", [
     (78.1994, 66.391, 12.31, 16.594, 18.192, 1.8),
     (75.6, 70.8, 3.22, 10.33, 14.5, 2.3)

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/nitrogen_cycling_tests/test_leaching_runoff_erosion.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/nitrogen_cycling_tests/test_leaching_runoff_erosion.py
@@ -1,8 +1,10 @@
 import pytest
 from math import exp, log
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call, PropertyMock, patch
 
 from SC_redesign.Crop_and_Soil.soil.nitrogen_cycling.leaching_runoff_erosion import LeachingRunoffErosion
+from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
+from SC_redesign.Crop_and_Soil.soil.layer_data import LayerData
 
 
 # --- Static method tests ---
@@ -21,7 +23,7 @@ def test_determine_nitrogen_concentration(soluble_nitrogen_amount: float,
                                                                                saturation_content)
 
 
-@pytest.mark.parametrize("nitrogen_concentration, runoff, runoff_extraction_coef", [
+@pytest.mark.parametrize("nitrogen_concentration,runoff,runoff_extraction_coef", [
     (0, 56, 0.1),
     (51, 0, 0.2),
     (108, 110, 0.3),
@@ -73,6 +75,29 @@ def test_determine_enrichment_ratio(daily_soil_lost: float) -> None:
     assert expected == LeachingRunoffErosion._determine_enrichment_ratio(daily_soil_lost)
 
 
+@pytest.mark.parametrize("nitrogen,density,depth,area,sediment", [
+    (13.44, 1.82, 20, 2.11, 0.8),
+    (44.996, 0.98, 25, 1.234, 0.44),
+    (66.101, 1.334, 17, 0.85, 0.55),
+    (5.223, 1.4, 31, 2.5, 0.76)
+])
+def test_calculate_eroded_organic_nitrogen(nitrogen: float, density: float, depth: float, area: float,
+                                           sediment: float) -> float:
+    """Tests that the amount of organic nitrogen lost to eroded sediment is calculated correctly."""
+    LayerData.determine_soil_nutrient_concentration = MagicMock(return_value=26)
+    LeachingRunoffErosion._determine_enrichment_ratio = MagicMock(return_value=2.5)
+    LeachingRunoffErosion._determine_erosion_nitrogen_loss_content = MagicMock(return_value=33)
+
+    observed = LeachingRunoffErosion._calculate_eroded_organic_nitrogen(nitrogen, density, depth, area, sediment)
+    expected_sediment_per_ha = sediment / area
+    expected_lost_nitrogen = min(nitrogen, 33)
+
+    LayerData.determine_soil_nutrient_concentration.assert_called_once_with(nitrogen, density, depth, area)
+    LeachingRunoffErosion._determine_enrichment_ratio.assert_called_once_with(expected_sediment_per_ha)
+    LeachingRunoffErosion._determine_erosion_nitrogen_loss_content(26, expected_sediment_per_ha, 2.5)
+    assert observed == expected_lost_nitrogen
+
+
 @pytest.mark.parametrize("nitrogen,field_capacity,percolation", [
     (33.41, 6.88, 1.44),
     (21.99, 9.664, 4.556),
@@ -106,8 +131,138 @@ def test_adjust_active_organic_nitrogen_concentration(active_nitrogen_concentrat
     (66.74, 8.5576, 1.0),
     (4.556, 0.671, 2.5)
 ])
-def test_determine_leached_nitrogen(nitrogen: float, percolation: float, leaching_coefficient: float) -> float:
+def test_determine_leached_nitrogen(nitrogen: float, percolation: float, leaching_coefficient: float) -> None:
     """Tests that the amount of nitrogen calculated to percolate out of the current layer is calculated correctly."""
     observed = LeachingRunoffErosion._determine_leached_nitrogen(nitrogen, percolation, leaching_coefficient)
     expected = (nitrogen / leaching_coefficient) * percolation
     assert observed == expected
+
+
+@pytest.mark.parametrize("nitrogen_content,field_capacity,percolation,extraction_coefficient,is_active", [
+    (35, 10.33, 3.11, 1.0, False),
+    (14.5, 6.75, 1.22, 2.5, True),
+    (22.45, 8.332, 2.45, 2.5, False)
+])
+def test_calculate_nitrogen_lost_to_leaching(nitrogen_content: float, field_capacity: float, percolation: float,
+                                             extraction_coefficient: float, is_active: bool) -> None:
+    """Tests that the correct amount of nitrogen is determined to be leached out of a soil layer."""
+    LeachingRunoffErosion._determine_nitrogen_percolation_water_concentration = MagicMock(return_value=46)
+    LeachingRunoffErosion._adjust_active_organic_nitrogen_concentration = MagicMock(return_value=30)
+    LeachingRunoffErosion._determine_leached_nitrogen = MagicMock(return_value=18)
+
+    observed = LeachingRunoffErosion._calculate_nitrogen_lost_to_leaching(nitrogen_content, field_capacity, percolation,
+                                                                          extraction_coefficient, is_active)
+
+    LeachingRunoffErosion._determine_nitrogen_percolation_water_concentration.assert_called_once_with(nitrogen_content,
+                                                                                                      field_capacity,
+                                                                                                      percolation)
+    if is_active:
+        LeachingRunoffErosion._adjust_active_organic_nitrogen_concentration.assert_called_once_with(46)
+        LeachingRunoffErosion._determine_leached_nitrogen.assert_called_once_with(30, percolation,
+                                                                                  extraction_coefficient)
+    else:
+        LeachingRunoffErosion._adjust_active_organic_nitrogen_concentration.assert_not_called()
+        LeachingRunoffErosion._determine_leached_nitrogen.assert_called_once_with(46, percolation,
+                                                                                  extraction_coefficient)
+    assert observed == min(nitrogen_content, 18)
+
+
+# --- Integration tests ---
+@pytest.mark.parametrize("nitrates,ammonium,fresh,active,stable,field_size", [
+    (78.1994, 66.391, 12.31, 16.594, 18.192, 1.8),
+    (75.6, 70.8, 3.22, 10.33, 14.5, 2.3)
+])
+def test_erode_nitrogen(nitrates: float, ammonium: float, fresh: float, active: float, stable: float,
+                        field_size: float) -> None:
+    """Tests that nitrogen is properly eroded from the surface of the field."""
+    with patch("SC_redesign.Crop_and_Soil.soil.layer_data.LayerData.saturation_content", new_callable=PropertyMock,
+               return_value=8.8):
+        layer = LayerData(top_depth=0, bottom_depth=20, field_size=field_size, ammonium_content=ammonium,
+                          bulk_density=1.6)
+        layer.nitrate_content = nitrates
+        layer.active_organic_nitrogen_content = active
+        layer.stable_organic_nitrogen_content = stable
+        layer.fresh_organic_nitrogen_content = fresh
+        layer.water_content = 5.6
+        data = SoilData(field_size=field_size, soil_layers=[layer], accumulated_runoff=2.1, eroded_sediment=0.92)
+        incorp = LeachingRunoffErosion(data)
+
+        incorp._calculate_inorganic_nitrogen_loss = MagicMock(return_value=45)
+        incorp._calculate_eroded_organic_nitrogen = MagicMock(return_value=3)
+
+        inorganic_loss_calls = [call(nitrates, 5.6, 8.8, 2.1, 0.1), call(ammonium, 5.6, 8.8, 2.1, 1.0)]
+        eroded_organic_nitrogen_calls = [call(fresh, 1.6, 20, field_size, 0.92),
+                                         call(stable, 1.6, 20, field_size, 0.92),
+                                         call(active, 1.6, 20, field_size, 0.92)]
+
+        incorp._erode_nitrogen(field_size)
+
+        incorp._calculate_inorganic_nitrogen_loss.assert_has_calls(inorganic_loss_calls)
+        incorp._calculate_eroded_organic_nitrogen.assert_has_calls(eroded_organic_nitrogen_calls)
+        assert incorp.data.soil_layers[0].nitrate_content == nitrates - 45
+        assert incorp.data.annual_runoff_nitrates_total == 45 * field_size
+        assert incorp.data.soil_layers[0].ammonium_content == ammonium - 45
+        assert incorp.data.annual_runoff_ammonium_total == 45 * field_size
+        assert incorp.data.soil_layers[0].fresh_organic_nitrogen_content == fresh - 3
+        assert incorp.data.annual_eroded_fresh_organic_nitrogen_total == 3 * field_size
+        assert incorp.data.soil_layers[0].stable_organic_nitrogen_content == stable - 3
+        assert incorp.data.annual_eroded_stable_organic_nitrogen_total == 3 * field_size
+        assert incorp.data.soil_layers[0].active_organic_nitrogen_content == active - 3
+        assert incorp.data.annual_eroded_active_organic_nitrogen_total == 3 * field_size
+
+
+def test_leach_nitrogen() -> None:
+    """Tests that nitrogen is properly removed from a layer and percolated to the next during the leaching process."""
+    with patch("SC_redesign.Crop_and_Soil.soil.layer_data.LayerData.field_capacity_content", new_callable=PropertyMock,
+               return_value=6.8):
+        data = SoilData(field_size=2.0)
+        incorp = LeachingRunoffErosion(data)
+
+        incorp.data.set_vectorized_layer_attribute("nitrate_content", [40] * 4)
+        incorp.data.set_vectorized_layer_attribute("ammonium_content", [35] * 4)
+        incorp.data.set_vectorized_layer_attribute("active_organic_nitrogen_content", [15] * 4)
+        incorp.data.set_vectorized_layer_attribute("percolated_water", [3.5, 0, 3.5, 3.5])
+
+        LeachingRunoffErosion._calculate_nitrogen_lost_to_leaching = MagicMock(return_value=10)
+
+        incorp._leach_nitrogen()
+
+        top_layer_nitrogen_lost_calls = [call(40, 6.8, 3.5, 1.0, False), call(35, 6.8, 3.5, 1.0, False),
+                                         call(15, 6.8, 3.5, 1.0, True)]
+        lower_layer_nitrogen_lost_calls = [call(40, 6.8, 3.5, 2.5, False), call(35, 6.8, 3.5, 1.0, False),
+                                           call(15, 6.8, 3.5, 1.0, True)] * 2
+        all_nitrogen_lost_calls = top_layer_nitrogen_lost_calls + lower_layer_nitrogen_lost_calls
+        LeachingRunoffErosion._calculate_nitrogen_lost_to_leaching.assert_has_calls(all_nitrogen_lost_calls)
+        soil_layers = incorp.data.soil_layers + [incorp.data.vadose_zone_layer]
+        for index in range(len(soil_layers)):
+            if index == 0 or index == 2:
+                assert soil_layers[index].nitrate_content == 30
+                assert soil_layers[index].ammonium_content == 25
+                assert soil_layers[index].active_organic_nitrogen_content == 5
+            elif index == 1:
+                assert soil_layers[index].nitrate_content == 50
+                assert soil_layers[index].ammonium_content == 45
+                assert soil_layers[index].active_organic_nitrogen_content == 25
+            elif index == 3:
+                assert soil_layers[index].nitrate_content == 40
+                assert soil_layers[index].ammonium_content == 35
+                assert soil_layers[index].active_organic_nitrogen_content == 15
+            else:
+                assert soil_layers[index].nitrate_content == 10
+                assert soil_layers[index].ammonium_content == 10
+                assert soil_layers[index].active_organic_nitrogen_content == 10
+
+
+def test_leach_and_erode_nitrogen() -> None:
+    """Tests that the top level routine of this module calls the right helper methods."""
+    field_size = 2.3
+    data = SoilData(field_size=2.3)
+    incorp = LeachingRunoffErosion(data)
+
+    incorp._erode_nitrogen = MagicMock()
+    incorp._leach_nitrogen = MagicMock()
+
+    incorp.leach_runoff_and_erode_nitrogen(field_size)
+
+    incorp._erode_nitrogen.assert_called_once_with(field_size)
+    incorp._leach_nitrogen.assert_called_once()

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/nitrogen_cycling_tests/test_leaching_runoff_erosion.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/nitrogen_cycling_tests/test_leaching_runoff_erosion.py
@@ -1,8 +1,11 @@
 import pytest
 from math import exp, log
+from unittest.mock import MagicMock
+
 from SC_redesign.Crop_and_Soil.soil.nitrogen_cycling.leaching_runoff_erosion import LeachingRunoffErosion
 
 
+# --- Static method tests ---
 @pytest.mark.parametrize("soluble_nitrogen_amount, soil_water_runoff_sum,saturation_content", [
     (102, 100, 99),
     (0.5, 1.8, 2.3),
@@ -25,13 +28,38 @@ def test_determine_nitrogen_concentration(soluble_nitrogen_amount: float,
     (54.3, 92.4, 0),
     (1, 5, 0.6)
 ])
-def test_determine_nitrate_runoff_amount(nitrogen_concentration: float, runoff: float,
-                                         runoff_extraction_coef: float) -> None:
-    """Tests that the amount of nitrate runoff for the first layer was calculated correctly"""
+def test_determine_nitrogen_runoff_amount(nitrogen_concentration: float, runoff: float,
+                                          runoff_extraction_coef: float) -> None:
+    """Tests that the amount of nitrogen runoff for the first layer was calculated correctly"""
     expected = nitrogen_concentration * runoff * runoff_extraction_coef
-    assert expected == LeachingRunoffErosion._determine_nitrate_runoff_amount(nitrogen_concentration,
-                                                                              runoff,
-                                                                              runoff_extraction_coef)
+    assert expected == LeachingRunoffErosion._determine_nitrogen_runoff_amount(nitrogen_concentration,
+                                                                               runoff,
+                                                                               runoff_extraction_coef)
+
+
+@pytest.mark.parametrize("nitrogen_content,water_content,saturation_content,runoff,extraction_coefficient", [
+    (67.8, 5.66, 8.99, 3.22, 0.1),
+    (35.445, 7.81, 6.54, 2.331, 1.0),
+    (45.1948, 4.51, 9.44, 1.334, 0.1),
+    (13.495, 5.03, 6.7, 1.4, 1.0)
+])
+def test_calculate_inorganic_nitrogen_loss(nitrogen_content: float, water_content: float, saturation_content: float,
+                                           runoff: float, extraction_coefficient: float) -> None:
+    """Tests that the correct amount of inorganic nitrogen is lost to runoff."""
+    LeachingRunoffErosion._determine_nitrogen_concentration = MagicMock(return_value=30)
+    LeachingRunoffErosion._determine_nitrogen_runoff_amount = MagicMock(return_value=25)
+
+    observed = LeachingRunoffErosion._calculate_inorganic_nitrogen_loss(nitrogen_content, water_content,
+                                                                        saturation_content, runoff,
+                                                                        extraction_coefficient)
+    expected_water_sum = water_content + runoff
+    expected_nitrogen_lost = min(nitrogen_content, 25)
+
+    LeachingRunoffErosion._determine_nitrogen_concentration.assert_called_once_with(nitrogen_content,
+                                                                                    expected_water_sum,
+                                                                                    saturation_content)
+    LeachingRunoffErosion._determine_nitrogen_runoff_amount.assert_called_once_with(30, runoff, extraction_coefficient)
+    assert observed == expected_nitrogen_lost
 
 
 @pytest.mark.parametrize("nitrogen_amount, layer_thickness,bulk_density", [

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/nitrogen_cycling_tests/test_leaching_runoff_erosion.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/nitrogen_cycling_tests/test_leaching_runoff_erosion.py
@@ -62,22 +62,6 @@ def test_calculate_inorganic_nitrogen_loss(nitrogen_content: float, water_conten
     assert observed == expected_nitrogen_lost
 
 
-@pytest.mark.parametrize("nitrogen_amount, layer_thickness,bulk_density", [
-    (102, 100, 99),
-    (0.5, 1.8, 2.3),
-    (2, 3, 4),
-    (0, 3, 4)
-])
-def test_determine_nitrogen_erosion_concentration(nitrogen_amount: float,
-                                                  layer_thickness: float,
-                                                  bulk_density: float) -> None:
-    """Tests that the soil nitrogen concentrations for the Fresh, Active, and Stable pools are calculated correctly"""
-    expected = (100 * nitrogen_amount) / (bulk_density * layer_thickness)
-    assert expected == LeachingRunoffErosion._determine_nitrogen_erosion_concentration(nitrogen_amount,
-                                                                                       layer_thickness,
-                                                                                       bulk_density)
-
-
 @pytest.mark.parametrize("daily_soil_lost", [
     5,  # lower values
     100,  # higher values


### PR DESCRIPTION
# Summary
Finishes the refactor of `leaching_runoff_erosion.py` and closes #504 

This PR is stacked on #487 

# Main Changes
- `leaching_runoff_erosion.py`
  - Now includes a top level method that calls the two helper methods that execute surface loss and leaching of nitrogen respectively.
  - Please pay special attention to `_leach_nitrogen()` and its test. This method is particularly complex because it requires doing calculations over the entire soil profile, saving the results, then applying those results over the entire soil profile.
  - Several `@staticmethod`s have been added as wrappers that calculate how much nitrogen is lost to a particular process, making it more convenient to execute the same process on different nitrogen pools.