### PR TITLE
Integrate `ManureEvent`s into `Field` module 

### DIFF
--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -289,7 +289,7 @@ class Field:
             Julian day on which this fertilizer application is occurring.
 
         """
-        info_map = {"class": self.__class__.__name__, "function": self._execute_fertilizer_application.__name__,
+        info_map = {"class": self.__class__.__name__, "function": self._record_fertilizer_application.__name__,
                     "prefix": f"field_name:'{self.field_data.name}'", "date": {"year": year, "day": day},
                     "mix_name": mix_name, "field_size": self.field_data.field_size}
         value = {"mass": total_mass, "nitrogen": nitrogen_mass, "phosphorus": phosphorus_mass,
@@ -332,6 +332,37 @@ class Field:
                                                                  self.available_fertilizer_mixes)
         self._execute_fertilizer_application(optimal_mix, unmet_nitrogen_demand, unmet_phosphorus_demand, year, day)
 
+    def _record_manure_application(self, dry_matter_mass: float, dry_matter_fraction: float, field_coverage: float,
+                                   nitrogen: float, phosphorus: float, potassium: float, year: int, day: int) -> None:
+        """
+        Records the amount of manure and related values for an individual manure application.
+
+        Parameters
+        ----------
+        dry_matter_mass : float
+            Dry weight equivalent of this application (kg)
+        dry_matter_fraction : float
+            Fraction of this manure application that is dry matter, in the range (0.0, 1.0] (unitless)
+        field_coverage : float
+            Fraction of the field this manure is applied to (unitless)
+        nitrogen : float
+            Mass of nitrogen in the manure applied (kg)
+        phosphorus : float
+            Mass of phosphorus in the manure applied (kg)
+        potassium : float
+            Mass of potassium in the manure applied (kg)
+        year : int
+            Calendar year in which this manure application occurs.
+        day : int
+            Julian day on which this manure application occurs.
+
+        """
+        info_map = {"class": self.__class__.__name__, "function": self._record_manure_application.__name__,
+                    "prefix": f"field_name:'{self.field_data.name}'", "date": {"year": year, "day": day},
+                    "field_size": self.field_data.field_size}
+        value = {"dry_matter_mass": dry_matter_mass, "dry_matter_fraction": dry_matter_fraction, "field_coverage":
+                 field_coverage, "nitrogen": nitrogen, "phosphorus": phosphorus, "potassium": potassium}
+        om.add_variable("manure_application", value, info_map)
     # </editor-fold>
 
     # <editor-fold desc="--- Scheduling Methods ---">

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -68,8 +68,9 @@ class Field:
         self.fertilizer_events = fertilizer_events or []
         """List of all fertilizer application events that will be applied to this field."""
 
-        self.available_fertilizer_mixes = fertilizer_mixes or {"100_0_0": {"N": 1.0, "P": 0.0, "K": 0.0},
-                                                               "26_4_24": {"N": 0.26, "P": 0.04, "K": 0.24}}
+        self.available_fertilizer_mixes = fertilizer_mixes or {}
+        self.available_fertilizer_mixes["100_0_0"] = {"N": 1.0, "P": 0.0, "K": 0.0}
+        self.available_fertilizer_mixes["26_4_24"] = {"N": 0.26, "P": 0.04, "K": 0.24}
         """List of all fertilizer mixes available for application to this field."""
 
         self.tiller = TillageApplication(self.field_data, self.soil.data)

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -1,5 +1,4 @@
 import math
-import pdb
 
 from SC_redesign.Crop_and_Soil.crop.crop import Crop
 from SC_redesign.Crop_and_Soil.crop.crop_data import CropData
@@ -409,7 +408,8 @@ class Field:
         """
         self.manure_events, todays_manure_events = self._filter_events(self.manure_events, time)
         for event in todays_manure_events:
