### PR TITLE
Integrate `FertilizerEvent`s into `Field`

### DIFF
--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -197,11 +197,11 @@ class Field:
         Parameters
         ----------
         nitrogen_fraction : float
-            Fraction of fertilizer mix that is nitrogen, in range [0.0, 1.0]
+            Fraction of fertilizer mix that is nitrogen, in range [0.0, 1.0] (unitless)
         phosphorus_fraction : float
-            Fraction of fertilizer mix that is phosphorus, in range [0.0, 1.0]
+            Fraction of fertilizer mix that is phosphorus, in range [0.0, 1.0] (unitless)
         potassium_fraction : float
-            Fraction of fertilizer mix that is potassium, in range [0.0, 1.0]
+            Fraction of fertilizer mix that is potassium, in range [0.0, 1.0] (unitless)
         requested_nitrogen : float
             Minimum mass of nitrogen to be included in fertilizer application (kg)
         requested_phosphorus : float

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -118,21 +118,7 @@ class Field:
         """ensure that the crop_proportions values sum to 1"""
         return sum([crop.data.field_proportion for crop in self.crops]) == 1.0
 
-    # <editor-fold desc="--- Setup Methods ---">
-    def setup_field(self, tillage_config):
-        """setup all the attributes that determine how the field will be managed"""
-        self.setup_tillage(tillage_config)
-
-    def setup_tillage(self, tillage_config):
-        """sets up the tillage details for this field"""
-        pass
-        # </editor-fold>
-
     # <editor-fold desc="--- Soil Management Methods ---">
-    def till_soil(self) -> None:
-        """till the soil"""
-        pass
-
     def _execute_fertilizer_application(self, mix_name: str, requested_nitrogen: float, requested_phosphorus: float,
                                         year: int, day: int) -> None:
         """

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -147,7 +147,31 @@ class Field:
         can be passed to the FertilizerApplication module.
 
         """
-        pass
+        try:
+            fertilizer_mix = self.available_fertilizer_mixes.get(event.mix_name)
+        except KeyError:
+            raise KeyError(f"'{self.field_data.name}': expected to have fertilizer mix for '{event.mix_name}', "
+                           f"received '{self.available_fertilizer_mixes}'.")
+        nitrogen_fraction = fertilizer_mix.get("N")
+        phosphorus_fraction = fertilizer_mix.get("P")
+        potassium_fraction = fertilizer_mix.get("K")
+
+        fertilizer_applied = self._formulate_fertilizer_required(nitrogen_fraction, phosphorus_fraction,
+                                                                 potassium_fraction, event.nitrogen_mass,
+                                                                 event.phosphorus_mass)
+        total_mass_applied = fertilizer_applied.get("mass")
+        phosphorus_applied = fertilizer_applied.get("phosphorus_mass")
+
+        # TODO: specify these fractions in fertilizer mixes - issue #573
+        inorganic_nitrogen_fraction = total_mass_applied / fertilizer_applied.get("nitrogen_mass")
+        ammonium_fraction = 0.0
+        organic_nitrogen_fraction = 0.0
+
+        self.fertilizer_applicator.apply_fertilizer(phosphorus_applied, total_mass_applied, inorganic_nitrogen_fraction,
+                                                    ammonium_fraction, organic_nitrogen_fraction,
+                                                    self.field_data.field_size)
+
+
 
     @staticmethod
     def _formulate_fertilizer_required(nitrogen_fraction: float, phosphorus_fraction: float,
@@ -221,21 +245,25 @@ class Field:
         """
         Filters out all events from a list that occur on the current day, and creates a new list with all the events
         that were filtered out.
+
         Parameters
         ----------
         all_events : List[Event]
             List of all Events that will occur over the run of the simulation in this field.
         time : Time
             Object containing the current day and year of the simulation.
+
         Returns
         -------
         Tuple
             A tuple containing the list of all Events that will occur in this field after the current day, and a list of
             Events that will occur on the current day.
+
         Notes
         -----
         This method is written to work with generic Events so that it may be used on all the different child classes of
         Event: PlantingEvent, HarvestEvent, ManureEvent, FertilizerEvent, and TillageEvent.
+
         """
         todays_events = [event for event in all_events if event.occurs_today(time)]
         remaining_events = [event for event in all_events if event not in todays_events]

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -189,11 +189,8 @@ class Field:
                                                     ammonium_fraction, organic_nitrogen_fraction,
                                                     self.field_data.field_size)
 
-        info_map = {"class": self.__class__.__name__, "function": self._execute_fertilizer_application.__name__,
-                    "prefix": f"field_name:'{self.field_data.name}'", "date": {"year": year, "day": day}}
-        value = {"mass": total_mass_applied, "nitrogen": nitrogen_applied, "phosphorus": phosphorus_applied,
-                 "potassium": potassium_applied}
-        om.add_variable("fertilizer_application", value, info_map)
+        self._record_fertilizer_application(mix_name, total_mass_applied, nitrogen_applied, phosphorus_applied,
+                                            potassium_applied, year, day)
 
     @staticmethod
     def _formulate_fertilizer_required(nitrogen_fraction: float, phosphorus_fraction: float,
@@ -231,6 +228,35 @@ class Field:
         return {"mass": total_mass, "nitrogen_mass": nitrogen_mass, "phosphorus_mass": phosphorus_mass,
                 "potassium_mass": potassium_mass}
 
+    def _record_fertilizer_application(self, mix_name: str, total_mass: float, nitrogen_mass: float,
+                                       phosphorus_mass: float, potassium_mass: float, year: int, day: int) -> None:
+        """
+        Records a fertilizer application and saves it to the Output manager.
+
+        Parameters
+        ----------
+        mix_name : str
+            The name of the mix this fertilizer application is composed of.
+        total_mass : float
+            The total mass of phosphorus applied.
+        nitrogen_mass : float
+            The mass of nitrogen applied.
+        phosphorus_mass : float
+            The mass of phosphorus applied.
+        potassium_mass : float
+            The mass of potassium applied.
+        year : int
+            Calendar year in which the fertilizer application is occurring.
+        day : int
+            Julian day on which this fertilizer application is occurring.
+
+        """
+        info_map = {"class": self.__class__.__name__, "function": self._execute_fertilizer_application.__name__,
+                    "prefix": f"field_name:'{self.field_data.name}'", "date": {"year": year, "day": day},
+                    "mix_name": mix_name, "field_size": self.field_data.field_size}
+        value = {"mass": total_mass, "nitrogen": nitrogen_mass, "phosphorus": phosphorus_mass,
+                 "potassium": potassium_mass}
+        om.add_variable("fertilizer_application", value, info_map)
     # </editor-fold>
 
     # <editor-fold desc="--- Scheduling Methods ---">

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -31,7 +31,7 @@ class Field:
 
     def __init__(self, field_data: Optional[FieldData] = None, soil: Optional[Soil] = None,
                  fertilizer_events: Optional[List[FertilizerEvent]] = None,
-                 fertilizer_mixes: Optional[Dict[str, Dict]] = None):
+                 fertilizer_mixes: Optional[Dict[str, Dict[str, float]]] = None):
         # field-wide attributes
         self.field_data = field_data or FieldData()
         """field data component"""
