### PR TITLE
Updates to OM variable name tracker

### DIFF
--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -351,16 +351,19 @@ class OutputManager(object):
         Collects names of all variables added to variables_pool along with the caller class and function contextual
         information to eventually be saved into a txt file in the given path to a directory.
         """
-        # vars_pool = self.variables_pool.copy()
-        # for key, value in vars_pool.items():
-        #     if isinstance(value, dict) and "info_maps" in value:
-        #         value.pop("info_maps")
+
         file_path = os.path.join(path, self._generate_file_name("variable_names", "txt"))
         var_set = set()
-        for key, value in self.variables_pool.items():
-            var_set.add(key)
-            var_set.update(f"{key}: {variable_name}" for values_list in value.values() for variable_dict in values_list
-                           if isinstance(variable_dict, dict) for variable_name in variable_dict.keys())
+        for class_and_function, variables_data in self.variables_pool.items():
+            for variable_data_value in variables_data.values():
+                for variable_data_item in variable_data_value:
+                    if isinstance(variable_data_item, dict):
+                        for variable_data_item_key, variable_data_item_value in variable_data_item.items():
+                            if isinstance(variable_data_item_value, dict):
+                                for variable_data_item_value_key in variable_data_item_value.keys():
+                                    var_set.add(f"{class_and_function}: {variable_data_item_value_key}")
+                            else:
+                                var_set.add(f"{class_and_function}: {variable_data_item_key}")
         var_list = sorted(var_set)  # sorted(set) sorts and then converts set into a list
 
         self._list_to_file_txt(var_list, file_path, exclude_info_maps=exclude_info_maps)

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -272,7 +272,7 @@ class OutputManager(object):
         except Exception as e:
             raise e
 
-    def _list_to_file_txt(self, data_list: List[str], path: str, exclude_info_maps: bool = False) -> None:
+    def _list_to_file_txt(self, data_list: List[str], path: str) -> None:
         """Saves a list into a text file
 
         Parameters
@@ -290,18 +290,7 @@ class OutputManager(object):
         """
         try:
             with open(path, "w") as var_names_file:
-                if exclude_info_maps:
-                    info_maps_absent_notice = "This simulation ran excluding info maps from the variables pool so no"\
-                     " data from info maps are included.\nIf you would like to see that data, run the simulation with"\
-                     " info maps included."
-                    var_names_file.write(info_maps_absent_notice + "\n\n")
-                else:
-                    info_maps_present_notice = "This simulation ran including info maps in the variables pool so"\
-                     " data from info maps are included.\nIf you would not like to see that data, run the simulation"\
-                     " with info maps excluded."
-                    var_names_file.write(info_maps_present_notice + "\n\n")
-                for variable_name in data_list:
-                    var_names_file.write(variable_name + "\n")
+                var_names_file.writelines(data_list)
         except Exception as e:
             raise e
 
@@ -346,34 +335,54 @@ class OutputManager(object):
         file_path = os.path.join(path, self._generate_file_name("errors", "json"))
         self._dict_to_file_json(self.errors_pool, file_path)
 
-    def collect_variable_names_and_contexts(self, path: str, exclude_info_maps: bool = False) -> None:
+    def save_variable_names_and_contexts(
+        self, path: str, exclude_info_maps: bool, format_option: str = "block"
+    ) -> None:
         """
