### PR TITLE
Logging Output Manager Filtering Activity

### DIFF
--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -416,7 +416,6 @@ class OutputManager(object):
                                       any(re.match(pattern, key) for pattern in filter_patterns)}
         filter_log_count_msg = f"There were {len(filter_pattern_matches)} matches for {input_file} filter patterns"
         self.add_log("num_filter_pattern_matches", filter_log_count_msg, info_map)
-        print(f"There were {len(filter_pattern_matches)} matches for {input_file} filter patterns")
         return filter_pattern_matches
 
     def save_variables(self, save_path: str, dir_path: str,

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -264,6 +264,10 @@ class OutputManager(object):
         serialized dictionary using the max_depth parameter.
 
         """
+        info_map = {"class": self.__class__.__name__,
+                    "function": self._dict_to_file_json.__name__,
+                    }
+        self.add_log("save_dict_file_try", f"Attempting to save to {path}.", info_map)
         try:
             with open(path, "w") as json_file:
                 json.dump(
@@ -271,6 +275,7 @@ class OutputManager(object):
                     json_file,
                     indent=0,
                 )
+                self.add_log("save_dict_file_success", f"Successfully saved to {path}.", info_map)
         except Exception as e:
             raise e
 
@@ -290,9 +295,14 @@ class OutputManager(object):
             If an error occurs while saving to the file
 
         """
+        info_map = {"class": self.__class__.__name__,
+                    "function": self._list_to_file_txt.__name__,
+                    }
+        self.add_log("save_txt_file_try", f"Attempting to save to {path}.", info_map)
         try:
             with open(path, "w") as var_names_file:
                 var_names_file.writelines(data_list)
+                self.add_log("save_txt_file_success", f"Successfully saved to {path}.", info_map)
         except Exception as e:
             raise e
 
@@ -320,6 +330,10 @@ class OutputManager(object):
 
     def _list_txt_file_names_in_dir(self, dir_path: str) -> List[str]:
         """ Returns the list of files in the given path"""
+        info_map = {"class": self.__class__.__name__,
+                    "function": self._list_txt_file_names_in_dir.__name__,
+                    }
+        self.add_log("search_path_for_filenames_try", f"Attempting to search in {dir_path}.", info_map)
         dir_path_check = Path(dir_path)
         if dir_path_check.is_dir():
             txt_files = []
@@ -327,6 +341,8 @@ class OutputManager(object):
             for filename in all_files:
                 if filename.endswith(".txt"):
                     txt_files.append(filename)
+            self.add_log("search_path_for_filenames_success", f"Successfully searched in {dir_path}"
+                         f" and found {len(txt_files)} text files.", info_map)
             return txt_files
         else:
             raise NotADirectoryError("The specified path must be a directory")
@@ -350,16 +366,14 @@ class OutputManager(object):
             If an error occurs while opening or reading the file.
 
         """
+        info_map = {"class": self.__class__.__name__,
+                    "function": self._load_txt_file_to_list.__name__,
+                    }
+        self.add_log("open_text_file", f"Attempting to open {path}.", info_map)
         try:
             with open(path) as text_file:
-                info_map = {"class": self.__class__.__name__,
-                            "function": self._load_txt_file_to_list.__name__,
-                            }
                 list_of_elements = text_file.read().splitlines()
-                if not list_of_elements:
-                    load_message = f"{path} was empty"
-                else:
-                    load_message = f"{path} had {len(list_of_elements)} filters"
+                load_message = f"Successfully opened {path}, it contained {len(list_of_elements)} filter patterns."
                 self.add_log("filter_pattern_file_load_log", load_message, info_map)
                 return list_of_elements
         except Exception as e:
@@ -398,18 +412,18 @@ class OutputManager(object):
         exclude_keyword = "exclude"
         filter_by_exclusion = filter_patterns and filter_patterns[exclude_keyword_location] == exclude_keyword
         if filter_by_exclusion:
-            filter_log_message = f"{input_file} contains exclude-keyword '{exclude_keyword}' at position"
-            f" {exclude_keyword_location}"
-            self.add_log("filtering_log", filter_log_message, info_map)
+            filter_vars_msg = f"{input_file} has exclude-keyword '{exclude_keyword}' at"\
+                f" position {exclude_keyword_location}."
             filter_pattern_matches = {key: self.variables_pool[key] for key in self.variables_pool.keys() if not
                                       any(re.match(pattern, key) for pattern in filter_patterns)}
         else:
-            filter_log_message = f"{input_file} does NOT contain exclude-keyword '{exclude_keyword}'"
-            f" at position {exclude_keyword_location}"
-            self.add_log("filtering_log", filter_log_message, info_map)
+            filter_vars_msg = f"{input_file} does NOT contain exclude-keyword '{exclude_keyword}'"\
+                f" at position {exclude_keyword_location}."
             filter_pattern_matches = {key: self.variables_pool[key] for key in self.variables_pool.keys() if
                                       any(re.match(pattern, key) for pattern in filter_patterns)}
-        filter_log_count_msg = f"There were {len(filter_pattern_matches)} matches for {input_file} filter patterns"
+        self.add_log("filtering_log", filter_vars_msg, info_map)
+        filter_log_count_msg = f"There were {len(filter_pattern_matches)} matches for the {len(filter_patterns)} filter"\
+            f" patterns in the {input_file} file."
         self.add_log("num_filter_pattern_matches", filter_log_count_msg, info_map)
         return filter_pattern_matches
 

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -315,7 +315,7 @@ class OutputManager(object):
         info_map = {"class": self.__class__.__name__,
                     "function": self._exclude_info_maps.__name__,
                     }
-        self.add_log("exclude info maps", "info maps were excluded", info_map)
+        self.add_log("exclude_info_maps", "info maps were excluded", info_map)
 
         pool_copy = pool.copy()
         for key, value in pool_copy.items():
@@ -362,10 +362,10 @@ class OutputManager(object):
                             }
                 list_of_elements = text_file.read().splitlines()
                 if not list_of_elements:
-                    self.add_log('filter pattern file load', f"{path} was empty", info_map)
+                    load_message = f"{path} was empty"
                 else:
-                    self.add_log('filter pattern file load', f"{path} had {len(list_of_elements)} filter"
-                                          " patterns", info_map)
+                    load_message = f"{path} had {len(list_of_elements)} filter"
+                self.add_log("filter_pattern_file_load_log", load_message, info_map)
                 return list_of_elements
         except Exception as e:
             raise e
@@ -403,17 +403,20 @@ class OutputManager(object):
         exclude_keyword = "exclude"
         filter_by_exclusion = filter_patterns and filter_patterns[exclude_keyword_location] == exclude_keyword
         if filter_by_exclusion:
-            self.add_log("filtering log", f"{input_file} contains exclude-keyword '{exclude_keyword}'"
-                                  f" at position {exclude_keyword_location}", info_map)
+            filter_log_message = f"{input_file} contains exclude-keyword '{exclude_keyword}' at position"
+            f" {exclude_keyword_location}"
+            self.add_log("filtering log", filter_log_message, info_map)
             filter_pattern_matches = {key: self.variables_pool[key] for key in self.variables_pool.keys() if not
                                       any(re.match(pattern, key) for pattern in filter_patterns)}
         else:
-            self.add_log("filtering log", f"{input_file} does NOT contain exclude-keyword '{exclude_keyword}'"
-                                  f" at position {exclude_keyword_location}", info_map)
+            filter_log_message = f"{input_file} does NOT contain exclude-keyword '{exclude_keyword}'"
+            f" at position {exclude_keyword_location}"
+            self.add_log("filtering log", filter_log_message, info_map)
             filter_pattern_matches = {key: self.variables_pool[key] for key in self.variables_pool.keys() if
                                       any(re.match(pattern, key) for pattern in filter_patterns)}
-        self.add_log("num of filter pattern matches", f"There were {len(filter_pattern_matches)} matches"
-                              f" for {input_file} filter patterns", info_map)
+        filter_log_count_msg = f"There were {len(filter_pattern_matches)} matches for {input_file} filter patterns"
+        self.add_log("num of filter pattern matches", filter_log_count_msg, info_map)
+        print(f"There were {len(filter_pattern_matches)} matches for {input_file} filter patterns")
         return filter_pattern_matches
 
     def save_variables(self, save_path: str, dir_path: str,

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -379,7 +379,7 @@ class OutputManager(object):
         except Exception as e:
             raise e
 
-    def _filter_variables_pool(self, filter_patterns: List[str], input_file: str) -> Dict[str, pool_element_type]:
+    def _filter_variables_pool(self, filter_patterns: List[str], input_file_name: Optional[str]) -> Dict[str, pool_element_type]:
         """
         Returns a filtered variables pool based on either inclusion or exclusion.
 

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -373,7 +373,7 @@ class OutputManager(object):
         try:
             with open(path) as text_file:
                 list_of_elements = text_file.read().splitlines()
-                load_message = f"Successfully opened {path}, it contained {len(list_of_elements)} filter patterns."
+                load_message = f"Successfully opened {path} and read {len(list_of_elements)} lines."
                 self.add_log("filter_pattern_file_load_log", load_message, info_map)
                 return list_of_elements
         except Exception as e:

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -418,7 +418,7 @@ class OutputManager(object):
                                       any(re.match(pattern, key) for pattern in filter_patterns)}
         else:
             filter_vars_msg = f"{input_file} does NOT contain exclude-keyword '{exclude_keyword}'"\
