### PR TITLE
Adding manure nutrients and nutrient request classes

### DIFF
--- a/RUFAS/routines/manure/manure_nutrients/manure_nutrients.py
+++ b/RUFAS/routines/manure/manure_nutrients/manure_nutrients.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+
+
+@dataclass(kw_only=True, frozen=True)
+class ManureNutrients:
+    """A class to store the relevant manure nutrient information to be passed to the crop and soil module"""
+
+    nitrogen: float = 0.0
+    """Amount of accumulated manure nitrogen derived from the manure module, kg."""
+
+    phosphorus: float = 0.0
+    """Amount of accumulated manure phosphorus derived from the manure module, kg."""
+
+    potassium: float = 0.0
+    """Amount of accumulated manure potassium derived from the manure module, kg."""
+
+    dry_matter: float = 0.0
+    """Amount of accumulated dry matter derived from the manure module, kg."""
+
+    total_manure_mass: float = 0.0
+    """Amount of accumulated manure mass derived from the manure module, kg."""
+
+    def __post_init__(self):
+        """
+        Validate the dataclass fields.
+
+        Raises
+        ------
+        ValueError
+            If any field is negative.
+
+        """
+        for field in fields(self):
+            if getattr(self, field.name) < 0:
+                raise ValueError(f'Field {field.name} must be non-negative.')
+
+    @property
+    def dry_matter_fraction(self) -> float:
+        """
+        Calculate the dry matter fraction of the manure.
+
+        Returns
+        -------
+        float
+            The dry matter fraction of the manure, unitless, between 0 and 1.
+
+        """
+        if self.total_manure_mass == 0.0:
+            return 0.0
+        return self.dry_matter / self.total_manure_mass
+
+    @property
+    def nitrogen_composition(self) -> float:
+        """
+        Calculate the nitrogen composition of the manure.
+
+        Returns
+        -------
+        float
+            The nitrogen composition of the manure, unitless, between 0 and 1.
+
+        """
+        if self.total_manure_mass == 0.0:
+            return 0.0
+        return self.nitrogen / self.total_manure_mass
+
+    @property
+    def phosphorus_composition(self) -> float:
+        """
+        Calculate the phosphorus composition of the manure.
+
+        Returns
+        -------
+        float
+            The phosphorus composition of the manure, unitless, between 0 and 1.
+
+        """
+        if self.total_manure_mass == 0.0:
+            return 0.0
+        return self.phosphorus / self.total_manure_mass
+
+    def __add__(self, other: ManureNutrients) -> ManureNutrients:
+        """
+        Add two ManureNutrients objects together.
+
+        Parameters
+        ----------
+        other : ManureNutrients
+            The other ManureNutrients object to add to this one.
+
+        Returns
+        -------
+        ManureNutrients
+            The sum of the two ManureNutrients objects.
+
+        Raises
+        ------
+        TypeError
+            If the other object is not a ManureNutrients object.
+
+        """
+        if not isinstance(other, ManureNutrients):
+            raise TypeError(f'Cannot add {type(self)} to {type(other)}.')
+
+        return ManureNutrients(**{f.name: getattr(self, f.name) + getattr(other, f.name) for f in fields(self)})
+
+    def __mul__(self, scalar: int | float) -> ManureNutrients:
+        """
+        Multiply a ManureNutrients object by a scalar (left multiplication, i.e. ManureNutrients * scalar).
+
+        Parameters
+        ----------
+        scalar : int | float
+            The scalar to multiply by.
+
+        Returns
+        -------
+        ManureNutrients
+            The product of the ManureNutrients object and the scalar.
+
+        Raises
+        ------
+        TypeError
+            If the other object is not an int or a float.
+        ValueError
+            If the scalar is negative.
+
+        """
+        if not isinstance(scalar, (int, float)):
+            raise TypeError(f'Cannot multiply {type(self)} by {type(scalar)}.')
+
+        if scalar < 0.0:
+            raise ValueError(f'Cannot multiply {type(self)} by a negative scalar.')
+
+        return ManureNutrients(**{f.name: getattr(self, f.name) * scalar for f in fields(self)})
+
+    def __sub__(self, other: ManureNutrients) -> ManureNutrients:
+        """
+        Subtract two ManureNutrients objects.
+
+        Parameters
+        ----------
+        other : ManureNutrients
+            The other ManureNutrients object to subtract from this one.
+
+        Returns
+        -------
+        ManureNutrients
+            The difference of the two ManureNutrients objects.
+
+        Raises
+        ------
+        TypeError
+            If the other object is not a ManureNutrients object.
+
+        """
+        if not isinstance(other, ManureNutrients):
+            raise TypeError(f'Cannot subtract {type(self)} from {type(other)}.')
+
+        return ManureNutrients(**{f.name: getattr(self, f.name) - getattr(other, f.name) for f in fields(self)})
+
+    def __rmul__(self, scalar: int | float) -> ManureNutrients:
+        """
+        Multiply a ManureNutrients object by a scalar (right multiplication, i.e., scalar * ManureNutrients).
+
+        Parameters
+        ----------
+        scalar : int | float
+            The scalar to multiply by.
+
+        Returns
+        -------
+        ManureNutrients
+            The product of the ManureNutrients object and the scalar.
+
+        """
+        return self.__mul__(scalar)