@@ -52,6 +52,7 @@ class Field:
         """List of all fertilizer application events that will in this field."""
 
         self.available_fertilizer_mixes = fertilizer_mixes or {}
+        """List of all fertilizer mixes available for application to this field."""
 
         self.tiller = TillageApplication(self.field_data, self.soil.data)
         """Provides interface to till the field."""
@@ -183,7 +184,7 @@ class Field:
         potassium_applied = fertilizer_applied.get("potassium_mass")
 
         # TODO: specify these fractions in fertilizer mixes - issue #573
-        inorganic_nitrogen_fraction = total_mass_applied / nitrogen_applied
+        inorganic_nitrogen_fraction = nitrogen_applied / total_mass_applied
         ammonium_fraction = 0.0
         organic_nitrogen_fraction = 0.0
 
@@ -192,7 +193,7 @@ class Field:
                                                     self.field_data.field_size)
 
         info_map = {"class": self.__class__.__name__, "function": self._execute_fertilizer_application.__name__,
-                    "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day}}
+                    "prefix": f"field_name:'{self.field_data.name}'", "date": {"year": year, "day": day}}
         value = {"mass": total_mass_applied, "nitrogen": nitrogen_applied, "phosphorus": phosphorus_applied,
                  "potassium": potassium_applied}
         om.add_variable("fertilizer_application", value, info_map)
@@ -262,7 +263,7 @@ class Field:
         """
         self.fertilizer_events, todays_fertilizer_events = self._create_and_update_events(self.fertilizer_events, time)
         for event in todays_fertilizer_events:
-            self._execute_fertilizer_event(event)
+            self._execute_fertilizer_application(event)
 
     @staticmethod
     def _create_and_update_events(all_events: List[Event], time: Time) -> Tuple[List[Event], List[Event]]:

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -12,6 +12,7 @@ from math import exp
 from SC_redesign.Crop_and_Soil.crop.harvest_operations import HarvestOperation
 from SC_redesign.Crop_and_Soil.field.manure_application import ManureApplication
 from RUFAS.classes import Time
+from RUFAS.output_manager import OutputManager
 
 # TODO: delete/replace the note block below once satisfied with the design
 """
@@ -21,6 +22,8 @@ in an agricultural field.
 
 Note that some of the field-level attributes will be tracked by the FieldData class
 """
+
+om = OutputManager()
 
 
 class Field:
@@ -170,8 +173,6 @@ class Field:
         self.fertilizer_applicator.apply_fertilizer(phosphorus_applied, total_mass_applied, inorganic_nitrogen_fraction,
                                                     ammonium_fraction, organic_nitrogen_fraction,
                                                     self.field_data.field_size)
-
-
 
     @staticmethod
     def _formulate_fertilizer_required(nitrogen_fraction: float, phosphorus_fraction: float,

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -252,6 +252,7 @@ class Field:
         value = {"mass": total_mass, "nitrogen": nitrogen_mass, "phosphorus": phosphorus_mass,
                  "potassium": potassium_mass}
         om.add_variable("fertilizer_application", value, info_map)
+
     # </editor-fold>
 
     # <editor-fold desc="--- Scheduling Methods ---">

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -79,7 +79,7 @@ class Field:
         """main Field function, runs all field routines based on current attribute configuration
 
         Args:
-            time: Time object containing the current year and day of the simulation.
+            time : a Time object, containing the current year and day that the simulation is on.
             current_weather: a CurrentWeather object, containing a collection of today's weather variables needed
                 for field processes.
 
@@ -291,7 +291,7 @@ class Field:
 
         Parameters
         ----------
-        time: Time
+        time : Time
             Time object containing the current day and year of the simulation.
 
         Notes
@@ -636,7 +636,6 @@ class Field:
         else:
             for crop in self.crops:
                 crop.data.is_dormant = False
-
     # </editor-fold>
 
     # <editor-fold desc="--- Field-level Methods ---">

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -135,44 +135,67 @@ class Field:
         """till the soil"""
         pass
 