-                f" at position {exclude_keyword_location}."
+                f" at position {exclude_keyword_location}. Performing filtering by inclusion."
             filter_pattern_matches = {key: self.variables_pool[key] for key in self.variables_pool.keys() if
                                       any(re.match(pattern, key) for pattern in filter_patterns)}
         self.add_log("filtering_log", filter_vars_msg, info_map)

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -312,6 +312,10 @@ class OutputManager(object):
             A copy of the given pool with info_maps removed from it.
 
         """
+        info_map = {"class": self.__class__.__name__,
+                    "function": self._exclude_info_maps().__name__,
+                    }
+        OutputManager.add_log("info maps were excluded", info_map)
 
         pool_copy = pool.copy()
         for key, value in pool_copy.items():
@@ -353,7 +357,14 @@ class OutputManager(object):
         """
         try:
             with open(path) as text_file:
-                return text_file.read().splitlines()
+                list_of_elements = text_file.read().splitlines()
+                exclude_keyword_location = 0
+                exclude_keyword = "exclude"
+                if list_of_elements[exclude_keyword_location] == exclude_keyword:
+                    info_map = {"class": self.__class__.__name__,
+                                "function": self._load_txt_file_to_list().__name__, }
+                    OutputManager.add_log(f"{text_file} contains exclude keyword", info_map)
+                return list_of_elements
         except Exception as e:
             raise e
 
