### PR TITLE
updated OM save_xyz func names to dump_xyz across model

### DIFF
--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -237,26 +237,26 @@ class OutputManager(object):
         return f"{caller_class}.{caller_function}"
 
     def _dict_to_file_json(self, data_dict: Dict[str, Any], path: str) -> None:
-        """Dumps a dictionary into a JSON file
+        """Saves a dictionary into a JSON file
 
         Parameters
         ----------
         data_dict : Dict[str, Any]
-            The dictionary to be dumped
+            The dictionary to be saved
         path : str
-            The path to the file to be dumped to
+            The path to the file to be saved
 
         Raises
         ------
         Exception
-            If an error occurs while dumping to the file
+            If an error occurs while saving to the file
 
         Notes
         -----
         The dictionary is first converted to a serializable format using
         `Utility.make_serializable()`.
 
-        The file is dumped into with no indentation.
+        The file is saved with no indentation.
 
         If you want to save time and space, limit the maximum depth of the
         serialized dictionary using the max_depth parameter.
@@ -273,19 +273,19 @@ class OutputManager(object):
             raise e
 
     def _list_to_file_txt(self, data_list: List[str], path: str) -> None:
-        """Dumps a list into a text file
+        """Saves a list into a text file
 
         Parameters
         ----------
         data_list : List[str]
-            The list of variable names to be dumped
+            The list of variable names to be saved
         path : str
-            The path to the file to be dumped to
+            The path to the file to be saved
 
         Raises
         ------
         Exception
-            If an error occurs while dumping to the file
+            If an error occurs while saving to the file
 
         """
         try:

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -237,26 +237,26 @@ class OutputManager(object):
         return f"{caller_class}.{caller_function}"
 
     def _dict_to_file_json(self, data_dict: Dict[str, Any], path: str) -> None:
-        """Saves a dictionary into a JSON file
+        """Dumps a dictionary into a JSON file
 
         Parameters
         ----------
         data_dict : Dict[str, Any]
-            The dictionary to be saved
+            The dictionary to be dumped
         path : str
-            The path to the file to be saved
+            The path to the file to be dumped to
 
         Raises
         ------
         Exception
-            If an error occurs while saving the file
+            If an error occurs while dumping to the file
 
         Notes
         -----
         The dictionary is first converted to a serializable format using
         `Utility.make_serializable()`.
 
-        The file is saved with no indentation.
+        The file is dumped into with no indentation.
 
         If you want to save time and space, limit the maximum depth of the
         serialized dictionary using the max_depth parameter.
@@ -273,19 +273,19 @@ class OutputManager(object):
             raise e
 
     def _list_to_file_txt(self, data_list: List[str], path: str) -> None:
-        """Saves a list into a text file
+        """Dumps a list into a text file
 
         Parameters
         ----------
         data_list : List[str]
-            The list of variable names to be saved
+            The list of variable names to be dumped
         path : str
-            The path to the file to be saved
+            The path to the file to be dumped to
 
         Raises
         ------
         Exception
-            If an error occurs while saving the file
+            If an error occurs while dumping to the file
 
         """
         try:
@@ -301,9 +301,9 @@ class OutputManager(object):
         timestamp = time.strftime(r"%d-%b-%Y_%a_%H-%M-%S", time.localtime())
         return f"{base_name}_{timestamp}.{extension}"
 
-    def save_variables(self, path: str, exclude_info_maps: bool = False) -> None:
+    def dump_variables(self, path: str, exclude_info_maps: bool = False) -> None:
         """
-        Saves variables_pool into a json file in the given path to a directory.
+        Dumps variables_pool into a json file in the given path to a directory.
         """
         vars_pool = self.variables_pool.copy()
         if exclude_info_maps:
@@ -314,40 +314,40 @@ class OutputManager(object):
         file_path = os.path.join(path, self._generate_file_name("variables", "json"))
         self._dict_to_file_json(self.variables_pool, file_path)
 
-    def save_logs(self, path: str) -> None:
+    def dump_logs(self, path: str) -> None:
         """
-        Saves logs_pool into a json file in the given path to a directory.
+        Dumps logs_pool into a json file in the given path to a directory.
         """
         file_path = os.path.join(path, self._generate_file_name("logs", "json"))
         self._dict_to_file_json(self.logs_pool, file_path)
 