-        Collects names of all variables added to variables_pool along with the caller class and function contextual
-        information to eventually be saved into a txt file in the given path to a directory.
+        saves names of all variables added to variables_pool along with the caller class
+        and function contextual information into a txt file in the given path to a directory.
+        TODO: expand the docstring and explain format_options: "block", "inline", and "verbose"
         """
 
-        file_path = os.path.join(path, self._generate_file_name("variable_names", "txt"))
-        var_set = set()
-        for class_and_function, variables_data in self.variables_pool.items():
-            for variable_data_value in variables_data.values():
-                for variable_data_item in variable_data_value:
-                    if isinstance(variable_data_item, dict):
-                        for variable_data_item_key, variable_data_item_value in variable_data_item.items():
-                            if isinstance(variable_data_item_value, dict):
-                                for variable_data_item_value_key in variable_data_item_value.keys():
-                                    var_set.add(f"{class_and_function}: {variable_data_item_value_key}")
-                            else:
-                                var_set.add(f"{class_and_function}: {variable_data_item_key}")
-        var_list = sorted(var_set)  # sorted(set) sorts and then converts set into a list
+        var_list = [f"_{exclude_info_maps=}, expect info_maps accordingly.\n"]
+        for name, variable_data in self.variables_pool.items():
+            if not variable_data["values"]:
+                var_list.append(f"{name}: **NO VARIABLES**\n")
+                continue
 
-        self._list_to_file_txt(var_list, file_path, exclude_info_maps=exclude_info_maps)
+            is_varible_nested = isinstance(variable_data["values"][0], Dict)
+            if is_varible_nested:
+                parsable_dicts = ["values", "info_maps"]
+            else:
+                var_list.append(f"{name}\n")
+                parsable_dicts = ["info_maps"]
+
+            if format_option == "block":
+                var_list.append(f"{name}\n")
+
+            prefix = name
+            if format_option == "block":
+                prefix = " " * len(name)
+
+            for parsable_dict in parsable_dicts:
+                keys = variable_data[parsable_dict][0].keys()
+                if format_option == "inline":
+                    var_list.append(f"{name}.{parsable_dict}: {list(keys)}\n")
+                else:
+                    for key in keys:
+                        var_list.append(f"{prefix}.{parsable_dict}: {key}\n")
+
+        file_path = os.path.join(
+            path, self._generate_file_name("variable_names", "txt")
+        )
+        self._list_to_file_txt(var_list, file_path)
 
     def save_all_pools(self, path: str, exclude_info_maps: bool = False) -> None:
         """
         Saves all pool into the given path to a directory.
         """
-        self.save_variables(path, exclude_info_maps=exclude_info_maps)
-        self.collect_variable_names_and_contexts(path, exclude_info_maps=exclude_info_maps)
+        self.save_variables(path, exclude_info_maps)
+        self.save_variable_names_and_contexts(path, exclude_info_maps)
         self.save_errors(path)
         self.save_logs(path)
         self.save_warnings(path)

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -336,12 +336,39 @@ class OutputManager(object):
         self._dict_to_file_json(self.errors_pool, file_path)
 
     def save_variable_names_and_contexts(
-        self, path: str, exclude_info_maps: bool, format_option: str = "block"
+        self, path: str, exclude_info_maps: bool, format_option: str = "verbose"
     ) -> None:
         """
-        saves names of all variables added to variables_pool along with the caller class
+        Saves names of all variables added to variables_pool along with the caller class
         and function contextual information into a txt file in the given path to a directory.
-        TODO: expand the docstring and explain format_options: "block", "inline", and "verbose"
+
+        Parameters
+        ----------
+        path : str
+            The path to the file to be saved
+        exclude_info_maps : bool
+            Flag to denote whether info_map data should be saved with variable names
+        format_options : {"block", "inline", "verbose"}
+            The selection for the formatting option of the text written to the variables names text file
+
+        Examples
+        --------
+        format_option: str = "block"
+        class_name.function_name.variable_name
+                                              .values: variable1_name
+                                              .values: variable2_name
+                                              .info_maps: variable3_name
+                                              .info_maps: variable4_name
+
+        format_option: str = "inline"
+        class_name.function_name.variable_name.values: [variable1_name, variable2_name]
+        class_name.function_name.variable_name.info_maps: [variable3_name, variable4_name]
+
+        format_option: str = "verbose"
+        class_name.function_name.variable_name.values: variable1_name
+        class_name.function_name.variable_name.values: variable2_name
+        class_name.function_name.variable_name.info_maps: variable3_name
+        class_name.function_name.variable_name.info_maps: variable4_name
         """
 
         var_list = [f"_{exclude_info_maps=}, expect info_maps accordingly.\n"]

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -350,8 +350,8 @@ class OutputManager(object):
                 var_list.append(f"{name}: **NO VARIABLES**\n")
                 continue
 
-            is_varible_nested = isinstance(variable_data["values"][0], Dict)
-            if is_varible_nested:
+            is_variable_nested = isinstance(variable_data["values"][0], Dict)
+            if is_variable_nested:
                 parsable_dicts = ["values", "info_maps"]
             else:
                 var_list.append(f"{name}\n")

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -272,7 +272,7 @@ class OutputManager(object):
         except Exception as e:
             raise e
 
-    def _list_to_file_txt(self, data_list: List[str], path: str) -> None:
+    def _list_to_file_txt(self, data_list: List[str], path: str, exclude_info_maps: bool = False) -> None:
         """Saves a list into a text file
 
         Parameters
