### PR TITLE
`Field`-level method to execute daily process components.

### DIFF
--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -350,7 +350,7 @@ class Field:
         it will allow subject-matter experts to more easily experiment with different orders.
 
         """
-        # TODO - issue #317
+        # TODO: implement snow addition, melting, and sublimation - issue #317
         snow_cover = 0
         total_plant_cover = self.field_data.current_residue + self._determine_total_above_ground_biomass()
         self.soil.soil_temp.daily_soil_temperature_update(current_weather.incoming_light,

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -363,7 +363,7 @@ class Field:
         self._cycle_water(current_weather)
 
         for crop in self.crops:
-            if crop.data.in_growing_season:
+            if not crop.data.in_growing_season:
                 continue
 
             crop.heat_units.absorb_heat_units(current_weather.mean_air_temperature, current_weather.min_air_temperature,

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -60,22 +60,9 @@ class Field:
         if self.field_data.is_tillage_day:
             self.till_soil()
 
-        # daily soil routine
-
-        # determine total amount of residue and above-ground biomass present on the given day
-        total_plant_cover = self.field_data.current_residue + self._determine_total_above_ground_biomass()
-
-        # TODO: track snow cover on soil surface somewhere - Issue #317
-        self.soil.daily_soil_routine(current_weather.incoming_light, current_weather.mean_air_temperature,
-                                     current_weather.min_air_temperature, current_weather.max_air_temperature,
-                                     total_plant_cover, current_weather.snow_fall,
-                                     current_weather.annual_mean_air_temperature)
-
-        # TODO: track snow cover on soil surface somewhere - Issue #317
-
         # --- Whole-Field Methods ---
         # Allow non-management field processes (water/nutrient cycling) to occur
-        self.cycle_water(current_weather)
+        self._execute_daily_processes(current_weather)
         # ... Other ...
 
         # --- Crop Management ---
@@ -349,7 +336,46 @@ class Field:
     # </editor-fold>
 
     # <editor-fold desc="--- Field-level Methods ---">
-    def cycle_water(self, current_weather: CurrentWeather):
+    def _execute_daily_processes(self, current_weather: CurrentWeather) -> None:
+        """Executes all daily updates on this field's soil and crop objects.
+
+        Parameters
+        ----------
+        current_weather : CurrentWeather
+            Object containing the environment conditions on this day.
+
+        Notes
+        -----
+        This method is designed to be called daily to do updates on the crops and soil profile in the field.
+
+        """
+        # TODO - issue #317
+        snow_cover = 0
+        total_plant_cover = self.field_data.current_residue + self._determine_total_above_ground_biomass()
+        self.soil.soil_temp.daily_soil_temperature_update(current_weather.incoming_light,
+                                                          current_weather.mean_air_temperature,
+                                                          current_weather.min_air_temperature,
+                                                          current_weather.max_air_temperature,
+                                                          total_plant_cover,
+                                                          snow_cover,
+                                                          current_weather.annual_mean_air_temperature)
+
+        self._cycle_water(current_weather)
+
+        for crop in self.crops:
+            if crop.data.in_growing_season:
+                continue
+
+            crop.heat_units.absorb_heat_units(current_weather.mean_air_temperature, current_weather.min_air_temperature,
+                                              current_weather.max_air_temperature)
+            crop.root_development.develop_roots()
+            crop.nitrogen_incorporation.incorporate_nitrogen(self.soil.data)
+            crop.phosphorus_incorporation.incorporate_phosphorus(self.soil.data)
+            crop.growth_constraints.constrain_growth(crop.data.max_transpiration, current_weather.mean_air_temperature)
+            crop.leaf_area_index.grow_canopy()
+            crop.biomass_allocation.allocate_biomass(current_weather.incoming_light)
+
+    def _cycle_water(self, current_weather: CurrentWeather):
         """allow the water to cycle through the field.
 
         Args:

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -346,7 +346,8 @@ class Field:
 
         Notes
         -----