--- a/RUFAS/routines/manure/manure_nutrients/nutrient_request.py
+++ b/RUFAS/routines/manure/manure_nutrients/nutrient_request.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass, fields
+
+
+@dataclass(kw_only=True, frozen=True)
+class NutrientRequest:
+    """A class that represents a request for nutrients from the crop and soil module."""
+
+    nitrogen: float = 0.0
+    """Amount of manure nitrogen requested, kg."""
+
+    phosphorus: float = 0.0
+    """Amount of manure phosphorus requested, kg."""
+
+    def __post_init__(self) -> None:
+        """
+        Validate the dataclass fields.
+
+        Raises:
+            ValueError
+                If any field is negative.
+            ValueError
+                If no fields are positive.
+
+        """
+        # Check that all fields are non-negative
+        for field in fields(self):
+            if getattr(self, field.name) < 0:
+                raise ValueError(f'Field {field.name} must be non-negative.')
+
+        # Check that at least one field is requested and positive
+        if any(getattr(self, field.name) > 0.0 for field in fields(self)):
+            return
+        else:
+            raise ValueError('At least one nutrient must be requested and positive.')

--- a/tests/test_manure_module/manure_nutrients/test_manure_nutrients.py
+++ b/tests/test_manure_module/manure_nutrients/test_manure_nutrients.py
@@ -16,7 +16,7 @@ from RUFAS.routines.manure.manure_nutrients.manure_nutrients import ManureNutrie
 )
 def test_manure_nutrients_init(nitrogen, phosphorus, potassium, dry_matter, total_manure_mass,
                                expected_dry_matter_fraction, expected_nitrogen_composition,
-                               expected_phosphorus_composition):
+                               expected_phosphorus_composition) -> None:
     """
     Unit test for the ManureNutrients class in manure_nutrients.py.
 
@@ -53,7 +53,7 @@ def test_manure_nutrients_init(nitrogen, phosphorus, potassium, dry_matter, tota
         {"nitrogen": 1.0, "phosphorus": 2.0, "potassium": 3.0, "dry_matter": 4.0, "total_manure_mass": -5.0},
     ],
 )
-def test_manure_nutrients_invalid_init(nutrient_values: dict[str, float]):
+def test_manure_nutrients_invalid_init(nutrient_values: dict[str, float]) -> None:
     """
     Unit test for the __post_init__ method in the ManureNutrients class in manure_nutrients.py.
 
