### PR TITLE
NRC Maintenance energy typo fix

### DIFF
--- a/RUFAS/routines/animal/ration/animal_requirements.py
+++ b/RUFAS/routines/animal/ration/animal_requirements.py
@@ -185,7 +185,7 @@ def calculate_NRC_energy_maintenance_requirements(body_weight: float, mature_bod
     elif animal_type in [AnimalType.HEIFER_I, AnimalType.HEIFER_II, AnimalType.HEIFER_III]:
         body_condition_score_9 = (body_condition_score_5 - 1) * 2 + 1
         net_energy_maintenance = (body_weight-conceptus_weight)**(0.75) * \
-            (0.086*(0.8 + (body_condition_score_9 - 1) * 0.5)) + \
+            (0.086*(0.8 + (body_condition_score_9 - 1) * 0.05)) + \
             0.0007*(20-previous_temperature)
     return net_energy_maintenance, conceptus_weight, calf_birth_weight
 

--- a/tests/test_animal.py
+++ b/tests/test_animal.py
@@ -135,14 +135,14 @@ def test_calculate_NRC_energy_maintenance_requirements(cow_a:dict, cow_b:dict, h
             heifer_a['body_weight'], heifer_a['mature_body_weight'], heifer_a['day_of_pregnancy'], heifer_a['BCS5'],
             heifer_a['PrevTemp'], heifer_a['animal_type'])
     assert (result_NEmaint, result_CW, result_CBW) == pytest.approx(
-        (14.23, 0, 0), rel=5e-1)
+        (5.08, 0, 0), rel=5e-1)
 
     result_NEmaint, result_CW, result_CBW = \
         RUFAS.routines.animal.ration.animal_requirements.calculate_NRC_energy_maintenance_requirements(
             heifer_b['body_weight'], heifer_b['mature_body_weight'], heifer_b['day_of_pregnancy'], heifer_b['BCS5'],
             heifer_b['PrevTemp'], heifer_b['animal_type'])
     assert (result_NEmaint, result_CW, result_CBW) == pytest.approx(
-        (19.07, 0, 43.92), rel=5e-1)
+        (6.81, 0, 43.92), rel=5e-1)
 
 
 def test_calculate_NRC_energy_growth_requirements(cow_a:dict, cow_b:dict, heifer_a:dict, heifer_b:dict)->None:


### PR DESCRIPTION
There was a small typo in the calculate_NRC_energy_maintenance_requiremets function in animal_requirements.py that resulted in over estimation of energy requirements. 

See the current pseudocode on Basecamp or here: https://docs.google.com/document/d/1jLxqY2rJC4BFfHlOpllHfbUItNUMRyyulKSS9X4hPOM/edit?usp=sharing  equation A.Heifer.A.4 for reference. 