-            pass
+            self._execute_manure_application(event.nitrogen_mass, event.phosphorus_mass, event.field_coverage,
+                                             event.year, event.day)
 
     def check_crop_harvest_schedule(self, time: Time) -> None:
         """

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -1,3 +1,5 @@
+import math
+
 from SC_redesign.Crop_and_Soil.crop.crop import Crop
 from SC_redesign.Crop_and_Soil.crop.crop_data import CropData
 from SC_redesign.Crop_and_Soil.crop.species_data_factory import CropSpecies, CropSpeciesDataFactory
@@ -64,7 +66,8 @@ class Field:
         self.fertilizer_events = fertilizer_events or []
         """List of all fertilizer application events that will be applied to this field."""
 
-        self.available_fertilizer_mixes = fertilizer_mixes or {}
+        self.available_fertilizer_mixes = fertilizer_mixes or {"100_0_0": {"N": 1.0, "P": 0.0, "K": 0.0},
+                                                               "26_4_24": {"N": 0.26, "P": 0.04, "K": 0.24}}
         """List of all fertilizer mixes available for application to this field."""
 
         self.tiller = TillageApplication(self.field_data, self.soil.data)
@@ -187,6 +190,40 @@ class Field:
                                             potassium_applied, year, day)
 
     @staticmethod
+    def _determine_optimal_fertilizer_mix(requested_nitrogen: float, requested_phosphorus: float,
+                                          available_mixes: Dict[str, Dict[str, float]]) -> str:
+        """
+        Takes the requested nutrients of a fertilizer application and determines which fertilizer mix would fill them
+        the most efficiently..
+
+        Parameters
+        ----------
+        requested_nitrogen : float
+            Minimum amount of nitrogen to be included in this fertilizer application.
+        requested_phosphorus : float
+            Minimum amount of phosphorus to be included in this fertilizer application.
+        available_mixes : Dict[str, Dict[str, float]]
+            List of fertilizer mixes available for application to the field.
+
+        Returns
+        -------
+        str
+            Name of the fertilizer mix which requires the least mass of fertilizer to fill the nutrient requests.
+
+        """
+        optimal_mix = None
+        least_fertilizer_mix_required = math.inf
+        for mix_name, mix_values in available_mixes:
+            if mix_name == "100_0_0":
+                continue
+            fertilizer_application = Field._formulate_fertilizer_required(mix_values["N"], mix_values["P"],
+                                                                          mix_values["K"], requested_nitrogen,
+                                                                          requested_phosphorus)
+            if fertilizer_application["mass"] < least_fertilizer_mix_required:
+                optimal_mix = mix_name
+        return optimal_mix
+
+    @staticmethod
     def _formulate_fertilizer_required(nitrogen_fraction: float, phosphorus_fraction: float,
                                        potassium_fraction: float, requested_nitrogen: float,
                                        requested_phosphorus: float) -> Dict[str, float]:
@@ -251,6 +288,42 @@ class Field:
         value = {"mass": total_mass, "nitrogen": nitrogen_mass, "phosphorus": phosphorus_mass,
                  "potassium": potassium_mass}
         om.add_variable("fertilizer_application", value, info_map)
+
+    def _execute_manure_application(self, requested_nitrogen: float, requested_phosphorus: float, field_coverage: float,
+                                    year: int, day: int) -> None:
+        """
+        Builds a manure application from the requested nutrient amounts and passes that application to the
+        ManureApplication module.
+
+        Parameters
+        ----------
+        requested_nitrogen : float
+            Mass of nitrogen requested to be in this manure application (kg)
+        requested_phosphorus : float
+            Mass of phosphorus requested to be in this manure application (kg)
+        field_coverage : float
+            Fraction of the field this manure is applied to (unitless)
+        year : int
+            Calendar year in which this manure application occurs.
+        day : int
+            Julian day on which this manure application occurs.
+
+        """
+        # TODO: integrate the manure manager's request manure method here when it is finished.
+        manure_filled_by_request = {"nitrogen": 0.0, "phosphorus": 0.0}
+
+        self.manure_applicator.apply_machine_manure(0.0, 0.0, 0.0, field_coverage, 1.0, 0.0, 0.0, 0.0)
+
+        unmet_nitrogen_demand = min(0.0, requested_nitrogen - manure_filled_by_request["nitrogen"])
+        unmet_phosphorus_demand = min(0.0, requested_phosphorus - manure_filled_by_request["phosphorus"])
+        if not unmet_nitrogen_demand and not unmet_phosphorus_demand:
+            return
+        elif unmet_phosphorus_demand and not unmet_nitrogen_demand:
+            optimal_mix = "100_0_0"
+        else:
+            optimal_mix = self._determine_optimal_fertilizer_mix(unmet_nitrogen_demand, unmet_phosphorus_demand,
+                                                                 self.available_fertilizer_mixes)
+        self._execute_fertilizer_application(optimal_mix, unmet_nitrogen_demand, unmet_phosphorus_demand, year, day)
 
     # </editor-fold>
 
@@ -369,6 +442,7 @@ class Field:
             else:
                 remaining_events.append(event)
         return remaining_events, todays_events
+
     # </editor-fold>
 
     # <editor-fold desc="--- Crop Management Methods ---">
@@ -650,6 +724,7 @@ class Field:
         else:
             for crop in self.crops:
                 crop.data.is_dormant = False
+
     # </editor-fold>
 
     # <editor-fold desc="--- Field-level Methods ---">

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -1,7 +1,7 @@
 from SC_redesign.Crop_and_Soil.crop.crop import Crop
 from SC_redesign.Crop_and_Soil.crop.crop_data import CropData
 from SC_redesign.Crop_and_Soil.crop.species_data_factory import CropSpecies, CropSpeciesDataFactory
-from SC_redesign.Crop_and_Soil.manager.events import Event, PlantingEvent, HarvestEvent, FertilizerEvent
+from SC_redesign.Crop_and_Soil.manager.events import Event, PlantingEvent, HarvestEvent, FertilizerEvent, ManureEvent
 from SC_redesign.Crop_and_Soil.manager.current_weather import CurrentWeather
 from SC_redesign.Crop_and_Soil.soil.soil import Soil
 from SC_redesign.Crop_and_Soil.field.field_data import FieldData
@@ -34,7 +34,8 @@ class Field:
                  plantings: Optional[List[PlantingEvent]] = None, harvestings: Optional[List[HarvestEvent]] = None,
                  custom_crop_specifications: Optional[Dict[str, Dict]] = None,
                  fertilizer_events: Optional[List[FertilizerEvent]] = None,
-                 fertilizer_mixes: Optional[Dict[str, Dict[str, float]]] = None):
+                 fertilizer_mixes: Optional[Dict[str, Dict[str, float]]] = None,
+                 manure_events: Optional[List[ManureEvent]] = None):
         # field-wide attributes
         self.field_data = field_data or FieldData()
         """field data component"""
@@ -61,7 +62,7 @@ class Field:
         """Provides interface for adding fertilizer to the field."""
 
         self.fertilizer_events = fertilizer_events or []
-        """List of all fertilizer application events that will in this field."""
+        """List of all fertilizer application events that will be applied to this field."""
 
         self.available_fertilizer_mixes = fertilizer_mixes or {}
         """List of all fertilizer mixes available for application to this field."""
@@ -69,11 +70,11 @@ class Field:
         self.tiller = TillageApplication(self.field_data, self.soil.data)
         """Provides interface to till the field."""
 
-        self.is_last_day_of_the_year = False  # TODO: This should be handled elsewhere
-        """is today the last day of the simulation year?"""
-
         self.manure_applicator = ManureApplication(self.soil.data)
         """Manure application interface."""
+
+        self.manure_events: List[ManureEvent] = manure_events or []
+        """List of all manure applications that will be applied to this field."""
 
     def manage_field(self, time: Time, current_weather: CurrentWeather) -> None:
         """main Field function, runs all field routines based on current attribute configuration