-        This method is designed to be called daily to do updates on the crops and soil profile in the field.
+        This method is designed to make it easier to change the order of process execution, which is desirable because
+        it will allow subject-matter experts to more easily experiment with different orders.
 
         """
         # TODO - issue #317

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -176,6 +176,67 @@ def test_amend_soil() -> None:
     field.soil.phosphorus_cycling.fertilizer.add_fertilizer_phosphorus.assert_called_once_with(0)
 
 
+@pytest.mark.parametrize("field_size,crops_growing,residue,light,mean_temp,min_temp,max_temp,annual_mean_temp,"
+                         "transpiration", [
+                             (1.5, False, 34.5, 128, 22.5, 18.9, 25.6, 19.22, 5.2),
+                             (2.4, True, 40.9, 150, 28, 24.55, 31.2, 17.9, 3.44),
+                             (0.8, True, 12.22, 222, 18.7, 13.44, 23.44, 16.4, 1.33)
+                         ])
+def test_execute_daily_processes(field_size: float, crops_growing: bool, residue: float, light: float, mean_temp: float,
+                                 min_temp: float, max_temp: float, annual_mean_temp: float,
+                                 transpiration: float) -> None:
+    """Tests that all component processes and subroutines are correctly called in Field."""
+    with patch("SC_redesign.Crop_and_Soil.crop.crop_data.CropData.in_growing_season", new_callable=PropertyMock,
+               return_value=crops_growing):
+        field_data = FieldData(field_size=field_size, current_residue=residue)
+        incorp = Field(field_data=field_data)
+        crop_1 = Crop()
+        crop_1.data.max_transpiration = transpiration
+        crop_2 = Crop()
+        crop_2.data.max_transpiration = transpiration
+        incorp.crops = [crop_1, crop_2]
+        current_weather = CurrentWeather(incoming_light=light, mean_air_temperature=mean_temp,
+                                         min_air_temperature=min_temp, max_air_temperature=max_temp,
+                                         annual_mean_air_temperature=annual_mean_temp)
+
+        incorp._determine_total_above_ground_biomass = MagicMock(return_value=89)
+        incorp.soil.soil_temp.daily_soil_temperature_update = MagicMock()
+        incorp._cycle_water = MagicMock()
+        for crop in incorp.crops:
+            crop.heat_units.absorb_heat_units = MagicMock()
+            crop.root_development = MagicMock()
+            crop.nitrogen_incorporation.incorporate_nitrogen = MagicMock()
+            crop.phosphorus_incorporation.incorporate_phosphorus = MagicMock()
+            crop.growth_constraints.constrain_growth = MagicMock()
+            crop.leaf_area_index.grow_canopy = MagicMock()
+            crop.biomass_allocation.allocate_biomass = MagicMock()
+
+        incorp._execute_daily_processes(current_weather)
+
+        incorp._determine_total_above_ground_biomass.assert_called_once()
+        incorp.soil.soil_temp.daily_soil_temperature_update.assert_called_once_with(light, mean_temp, min_temp,
+                                                                                    max_temp, 89 + residue, 0,
+                                                                                    annual_mean_temp)
+        incorp._cycle_water.assert_called_once_with(current_weather)
+        for crop in incorp.crops:
+            if crops_growing:
+                crop.heat_units.absorb_heat_units.assert_called_once_with(mean_temp, min_temp, max_temp)
+                crop.root_development.develop_roots.assert_called_once()
+                crop.nitrogen_incorporation.incorporate_nitrogen.assert_called_once_with(incorp.soil.data)
+                crop.phosphorus_incorporation.incorporate_phosphorus.assert_called_once_with(incorp.soil.data)
+                crop.growth_constraints.constrain_growth.assert_called_once_with(transpiration, mean_temp)
+                crop.leaf_area_index.grow_canopy.assert_called_once()
+                crop.biomass_allocation.allocate_biomass.assert_called_once_with(light)
+            else:
+                crop.heat_units.absorb_heat_units.assert_not_called()
+                crop.root_development.develop_roots.assert_not_called()
+                crop.nitrogen_incorporation.incorporate_nitrogen.assert_not_called()
+                crop.phosphorus_incorporation.incorporate_phosphorus.assert_not_called()
+                crop.growth_constraints.constrain_growth.assert_not_called()
+                crop.leaf_area_index.grow_canopy.assert_not_called()
+                crop.biomass_allocation.allocate_biomass.assert_not_called()
+
+
 @pytest.mark.parametrize("field_size,rainfall,runoff,high_water_table,residue,light,min_temp,max_temp,mean_temp,"
                          "surface_residue,crop_1_proportion,crop_2_proportion,crops_growing", [
                              (1.9, 4.66, 1.22, False, 30.6, 200, 16.5, 20.5, 18.5, 44.5, 0.6, 0.4, True),

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -226,7 +226,7 @@ def test_cycle_water(field_size: float, rainfall: float, runoff: float, high_wat
         crop_2.water_dynamics.cycle_water = MagicMock()
         crop_2.water_uptake.uptake_water = MagicMock()
 
-        incorp.cycle_water(current_weather)
+        incorp._cycle_water(current_weather)
 
         incorp._determine_watering_amount.assert_called_once_with(rainfall)
         incorp._handle_water_in_crop_canopies.assert_called_once_with(rainfall)

--- a/SC_redesign/docs_SC/Admin/finish_line_doc.md
+++ b/SC_redesign/docs_SC/Admin/finish_line_doc.md
@@ -47,7 +47,7 @@ so there is a need to make sure all these processes are coordinated between Crop
 - [x] Create a method that can be run on a daily basis which handles all water operations at the field level.
 
 #### Growth/Non-water Component Processes
-- [ ] Create a method that can be run on a daily basis that will run all daily crop growth and soil update operations.
+- [x] Create a method that can be run on a daily basis that will run all daily crop growth and soil update operations.
 
 #### Tillage
 - [ ] Refactor the old `tillage.py`.


### PR DESCRIPTION
# Summary
Adds a method that handles calling all daily update routines for crops and soil in the field.

# Changes
- `_execute_daily_processes()` added. This is the method that actually calls all the growth and non-water related update routines. It is tested in `test_field.py`.
- `cycle_water()` has been changed to `_cycle_water()`, because it should only be called internally by `Field`.
- `_execute_daily_processes()` is now called by `manage_field()` which is the main public-facing method that will be called daily during the simulation. Note `manage_field()` is not tested because it is not finished, and some important features like scheduling mechanism have not been implemented yet.