@@ -380,10 +391,14 @@ class OutputManager(object):
         as inclusionary.
 
         """
+        info_map = {"class": self.__class__.__name__,
+                    "function": self._filter_variables_pool().__name__,
+                    }
         exclude_keyword_location = 0
         exclude_keyword = "exclude"
         filter_by_exclusion = filter_patterns and filter_patterns[exclude_keyword_location] == exclude_keyword
         if filter_by_exclusion:
+            OutputManager.add_log("")
             return {key: self.variables_pool[key] for key in self.variables_pool.keys() if not
                     any(re.match(pattern, key) for pattern in filter_patterns)}
         else:

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -312,11 +312,6 @@ class OutputManager(object):
             A copy of the given pool with info_maps removed from it.
 
         """
-        info_map = {"class": self.__class__.__name__,
-                    "function": self._exclude_info_maps.__name__,
-                    }
-        self.add_log("exclude_info_maps", "info maps were excluded", info_map)
-
         pool_copy = pool.copy()
         for key, value in pool_copy.items():
             if isinstance(value, dict) and "info_maps" in value:
@@ -364,7 +359,7 @@ class OutputManager(object):
                 if not list_of_elements:
                     load_message = f"{path} was empty"
                 else:
-                    load_message = f"{path} had {len(list_of_elements)} filter"
+                    load_message = f"{path} had {len(list_of_elements)} filters"
                 self.add_log("filter_pattern_file_load_log", load_message, info_map)
                 return list_of_elements
         except Exception as e:
@@ -436,6 +431,10 @@ class OutputManager(object):
             Flag for whether or not the user wants to include info_maps data in their results files.
 
         """
+        info_map = {"class": self.__class__.__name__,
+                    "function": self.save_variables.__name__,
+                    }
+        self.add_log("exclude_info_maps", f"exclude_info_maps flag set to {exclude_info_maps}", info_map)
         list_of_filter_files = self._list_txt_file_names_in_dir(dir_path)
         for filter_file in list_of_filter_files:
             input_path = os.path.join(dir_path, filter_file)

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -388,7 +388,7 @@ class OutputManager(object):
         filter_patterns : List[str]
             A list of patterns the user has selected to filter the variables pool.
 
-        input_file : str
+        input_file_name : str, optional
             The filter patterns file name - necessary for logging purposes
 
         Returns

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -405,17 +405,17 @@ class OutputManager(object):
         if filter_by_exclusion:
             filter_log_message = f"{input_file} contains exclude-keyword '{exclude_keyword}' at position"
             f" {exclude_keyword_location}"
-            self.add_log("filtering log", filter_log_message, info_map)
+            self.add_log("filtering_log", filter_log_message, info_map)
             filter_pattern_matches = {key: self.variables_pool[key] for key in self.variables_pool.keys() if not
                                       any(re.match(pattern, key) for pattern in filter_patterns)}
         else:
             filter_log_message = f"{input_file} does NOT contain exclude-keyword '{exclude_keyword}'"
             f" at position {exclude_keyword_location}"
-            self.add_log("filtering log", filter_log_message, info_map)
+            self.add_log("filtering_log", filter_log_message, info_map)
             filter_pattern_matches = {key: self.variables_pool[key] for key in self.variables_pool.keys() if
                                       any(re.match(pattern, key) for pattern in filter_patterns)}
         filter_log_count_msg = f"There were {len(filter_pattern_matches)} matches for {input_file} filter patterns"
-        self.add_log("num of filter pattern matches", filter_log_count_msg, info_map)
+        self.add_log("num_filter_pattern_matches", filter_log_count_msg, info_map)
         print(f"There were {len(filter_pattern_matches)} matches for {input_file} filter patterns")
         return filter_pattern_matches
 

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 import re
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 import json
 import os
 import time
@@ -379,7 +379,8 @@ class OutputManager(object):
         except Exception as e:
             raise e
 
-    def _filter_variables_pool(self, filter_patterns: List[str], input_file_name: Optional[str]) -> Dict[str, pool_element_type]:
+    def _filter_variables_pool(self, filter_patterns: List[str], input_file_name: Optional[str]
+                               ) -> Dict[str, pool_element_type]:
         """
         Returns a filtered variables pool based on either inclusion or exclusion.
 