@@ -87,6 +88,8 @@ class Field:
         """
         # --- Soil Management---
         self.check_fertilizer_application_schedule(time)
+
+        self.check_manure_application_schedule(time)
 
         # --- Whole-Field Methods ---
         # Allow non-management field processes (water/nutrient cycling) to occur
@@ -115,10 +118,6 @@ class Field:
                 self.graze_field()
 
             self.harvest_scheduled_crops()
-
-        # annual resets
-        if self.is_last_day_of_the_year:
-            self.perform_annual_reset()
 
         pass
 
@@ -285,6 +284,20 @@ class Field:
         for event in todays_fertilizer_events:
             self._execute_fertilizer_application(event.mix_name, event.nitrogen_mass, event.phosphorus_mass, event.year,
                                                  event.day)
+
+    def check_manure_application_schedule(self, time: Time) -> None:
+        """
+        Checks list of ManureEvents, sends all that occur today to another method to be executed.
+
+        Parameters
+        ----------
+        time : Time
+            Object containing the current year and day of the simulation.
+
+        """
+        self.manure_events, todays_manure_events = self._filter_events(self.manure_events, time)
+        for event in todays_manure_events:
+            pass
 
     def check_crop_harvest_schedule(self, time: Time) -> None:
         """

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -71,7 +71,8 @@ class Field:
         self.available_fertilizer_mixes = fertilizer_mixes or {}
         self.available_fertilizer_mixes["100_0_0"] = {"N": 1.0, "P": 0.0, "K": 0.0}
         self.available_fertilizer_mixes["26_4_24"] = {"N": 0.26, "P": 0.04, "K": 0.24}