@@ -61,11 +61,14 @@ def test_manure_nutrients_invalid_init(nutrient_values: dict[str, float]):
     expecting it to raise an error when any of the attributes are negative.
 
     """
-    with pytest.raises(ValueError):
-        ManureNutrients(**nutrient_values)
+    for key in nutrient_values:
+        if nutrient_values[key] < 0:
+            with pytest.raises(ValueError, match=f'Field {key} must be non-negative.'):
+                ManureNutrients(**nutrient_values)
+            break
 
 
-def test_manure_nutrients_add_subtract():
+def test_manure_nutrients_add_subtract() -> None:
     """
     Unit test for the addition and subtraction operations (__add__, __sub__)
     in the ManureNutrients class in manure_nutrients.py.
@@ -108,8 +111,8 @@ def test_manure_nutrients_add_subtract():
     assert nutrients_subtracted.total_manure_mass == pytest.approx(1.0)
 
 
-@pytest.mark.parametrize("multiplier", [0, 2, 3.5, 1e10, -1])
-def test_manure_nutrients_multiplication(multiplier: int | float):
+@pytest.mark.parametrize("multiplier", [0, 2, 3.5, 1e10, -1, None])
+def test_manure_nutrients_multiplication(multiplier: int | float | None) -> None:
     """
     Unit test for the arithmetic operations (__mul__, __rmul__)
     in the ManureNutrients class in manure_nutrients.py.
@@ -128,7 +131,12 @@ def test_manure_nutrients_multiplication(multiplier: int | float):
     )
 
     # Act and Assert
-    if multiplier >= 0:
+    if type(multiplier) not in [int, float]:
+        with pytest.raises(TypeError, match=f'Cannot multiply {type(nutrients)} by {type(multiplier)}.'):
+            nutrients * multiplier
+        with pytest.raises(TypeError, match=f'Cannot multiply {type(nutrients)} by {type(multiplier)}.'):
+            multiplier * nutrients
+    elif multiplier >= 0:
         nutrients_multiplied = nutrients * multiplier
         nutrients_multiplied_2 = multiplier * nutrients
 
@@ -144,8 +152,8 @@ def test_manure_nutrients_multiplication(multiplier: int | float):
         assert nutrients_multiplied_2.dry_matter == pytest.approx(4.0 * multiplier)
         assert nutrients_multiplied_2.total_manure_mass == pytest.approx(5.0 * multiplier)
     else:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=f'Cannot multiply {type(nutrients)} by a negative scalar.'):
             nutrients * multiplier
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=f'Cannot multiply {type(nutrients)} by a negative scalar.'):
             multiplier * nutrients

--- a/tests/test_manure_module/manure_nutrients/test_manure_nutrients.py
+++ b/tests/test_manure_module/manure_nutrients/test_manure_nutrients.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import pytest
+from pytest import approx, mark
+
+from RUFAS.routines.manure.manure_nutrients.manure_nutrients import ManureNutrients
+
+
+@mark.parametrize(
+    "nitrogen, phosphorus, potassium, dry_matter, total_manure_mass, "
+    "expected_dry_matter_fraction, expected_nitrogen_composition, expected_phosphorus_composition",
+    [
+        (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),  # All attributes are zero
+        (1.0, 2.0, 3.0, 4.0, 5.0, 4.0 / 5.0, 1.0 / 5.0, 2.0 / 5.0),  # All attributes have some values
+    ]
+)
+def test_manure_nutrients_init(nitrogen, phosphorus, potassium, dry_matter, total_manure_mass,
+                               expected_dry_matter_fraction, expected_nitrogen_composition,
+                               expected_phosphorus_composition):
+    """
+    Unit test for the ManureNutrients class in manure_nutrients.py.
+
+    Test the initialization of the ManureNutrients dataclass and properties that compute manure composition.
+
+    """
+    # Act
+    nutrients = ManureNutrients(
+        nitrogen=nitrogen,
+        phosphorus=phosphorus,
+        potassium=potassium,
+        dry_matter=dry_matter,
+        total_manure_mass=total_manure_mass,
+    )
+
+    # Assert
+    assert nutrients.nitrogen == approx(nitrogen)
+    assert nutrients.phosphorus == approx(phosphorus)
+    assert nutrients.potassium == approx(potassium)
+    assert nutrients.dry_matter == approx(dry_matter)
+    assert nutrients.total_manure_mass == approx(total_manure_mass)
+    assert nutrients.dry_matter_fraction == approx(expected_dry_matter_fraction)
+    assert nutrients.nitrogen_composition == approx(expected_nitrogen_composition)
+    assert nutrients.phosphorus_composition == approx(expected_phosphorus_composition)
+
+
+@pytest.mark.parametrize(
+    "nutrient_values",
+    [
+        {"nitrogen": -1.0, "phosphorus": 2.0, "potassium": 3.0, "dry_matter": 4.0, "total_manure_mass": 5.0},
+        {"nitrogen": 1.0, "phosphorus": -2.0, "potassium": 3.0, "dry_matter": 4.0, "total_manure_mass": 5.0},
+        {"nitrogen": 1.0, "phosphorus": 2.0, "potassium": -3.0, "dry_matter": 4.0, "total_manure_mass": 5.0},
+        {"nitrogen": 1.0, "phosphorus": 2.0, "potassium": 3.0, "dry_matter": -4.0, "total_manure_mass": 5.0},
+        {"nitrogen": 1.0, "phosphorus": 2.0, "potassium": 3.0, "dry_matter": 4.0, "total_manure_mass": -5.0},
+    ],
+)
+def test_manure_nutrients_invalid_init(nutrient_values: dict[str, float]):
+    """
+    Unit test for the __post_init__ method in the ManureNutrients class in manure_nutrients.py.
+
+    Test the validation in the initialization of the ManureNutrients class,
+    expecting it to raise an error when any of the attributes are negative.
+
+    """
+    with pytest.raises(ValueError):
+        ManureNutrients(**nutrient_values)
+
+
+def test_manure_nutrients_add_subtract():
+    """
+    Unit test for the addition and subtraction operations (__add__, __sub__)
+    in the ManureNutrients class in manure_nutrients.py.
+
+    Test the results of these operations on two ManureNutrients instances.
+
+    """
+    # Arrange
+    nutrients = ManureNutrients(
+        nitrogen=1.0,
+        phosphorus=2.0,
+        potassium=3.0,
+        dry_matter=4.0,
+        total_manure_mass=5.0,
+    )
+
+    nutrients2 = ManureNutrients(
+        nitrogen=2.0,
+        phosphorus=3.0,
+        potassium=4.0,
+        dry_matter=5.0,
+        total_manure_mass=6.0,
+    )
+
+    # Act
+    nutrients_added = nutrients + nutrients2
+    nutrients_subtracted = nutrients2 - nutrients
+
+    # Assert
+    assert nutrients_added.nitrogen == pytest.approx(3.0)
+    assert nutrients_added.phosphorus == pytest.approx(5.0)
+    assert nutrients_added.potassium == pytest.approx(7.0)
+    assert nutrients_added.dry_matter == pytest.approx(9.0)
+    assert nutrients_added.total_manure_mass == pytest.approx(11.0)
+
+    assert nutrients_subtracted.nitrogen == pytest.approx(1.0)
+    assert nutrients_subtracted.phosphorus == pytest.approx(1.0)
+    assert nutrients_subtracted.potassium == pytest.approx(1.0)
+    assert nutrients_subtracted.dry_matter == pytest.approx(1.0)
+    assert nutrients_subtracted.total_manure_mass == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("multiplier", [0, 2, 3.5, 1e10, -1])
+def test_manure_nutrients_multiplication(multiplier: int | float):
+    """
+    Unit test for the arithmetic operations (__mul__, __rmul__)
+    in the ManureNutrients class in manure_nutrients.py.
+
+    Test the result of these operations with various multipliers,
+    including edge values such as 0, large numbers, and negative numbers.
+
+    """
+    # Arrange
+    nutrients = ManureNutrients(
+        nitrogen=1.0,
+        phosphorus=2.0,
+        potassium=3.0,
+        dry_matter=4.0,
+        total_manure_mass=5.0,
+    )
+
+    # Act and Assert
+    if multiplier >= 0:
+        nutrients_multiplied = nutrients * multiplier
+        nutrients_multiplied_2 = multiplier * nutrients
+
+        assert nutrients_multiplied.nitrogen == pytest.approx(1.0 * multiplier)
+        assert nutrients_multiplied.phosphorus == pytest.approx(2.0 * multiplier)
+        assert nutrients_multiplied.potassium == pytest.approx(3.0 * multiplier)
+        assert nutrients_multiplied.dry_matter == pytest.approx(4.0 * multiplier)
+        assert nutrients_multiplied.total_manure_mass == pytest.approx(5.0 * multiplier)
+
+        assert nutrients_multiplied_2.nitrogen == pytest.approx(1.0 * multiplier)
+        assert nutrients_multiplied_2.phosphorus == pytest.approx(2.0 * multiplier)
+        assert nutrients_multiplied_2.potassium == pytest.approx(3.0 * multiplier)
+        assert nutrients_multiplied_2.dry_matter == pytest.approx(4.0 * multiplier)
+        assert nutrients_multiplied_2.total_manure_mass == pytest.approx(5.0 * multiplier)
+    else:
+        with pytest.raises(ValueError):
+            nutrients * multiplier
+
+        with pytest.raises(ValueError):
+            multiplier * nutrients

--- a/tests/test_manure_module/manure_nutrients/test_nutrient_request.py
+++ b/tests/test_manure_module/manure_nutrients/test_nutrient_request.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pytest
+from pytest import approx, mark
+
+from RUFAS.routines.manure.manure_nutrients.nutrient_request import NutrientRequest
+
+
+@mark.parametrize(
+    "nitrogen, phosphorus",
+    [
+        (0.0, 0.0),  # No nutrients requested
+        (-1.0, 0.0),  # Negative nitrogen requested
+        (1.0, -2.0),  # Negative phosphorus requested
+    ]
+)
+def test_nutrient_request_invalid_init(nitrogen: float, phosphorus: float):
+    """
+    Unit test for the __post_init__ method in the NutrientRequest class in nutrient_request.py.
+
+    Test the validation in the initialization of the NutrientRequest class,
+    expecting it to raise an error when no nutrients are requested or
+    when a negative amount of any nutrient is requested.
+
+    """
+    with pytest.raises(ValueError):
+        NutrientRequest(nitrogen=nitrogen, phosphorus=phosphorus)
+
+
+@mark.parametrize(
+    "nitrogen, phosphorus",
+    [
+        (0.0, 1.0),  # Only phosphorus requested
+        (1.0, 0.0),  # Only nitrogen requested
+        (1.0, 2.0),  # Both nutrients requested
+    ]
+)
+def test_nutrient_request_valid_init(nitrogen: float, phosphorus: float):
+    """
+    Unit test for the NutrientRequest class in nutrient_request.py.
+
+    Test the initialization of the NutrientRequest dataclass with valid values.
+
+    """
+    # Act
+    nutrient_request = NutrientRequest(nitrogen=nitrogen, phosphorus=phosphorus)
+
+    # Assert
+    assert nutrient_request.nitrogen == approx(nitrogen)
+    assert nutrient_request.phosphorus == approx(phosphorus)


### PR DESCRIPTION
This PR is the first of several that deals with connecting the manure module to the crop and soil module. 

The two new code files are:

`manure_nutrients.py`: introduces the ManureNutrients class that stores relevant manure nutrient content to the field. This class also handles validation and arithmetic operations for nutrient amounts, allowing them to behave like primitive data types.

`nutrient_request.py`: introduces the NutrientRequest class that represents a request from the field. It verifies that the values in a request are non-negative and they have at least a positive value. 