@@ -286,12 +286,22 @@ class OutputManager(object):
         ------
         Exception
             If an error occurs while saving the file
-        
+
         """
         try:
-            with open(path, 'w') as var_names_file:
+            with open(path, "w") as var_names_file:
+                if exclude_info_maps:
+                    info_maps_absent_notice = "This simulation ran excluding info maps from the variables pool so no"\
+                     " data from info maps are included.\nIf you would like to see that data, run the simulation with"\
+                     " info maps included."
+                    var_names_file.write(info_maps_absent_notice + "\n\n")
+                else:
+                    info_maps_present_notice = "This simulation ran including info maps in the variables pool so"\
+                     " data from info maps are included.\nIf you would not like to see that data, run the simulation"\
+                     " with info maps excluded."
+                    var_names_file.write(info_maps_present_notice + "\n\n")
                 for variable_name in data_list:
-                    var_names_file.write(variable_name + '\n')
+                    var_names_file.write(variable_name + "\n")
         except Exception as e:
             raise e
 
@@ -336,30 +346,31 @@ class OutputManager(object):
         file_path = os.path.join(path, self._generate_file_name("errors", "json"))
         self._dict_to_file_json(self.errors_pool, file_path)
 
-    def save_variable_names(self, path: str) -> None:
+    def collect_variable_names_and_contexts(self, path: str, exclude_info_maps: bool = False) -> None:
         """