-    def save_warnings(self, path: str) -> None:
+    def dump_warnings(self, path: str) -> None:
         """
-        Saves warnings_pool into a json file in the given path to a directory.
+        Dumps warnings_pool into a json file in the given path to a directory.
         """
         file_path = os.path.join(path, self._generate_file_name("warnings", "json"))
         self._dict_to_file_json(self.warnings_pool, file_path)
 
-    def save_errors(self, path: str) -> None:
+    def dump_errors(self, path: str) -> None:
         """
-        Saves errors_pool into a json file in the given path to a directory.
+        Dumps errors_pool into a json file in the given path to a directory.
         """
         file_path = os.path.join(path, self._generate_file_name("errors", "json"))
         self._dict_to_file_json(self.errors_pool, file_path)
 
-    def save_variable_names_and_contexts(
+    def dump_variable_names_and_contexts(
         self, path: str, exclude_info_maps: bool, format_option: str = "verbose"
     ) -> None:
         """
-        Saves names of all variables added to variables_pool along with the caller class
+        Dumps names of all variables added to variables_pool along with the caller class
         and function contextual information into a txt file in the given path to a directory.
 
         Parameters
         ----------
         path : str
-            The path to the file to be saved
+            The path to the file to be dumped to
         exclude_info_maps : bool
-            Flag to denote whether info_map data should be saved with variable names
+            Flag to denote whether info_map data should be dumped with variable names
         format_options : {"block", "inline", "verbose"}
             The selection for the formatting option of the text written to the variables names text file
 
@@ -404,15 +404,15 @@ class OutputManager(object):
         )
         self._list_to_file_txt(var_list, file_path)
 
-    def save_all_pools(self, path: str, exclude_info_maps: bool = False) -> None:
+    def dump_all_pools(self, path: str, exclude_info_maps: bool = False) -> None:
         """
-        Saves all pool into the given path to a directory.
+        dumps all pool into the given path to a directory.
         """
-        self.save_variables(path, exclude_info_maps)
-        self.save_variable_names_and_contexts(path, exclude_info_maps)
-        self.save_errors(path)
-        self.save_logs(path)
-        self.save_warnings(path)
+        self.dump_variables(path, exclude_info_maps)
+        self.dump_variable_names_and_contexts(path, exclude_info_maps)
+        self.dump_errors(path)
+        self.dump_logs(path)
+        self.dump_warnings(path)
 
     def flush_pools(self) -> None:
         """

--- a/main.py
+++ b/main.py
@@ -63,7 +63,7 @@ def execute_simulations_from_files(
         output_manager.flush_pools()
         simulator = SimulationEngine(input_file_path)
         simulator.simulate()
-        output_manager.save_all_pools(r"output", exclude_info_maps)
+        output_manager.dump_all_pools(r"output", exclude_info_maps)
 
 
 def parse_gnu_args():

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -533,55 +533,55 @@ def output_manager_original_method_states(
         "add_error": mock_output_manager.add_error,
         "add_log": mock_output_manager.add_log,
         "add_warning": mock_output_manager.add_warning,
-        "save_variables": mock_output_manager.save_variables,
-        "save_logs": mock_output_manager.save_logs,
-        "save_warnings": mock_output_manager.save_warnings,
-        "save_errors": mock_output_manager.save_errors,
-        "save_variable_names_and_contexts": mock_output_manager.save_variable_names_and_contexts,
+        "dump_variables": mock_output_manager.dump_variables,
+        "dump_logs": mock_output_manager.dump_logs,
+        "dump_warnings": mock_output_manager.dump_warnings,
+        "dump_errors": mock_output_manager.dump_errors,
+        "dump_variable_names_and_contexts": mock_output_manager.dump_variable_names_and_contexts,
     }
 
 
-def test_save_all_pools(
+def test_dump_all_pools(
     mock_output_manager: OutputManager,
     output_manager_original_method_states: Dict[str, Callable],
 ) -> None:
-    """Test case for function save_all_pools in output_manager.py"""
+    """Test case for function dump_all_pools in output_manager.py"""
     path = "dummy_path"
-    mock_output_manager.save_errors = MagicMock()
-    mock_output_manager.save_warnings = MagicMock()
-    mock_output_manager.save_logs = MagicMock()
-    mock_output_manager.save_variables = MagicMock()
-    mock_output_manager.save_variable_names_and_contexts = MagicMock()
+    mock_output_manager.dump_errors = MagicMock()
+    mock_output_manager.dump_warnings = MagicMock()
+    mock_output_manager.dump_logs = MagicMock()
+    mock_output_manager.dump_variables = MagicMock()
+    mock_output_manager.dump_variable_names_and_contexts = MagicMock()
 
-    mock_output_manager.save_all_pools(path, exclude_info_maps=False)
+    mock_output_manager.dump_all_pools(path, exclude_info_maps=False)
 
-    mock_output_manager.save_errors.assert_called_once_with(path)
-    mock_output_manager.save_warnings.assert_called_once_with(path)
-    mock_output_manager.save_logs.assert_called_once_with(path)
-    mock_output_manager.save_variables.assert_called_once_with(
+    mock_output_manager.dump_errors.assert_called_once_with(path)
+    mock_output_manager.dump_warnings.assert_called_once_with(path)
+    mock_output_manager.dump_logs.assert_called_once_with(path)
+    mock_output_manager.dump_variables.assert_called_once_with(
         path, False
     )
-    mock_output_manager.save_variable_names_and_contexts.assert_called_once_with(path, False)
+    mock_output_manager.dump_variable_names_and_contexts.assert_called_once_with(path, False)
 
-    mock_output_manager.save_all_pools(path, exclude_info_maps=True)
-    mock_output_manager.save_variables.assert_called_with(path, True)
-    assert mock_output_manager.save_logs.call_count == 2
-    assert mock_output_manager.save_warnings.call_count == 2
-    assert mock_output_manager.save_errors.call_count == 2
+    mock_output_manager.dump_all_pools(path, exclude_info_maps=True)
+    mock_output_manager.dump_variables.assert_called_with(path, True)
+    assert mock_output_manager.dump_logs.call_count == 2
+    assert mock_output_manager.dump_warnings.call_count == 2
+    assert mock_output_manager.dump_errors.call_count == 2
 
     # Restore original methods
-    mock_output_manager.save_variables = output_manager_original_method_states[
-        "save_variables"
+    mock_output_manager.dump_variables = output_manager_original_method_states[
+        "dump_variables"
     ]
-    mock_output_manager.save_logs = output_manager_original_method_states["save_logs"]
-    mock_output_manager.save_warnings = output_manager_original_method_states[
-        "save_warnings"
+    mock_output_manager.dump_logs = output_manager_original_method_states["dump_logs"]
+    mock_output_manager.dump_warnings = output_manager_original_method_states[
+        "dump_warnings"
     ]
-    mock_output_manager.save_errors = output_manager_original_method_states[
-        "save_errors"
+    mock_output_manager.dump_errors = output_manager_original_method_states[
+        "dump_errors"
     ]
-    mock_output_manager.save_variable_names_and_contexts = output_manager_original_method_states[
-        "save_variable_names_and_contexts"
+    mock_output_manager.dump_variable_names_and_contexts = output_manager_original_method_states[
+        "dump_variable_names_and_contexts"
     ]
 
 
@@ -598,15 +598,15 @@ def test_generate_file_name(mocker: MockerFixture) -> None:
     )
 
 
-def test_save_variables(
+def test_dump_variables(
     mock_output_manager: OutputManager,
     output_manager_original_method_states: Dict[str, Callable],
 ) -> None:
-    """Test case for function save_variables in output_manager.py"""
+    """Test case for function dump_variables in output_manager.py"""
     mock_output_manager._generate_file_name = MagicMock(return_value="dummy_name")
     mock_output_manager._dict_to_file_json = MagicMock()
 
-    mock_output_manager.save_variables("dummy_path")
+    mock_output_manager.dump_variables("dummy_path")
 
     mock_output_manager._generate_file_name.assert_called_once_with("variables", "json")
     mock_output_manager._dict_to_file_json.assert_called_once_with(
@@ -622,15 +622,15 @@ def test_save_variables(
     ]
 
 
-def test_save_logs(
+def test_dump_logs(
     mock_output_manager: OutputManager,
     output_manager_original_method_states: Dict[str, Callable],
 ) -> None:
-    """Test case for function save_logs in output_manager.py"""
+    """Test case for function dump_logs in output_manager.py"""
     mock_output_manager._generate_file_name = MagicMock(return_value="dummy_name")
     mock_output_manager._dict_to_file_json = MagicMock()
 
-    mock_output_manager.save_logs("dummy_path")
+    mock_output_manager.dump_logs("dummy_path")
 
     mock_output_manager._generate_file_name.assert_called_once_with("logs", "json")
     mock_output_manager._dict_to_file_json.assert_called_once_with(
@@ -646,15 +646,15 @@ def test_save_logs(
     ]
 
 
-def test_save_warnings(
+def test_dump_warnings(
     mock_output_manager: OutputManager,
     output_manager_original_method_states: Dict[str, Callable],
 ) -> None:
-    """Test case for function save_warnings in output_manager.py"""
+    """Test case for function dump_warnings in output_manager.py"""
     mock_output_manager._generate_file_name = MagicMock(return_value="dummy_name")
     mock_output_manager._dict_to_file_json = MagicMock()
 
-    mock_output_manager.save_warnings("dummy_path")
+    mock_output_manager.dump_warnings("dummy_path")
 
     mock_output_manager._generate_file_name.assert_called_once_with("warnings", "json")
     mock_output_manager._dict_to_file_json.assert_called_once_with(
@@ -670,15 +670,15 @@ def test_save_warnings(
     ]
 
 
-def test_save_errors(
+def test_dump_errors(
     mock_output_manager: OutputManager,
     output_manager_original_method_states: Dict[str, Callable],
 ) -> None:
-    """Test case for function save_errors in output_manager.py"""
+    """Test case for function dump_errors in output_manager.py"""
     mock_output_manager._generate_file_name = MagicMock(return_value="dummy_name")
     mock_output_manager._dict_to_file_json = MagicMock()
 
-    mock_output_manager.save_errors("dummy_path")
+    mock_output_manager.dump_errors("dummy_path")
 
     mock_output_manager._generate_file_name.assert_called_once_with("errors", "json")
     mock_output_manager._dict_to_file_json.assert_called_once_with(
@@ -694,16 +694,16 @@ def test_save_errors(
     ]
 
 
-def test_save_variable_names_and_contexts(
+def test_dump_variable_names_and_contexts(
     mock_output_manager: OutputManager,
     output_manager_original_method_states: Dict[str, Callable],
 ) -> None:
-    """Test case for function save_variable_names_and_contexts in output_manager.py"""
+    """Test case for function dump_variable_names_and_contexts in output_manager.py"""
     dummy_list = ['_exclude_info_maps=False, expect info_maps accordingly.\n']
     mock_output_manager._generate_file_name = MagicMock(return_value="dummy_name")
     mock_output_manager._list_to_file_txt = MagicMock()
 
-    mock_output_manager.save_variable_names_and_contexts("dummy_path", False)
+    mock_output_manager.dump_variable_names_and_contexts("dummy_path", False)
 
     mock_output_manager._generate_file_name.assert_called_once_with("variable_names", "txt")
     mock_output_manager._list_to_file_txt.assert_called_once_with(

--- a/tests/test_user_prompt.py
+++ b/tests/test_user_prompt.py
@@ -345,7 +345,7 @@ def test_execute_simulations_from_files(mocker: MockerFixture) -> None:
     # Arrange
     mock_output_manager = mocker.MagicMock(auto_spec=OutputManager)
     mock_output_manager.flush_pools.return_value = None
-    mock_output_manager.save_all_pools.return_value = None
+    mock_output_manager.dump_all_pools.return_value = None
     mocker.patch("main.OutputManager", return_value=mock_output_manager)
     file_path1 = Path("file1.json")
     file_path2 = Path("file2.json")
@@ -367,8 +367,8 @@ def test_execute_simulations_from_files(mocker: MockerFixture) -> None:
     ]
     assert mock_simulator.simulate.call_count == len(file_list)
     assert mock_output_manager.flush_pools.call_count == len(file_list)
-    assert mock_output_manager.save_all_pools.call_count == len(file_list)
-    assert mock_output_manager.save_all_pools.call_args_list == [
+    assert mock_output_manager.dump_all_pools.call_count == len(file_list)
+    assert mock_output_manager.dump_all_pools.call_args_list == [
         mocker.call("output", True)
     ] * len(file_list)
 


### PR DESCRIPTION
This PR seeks to address issue #521 to update the names of all the OM save_xyz functions to dump_xyz which more accurately reflects what they do.

Changes were made in OutputManager.py, test_misc.py, test_user_prompt.py, and main.py.

Doc strings were also updated from save -> dump.

A search across files for "save_" after these changes were made yielded no further references to the save_xyz OM functions.

Tested by running a simulation as well as running the test suite and did not find any issues.