-        """List of all fertilizer mixes available for application to this field."""
+        """List of all fertilizer mixes available for application to this field. The 100_0_0 and 26_4_24 mixes will
+            always be available as supplements to unfulfilled manure nutrient demands."""
 
         self.tiller = TillageApplication(self.field_data, self.soil.data)
         """Provides interface to till the field."""

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -194,7 +194,7 @@ class Field:
                                           available_mixes: Dict[str, Dict[str, float]]) -> str:
         """
         Takes the requested nutrients of a fertilizer application and determines which fertilizer mix would fill them
-        the most efficiently..
+        the most efficiently.
 
         Parameters
         ----------
@@ -210,10 +210,16 @@ class Field:
         str
             Name of the fertilizer mix which requires the least mass of fertilizer to fill the nutrient requests.
 
+        Notes
+        -----
+        The optimal fertilizer mix is currently the one that requires the least amount of fertilizer to meet the
+        demanded nutrients, but a more realistic definition of "optimal" may mean the mix that costs the least to fill
+        the requested nutrients with.
+
         """
         optimal_mix = None
         least_fertilizer_mix_required = math.inf
-        for mix_name, mix_values in available_mixes:
+        for mix_name, mix_values in available_mixes.items():
             if mix_name == "100_0_0":
                 continue
             fertilizer_application = Field._formulate_fertilizer_required(mix_values["N"], mix_values["P"],
@@ -221,6 +227,7 @@ class Field:
                                                                           requested_phosphorus)
             if fertilizer_application["mass"] < least_fertilizer_mix_required:
                 optimal_mix = mix_name
+                least_fertilizer_mix_required = fertilizer_application["mass"]
         return optimal_mix
 
     @staticmethod

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -1,4 +1,5 @@
 import math
+import pdb
 
 from SC_redesign.Crop_and_Soil.crop.crop import Crop
 from SC_redesign.Crop_and_Soil.crop.crop_data import CropData
@@ -321,11 +322,11 @@ class Field:
 
         self.manure_applicator.apply_machine_manure(0.0, 0.0, 0.0, field_coverage, 1.0, 0.0, 0.0, 0.0)
 
-        unmet_nitrogen_demand = min(0.0, requested_nitrogen - manure_filled_by_request["nitrogen"])
-        unmet_phosphorus_demand = min(0.0, requested_phosphorus - manure_filled_by_request["phosphorus"])
-        if not unmet_nitrogen_demand and not unmet_phosphorus_demand:
+        unmet_nitrogen_demand = max(0.0, requested_nitrogen - manure_filled_by_request["nitrogen"])
+        unmet_phosphorus_demand = max(0.0, requested_phosphorus - manure_filled_by_request["phosphorus"])
+        if unmet_nitrogen_demand == 0.0 and unmet_phosphorus_demand == 0.0:
             return