-    def _execute_fertilizer_event(self, event: FertilizerEvent) -> None:
+    def _execute_fertilizer_application(self, mix_name: str, requested_nitrogen: float, requested_phosphorus: float,
+                                        year: int, day: int) -> None:
         """
-        Executes a fertilizer application as defined in the FertilizerEvent passed.
+        Executes a fertilizer application based on the requested amounts of nutrients.
 
         Parameters
         ----------
-        event : FertilizerEvent
-            The fertilizer event containing all the necessary information to formulate a single fertilizer application.
+        mix_name : str
+            The name of the mix this fertilizer application should be composed of.
+        requested_nitrogen : float
+            Minimum amount of nitrogen to be included in this fertilizer application.
+        requested_phosphorus : float
+            Minimum amount of phosphorus to be included in this fertilizer application.
+        year : int
+            Calendar year in which the fertilizer application is occurring.
+        day : int
+            Julian day on which this fertilizer application is occurring.
+
+        Raises
+        ------
+        KeyError
+            If the specified fertilizer mix is not defined in the list of available fertilizers to this field.
 
         Notes
         -----
-        This method is responsible for translating all the information provided in the FertilizerEvent into data that
-        can be passed to the FertilizerApplication module.
+        This method is responsible for determining the exact amounts of fertilizer and nutrients added to the field,
+        passing those amount to the FertilizerApplication module, and recording the fertilizer application to the
+        OutputManager.
 
         """
         try:
-            fertilizer_mix = self.available_fertilizer_mixes.get(event.mix_name)
+            fertilizer_mix = self.available_fertilizer_mixes.get(mix_name)
         except KeyError:
-            raise KeyError(f"'{self.field_data.name}': expected to have fertilizer mix for '{event.mix_name}', "
+            raise KeyError(f"'{self.field_data.name}': expected to have fertilizer mix for '{mix_name}', "
                            f"received '{self.available_fertilizer_mixes}'.")
         nitrogen_fraction = fertilizer_mix.get("N")
         phosphorus_fraction = fertilizer_mix.get("P")
         potassium_fraction = fertilizer_mix.get("K")
 
         fertilizer_applied = self._formulate_fertilizer_required(nitrogen_fraction, phosphorus_fraction,
-                                                                 potassium_fraction, event.nitrogen_mass,
-                                                                 event.phosphorus_mass)
+                                                                 potassium_fraction, requested_nitrogen,
+                                                                 requested_phosphorus)
         total_mass_applied = fertilizer_applied.get("mass")
         phosphorus_applied = fertilizer_applied.get("phosphorus_mass")
+        nitrogen_applied = fertilizer_applied.get("nitrogen_mass")
+        potassium_applied = fertilizer_applied.get("potassium_mass")
 
         # TODO: specify these fractions in fertilizer mixes - issue #573
-        inorganic_nitrogen_fraction = total_mass_applied / fertilizer_applied.get("nitrogen_mass")
+        inorganic_nitrogen_fraction = total_mass_applied / nitrogen_applied
         ammonium_fraction = 0.0
         organic_nitrogen_fraction = 0.0
 
         self.fertilizer_applicator.apply_fertilizer(phosphorus_applied, total_mass_applied, inorganic_nitrogen_fraction,
                                                     ammonium_fraction, organic_nitrogen_fraction,
                                                     self.field_data.field_size)