@@ -412,18 +413,18 @@ class OutputManager(object):
         exclude_keyword = "exclude"
         filter_by_exclusion = filter_patterns and filter_patterns[exclude_keyword_location] == exclude_keyword
         if filter_by_exclusion:
-            filter_vars_msg = f"{input_file} has exclude-keyword '{exclude_keyword}' at"\
+            filter_vars_msg = f"{input_file_name} has exclude-keyword '{exclude_keyword}' at"\
                 f" position {exclude_keyword_location}. Performing filtering by exclusion."
             filter_pattern_matches = {key: self.variables_pool[key] for key in self.variables_pool.keys() if not
                                       any(re.match(pattern, key) for pattern in filter_patterns)}
         else:
-            filter_vars_msg = f"{input_file} does NOT contain exclude-keyword '{exclude_keyword}'"\
+            filter_vars_msg = f"{input_file_name} does NOT contain exclude-keyword '{exclude_keyword}'"\
                 f" at position {exclude_keyword_location}. Performing filtering by inclusion."
             filter_pattern_matches = {key: self.variables_pool[key] for key in self.variables_pool.keys() if
                                       any(re.match(pattern, key) for pattern in filter_patterns)}
         self.add_log("filtering_log", filter_vars_msg, info_map)
-        filter_log_count_msg = f"There were {len(filter_pattern_matches)} matches for the {len(filter_patterns)} filter"\
-            f" patterns in the {input_file} file."
+        filter_log_count_msg = f"There were {len(filter_pattern_matches)} matches for the {len(filter_patterns)}"\
+            f" filter patterns in the {input_file_name} file."
         self.add_log("num_filter_pattern_matches", filter_log_count_msg, info_map)
         return filter_pattern_matches
 

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -313,9 +313,9 @@ class OutputManager(object):
 
         """
         info_map = {"class": self.__class__.__name__,
-                    "function": self._exclude_info_maps().__name__,
+                    "function": self._exclude_info_maps.__name__,
                     }
-        OutputManager.add_log("info maps were excluded", info_map)
+        self.add_log("exclude info maps", "info maps were excluded", info_map)
 
         pool_copy = pool.copy()
         for key, value in pool_copy.items():
@@ -358,13 +358,13 @@ class OutputManager(object):
         try:
             with open(path) as text_file:
                 info_map = {"class": self.__class__.__name__,
-                            "function": self._load_txt_file_to_list().__name__,
+                            "function": self._load_txt_file_to_list.__name__,
                             }
                 list_of_elements = text_file.read().splitlines()
                 if not list_of_elements:
-                    OutputManager.add_log('filter pattern file load', f"{path} was empty", info_map)
+                    self.add_log('filter pattern file load', f"{path} was empty", info_map)
                 else:
-                    OutputManager.add_log('filter pattern file load', f"{path} had {len(list_of_elements)} filter"
+                    self.add_log('filter pattern file load', f"{path} had {len(list_of_elements)} filter"
                                           " patterns", info_map)
                 return list_of_elements
         except Exception as e:
@@ -397,21 +397,24 @@ class OutputManager(object):
 
         """
         info_map = {"class": self.__class__.__name__,
-                    "function": self._filter_variables_pool().__name__,
+                    "function": self._filter_variables_pool.__name__,
                     }
         exclude_keyword_location = 0
         exclude_keyword = "exclude"
         filter_by_exclusion = filter_patterns and filter_patterns[exclude_keyword_location] == exclude_keyword
         if filter_by_exclusion:
-            OutputManager.add_log("filtering log", f"{input_file} contains exclude-keyword '{exclude_keyword}'"
+            self.add_log("filtering log", f"{input_file} contains exclude-keyword '{exclude_keyword}'"
                                   f" at position {exclude_keyword_location}", info_map)
-            return {key: self.variables_pool[key] for key in self.variables_pool.keys() if not
-                    any(re.match(pattern, key) for pattern in filter_patterns)}
+            filter_pattern_matches = {key: self.variables_pool[key] for key in self.variables_pool.keys() if not
+                                      any(re.match(pattern, key) for pattern in filter_patterns)}
         else:
-            OutputManager.add_log("filtering log", f"{input_file} does NOT contain exclude-keyword '{exclude_keyword}'"
+            self.add_log("filtering log", f"{input_file} does NOT contain exclude-keyword '{exclude_keyword}'"
                                   f" at position {exclude_keyword_location}", info_map)
-            return {key: self.variables_pool[key] for key in self.variables_pool.keys() if
-                    any(re.match(pattern, key) for pattern in filter_patterns)}
+            filter_pattern_matches = {key: self.variables_pool[key] for key in self.variables_pool.keys() if
+                                      any(re.match(pattern, key) for pattern in filter_patterns)}
+        self.add_log("num of filter pattern matches", f"There were {len(filter_pattern_matches)} matches"
+                              f" for {input_file} filter patterns", info_map)
+        return filter_pattern_matches
 
     def save_variables(self, save_path: str, dir_path: str,
                        exclude_info_maps: bool = False) -> None:

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -357,18 +357,20 @@ class OutputManager(object):
         """
         try:
             with open(path) as text_file:
+                info_map = {"class": self.__class__.__name__,
+                            "function": self._load_txt_file_to_list().__name__,
+                            }
                 list_of_elements = text_file.read().splitlines()
-                exclude_keyword_location = 0
-                exclude_keyword = "exclude"
-                if list_of_elements[exclude_keyword_location] == exclude_keyword:
-                    info_map = {"class": self.__class__.__name__,
-                                "function": self._load_txt_file_to_list().__name__, }
-                    OutputManager.add_log(f"{text_file} contains exclude keyword", info_map)
+                if not list_of_elements:
+                    OutputManager.add_log('filter pattern file load', f"{path} was empty", info_map)
+                else:
+                    OutputManager.add_log('filter pattern file load', f"{path} had {len(list_of_elements)} filter"
+                                          " patterns", info_map)
                 return list_of_elements
         except Exception as e:
             raise e
 
-    def _filter_variables_pool(self, filter_patterns: List[str]) -> Dict[str, pool_element_type]:
+    def _filter_variables_pool(self, filter_patterns: List[str], input_file: str) -> Dict[str, pool_element_type]:
         """
         Returns a filtered variables pool based on either inclusion or exclusion.
 
@@ -376,6 +378,9 @@ class OutputManager(object):
         ----------
         filter_patterns : List[str]
             A list of patterns the user has selected to filter the variables pool.
+
+        input_file : str
+            The filter patterns file name - necessary for logging purposes
 
         Returns
         -------
@@ -398,10 +403,13 @@ class OutputManager(object):
         exclude_keyword = "exclude"
         filter_by_exclusion = filter_patterns and filter_patterns[exclude_keyword_location] == exclude_keyword
         if filter_by_exclusion:
-            OutputManager.add_log("")
+            OutputManager.add_log("filtering log", f"{input_file} contains exclude-keyword '{exclude_keyword}'"
+                                  f" at position {exclude_keyword_location}", info_map)
             return {key: self.variables_pool[key] for key in self.variables_pool.keys() if not
                     any(re.match(pattern, key) for pattern in filter_patterns)}
         else:
+            OutputManager.add_log("filtering log", f"{input_file} does NOT contain exclude-keyword '{exclude_keyword}'"
+                                  f" at position {exclude_keyword_location}", info_map)
             return {key: self.variables_pool[key] for key in self.variables_pool.keys() if
                     any(re.match(pattern, key) for pattern in filter_patterns)}
 
@@ -424,14 +432,13 @@ class OutputManager(object):
 
         """
         list_of_filter_files = self._list_txt_file_names_in_dir(dir_path)
-        for input_file in list_of_filter_files:
-            input_path = os.path.join(dir_path, input_file)
-            inclusion_keys = self._load_txt_file_to_list(input_path)
-            filtered_pool = self._filter_variables_pool(inclusion_keys)
-
+        for filter_file in list_of_filter_files:
+            input_path = os.path.join(dir_path, filter_file)
+            filter_patterns = self._load_txt_file_to_list(input_path)
+            filtered_pool = self._filter_variables_pool(filter_patterns, filter_file)
             if exclude_info_maps:
                 filtered_pool = self._exclude_info_maps(filtered_pool)
-            file_path = os.path.join(save_path, self._generate_file_name(f"saved_variables_{input_file}", "json"))
+            file_path = os.path.join(save_path, self._generate_file_name(f"saved_variables_{filter_file}", "json"))
             self._dict_to_file_json(filtered_pool, file_path)
 
     def dump_variables(self, path: str, exclude_info_maps: bool = False) -> None:

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -413,7 +413,7 @@ class OutputManager(object):
         filter_by_exclusion = filter_patterns and filter_patterns[exclude_keyword_location] == exclude_keyword
         if filter_by_exclusion:
             filter_vars_msg = f"{input_file} has exclude-keyword '{exclude_keyword}' at"\
-                f" position {exclude_keyword_location}."
+                f" position {exclude_keyword_location}. Performing filtering by exclusion."
             filter_pattern_matches = {key: self.variables_pool[key] for key in self.variables_pool.keys() if not
                                       any(re.match(pattern, key) for pattern in filter_patterns)}
         else:

--- a/input/output_filters/example_list_of_exclude_regex_patterns.txt
+++ b/input/output_filters/example_list_of_exclude_regex_patterns.txt
@@ -1,2 +1,6 @@
+exclude
+Feed.summarize_feed_storage.nutrients_summary
 ^LifeCycleManager.*update$
 .*milk.*update
+MilkingParlor.calc_wash_water_volume_used_in_holding_area.wash_water_volume_used_in_holding_area
+MilkingParlor.__init__.fresh_water_use_rate

--- a/main.py
+++ b/main.py
@@ -63,8 +63,8 @@ def execute_simulations_from_files(
         output_manager.flush_pools()
         simulator = SimulationEngine(input_file_path)
         simulator.simulate()
-        output_manager.dump_all_pools(r"output", exclude_info_maps)
         output_manager.save_variables(r"output", r"input/output_filters/", exclude_info_maps)
+        output_manager.dump_all_pools(r"output", exclude_info_maps)
 
 
 def parse_gnu_args():

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -853,10 +853,11 @@ def test_filter_variables_pool_include_empty_filter_pattern_pool(
         "key2": "value2",
         "key3": "value3"
     }
+    dummy_input_file = ""
     filter_patterns = []
     expected_result = {}
 
-    assert mock_output_manager._filter_variables_pool(filter_patterns) == expected_result
+    assert mock_output_manager._filter_variables_pool(filter_patterns, dummy_input_file) == expected_result
 
     # Restore original method
     mock_output_manager._filter_variables_pool = output_manager_original_method_states[
@@ -876,6 +877,7 @@ def test_filter_variables_pool_exclude_empty_filter_pattern_pool(
         "key2": "value2",
         "key3": "value3"
     }
+    dummy_input_file = ""
     filter_patterns = ["exclude"]
     expected_result = {
         "key1": "value1",
@@ -883,7 +885,7 @@ def test_filter_variables_pool_exclude_empty_filter_pattern_pool(
         "key3": "value3"
     }
 
-    assert mock_output_manager._filter_variables_pool(filter_patterns) == expected_result
+    assert mock_output_manager._filter_variables_pool(filter_patterns, dummy_input_file) == expected_result
 
     # Restore original method
     mock_output_manager._filter_variables_pool = output_manager_original_method_states[
@@ -902,13 +904,14 @@ def test_filter_variables_pool_with_matching_filters_in_pattern_pool(
         "key2": "value2",
         "key3": "value3"
     }
+    dummy_input_file = ""
     filter_patterns = ["key1", "key2"]
     expected_result = {
         "key1": "value1",
         "key2": "value2"
     }
 
-    assert mock_output_manager._filter_variables_pool(filter_patterns) == expected_result
+    assert mock_output_manager._filter_variables_pool(filter_patterns, dummy_input_file) == expected_result
 
     # Restore original method
     mock_output_manager._filter_variables_pool = output_manager_original_method_states[
@@ -928,12 +931,13 @@ def test_filter_variables_pool_exclude_matching_filters_in_pattern_pool(
         "key2": "value2",
         "key3": "value3"
     }
+    dummy_input_file = ""
     filter_patterns = ["exclude", "key1", "key2"]
     expected_result = {
         "key3": "value3"
     }
 
-    assert mock_output_manager._filter_variables_pool(filter_patterns) == expected_result
+    assert mock_output_manager._filter_variables_pool(filter_patterns, dummy_input_file) == expected_result
 
     # Restore original method
     mock_output_manager._filter_variables_pool = output_manager_original_method_states[
@@ -953,12 +957,13 @@ def test_filter_variables_pool_non_matching_pattern(
         "key2": "value2",
         "key3": "value3"
     }
+    dummy_input_file = ""
     filter_patterns = ["key1", "key4"]
     expected_result = {
         "key1": "value1"
     }
 
-    assert mock_output_manager._filter_variables_pool(filter_patterns) == expected_result
+    assert mock_output_manager._filter_variables_pool(filter_patterns, dummy_input_file) == expected_result
 
     # Restore original method
     mock_output_manager._filter_variables_pool = output_manager_original_method_states[
@@ -978,13 +983,14 @@ def test_filter_variables_pool_exclude_non_matching_pattern(
         "key2": "value2",
         "key3": "value3"
     }
+    dummy_input_file = ""
     filter_patterns = ["exclude", "key1", "key4"]
     expected_result = {
         "key2": "value2",
         "key3": "value3"
     }
 
-    assert mock_output_manager._filter_variables_pool(filter_patterns) == expected_result
+    assert mock_output_manager._filter_variables_pool(filter_patterns, dummy_input_file) == expected_result
 
 
 def test_filter_variables_pool_duplicate_patterns(
@@ -998,12 +1004,13 @@ def test_filter_variables_pool_duplicate_patterns(
         "key2": "value2",
         "key3": "value3"
     }
+    dummy_input_file = ""
     filter_patterns = ["key1", "key1"]
     expected_result = {
         "key1": "value1"
     }
 
-    assert mock_output_manager._filter_variables_pool(filter_patterns) == expected_result
+    assert mock_output_manager._filter_variables_pool(filter_patterns, dummy_input_file) == expected_result
 
     # Restore original method
     mock_output_manager._filter_variables_pool = output_manager_original_method_states[
@@ -1023,13 +1030,14 @@ def test_filter_variables_pool_exclude_duplicate_patterns(
         "key2": "value2",
         "key3": "value3"
     }
+    dummy_input_file = ""
     filter_patterns = ["exclude", "key1", "key1"]
     expected_result = {
         "key2": "value2",
         "key3": "value3"
     }
 
-    assert mock_output_manager._filter_variables_pool(filter_patterns) == expected_result
+    assert mock_output_manager._filter_variables_pool(filter_patterns, dummy_input_file) == expected_result
 
     # Restore original method
     mock_output_manager._filter_variables_pool = output_manager_original_method_states[
@@ -1037,14 +1045,9 @@ def test_filter_variables_pool_exclude_duplicate_patterns(
     ]
     mock_output_manager.variables_pool = {}
 
-
-def test_filter_variables_pool_regex_patterns(
-    mock_output_manager: OutputManager,
-    output_manager_original_method_states: Dict[str, Callable]
-) -> None:
-    """Test case for pattern pool using regex patterns with
-    function _filter_variables_pool in output_manager.py"""
-    mock_output_manager.variables_pool = {
+@pytest.fixture
+def mock_variables_pool() -> Dict[str, str]:
+    dummy_variables_pool = {
         "DummyClass1.dummy_fun1.dummy_var1": "value1",
         "DummyClass1.dummy_fun1.dummy_var2": "value2",  # same class as prev, same fun, different var
         "DummyClass2.dummy_fun2.dummy_var3": "value3",  # new class, new fun, new var
@@ -1053,6 +1056,18 @@ def test_filter_variables_pool_regex_patterns(
         "DummyClass3.dummy_fun4.dummy_var2": "value6",  # new class, new fun, same var name as 2nd entry
         "DummyClass4.dummy_fun2.dummy_var5": "value7"   # new class, same fun name as 3rd entry, new var
     }
+    return dummy_variables_pool
+
+
+def test_filter_variables_pool_regex_patterns(
+    mock_output_manager: OutputManager,
+    output_manager_original_method_states: Dict[str, Callable],
+    mock_variables_pool: Dict[str, str],
+) -> None:
+    """Test case for pattern pool using regex patterns with
+    function _filter_variables_pool in output_manager.py"""
+    mock_output_manager.variables_pool = mock_variables_pool
+    dummy_input_file = ""
 
     # get all Class1 vars
     filter_patterns = ["^DummyClass1.*"]
@@ -1061,7 +1076,7 @@ def test_filter_variables_pool_regex_patterns(
         "DummyClass1.dummy_fun1.dummy_var2": "value2"
     }
 
-    assert mock_output_manager._filter_variables_pool(filter_patterns) == expected_result
+    assert mock_output_manager._filter_variables_pool(filter_patterns, dummy_input_file) == expected_result
 
     # get only vars from fun2s
     filter_patterns = [".*fun2.*"]
@@ -1070,7 +1085,7 @@ def test_filter_variables_pool_regex_patterns(
         "DummyClass4.dummy_fun2.dummy_var5": "value7"
     }
 
-    assert mock_output_manager._filter_variables_pool(filter_patterns) == expected_result
+    assert mock_output_manager._filter_variables_pool(filter_patterns, dummy_input_file) == expected_result
 
     # get Class2 with var4 but not Class2 with var3
     filter_patterns = ["^DummyClass2.*var4$"]
@@ -1079,7 +1094,7 @@ def test_filter_variables_pool_regex_patterns(
         "DummyClass2.dummy_fun4.dummy_var4": "value5"
     }
 
-    assert mock_output_manager._filter_variables_pool(filter_patterns) == expected_result
+    assert mock_output_manager._filter_variables_pool(filter_patterns, dummy_input_file) == expected_result
 
     # get all var2s and var4s
     filter_patterns = [".*var2$", ".*var4$"]
@@ -1090,7 +1105,7 @@ def test_filter_variables_pool_regex_patterns(
         "DummyClass3.dummy_fun4.dummy_var2": "value6"
     }
 
-    assert mock_output_manager._filter_variables_pool(filter_patterns) == expected_result
+    assert mock_output_manager._filter_variables_pool(filter_patterns, dummy_input_file) == expected_result
 
     # Restore original method
     mock_output_manager._filter_variables_pool = output_manager_original_method_states[
@@ -1101,19 +1116,13 @@ def test_filter_variables_pool_regex_patterns(
 
 def test_filter_variables_pool_exclude_regex_patterns(
     mock_output_manager: OutputManager,
-    output_manager_original_method_states: Dict[str, Callable]
+    output_manager_original_method_states: Dict[str, Callable],
+    mock_variables_pool: Dict[str, str],
 ) -> None:
     """Test case for pattern pool with regex patterns and exclude keyword with
     function _filter_variables_pool in output_manager.py"""
-    mock_output_manager.variables_pool = {
-        "DummyClass1.dummy_fun1.dummy_var1": "value1",
-        "DummyClass1.dummy_fun1.dummy_var2": "value2",  # same class as prev, same fun, different var
-        "DummyClass2.dummy_fun2.dummy_var3": "value3",  # new class, new fun, new var
-        "DummyClass2.dummy_fun3.dummy_var4": "value4",  # same class as prev, new fun, new var
-        "DummyClass2.dummy_fun4.dummy_var4": "value5",  # same class as prev, new fun, same var
-        "DummyClass3.dummy_fun4.dummy_var2": "value6",  # new class, new fun, same var name as 2nd entry
-        "DummyClass4.dummy_fun2.dummy_var5": "value7"   # new class, same fun name as 3rd entry, new var
-    }
+    mock_output_manager.variables_pool = mock_variables_pool
+    dummy_input_file = ""
 
     # get everything except Class1 vars
     filter_patterns = ["exclude", "^DummyClass1.*"]
@@ -1125,7 +1134,7 @@ def test_filter_variables_pool_exclude_regex_patterns(
         "DummyClass4.dummy_fun2.dummy_var5": "value7"
     }
 
-    assert mock_output_manager._filter_variables_pool(filter_patterns) == expected_result
+    assert mock_output_manager._filter_variables_pool(filter_patterns, dummy_input_file) == expected_result
 
     # get everything except vars from fun2s
     filter_patterns = ["exclude", ".*fun2.*"]
@@ -1137,7 +1146,7 @@ def test_filter_variables_pool_exclude_regex_patterns(
         "DummyClass3.dummy_fun4.dummy_var2": "value6"
     }
 
-    assert mock_output_manager._filter_variables_pool(filter_patterns) == expected_result
+    assert mock_output_manager._filter_variables_pool(filter_patterns, dummy_input_file) == expected_result
 
     # get everything without Class2 with var4
     filter_patterns = ["exclude", "^DummyClass2.*var4$"]
@@ -1149,7 +1158,7 @@ def test_filter_variables_pool_exclude_regex_patterns(
         "DummyClass4.dummy_fun2.dummy_var5": "value7"
     }
 
-    assert mock_output_manager._filter_variables_pool(filter_patterns) == expected_result
+    assert mock_output_manager._filter_variables_pool(filter_patterns, dummy_input_file) == expected_result
 
     # get everything that doesn't have var2s and var4s
     filter_patterns = ["exclude", ".*var2$", ".*var4$"]
@@ -1159,7 +1168,7 @@ def test_filter_variables_pool_exclude_regex_patterns(
         "DummyClass4.dummy_fun2.dummy_var5": "value7"
     }
 
-    assert mock_output_manager._filter_variables_pool(filter_patterns) == expected_result
+    assert mock_output_manager._filter_variables_pool(filter_patterns, dummy_input_file) == expected_result
 
     # Restore original method
     mock_output_manager._filter_variables_pool = output_manager_original_method_states[


### PR DESCRIPTION
This PR adds OM logging within OM's own filtering functions.

This tracks vital OM filtering activity including:
- The status of the exclude_info_maps flag for the simulation
- The number of filter files found in the filter files directory
- Whether the exclude_keyword was found in the first position of each particular filter file
- The number of keys resulting from each application of the filter file's patterns to the variables pool

This will be helpful to users and developers diagnose unexpected results found in filtered variables output files.

Also updates unit testing accordingly.

Note:
- Fixes issue of OM only logging one of the new logs by switching the order of OM function calls in main.py