-        elif unmet_phosphorus_demand and not unmet_nitrogen_demand:
+        elif not unmet_nitrogen_demand == 0.0 and unmet_phosphorus_demand == 0.0:
             optimal_mix = "100_0_0"
         else:
             optimal_mix = self._determine_optimal_fertilizer_mix(unmet_nitrogen_demand, unmet_phosphorus_demand,

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -65,7 +65,7 @@ def test_check_crop_planting_schedule(all_events: List[PlantingEvent], events_re
     ([FertilizerEvent("mix_1", 150, 20, 1992, 80, 0, 1.0), FertilizerEvent("mix_1", 25, 5, 1992, 250, 0, 1.0),
       FertilizerEvent("mix_1", 100, 50, 1993, 80, 0, 1.0)], [FertilizerEvent("mix_1", 25, 5, 1992, 250, 0, 1.0),
                                                              FertilizerEvent("mix_1", 100, 50, 1993, 80, 0, 1.0)],
-                                                            [FertilizerEvent("mix_1", 150, 20, 1992, 80, 0, 1.0)]),
+     [FertilizerEvent("mix_1", 150, 20, 1992, 80, 0, 1.0)]),
     ([FertilizerEvent("mix_1", 50, 10, 1998, 90, 0, 1.0), FertilizerEvent("mix_1", 50, 10, 1999, 90, 0, 1.0),
       FertilizerEvent("mix_1", 50, 10, 2000, 90, 0, 1.0)], [FertilizerEvent("mix_1", 50, 10, 1998, 90, 0, 1.0),
                                                             FertilizerEvent("mix_1", 50, 10, 1999, 90, 0, 1.0),
@@ -509,12 +509,18 @@ def test_execute_fertilizer_application(mix_name: str, requested_n: float, reque
     field._record_fertilizer_application.assert_called_once_with(mix_name, 100, 20, 15, 10, year, day)
 
 
-
 @pytest.mark.parametrize("nitrogen,phosphorus,mixes,expected", [
     (100, 20, {"100_0_0": {"N": 1.0, "P": 0.0, "K": 0.0}, "26_4_24": {"N": 0.26, "P": 0.04, "K": 0.24}}, "26_4_24"),
     (50, 60, {"30_40_50": {"N": 0.3, "P": 0.4, "K": 0.5}}, "30_40_50"),
-    (22.5, 33, {})
+    (22.5, 33, {"25_15_28": {"N": 0.25, "P": 0.15, "K": 0.28}, "33_40_3": {"N": 0.33, "P": 0.4, "K": 0.28},
+                "40_22_6": {"N": 0.4, "P": 0.22, "K": 0.06}}, "33_40_3")
 ])
+def test_determine_optimal_fertilizer_mix(nitrogen: float, phosphorus: float, mixes: Dict[str, Dict[str, float]],
+                                          expected: float) -> None:
+    """Tests that the optimal mix for meeting the requested nutrients is found correctly."""
+    actual = Field._determine_optimal_fertilizer_mix(nitrogen, phosphorus, mixes)
+    assert actual == expected
+
 
 @pytest.mark.parametrize("nitrogen_frac,phosphorus_frac,potassium_frac,requested_nitrogen,requested_phosphorus,"
                          "expected", [
@@ -538,9 +544,9 @@ def test_formulate_fertilizer_required(nitrogen_frac: float, phosphorus_frac: fl
 
 @pytest.mark.parametrize("mix_name,total_mass,nitrogen_mass,phosphorus_mass,potassium_mass,year,day,field_name,"
                          "field_size", [
-                                        ("mix_1", 100, 20, 20, 20, 1992, 90, "field_1", 1.4),
-                                        ("mix_2", 30, 10, 3, 3, 1994, 120, "field_2", 4.3)
-                                        ])
+                             ("mix_1", 100, 20, 20, 20, 1992, 90, "field_1", 1.4),
+                             ("mix_2", 30, 10, 3, 3, 1994, 120, "field_2", 4.3)
+                         ])
 def test_record_fertilizer_application(mix_name: str, total_mass: float, nitrogen_mass: float, phosphorus_mass: float,
                                        potassium_mass: float, year: int, day: int, field_name: str,
                                        field_size: float) -> None:

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -7,7 +7,7 @@ from SC_redesign.Crop_and_Soil.crop.crop_data import CropData
 from SC_redesign.Crop_and_Soil.crop.harvest_operations import HarvestOperation
 from SC_redesign.Crop_and_Soil.crop.species_data_factory import CropSpecies
 from SC_redesign.Crop_and_Soil.manager.current_weather import CurrentWeather
-from SC_redesign.Crop_and_Soil.manager.events import Event, PlantingEvent, HarvestEvent, FertilizerEvent
+from SC_redesign.Crop_and_Soil.manager.events import Event, PlantingEvent, HarvestEvent, FertilizerEvent, ManureEvent
 from SC_redesign.Crop_and_Soil.soil.soil import Soil
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 from SC_redesign.Crop_and_Soil.field.field import Field
@@ -89,6 +89,41 @@ def test_check_fertilizer_application_schedule(events: List[FertilizerEvent], re
                                              event.day))
     field._filter_events.assert_called_once_with(events, mocked_time)
     field._execute_fertilizer_application.assert_has_calls(expected_execution_calls)
+
+
+@pytest.mark.parametrize("events,remaining_events,current_events", [
+    ([ManureEvent(1991, 120, 100, 20, 0.8, 0.0, 1.0), ManureEvent(1992, 120, 100, 20, 0.8, 0.0, 1.0),
+      ManureEvent(1993, 120, 100, 20, 0.8, 0.0, 1.0)],
+     [ManureEvent(1992, 120, 100, 20, 0.8, 0.0, 1.0), ManureEvent(1993, 120, 100, 20, 0.8, 0.0, 1.0)],
+     [ManureEvent(1991, 120, 100, 20, 0.8, 0.0, 1.0)]),
+    ([ManureEvent(1991, 125, 100, 20, 0.8, 0.0, 1.0), ManureEvent(1992, 125, 100, 20, 0.8, 0.0, 1.0),
+      ManureEvent(1993, 125, 100, 20, 0.8, 0.0, 1.0)],
+     [ManureEvent(1991, 125, 100, 20, 0.8, 0.0, 1.0), ManureEvent(1992, 125, 100, 20, 0.8, 0.0, 1.0),
+      ManureEvent(1993, 125, 100, 20, 0.8, 0.0, 1.0)], []),
+    ([ManureEvent(1991, 120, 100, 20, 0.8, 0.0, 1.0), ManureEvent(1991, 120, 90, 20, 0.8, 0.0, 1.0),
+      ManureEvent(1991, 120, 80, 40, 0.8, 0.0, 1.0)], [],
+     [ManureEvent(1991, 120, 100, 20, 0.8, 0.0, 1.0), ManureEvent(1991, 120, 90, 20, 0.8, 0.0, 1.0),
+      ManureEvent(1991, 120, 80, 40, 0.8, 0.0, 1.0)])
+])
+def test_check_manure_application_schedule(events: List[ManureEvent], remaining_events: List[ManureEvent],
+                                           current_events: List[ManureEvent]) -> None:
+    """Tests that ManureEvents are correctly checked for and executed when scheduled."""
+    field = Field(manure_events=events)
+    field._filter_events = MagicMock(return_value=(remaining_events, current_events))
+    field._execute_manure_application = MagicMock()
+    mocked_time = MagicMock(Time)
+    setattr(mocked_time, "calendar_year", 1991)
+    setattr(mocked_time, "day", 120)
+
+    field.check_manure_application_schedule(mocked_time)
+
+    expected_execution_calls = []
+    for event in current_events:
+        expected_execution_calls.append(call(event.nitrogen_mass, event.phosphorus_mass, event.field_coverage,
+                                             event.year, event.day))
+    field._filter_events.assert_called_once_with(events, mocked_time)
+    assert field.manure_events == remaining_events
+    field._execute_manure_application.assert_has_calls(expected_execution_calls)
 
 
 @pytest.mark.parametrize("year,day,all_harvest_events,current_harvest_events", [

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -565,6 +565,32 @@ def test_record_fertilizer_application(mix_name: str, total_mass: float, nitroge
     assert actual["values"].__contains__(expected_value)
 
 
+@pytest.mark.parametrize("field_name,field_size,dry_mass,dry_fraction,coverage,nitrogen,phosphorus,potassium,"
+                         "year,day,expected_info,expected_values", [
+                             ("test_1", 1.3, 100, 0.1, 0.8, 10, 15, 12.5, 1991, 75,
+                              {"prefix": "field_name:'test_1'", "date": {"year": 1991, "day": 75}, "field_size": 1.3},
+                              {"dry_matter_mass": 100, "dry_matter_fraction": 0.1, "field_coverage": 0.8,
+                               "nitrogen": 10, "phosphorus": 15,
+                               "potassium": 12.5}),
+                             ("test_2", 2.4, 144.6, 0.3, 0.92, 40, 43.1, 14.55, 1994, 200,
+                              {"prefix": "field_name:'test_2'", "date": {"year": 1994, "day": 200}, "field_size": 2.4},
+                              {"dry_matter_mass": 144.6, "dry_matter_fraction": 0.3, "field_coverage": 0.92,
+                               "nitrogen": 40, "phosphorus": 43.1,
+                               "potassium": 14.55})
+                         ])
+def test_record_manure_application(field_name: str, field_size: float, dry_mass: float, dry_fraction: float,
+                                   coverage: float, nitrogen: float, phosphorus: float, potassium: float, year: int,
+                                   day: int, expected_info: Dict, expected_values: Dict) -> None:
+    """Tests that manure applications are recorded correctly."""
+    field = Field(field_data=FieldData(name=field_name, field_size=field_size))
+
+    field._record_manure_application(dry_mass, dry_fraction, coverage, nitrogen, phosphorus, potassium, year, day)
+
+    actual = om.variables_pool[f"field_name:'{field_name}'.manure_application"]
+    assert actual["info_maps"].__contains__(expected_info)
+    assert actual["values"].__contains__(expected_values)
+
+
 @pytest.mark.parametrize("field_size,crops_growing,residue,light,mean_temp,min_temp,max_temp,annual_mean_temp,"
                          "transpiration", [
                              (1.5, False, 34.5, 128, 22.5, 18.9, 25.6, 19.22, 5.2),

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -509,6 +509,13 @@ def test_execute_fertilizer_application(mix_name: str, requested_n: float, reque
     field._record_fertilizer_application.assert_called_once_with(mix_name, 100, 20, 15, 10, year, day)
 
 
+
+@pytest.mark.parametrize("nitrogen,phosphorus,mixes,expected", [
+    (100, 20, {"100_0_0": {"N": 1.0, "P": 0.0, "K": 0.0}, "26_4_24": {"N": 0.26, "P": 0.04, "K": 0.24}}, "26_4_24"),
+    (50, 60, {"30_40_50": {"N": 0.3, "P": 0.4, "K": 0.5}}, "30_40_50"),
+    (22.5, 33, {})
+])
+
 @pytest.mark.parametrize("nitrogen_frac,phosphorus_frac,potassium_frac,requested_nitrogen,requested_phosphorus,"
                          "expected", [
                              (0.2, 0.1, 0.3, 100.0, 80.0, {"mass": 800.0, "nitrogen_mass": 160.0,

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -565,6 +565,35 @@ def test_record_fertilizer_application(mix_name: str, total_mass: float, nitroge
     assert actual["values"].__contains__(expected_value)
 
 
+@pytest.mark.parametrize("nitrogen,phosphorus,coverage,year,day,fertilizer_applied,only_nitrogen_unmet", [
+    (100, 75, 0.9, 1993, 175, True, False),
+    (33, 0, 0.88, 2003, 200, True, True),
+    (0, 0, 0.5, 1996, 155, False, False)
+])
+def test_execute_manure_application(nitrogen: float, phosphorus: float, coverage: float, year: int, day: int,
+                                    fertilizer_applied: bool, only_nitrogen_unmet: bool) -> None:
+    """Tests that manure is applied to the soil correctly."""
+    field = Field()
+    field.manure_applicator.apply_machine_manure = MagicMock()
+    field._determine_optimal_fertilizer_mix = MagicMock(return_value="expected_optimal_mix")
+    field._execute_fertilizer_application = MagicMock()
+
+    field._execute_manure_application(nitrogen, phosphorus, coverage, year, day)
+
+    field.manure_applicator.apply_machine_manure.assert_called_once_with(0.0, 0.0, 0.0, coverage, 1.0, 0.0, 0.0, 0.0)
+    if fertilizer_applied and only_nitrogen_unmet:
+        field._determine_optimal_fertilizer_mix.assert_not_called()
+        field._execute_fertilizer_application.assert_called_once_with("100_0_0", nitrogen, phosphorus, year, day)
+    elif fertilizer_applied and not only_nitrogen_unmet:
+        field._determine_optimal_fertilizer_mix.assert_called_once_with(nitrogen, phosphorus,
+                                                                        field.available_fertilizer_mixes)
+        field._execute_fertilizer_application.assert_called_once_with("expected_optimal_mix", nitrogen, phosphorus,
+                                                                      year, day)
+    else:
+        field._determine_optimal_fertilizer_mix.assert_not_called()
+        field._execute_fertilizer_application.assert_not_called()
+
+
 @pytest.mark.parametrize("field_name,field_size,dry_mass,dry_fraction,coverage,nitrogen,phosphorus,potassium,"
                          "year,day,expected_info,expected_values", [
                              ("test_1", 1.3, 100, 0.1, 0.8, 10, 15, 12.5, 1991, 75,

--- a/SC_redesign/docs_SC/Admin/finish_line_doc.md
+++ b/SC_redesign/docs_SC/Admin/finish_line_doc.md
@@ -83,10 +83,10 @@ run of the simulation.
     - [x] Implement and test `plant_crop()` to take a crop specification, initialize a `Crop`, and add it to the `crops` 
     attribute of `Field`. - 2 points
     - Implement and test `check_crop_harvesting_schedule()`, which will
-      - [ ] Iterate through list of `HarvestEvent`s and execute all operations that it finds on the current day. - 2 points
-      - [ ] Iterate through the `crops` attribute to check if any are harvested using optimal (a.k.a. heat scheduled 
+      - [x] Iterate through list of `HarvestEvent`s and execute all operations that it finds on the current day. - 2 points
+      - [x] Iterate through the `crops` attribute to check if any are harvested using optimal (a.k.a. heat scheduled 
       harvesting) and if so, harvest them if they have met the optimal harvesting threshold. - 2 points
-    - [ ] Add calls to `check_crop_planting_schedule()` and `check_crop_harvesting_schedule()` in `Field`s daily 
+    - [x] Add calls to `check_crop_planting_schedule()` and `check_crop_harvesting_schedule()` in `Field`s daily 
     routine. - 1 point
 - Tillage
   - [x] Implement and test tillage application scheduler. - 3 points
@@ -100,9 +100,9 @@ run of the simulation.
   - [x] Add call to `check_fertilizer_schedule()` in `Field`s daily routine. - 1 point
 - Manure
   - [x] Implement and test manure application scheduler. - 3 points
-  - [ ] Implement and test `check_manure_schedule()` which will iterate through a list of `ManureEvent`s and collect and 
+  - [x] Implement and test `check_manure_schedule()` which will iterate through a list of `ManureEvent`s and collect and 
   execute all the ones that happen on the current day. - 2 points
-  - [ ] Add call to `check_manure_schedule()` in `Field`s daily routine. - 1 point
+  - [x] Add call to `check_manure_schedule()` in `Field`s daily routine. - 1 point
 
 ### Field Manager
 - Implement and test methods to translate user input into configuration dictionary.


### PR DESCRIPTION
This PR adds the functionality for `Field` to apply manure to the field based on a series of `ManureEvent`s.

- A list of `ManureEvent`s has been added which will dictate exactly what the `Field` module requests from the manure manager when a manure application is scheduled to happen.
- `available_fertilizer_mixes` now has some default mixes that will always be available if no other mixes are provided.
- `check_manure_application_schedule()` now checks for all manure applications that should happen on a single day and passes them to be executed, and is called every day from the main routine in `Field`
- `_execute_manure_application()` takes the fields from a single `ManureEvent`, request and apply manure based on those fields, and meet any unmet nutrient demands with fertilizer.
- `_determine_optimal_fertilizer_mix()` takes nutrient demands and a list of available fertilizers, and determines which mix can be used to meet the demands with the least amount of fertilizer.
- `_record_manure_application()` records the actual amounts of manure and nutrients that are applied to the field to the `OutputManager`. 

Note: once the method for requesting manure in the `ManureManagement` module is finished, it will need to be integrated into `_execute_manure_application()` - there are placeholder values hardcoded there for now.