+
+        info_map = {"class": self.__class__.__name__, "function": self._execute_fertilizer_application.__name__,
+                    "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day}}
+        value = {"mass": total_mass_applied, "nitrogen": nitrogen_applied, "phosphorus": phosphorus_applied,
+                 "potassium": potassium_applied}
+        om.add_variable("fertilizer_application", value, info_map)
 
     @staticmethod
     def _formulate_fertilizer_required(nitrogen_fraction: float, phosphorus_fraction: float,

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -170,7 +170,7 @@ class Field:
         fertilizer_applied = self._formulate_fertilizer_required(nitrogen_fraction, phosphorus_fraction,
                                                                  potassium_fraction, requested_nitrogen,
                                                                  requested_phosphorus)
-        total_mass_applied = fertilizer_applied.get("mass")
+        total_mass_applied = fertilizer_applied.get("total_mass")
         phosphorus_applied = fertilizer_applied.get("phosphorus_mass")
         nitrogen_applied = fertilizer_applied.get("nitrogen_mass")
         potassium_applied = fertilizer_applied.get("potassium_mass")
@@ -220,7 +220,7 @@ class Field:
         nitrogen_mass = total_mass * nitrogen_fraction
         phosphorus_mass = total_mass * phosphorus_fraction
         potassium_mass = total_mass * potassium_fraction
-        return {"mass": total_mass, "nitrogen_mass": nitrogen_mass, "phosphorus_mass": phosphorus_mass,
+        return {"total_mass": total_mass, "nitrogen_mass": nitrogen_mass, "phosphorus_mass": phosphorus_mass,
                 "potassium_mass": potassium_mass}
 
     def _record_fertilizer_application(self, mix_name: str, total_mass: float, nitrogen_mass: float,

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -47,7 +47,7 @@ class Field:
         self.crops: List[Crop] = list()  # empty crop list
         """crops currently in the field"""
 
-        self.planting_events: List[PlantingEvent] = plantings
+        self.planting_events: List[PlantingEvent] = plantings or []
         """List of all planting events that will occur over the run of the simulation in this field."""
 
         self.custom_crop_specifications: Dict[str, Dict] = custom_crop_specifications or {}
@@ -119,18 +119,12 @@ class Field:
         return sum([crop.data.field_proportion for crop in self.crops]) == 1.0
 
     # <editor-fold desc="--- Setup Methods ---">
-    def setup_field(self, soil_config, tillage_config, amendment_config):
+    def setup_field(self, tillage_config):
         """setup all the attributes that determine how the field will be managed"""
-        self.soil = Soil(soil_config)
         self.setup_tillage(tillage_config)
-        self.setup_amendments(amendment_config)
 
     def setup_tillage(self, tillage_config):
         """sets up the tillage details for this field"""
-        pass
-
-    def setup_amendments(self, amendment_config):
-        """sets up the nutrient amendment details (manure and fertilizer) for this field"""
         pass
         # </editor-fold>
 
@@ -267,7 +261,8 @@ class Field:
         """
         self.fertilizer_events, todays_fertilizer_events = self._create_and_update_events(self.fertilizer_events, time)
         for event in todays_fertilizer_events:
-            self._execute_fertilizer_application(event)
+            self._execute_fertilizer_application(event.mix_name, event.nitrogen_mass, event.phosphorus_mass, event.year,
+                                                 event.day)
 
     @staticmethod
     def _create_and_update_events(all_events: List[Event], time: Time) -> Tuple[List[Event], List[Event]]:

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -2,14 +2,16 @@ from SC_redesign.Crop_and_Soil.crop.crop import Crop
 from SC_redesign.Crop_and_Soil.crop.crop_data import CropData
 from SC_redesign.Crop_and_Soil.crop.species_data_factory import CropSpecies, CropSpeciesDataFactory
 from SC_redesign.Crop_and_Soil.manager.current_weather import CurrentWeather
+from SC_redesign.Crop_and_Soil.manager.events import Event, FertilizerEvent
 from SC_redesign.Crop_and_Soil.soil.soil import Soil
 from SC_redesign.Crop_and_Soil.field.field_data import FieldData
 from SC_redesign.Crop_and_Soil.field.fertilizer_application import FertilizerApplication
 from SC_redesign.Crop_and_Soil.field.tillage_application import TillageApplication
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Tuple
 from math import exp
 from SC_redesign.Crop_and_Soil.crop.harvest_operations import HarvestOperation
 from SC_redesign.Crop_and_Soil.field.manure_application import ManureApplication
+from RUFAS.classes import Time
 
 # TODO: delete/replace the note block below once satisfied with the design
 """
@@ -24,7 +26,9 @@ Note that some of the field-level attributes will be tracked by the FieldData cl
 class Field:
     """object representing an agricultural field"""
 
-    def __init__(self, field_data: Optional[FieldData] = None, soil: Optional[Soil] = None):
+    def __init__(self, field_data: Optional[FieldData] = None, soil: Optional[Soil] = None,
+                 fertilizer_events: Optional[List[FertilizerEvent]] = None,
+                 fertilizer_mixes: Optional[Dict[str, Dict]] = None):
         # field-wide attributes
         self.field_data = field_data or FieldData()
         """field data component"""
@@ -40,6 +44,12 @@ class Field:
         # Soil amendment attributes
         self.fertilizer_applicator = FertilizerApplication(self.soil)
         """Provides interface for adding fertilizer to the field."""
+
+        self.fertilizer_events = fertilizer_events or []
+        """List of all fertilizer application events that will in this field."""
+
+        self.available_fertilizer_mixes = fertilizer_mixes or {}
+
         self.tiller = TillageApplication(self.field_data, self.soil.data)
         """Provides interface to till the field."""
 
@@ -49,28 +59,18 @@ class Field:
         self.manure_applicator = ManureApplication(self.soil.data)
         """Manure application interface."""
 
-    def manage_field(self, day: int, year: int, current_weather: CurrentWeather) -> None:
+    def manage_field(self, time: Time, current_weather: CurrentWeather) -> None:
         """main Field function, runs all field routines based on current attribute configuration
 
         Args:
-            day: the current (sequential) day of the simulation  - TODO: not yet implemented
-            year: the current (sequential) year of the simulation - TODO: not yet implemented
+            time: Time object containing the current year and day of the simulation.
             current_weather: a CurrentWeather object, containing a collection of today's weather variables needed
                 for field processes.
 
         Details: **All the logic (after setup) will go in this function**
         """
-        # What needs to be done today?
-        self.check_schedule(day, year)
-
         # --- Soil Management---
-        # nutrient amendments
-        if self.field_data.is_amendment_day:
-            self.amend_soil()
-
-        # tillage
-        if self.field_data.is_tillage_day:
-            self.till_soil()
+        self.check_fertilizer_application_schedule(time)
 
         # --- Whole-Field Methods ---
         # Allow non-management field processes (water/nutrient cycling) to occur
@@ -93,7 +93,6 @@ class Field:
             if self.field_data.grazers_present:
                 self.graze_field()
 
-            self.check_harvest_schedules(day, year)
             self.harvest_scheduled_crops()
 
         # annual resets
@@ -133,10 +132,58 @@ class Field:
         """till the soil"""
         pass
 
-    def amend_soil(self) -> None:
-        """amend the soil with nutrients"""
-        self.soil.phosphorus_cycling.fertilizer.add_fertilizer_phosphorus(0)
-        return
+    def _execute_fertilizer_event(self, event: FertilizerEvent) -> None:
+        """
+        Executes a fertilizer application as defined in the FertilizerEvent passed.
+
+        Parameters
+        ----------
+        event : FertilizerEvent
+            The fertilizer event containing all the necessary information to formulate a single fertilizer application.
+
+        Notes
+        -----
+        This method is responsible for translating all the information provided in the FertilizerEvent into data that
+        can be passed to the FertilizerApplication module.
+
+        """
+        pass
+
+    @staticmethod
+    def _formulate_fertilizer_required(nitrogen_fraction: float, phosphorus_fraction: float,
+                                       potassium_fraction: float, requested_nitrogen: float,
+                                       requested_phosphorus: float) -> Dict[str, float]:
+        """
+        Determines the total mass of a specific fertilizer mix needed to meet the specified nutrient requirements.
+
+        Parameters
+        ----------
+        nitrogen_fraction : float
+            Fraction of fertilizer mix that is nitrogen, in range [0.0, 1.0]
+        phosphorus_fraction : float
+            Fraction of fertilizer mix that is phosphorus, in range [0.0, 1.0]
+        potassium_fraction : float
+            Fraction of fertilizer mix that is potassium, in range [0.0, 1.0]
+        requested_nitrogen : float
+            Minimum mass of nitrogen to be included in fertilizer application (kg)
+        requested_phosphorus : float
+            Minimum mass of phosphorus to be included in fertilizer application (kg)
+
+        Returns
+        -------
+        Dict[str, float]
+            The total mass of fertilizer, and the masses of nitrogen, phosphorus, and potassium in the fertilizer.
+
+        """
+        minimum_mass_for_nitrogen = (0 if nitrogen_fraction == 0 else (requested_nitrogen / nitrogen_fraction))
+        minimum_mass_for_phosphorus = (0 if phosphorus_fraction == 0 else (requested_phosphorus / phosphorus_fraction))
+
+        total_mass = max(minimum_mass_for_nitrogen, minimum_mass_for_phosphorus)
+        nitrogen_mass = total_mass * nitrogen_fraction
+        phosphorus_mass = total_mass * phosphorus_fraction
+        potassium_mass = total_mass * potassium_fraction
+        return {"mass": total_mass, "nitrogen_mass": nitrogen_mass, "phosphorus_mass": phosphorus_mass,
+                "potassium_mass": potassium_mass}
 
     # </editor-fold>
 
@@ -154,6 +201,46 @@ class Field:
             For example, if we need to plant a crop today, this method will set `self.field_data.is_planting_day=True`.
          """
         pass
+
+    def check_fertilizer_application_schedule(self, time: Time) -> None:
+        """
+        Checks list of FertilizerEvents, and removes all that occur on the current day from the list.
+
+        Parameters
+        ----------
+        time : Time
+            Object containing the current year and day of the simulation.
+
+        """
+        self.fertilizer_events, todays_fertilizer_events = self._create_and_update_events(self.fertilizer_events, time)
+        for event in todays_fertilizer_events:
+            self._execute_fertilizer_event(event)
+
+    @staticmethod
+    def _create_and_update_events(all_events: List[Event], time: Time) -> Tuple[List[Event], List[Event]]:
+        """
+        Filters out all events from a list that occur on the current day, and creates a new list with all the events
+        that were filtered out.
+        Parameters
+        ----------
+        all_events : List[Event]
+            List of all Events that will occur over the run of the simulation in this field.
+        time : Time
+            Object containing the current day and year of the simulation.
+        Returns
+        -------
+        Tuple
+            A tuple containing the list of all Events that will occur in this field after the current day, and a list of
+            Events that will occur on the current day.
+        Notes
+        -----
+        This method is written to work with generic Events so that it may be used on all the different child classes of
+        Event: PlantingEvent, HarvestEvent, ManureEvent, FertilizerEvent, and TillageEvent.
+        """
+        todays_events = [event for event in all_events if event.occurs_today(time)]
+        remaining_events = [event for event in all_events if event not in todays_events]
+        return remaining_events, todays_events
+
     # </editor-fold>
 
     # <editor-fold desc="--- Crop Management Methods ---">
@@ -345,6 +432,7 @@ class Field:
         else:
             for crop in self.crops:
                 crop.data.is_dormant = False
+
     # </editor-fold>
 
     # <editor-fold desc="--- Field-level Methods ---">

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -233,13 +233,13 @@ class Field:
         mix_name : str
             The name of the mix this fertilizer application is composed of.
         total_mass : float
-            The total mass of phosphorus applied.
+            The total mass of phosphorus applied (kg)
         nitrogen_mass : float
-            The mass of nitrogen applied.
+            The mass of nitrogen applied (kg)
         phosphorus_mass : float
-            The mass of phosphorus applied.
+            The mass of phosphorus applied (kg)
         potassium_mass : float
-            The mass of potassium applied.
+            The mass of potassium applied (kg)
         year : int
             Calendar year in which the fertilizer application is occurring.
         day : int

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -13,6 +13,9 @@ from SC_redesign.Crop_and_Soil.field.field_data import FieldData
 from SC_redesign.Crop_and_Soil.crop.dormancy import Dormancy
 from SC_redesign.Crop_and_Soil.crop_and_soil_constants import LITERS_TO_CUBIC_MILLIMETERS, \
     HECTARES_TO_SQUARE_MILLIMETERS
+from RUFAS.output_manager import OutputManager
+
+om = OutputManager()
 
 
 @pytest.mark.parametrize("daylength,threshold_daylength", [
@@ -166,6 +169,37 @@ def test_harvest_scheduled_crops():
     crop1.crop_management.manage_harvest.assert_called_once()
     crop2.crop_management.manage_harvest.assert_not_called()
     crop3.crop_management.manage_harvest.assert_called_once()
+
+
+@pytest.mark.parametrize("mix_name,requested_n,requested_p,year,day,field_size", {
+    ("test_mix_1", 80.0, 30.0, 1993, 100, 3.1),
+    ("test_mix_2", 150.0, 89.0, 2001, 240, 1.3),
+    ("test_mix_3", 10.0, 90.33, 1992, 30, 2.44),
+    ("test_mix_4", 0.0, 50.0, 1996, 60, 1.45),
+    ("test_mix_5", 67.5, 0.0, 1998, 200, 2.3),
+    ("test_mix_6", 0.0, 0.0, 1988, 120, 0.5)
+})
+def test_execute_fertilizer_application(mix_name: str, requested_n: float, requested_p: float,
+                                        year: int, day: int, field_size: float) -> None:
+    """Tests that fertilizer applications are being correctly executed and recorded."""
+    field_data = FieldData(name="test", field_size=field_size)
+    field = Field(field_data=field_data, fertilizer_mixes={mix_name: {"N": 0.3, "P": 0.2, "K": 0.5}})
+    field._formulate_fertilizer_required = MagicMock(return_value={"mass": 100, "nitrogen_mass": 20,
+                                                                   "phosphorus_mass": 15,
+                                                                   "potassium_mass": 10})
+    field.fertilizer_applicator.apply_fertilizer = MagicMock()
+
+    field._execute_fertilizer_application(mix_name, requested_n, requested_p, year, day)
+
+    expected_nitrogen_fraction = 0.2
+    expected_info_map = {"prefix": "field_name:'test'", "date": {"year": year, "day": day}}
+    expected_value = {"mass": 100, "nitrogen": 20, "phosphorus": 15, "potassium": 10}
+    field._formulate_fertilizer_required.assert_called_once_with(0.3, 0.2, 0.5, requested_n, requested_p)
+    field.fertilizer_applicator.apply_fertilizer.assert_called_once_with(15, 100, expected_nitrogen_fraction, 0.0, 0.0,
+                                                                         field_size)
+    actual = om.variables_pool["field_name:'test'.fertilizer_application"]
+    assert actual["info_maps"].__contains__(expected_info_map)
+    assert actual["values"].__contains__(expected_value)
 
 
 @pytest.mark.parametrize("nitrogen_frac,phosphorus_frac,potassium_frac,requested_nitrogen,requested_phosphorus,"

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -168,12 +168,24 @@ def test_harvest_scheduled_crops():
     crop3.crop_management.manage_harvest.assert_called_once()
 
 
-def test_amend_soil() -> None:
-    """Tests that amend_soil() properly calls all the subroutines that add nutrients to the field"""
-    field = Field()
-    field.soil.phosphorus_cycling.fertilizer.add_fertilizer_phosphorus = MagicMock()
-    field.amend_soil()
-    field.soil.phosphorus_cycling.fertilizer.add_fertilizer_phosphorus.assert_called_once_with(0)
+@pytest.mark.parametrize("nitrogen_frac,phosphorus_frac,potassium_frac,requested_nitrogen,requested_phosphorus,"
+                         "expected", [
+                             (0.2, 0.1, 0.3, 100.0, 80.0, {"mass": 800.0, "nitrogen_mass": 160.0,
+                                                           "phosphorus_mass": 80.0, "potassium_mass": 240.0}),
+                             (0.82, 0.0, 0.0, 200.0, 50.0, {"mass": 243.90243902439025, "nitrogen_mass": 200.0,
+                                                            "phosphorus_mass": 0.0, "potassium_mass": 0.0}),
+                             (0.4, 0.2, 0.1, 80.0, 40.0, {"mass": 200.0, "nitrogen_mass": 80.0,
+                                                          "phosphorus_mass": 40.0, "potassium_mass": 20.0}),
+                             (0.05, 0.1, 0.3, 45.0, 100.0, {"mass": 1000.0, "nitrogen_mass": 50.0,
+                                                            "phosphorus_mass": 100.0, "potassium_mass": 300.0})
+                         ])
+def test_formulate_fertilizer_required(nitrogen_frac: float, phosphorus_frac: float, potassium_frac: float,
+                                       requested_nitrogen: float, requested_phosphorus: float,
+                                       expected: Dict[str, float]) -> None:
+    """Tests that fertilizer formulations are made correctly."""
+    actual = Field._formulate_fertilizer_required(nitrogen_frac, phosphorus_frac, potassium_frac, requested_nitrogen,
+                                                  requested_phosphorus)
+    assert actual == expected
 
 
 @pytest.mark.parametrize("field_size,crops_growing,residue,light,mean_temp,min_temp,max_temp,annual_mean_temp,"

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -6,7 +6,7 @@ from SC_redesign.Crop_and_Soil.crop.crop import Crop
 from SC_redesign.Crop_and_Soil.crop.crop_data import CropData
 from SC_redesign.Crop_and_Soil.crop.species_data_factory import CropSpecies
 from SC_redesign.Crop_and_Soil.manager.current_weather import CurrentWeather
-from SC_redesign.Crop_and_Soil.manager.events import Event, PlantingEvent, HarvestEvent
+from SC_redesign.Crop_and_Soil.manager.events import Event, PlantingEvent, HarvestEvent, FertilizerEvent
 from SC_redesign.Crop_and_Soil.soil.soil import Soil
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 from SC_redesign.Crop_and_Soil.field.field import Field
@@ -54,6 +54,38 @@ def test_check_crop_planting_schedule(all_events: List[PlantingEvent], events_re
     field._create_and_update_events.assert_has_calls(expected_create_and_update_events_calls)
     assert field._plant_crop.call_count == len(events_occurring_today)
     assert field.planting_events == events_remaining
+
+
+@pytest.mark.parametrize("events,remaining_events,current_events", [
+    ([FertilizerEvent("mix_1", 100, 20, 1993, 75, 0, 1.0), FertilizerEvent("mix_2", 20, 20, 1993, 75, 0, 1.0),
+      FertilizerEvent("mix_3", 15, 15, 1993, 75, 0, 1.0)], [], [FertilizerEvent("mix_1", 100, 20, 1993, 75, 0, 1.0),
+                                                                FertilizerEvent("mix_2", 20, 20, 1993, 75, 0, 1.0),
+                                                                FertilizerEvent("mix_3", 15, 15, 1993, 75, 0, 1.0)]),
+    ([FertilizerEvent("mix_1", 150, 20, 1992, 80, 0, 1.0), FertilizerEvent("mix_1", 25, 5, 1992, 250, 0, 1.0),
+      FertilizerEvent("mix_1", 100, 50, 1993, 80, 0, 1.0)], [FertilizerEvent("mix_1", 25, 5, 1992, 250, 0, 1.0),
+                                                             FertilizerEvent("mix_1", 100, 50, 1993, 80, 0, 1.0)],
+                                                             [FertilizerEvent("mix_1", 150, 20, 1992, 80, 0, 1.0)]),
+    ([FertilizerEvent("mix_1", 50, 10, 1998, 90, 0, 1.0), FertilizerEvent("mix_1", 50, 10, 1999, 90, 0, 1.0),
+      FertilizerEvent("mix_1", 50, 10, 2000, 90, 0, 1.0)], [FertilizerEvent("mix_1", 50, 10, 1998, 90, 0, 1.0),
+                                                            FertilizerEvent("mix_1", 50, 10, 1999, 90, 0, 1.0),
+                                                            FertilizerEvent("mix_1", 50, 10, 2000, 90, 0, 1.0)], [])
+])
+def test_check_fertilizer_application_schedule(events: List[FertilizerEvent], remaining_events: List[FertilizerEvent],
+                                               current_events: List[FertilizerEvent]) -> None:
+    """Tests that fertilizer events that occur on the current day are properly selected and executed."""
+    field = Field(fertilizer_events=events)
+    field._create_and_update_events = MagicMock(return_value=(remaining_events, current_events))
+    field._execute_fertilizer_application = MagicMock()
+    mocked_time = MagicMock(Time)
+
+    field.check_fertilizer_application_schedule(mocked_time)
+    
+    expected_execution_calls = []
+    for event in current_events:
+        expected_execution_calls.append(call(event.mix_name, event.nitrogen_mass, event.phosphorus_mass, event.year,
+                                             event.day))
+    field._create_and_update_events.assert_called_once_with(events, mocked_time)
+    field._execute_fertilizer_application.assert_has_calls(expected_execution_calls)
 
 
 @pytest.mark.parametrize("events,year,day,expected_remaining,expected_current", [
@@ -143,7 +175,7 @@ def test_plant_crop_error(field_name: str, crop_reference: str, custom_crop_spec
     ([Crop(), Crop(), Crop(), Crop()], 0.25),
     ([], None)
 ])
-def test_rest_crop_field_coverage_fractions(crop_list: List[Crop], expected_field_proportion: float) -> None:
+def test_reset_crop_field_coverage_fractions(crop_list: List[Crop], expected_field_proportion: float) -> None:
     """Tests that crops in a field correctly have their proportion reset when there are other crops present."""
     field = Field()
     field.crops = crop_list

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -494,7 +494,7 @@ def test_execute_fertilizer_application(mix_name: str, requested_n: float, reque
     """Tests that fertilizer applications are being correctly executed and recorded."""
     field_data = FieldData(name="test", field_size=field_size)
     field = Field(field_data=field_data, fertilizer_mixes={mix_name: {"N": 0.3, "P": 0.2, "K": 0.5}})
-    field._formulate_fertilizer_required = MagicMock(return_value={"mass": 100, "nitrogen_mass": 20,
+    field._formulate_fertilizer_required = MagicMock(return_value={"total_mass": 100, "nitrogen_mass": 20,
                                                                    "phosphorus_mass": 15,
                                                                    "potassium_mass": 10})
     field.fertilizer_applicator.apply_fertilizer = MagicMock()
@@ -511,13 +511,13 @@ def test_execute_fertilizer_application(mix_name: str, requested_n: float, reque
 
 @pytest.mark.parametrize("nitrogen_frac,phosphorus_frac,potassium_frac,requested_nitrogen,requested_phosphorus,"
                          "expected", [
-                             (0.2, 0.1, 0.3, 100.0, 80.0, {"mass": 800.0, "nitrogen_mass": 160.0,
+                             (0.2, 0.1, 0.3, 100.0, 80.0, {"total_mass": 800.0, "nitrogen_mass": 160.0,
                                                            "phosphorus_mass": 80.0, "potassium_mass": 240.0}),
-                             (0.82, 0.0, 0.0, 200.0, 50.0, {"mass": 243.90243902439025, "nitrogen_mass": 200.0,
+                             (0.82, 0.0, 0.0, 200.0, 50.0, {"total_mass": 243.90243902439025, "nitrogen_mass": 200.0,
                                                             "phosphorus_mass": 0.0, "potassium_mass": 0.0}),
-                             (0.4, 0.2, 0.1, 80.0, 40.0, {"mass": 200.0, "nitrogen_mass": 80.0,
+                             (0.4, 0.2, 0.1, 80.0, 40.0, {"total_mass": 200.0, "nitrogen_mass": 80.0,
                                                           "phosphorus_mass": 40.0, "potassium_mass": 20.0}),
-                             (0.05, 0.1, 0.3, 45.0, 100.0, {"mass": 1000.0, "nitrogen_mass": 50.0,
+                             (0.05, 0.1, 0.3, 45.0, 100.0, {"total_mass": 1000.0, "nitrogen_mass": 50.0,
                                                             "phosphorus_mass": 100.0, "potassium_mass": 300.0})
                          ])
 def test_formulate_fertilizer_required(nitrogen_frac: float, phosphorus_frac: float, potassium_frac: float,

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -64,7 +64,7 @@ def test_check_crop_planting_schedule(all_events: List[PlantingEvent], events_re
     ([FertilizerEvent("mix_1", 150, 20, 1992, 80, 0, 1.0), FertilizerEvent("mix_1", 25, 5, 1992, 250, 0, 1.0),
       FertilizerEvent("mix_1", 100, 50, 1993, 80, 0, 1.0)], [FertilizerEvent("mix_1", 25, 5, 1992, 250, 0, 1.0),
                                                              FertilizerEvent("mix_1", 100, 50, 1993, 80, 0, 1.0)],
-                                                             [FertilizerEvent("mix_1", 150, 20, 1992, 80, 0, 1.0)]),
+                                                            [FertilizerEvent("mix_1", 150, 20, 1992, 80, 0, 1.0)]),
     ([FertilizerEvent("mix_1", 50, 10, 1998, 90, 0, 1.0), FertilizerEvent("mix_1", 50, 10, 1999, 90, 0, 1.0),
       FertilizerEvent("mix_1", 50, 10, 2000, 90, 0, 1.0)], [FertilizerEvent("mix_1", 50, 10, 1998, 90, 0, 1.0),
                                                             FertilizerEvent("mix_1", 50, 10, 1999, 90, 0, 1.0),
@@ -79,7 +79,7 @@ def test_check_fertilizer_application_schedule(events: List[FertilizerEvent], re
     mocked_time = MagicMock(Time)
 
     field.check_fertilizer_application_schedule(mocked_time)
-    
+
     expected_execution_calls = []
     for event in current_events:
         expected_execution_calls.append(call(event.mix_name, event.nitrogen_mass, event.phosphorus_mass, event.year,
@@ -313,18 +313,15 @@ def test_execute_fertilizer_application(mix_name: str, requested_n: float, reque
                                                                    "phosphorus_mass": 15,
                                                                    "potassium_mass": 10})
     field.fertilizer_applicator.apply_fertilizer = MagicMock()
+    field._record_fertilizer_application = MagicMock()
 
     field._execute_fertilizer_application(mix_name, requested_n, requested_p, year, day)
 
     expected_nitrogen_fraction = 0.2
-    expected_info_map = {"prefix": "field_name:'test'", "date": {"year": year, "day": day}}
-    expected_value = {"mass": 100, "nitrogen": 20, "phosphorus": 15, "potassium": 10}
     field._formulate_fertilizer_required.assert_called_once_with(0.3, 0.2, 0.5, requested_n, requested_p)
     field.fertilizer_applicator.apply_fertilizer.assert_called_once_with(15, 100, expected_nitrogen_fraction, 0.0, 0.0,
                                                                          field_size)
-    actual = om.variables_pool["field_name:'test'.fertilizer_application"]
-    assert actual["info_maps"].__contains__(expected_info_map)
-    assert actual["values"].__contains__(expected_value)
+    field._record_fertilizer_application.assert_called_once_with(mix_name, 100, 20, 15, 10, year, day)
 
 
 @pytest.mark.parametrize("nitrogen_frac,phosphorus_frac,potassium_frac,requested_nitrogen,requested_phosphorus,"
@@ -345,6 +342,29 @@ def test_formulate_fertilizer_required(nitrogen_frac: float, phosphorus_frac: fl
     actual = Field._formulate_fertilizer_required(nitrogen_frac, phosphorus_frac, potassium_frac, requested_nitrogen,
                                                   requested_phosphorus)
     assert actual == expected
+
+
+@pytest.mark.parametrize("mix_name,total_mass,nitrogen_mass,phosphorus_mass,potassium_mass,year,day,field_name,"
+                         "field_size", [
+                                        ("mix_1", 100, 20, 20, 20, 1992, 90, "field_1", 1.4),
+                                        ("mix_2", 30, 10, 3, 3, 1994, 120, "field_2", 4.3)
+                                        ])
+def test_record_fertilizer_application(mix_name: str, total_mass: float, nitrogen_mass: float, phosphorus_mass: float,
+                                       potassium_mass: float, year: int, day: int, field_name: str,
+                                       field_size: float) -> None:
+    """Tests that fertilizer applications are correctly recorded in the OutputManager."""
+    field = Field(field_data=FieldData(name=field_name, field_size=field_size))
+
+    field._record_fertilizer_application(mix_name, total_mass, nitrogen_mass, phosphorus_mass, potassium_mass, year,
+                                         day)
+
+    expected_info_map = {"prefix": f"field_name:'{field_name}'", "date": {"year": year, "day": day},
+                         "mix_name": mix_name, "field_size": field_size}
+    expected_value = {"mass": total_mass, "nitrogen": nitrogen_mass, "phosphorus": phosphorus_mass,
+                      "potassium": potassium_mass}
+    actual = om.variables_pool[f"field_name:'{field_name}'.fertilizer_application"]
+    assert actual["info_maps"].__contains__(expected_info_map)
+    assert actual["values"].__contains__(expected_value)
 
 
 @pytest.mark.parametrize("field_size,crops_growing,residue,light,mean_temp,min_temp,max_temp,annual_mean_temp,"

--- a/SC_redesign/docs_SC/Admin/finish_line_doc.md
+++ b/SC_redesign/docs_SC/Admin/finish_line_doc.md
@@ -95,9 +95,9 @@ run of the simulation.
   - [ ] Add call to `check_tillage_schedule()` in `Field`s daily routine. - 1 point
 - Fertilizer
   - [x] Implement and test fertilizer application scheduler. - 3 points
-  - [ ] Implement and test `check_fertilizer_schedule()` which will iterate through a list of `FertilizerEvent`s and 
+  - [x] Implement and test `check_fertilizer_schedule()` which will iterate through a list of `FertilizerEvent`s and 
   collect and execute all the ones that happen on the current day. - 2 points
-  - [ ] Add call to `check_fertilizer_schedule()` in `Field`s daily routine. - 1 point
+  - [x] Add call to `check_fertilizer_schedule()` in `Field`s daily routine. - 1 point
 - Manure
   - [ ] Implement and test manure application scheduler. - 3 points
   - [ ] Implement and test `check_manure_schedule()` which will iterate through a list of `ManureEvent`s and collect and 


### PR DESCRIPTION
This PR integrates `FertilizerEvent`s into `Field` and adds the necessary methods for checking and executing fertilizer applications on a daily basis.

- `check_fertilizer_application()` determines if any of the `Field`s scheduled fertilizer events need to be executed that day, and if so passes them to be executed.
- `_formulate_fertilizer_required()` determines the minimum of amount of fertilizer that is need of a particular mix in order to fill the specified nutrient requirements.
- `_execute_fertilizer_application()` takes the values from a `FertilizerEvent`, determines how much fertilizer and nutrients will actually be applied, and then passes those values in the appropriate form to the `FertilizerApplication` module.
- `_record_fertilizer_application()` adds the data from individual application events to the `OutputManager`.
- All methods listed above are tested in 'test_field.py`.
- Several old placeholder methods for `Field` setup and event execution have been removed.
- `finish_line_doc.md` has been updated to reflect progress made.