-        Saves names of all variables added to variables_pool into a json file in the given path to a directory.
+        Collects names of all variables added to variables_pool along with the caller class and function contextual
+        information to eventually be saved into a txt file in the given path to a directory.
         """
-        vars_pool = self.variables_pool.copy()
-        for key, value in vars_pool.items():
-            if isinstance(value, dict) and "info_maps" in value:
-                value.pop("info_maps")
+        # vars_pool = self.variables_pool.copy()
+        # for key, value in vars_pool.items():
+        #     if isinstance(value, dict) and "info_maps" in value:
+        #         value.pop("info_maps")
         file_path = os.path.join(path, self._generate_file_name("variable_names", "txt"))
         var_set = set()
-        for key, value in vars_pool.items():
+        for key, value in self.variables_pool.items():
             var_set.add(key)
             var_set.update(f"{key}: {variable_name}" for values_list in value.values() for variable_dict in values_list
                            if isinstance(variable_dict, dict) for variable_name in variable_dict.keys())
         var_list = sorted(var_set)  # sorted(set) sorts and then converts set into a list
 
-        self._list_to_file_txt(var_list, file_path)
+        self._list_to_file_txt(var_list, file_path, exclude_info_maps=exclude_info_maps)
 
     def save_all_pools(self, path: str, exclude_info_maps: bool = False) -> None:
         """
         Saves all pool into the given path to a directory.
         """
         self.save_variables(path, exclude_info_maps=exclude_info_maps)
-        self.save_variable_names(path)
+        self.collect_variable_names_and_contexts(path, exclude_info_maps=exclude_info_maps)
         self.save_errors(path)
         self.save_logs(path)
         self.save_warnings(path)

--- a/input/animal_management.json
+++ b/input/animal_management.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "start_date": "2009:244",
-    "end_date": "2010:264",
+    "end_date": "2009:264",
     "csv_dir": "output/CSVs/",
     "graphic_dir": "output/graphics/",
     "run_tests": true,

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -537,7 +537,7 @@ def output_manager_original_method_states(
         "save_logs": mock_output_manager.save_logs,
         "save_warnings": mock_output_manager.save_warnings,
         "save_errors": mock_output_manager.save_errors,
-        "save_variable_names": mock_output_manager.save_variable_names,
+        "collect_variable_names_and_contexts": mock_output_manager.collect_variable_names_and_contexts,
     }
 
 
@@ -551,7 +551,7 @@ def test_save_all_pools(
     mock_output_manager.save_warnings = MagicMock()
     mock_output_manager.save_logs = MagicMock()
     mock_output_manager.save_variables = MagicMock()
-    mock_output_manager.save_variable_names = MagicMock()
+    mock_output_manager.collect_variable_names_and_contexts = MagicMock()
 
     mock_output_manager.save_all_pools(path, exclude_info_maps=False)
 
@@ -561,7 +561,7 @@ def test_save_all_pools(
     mock_output_manager.save_variables.assert_called_once_with(
         path, exclude_info_maps=False
     )
-    mock_output_manager.save_variable_names.assert_called_once_with(path)
+    mock_output_manager.collect_variable_names_and_contexts.assert_called_once_with(path, exclude_info_maps=False)
 
     mock_output_manager.save_all_pools(path, exclude_info_maps=True)
     mock_output_manager.save_variables.assert_called_with(path, exclude_info_maps=True)
@@ -580,8 +580,8 @@ def test_save_all_pools(
     mock_output_manager.save_errors = output_manager_original_method_states[
         "save_errors"
     ]
-    mock_output_manager.save_variable_names = output_manager_original_method_states[
-        "save_variable_names"
+    mock_output_manager.collect_variable_names_and_contexts = output_manager_original_method_states[
+        "collect_variable_names_and_contexts"
     ]
 
 
@@ -694,20 +694,20 @@ def test_save_errors(
     ]
 
 
-def test_save_variable_names(
+def test_collect_variable_names_and_contexts(
     mock_output_manager: OutputManager,
     output_manager_original_method_states: Dict[str, Callable],
 ) -> None:
-    """Test case for function save_variable_names in output_manager.py"""
+    """Test case for function collect_variable_names_and_contexts in output_manager.py"""
     dummy_list = []
     mock_output_manager._generate_file_name = MagicMock(return_value="dummy_name")
     mock_output_manager._list_to_file_txt = MagicMock()
 
-    mock_output_manager.save_variable_names("dummy_path")
+    mock_output_manager.collect_variable_names_and_contexts("dummy_path", exclude_info_maps=False)
 
     mock_output_manager._generate_file_name.assert_called_once_with("variable_names", "txt")
     mock_output_manager._list_to_file_txt.assert_called_once_with(
-        dummy_list, os.path.join("dummy_path", "dummy_name")
+        dummy_list, os.path.join("dummy_path", "dummy_name",), exclude_info_maps=False
     )
 
     # Restore original methods
@@ -730,8 +730,9 @@ def test_list_to_file_txt(
 
     mock_output_manager._list_to_file_txt(dummy_list, dummy_file_path)
     with open(dummy_file_path) as read_dummy_file:
-        dummy_file_content = read_dummy_file.read().strip().split('\n')
-    assert dummy_file_content == dummy_list
+        dummy_file_content = read_dummy_file.read().strip()
+    assert "This simulation ran including info maps" in dummy_file_content
+    assert "apple\nbanana\ncherry" in dummy_file_content
 
     with pytest.raises(TypeError) as e:
         mock_output_manager._list_to_file_txt(1234, dummy_file_path)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -537,7 +537,7 @@ def output_manager_original_method_states(
         "save_logs": mock_output_manager.save_logs,
         "save_warnings": mock_output_manager.save_warnings,
         "save_errors": mock_output_manager.save_errors,
-        "collect_variable_names_and_contexts": mock_output_manager.collect_variable_names_and_contexts,
+        "save_variable_names_and_contexts": mock_output_manager.save_variable_names_and_contexts,
     }
 
 
@@ -551,7 +551,7 @@ def test_save_all_pools(
     mock_output_manager.save_warnings = MagicMock()
     mock_output_manager.save_logs = MagicMock()
     mock_output_manager.save_variables = MagicMock()
-    mock_output_manager.collect_variable_names_and_contexts = MagicMock()
+    mock_output_manager.save_variable_names_and_contexts = MagicMock()
 
     mock_output_manager.save_all_pools(path, exclude_info_maps=False)
 
@@ -559,12 +559,12 @@ def test_save_all_pools(
     mock_output_manager.save_warnings.assert_called_once_with(path)
     mock_output_manager.save_logs.assert_called_once_with(path)
     mock_output_manager.save_variables.assert_called_once_with(
-        path, exclude_info_maps=False
+        path, False
     )
-    mock_output_manager.collect_variable_names_and_contexts.assert_called_once_with(path, exclude_info_maps=False)
+    mock_output_manager.save_variable_names_and_contexts.assert_called_once_with(path, False)
 
     mock_output_manager.save_all_pools(path, exclude_info_maps=True)
-    mock_output_manager.save_variables.assert_called_with(path, exclude_info_maps=True)
+    mock_output_manager.save_variables.assert_called_with(path, True)
     assert mock_output_manager.save_logs.call_count == 2
     assert mock_output_manager.save_warnings.call_count == 2
     assert mock_output_manager.save_errors.call_count == 2
@@ -580,8 +580,8 @@ def test_save_all_pools(
     mock_output_manager.save_errors = output_manager_original_method_states[
         "save_errors"
     ]
-    mock_output_manager.collect_variable_names_and_contexts = output_manager_original_method_states[
-        "collect_variable_names_and_contexts"
+    mock_output_manager.save_variable_names_and_contexts = output_manager_original_method_states[
+        "save_variable_names_and_contexts"
     ]
 
 
@@ -694,20 +694,20 @@ def test_save_errors(
     ]
 
 
-def test_collect_variable_names_and_contexts(
+def test_save_variable_names_and_contexts(
     mock_output_manager: OutputManager,
     output_manager_original_method_states: Dict[str, Callable],
 ) -> None:
-    """Test case for function collect_variable_names_and_contexts in output_manager.py"""
-    dummy_list = []
+    """Test case for function save_variable_names_and_contexts in output_manager.py"""
+    dummy_list = ['_exclude_info_maps=False, expect info_maps accordingly.\n']
     mock_output_manager._generate_file_name = MagicMock(return_value="dummy_name")
     mock_output_manager._list_to_file_txt = MagicMock()
 
-    mock_output_manager.collect_variable_names_and_contexts("dummy_path", exclude_info_maps=False)
+    mock_output_manager.save_variable_names_and_contexts("dummy_path", False)
 
     mock_output_manager._generate_file_name.assert_called_once_with("variable_names", "txt")
     mock_output_manager._list_to_file_txt.assert_called_once_with(
-        dummy_list, os.path.join("dummy_path", "dummy_name",), exclude_info_maps=False
+        dummy_list, os.path.join("dummy_path", "dummy_name")
     )
 
     # Restore original methods
@@ -730,9 +730,8 @@ def test_list_to_file_txt(
 
     mock_output_manager._list_to_file_txt(dummy_list, dummy_file_path)
     with open(dummy_file_path) as read_dummy_file:
-        dummy_file_content = read_dummy_file.read().strip()
-    assert "This simulation ran including info maps" in dummy_file_content
-    assert "apple\nbanana\ncherry" in dummy_file_content
+        dummy_file_content = read_dummy_file.read()
+    assert "applebananacherry" in dummy_file_content
 
     with pytest.raises(TypeError) as e:
         mock_output_manager._list_to_file_txt(1234, dummy_file_path)


### PR DESCRIPTION
This PR makes some updates to improve and expand performance of the OM variable-tracking method:

1. Renamed method to `collect_variable_names_and_contexts` to better describe what it does.
2. Adjusted docstrings of method to also better describe it's function.
3. Removed unneeded copying of variables pool within method.
4. Passed this method the exclude_info_maps flag to then send to its partner method, `_list_to_file_text` which allows that method to write an appropriate header message in the saved file regarding whether or not the list of variables includes info_map variable names.
5. Renamed variables within nested looping structure that pulls out variable names from variables pool to hopefully better show its logic.
6. Reworked testing to reflect these changes both for the `collect_variable_names_and_contexts` and `_list_to_file_text` methods.

The resulting variable names list with the info_maps included is nearly twice as long as the previous version of this method which did not collect info_map variable data.