### PR TITLE
Clean and polish `Field` and `CropManagement`

### DIFF
--- a/SC_redesign/Crop_and_Soil/crop/crop_management.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_management.py
@@ -61,13 +61,10 @@ class CropManagement:
         self._record_yield(field_name, field_size, year, day)
         self._transfer_residue(soil_data)
 
-    def graze(self):  # TODO: implement grazing method (SWAT 6:1.3)
-        pass
+    # TODO: implement grazing feature - issue #590
 
     # ---- Sub Methods ----
-    def collect_cut_yield(self, collected_fraction):  # TODO: implement for in-field drying - needed? GitHub Issue #162
-        """collect yield that has been previously cut and left in the field"""
-        pass
+    # TODO: implement management practice for dry-down and collecting cut yields that have been left in the field - #353
 
     def kill(self) -> None:
         """kills the plant, preventing it from growing, and converts all biomass to residue

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -18,13 +18,12 @@ from RUFAS.classes import Time
 from RUFAS.output_manager import OutputManager
 from copy import copy
 
-# TODO: delete/replace the note block below once satisfied with the design
-"""
-The current (Feb-2023) state of this module is to guide the development and provide structure for the field and farm
-manager classes. The field class, as laid out here, handles the management actions and scenarios that can be performed
-in an agricultural field.
 
-Note that some of the field-level attributes will be tracked by the FieldData class
+"""
+This is a high-level module that represents an simulates an entire field. It is responsible for executing the daily
+biophysical routines which take place in soil columns and in crops planted in the field. It is also responsible for the
+management of schedules, executing, and reporting of farm management events, including planting and harvesting crops,
+adding manure and fertilizer to the soil, and tilling the soil.
 """
 
 om = OutputManager()
@@ -87,15 +86,23 @@ class Field:
         """List of all manure applications that will be applied to this field."""
 
     def manage_field(self, time: Time, current_weather: CurrentWeather) -> None:
-        """main Field function, runs all field routines based on current attribute configuration
+        """
+        Main Field routine, runs all subroutines routines based on current attribute configuration.
 
-        Args:
-            time : a Time object, containing the current year and day that the simulation is on.
-            current_weather: a CurrentWeather object, containing a collection of today's weather variables needed
-                for field processes.
+        Parameters
+        ----------
+        time : Time
+            Contains the current year and day that the simulation is on.
+        current_weather : CurrentWeather
+            Contains a collection of today's weather variables needed for field processes.
 
+        Notes
+        -----
+        This method starts by executing any soil amendments that may be scheduled for the day. Then it executes the
+        daily update routines for the soil profile and active crops in the field. It then plants and/or harvests crops,
+        checks if active crops need to go into dormancy, and resets crop attributes in both the crops and in the field's
+        data object.
 
-        Details: **All the logic (after setup) will go in this function**
         """
         # --- Soil Management---
         self._check_fertilizer_application_schedule(time)

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -98,11 +98,11 @@ class Field:
         Details: **All the logic (after setup) will go in this function**
         """
         # --- Soil Management---
-        self.check_fertilizer_application_schedule(time)
+        self._check_fertilizer_application_schedule(time)
 
-        self.check_manure_application_schedule(time)
+        self._check_manure_application_schedule(time)
 
-        self.check_tillage_schedule(time)
+        self._check_tillage_schedule(time)
 
         # --- Whole-Field Methods ---
         # Allow non-management field processes (water/nutrient cycling) to occur
@@ -110,19 +110,14 @@ class Field:
         # ... Other ...
 
         # --- Crop Management ---
-        self.assess_dormancy(current_weather.daylength)
+        self._assess_dormancy(current_weather.daylength)
 
-        self.check_crop_planting_schedule(time)
+        self._check_crop_planting_schedule(time)
 
-        self.check_crop_harvest_schedule(time)
+        self._check_crop_harvest_schedule(time)
 
         self._remove_dead_crops()
         self._reset_crop_field_coverage_fractions()
-
-    @property
-    def _composition_sums_to_one(self) -> bool:
-        """ensure that the crop_proportions values sum to 1"""
-        return sum([crop.data.field_proportion for crop in self.crops]) == 1.0
 
     # <editor-fold desc="--- Soil Management Methods ---">
     def _execute_fertilizer_application(self, mix_name: str, requested_nitrogen: float, requested_phosphorus: float,
@@ -361,7 +356,7 @@ class Field:
     # </editor-fold>
 
     # <editor-fold desc="--- Scheduling Methods ---">
-    def check_crop_planting_schedule(self, time: Time) -> None:
+    def _check_crop_planting_schedule(self, time: Time) -> None:
         """
         Checks the list of PlantingEvents, and all that are scheduled to happen are passed on to another method to be
         executed.
@@ -376,7 +371,7 @@ class Field:
         for event in todays_planting_events:
             self._plant_crop(event.crop_reference, event.use_heat_scheduled_harvest, time)
 
-    def check_fertilizer_application_schedule(self, time: Time) -> None:
+    def _check_fertilizer_application_schedule(self, time: Time) -> None:
         """
         Checks list of FertilizerEvents, and removes all that occur on the current day from the list.
 
@@ -391,7 +386,7 @@ class Field:
             self._execute_fertilizer_application(event.mix_name, event.nitrogen_mass, event.phosphorus_mass, event.year,
                                                  event.day)
 
-    def check_tillage_schedule(self, time: Time) -> None:
+    def _check_tillage_schedule(self, time: Time) -> None:
         """
         Checks the list of Events, and all that are scheduled to happen are passed on to another method to be
         executed.
@@ -406,7 +401,7 @@ class Field:
             self.tiller.till_soil(event.tillage_depth, event.incorporation_fraction, event.mixing_fraction,
                                   time.calendar_year, time.day)
 
-    def check_manure_application_schedule(self, time: Time) -> None:
+    def _check_manure_application_schedule(self, time: Time) -> None:
         """
         Checks list of ManureEvents, sends all that occur today to another method to be executed.
 
@@ -421,7 +416,7 @@ class Field:
             self._execute_manure_application(event.nitrogen_mass, event.phosphorus_mass, event.field_coverage,
                                              event.year, event.day)
 
-    def check_crop_harvest_schedule(self, time: Time) -> None:
+    def _check_crop_harvest_schedule(self, time: Time) -> None:
         """
         Checks for all crops for potential harvests that may happen on the current day.
 
@@ -529,7 +524,7 @@ class Field:
         """
         supported_species = set(item.value for item in CropSpecies)
         if crop_reference in supported_species:
-            crop = self.make_supported_crop(crop_reference)
+            crop = self._make_supported_crop(crop_reference)
         else:
             try:
                 crop_specifications = copy(self.custom_crop_specifications[crop_reference])
@@ -537,7 +532,7 @@ class Field:
                 raise KeyError(f"'{self.field_data.name}': expected to have crop specification for '{crop_reference}', "
                                f"received specifications for '{tuple(self.custom_crop_specifications.keys())}' crop "
                                f"types.")
-            crop = self.make_crop_from_config_dict(crop_specifications)
+            crop = self._make_crop_from_config_dict(crop_specifications)
         crop.data.use_heat_scheduling = use_heat_scheduled_harvesting
         crop.data.id = crop_reference
 
@@ -627,7 +622,7 @@ class Field:
             crop.data.field_proportion = field_coverage_fraction
 
     @staticmethod
-    def make_crop_from_config_dict(config: Dict) -> Crop:
+    def _make_crop_from_config_dict(config: Dict) -> Crop:
         """Initializes a new crop from a configuration dictionary
 
         Args:
@@ -644,14 +639,14 @@ class Field:
             species = config.pop("species")
 
             if species in accepted_species:
-                return Field.make_supported_crop(species=species, **config)
+                return Field._make_supported_crop(species=species, **config)
             else:
                 config["species"] = "custom " + str(species)
 
-        return Field.make_custom_crop(**config)
+        return Field._make_custom_crop(**config)
 
     @staticmethod
-    def make_supported_crop(species: str, **specs) -> Crop:
+    def _make_supported_crop(species: str, **specs) -> Crop:
         """creates a crop instance with attributes determined by the species of the crop.
 
         Args:
@@ -670,7 +665,7 @@ class Field:
         return Crop(crop_data)
 
     @staticmethod
-    def make_custom_crop(**specs) -> Crop:
+    def _make_custom_crop(**specs) -> Crop:
         """creates a crop instance with customized attributes.
 
         Args:
@@ -682,7 +677,7 @@ class Field:
         crop_data = CropData(**specs)
         return Crop(crop_data)
 
-    def assess_dormancy(self, daylength: float) -> None:
+    def _assess_dormancy(self, daylength: float) -> None:
         """Transitions all crops to dormancy, that are capable of going dormant
 
         Args:

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -80,9 +80,6 @@ class Field:
         self.tillage_events: List[TillageEvent] = tillage_events
         """List of all tillage events that will occur over the run of the simulation in this field."""
 
-        self.is_last_day_of_the_year = False  # TODO: This should be handled elsewhere
-        """is today the last day of the simulation year?"""
-
         self.manure_applicator = ManureApplication(self.soil.data)
         """Manure application interface."""
 
@@ -105,8 +102,7 @@ class Field:
 
         self.check_manure_application_schedule(time)
 
-        # tillage
-        self.check_tillage_schedule()
+        self.check_tillage_schedule(time)
 
         # --- Whole-Field Methods ---
         # Allow non-management field processes (water/nutrient cycling) to occur
@@ -114,30 +110,14 @@ class Field:
         # ... Other ...
 
         # --- Crop Management ---
-        # planting
+        self.assess_dormancy(current_weather.daylength)
+
         self.check_crop_planting_schedule(time)
 
-        # Harvesting.
         self.check_crop_harvest_schedule(time)
 
         self._remove_dead_crops()
         self._reset_crop_field_coverage_fractions()
-
-        # perform remaining tasks if crops currently in field
-        if self.crops is not None:
-
-            self.assess_dormancy(current_weather.daylength)
-
-            self.grow_crops(current_weather.incoming_light, current_weather.min_air_temperature,
-                            current_weather.mean_air_temperature, current_weather.max_air_temperature)
-
-            if self.field_data.grazers_present:
-                self.graze_field()
-
-            self.check_harvest_schedules(time.day, time.year)
-            self.harvest_scheduled_crops()
-
-        pass
 
     @property
     def _composition_sums_to_one(self) -> bool:
@@ -424,8 +404,7 @@ class Field:
         self.tillage_events, todays_events = self._filter_events(self.tillage_events, time)
         for event in todays_events:
             self.tiller.till_soil(event.tillage_depth, event.incorporation_fraction, event.mixing_fraction,
-                                  time.calendar_year,
-                                  time.day)
+                                  time.calendar_year, time.day)
 
     def check_manure_application_schedule(self, time: Time) -> None:
         """
@@ -702,78 +681,6 @@ class Field:
         """
         crop_data = CropData(**specs)
         return Crop(crop_data)
-
-    def reset_perennial(self):
-        """resets some attributes for perennial crops at the start of the new growing season"""
-        pass
-
-    def _get_soil_layer_attributes_for_crop_growth(self) -> Dict[str, List[float]]:
-        """restructure soil layer data to be used for crop growth methods"""
-        layer_attr_dict = {"depths": [],
-                           "nitrates": [],
-                           "phosphates": []}
-        for layer in self.soil.data.soil_layers:
-            layer_attr_dict["depths"].append(layer.bottom_depth)
-            layer_attr_dict["nitrates"].append(layer.nitrate)
-            layer_attr_dict["phosphates"].append(layer.phosphate)
-
-        return layer_attr_dict
-
-        # NOTE: I had originally opted to have separate properties in the Soil class that made these lists,
-        # but, unless other classes need these variables in this format, this seems to be most efficient.
-        # i.e.,
-        #
-        # @property
-        # def layer_depths(self):
-        #     """Get a list of the lowest depth for each soil layer"""
-        #     return [layer.bottom_depth for layer in self.data.soil_layers]
-        #
-        # @property
-        # def layer_nitrates(self):
-        #     """Place the nitrate values from each soil layer into a list"""
-        #     return [layer.nitrate for layer in self.data.soil_layers]
-        #
-        # @property
-        # def layer_phosphates(self):
-        #     """Place the nitrate values from each soil layer into a list"""
-        #     return [layer.phosphate for layer in self.data.soil_layers]
-
-    def grow_crops(self, incoming_light, min_air_temperature, mean_air_temperature, max_air_temperature) -> None:
-        """allow the current crops to execute their daily growth routines"""
-        for this_crop in self.crops:
-            this_crop.grow_crop(soil_data=self.soil.data, incoming_light=incoming_light,
-                                mean_air_temperature=mean_air_temperature, min_air_temperature=min_air_temperature,
-                                max_air_temperature=max_air_temperature)
-
-    def check_harvest_schedules(self, day, year) -> None:
-        """executes the check_harvest_schedule method for each crop, passing the current day and year"""
-        for crop in self.crops:
-            crop.crop_management.check_harvest_schedule(current_day=day, current_year=year)
-
-    def harvest_scheduled_crops(self) -> None:
-        """perform the harvest operation on all crops in the field, depending on the harvest operation, if today is
-        the crop's harvest day.
-
-        After the harvest, this method adds any residue to the soil. Root residue is only added if the
-        harvest operation killed the crop.
-        """
-        for crop in self.crops:
-            if not crop.data.is_harvest_day:
-                continue  # move on to checking next crop
-
-            if crop.data.next_harvest_operation == HarvestOperation.HARVEST:
-                crop.crop_management.manage_harvest(cut=True, collect=True, kill=True)
-
-            if crop.data.next_harvest_operation == HarvestOperation.HARVEST_NOKILL:
-                crop.crop_management.manage_harvest(cut=True, collect_yield=True, kill=False)
-
-            self.soil.data.plant_surface_residue += (crop.data.yield_residue or 0)
-            if not crop.data.is_alive:
-                self.soil.data.plant_root_residue += (crop.data.root_biomass or 0)
-
-    def graze_field(self):  # TODO: placeholder; no grazing method currently implemented in RUFAS
-        """allow grazers to graze in the field during the current day"""
-        pass
 
     def assess_dormancy(self, daylength: float) -> None:
         """Transitions all crops to dormancy, that are capable of going dormant

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -156,7 +156,7 @@ class Field:
 
         """
         try:
-            fertilizer_mix = self.available_fertilizer_mixes.get(mix_name)
+            fertilizer_mix = self.available_fertilizer_mixes[mix_name]
         except KeyError:
             raise KeyError(f"'{self.field_data.name}': expected to have fertilizer mix for '{mix_name}', "
                            f"received '{self.available_fertilizer_mixes}'.")

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -30,7 +30,6 @@ om = OutputManager()
 
 
 class Field:
-    """object representing an agricultural field"""
 
     def __init__(self, field_data: Optional[FieldData] = None, soil: Optional[Soil] = None,
                  plantings: Optional[List[PlantingEvent]] = None, harvestings: Optional[List[HarvestEvent]] = None,

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -20,7 +20,7 @@ from copy import copy
 
 
 """
-This is a high-level module that represents an simulates an entire field. It is responsible for executing the daily
+This is a high-level module that represents and simulates an entire field. It is responsible for executing the daily
 biophysical routines which take place in soil columns and in crops planted in the field. It is also responsible for the
 management of schedules, executing, and reporting of farm management events, including planting and harvesting crops,
 adding manure and fertilizer to the soil, and tilling the soil.

--- a/SC_redesign/Crop_and_Soil/tests_SC/crop_tests/test_crop_management.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/crop_tests/test_crop_management.py
@@ -88,14 +88,6 @@ def test_dry_down():
     assert pytest.approx(crop.data.above_ground_biomass) == 10.2 * (1 - 0.18)
 
 
-def test_graze():
-    warnings.warn("no graze method implemented")
-
-
-def test_collect_cut_yields():
-    warnings.warn("no collect cut yields method implemented")
-
-
 @pytest.mark.parametrize("heat_sched,heat_frac,harv_day,harv_yr,this_day,this_yr", [
     (False, 1.20, 100, 0, 80, 0),  # scheduled, too early (conflicting heat)
     (False, 1.00, 100, 0, 100, 0),  # scheduled, exactly right (conflicting heat)

--- a/SC_redesign/Crop_and_Soil/tests_SC/crop_tests/test_crop_management.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/crop_tests/test_crop_management.py
@@ -1,5 +1,3 @@
-import warnings
-
 import pytest
 from mock.mock import MagicMock
 from SC_redesign.Crop_and_Soil.crop.crop_management import CropManagement

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -488,35 +488,6 @@ def test_make_crop_from_config_dict(config: dict):
         Field.make_custom_crop.assert_called_once()
 
 
-def test_check_harvest_schedules():
-    """ensure that harvest schedules are checked for all crops"""
-    field = Field()
-    crop1, crop2, crop3 = Crop(), Crop(), Crop()
-    crop1.crop_management.check_harvest_schedule = MagicMock()
-    crop2.crop_management.check_harvest_schedule = MagicMock()
-    crop3.crop_management.check_harvest_schedule = MagicMock()
-    field.crops = [crop1, crop2, crop3]
-    field.check_harvest_schedules(100, 0)
-    crop1.crop_management.check_harvest_schedule.assert_called_once_with(current_day=100, current_year=0)
-    crop2.crop_management.check_harvest_schedule.assert_called_once_with(current_day=100, current_year=0)
-    crop3.crop_management.check_harvest_schedule.assert_called_once_with(current_day=100, current_year=0)
-
-
-def test_harvest_scheduled_crops():
-    """ensure that crops are harvested when appropriate"""
-    field = Field()
-    crop1, crop2, crop3 = Crop(CropData(is_harvest_day=True)), Crop(CropData(is_harvest_day=False)), \
-        Crop(CropData(is_harvest_day=True))
-    crop1.crop_management.manage_harvest = MagicMock()
-    crop2.crop_management.manage_harvest = MagicMock()
-    crop3.crop_management.manage_harvest = MagicMock()
-    field.crops = [crop1, crop2, crop3]
-    field.harvest_scheduled_crops()
-    crop1.crop_management.manage_harvest.assert_called_once()
-    crop2.crop_management.manage_harvest.assert_not_called()
-    crop3.crop_management.manage_harvest.assert_called_once()
-
-
 @pytest.mark.parametrize("mix_name,requested_n,requested_p,year,day,field_size", {
     ("test_mix_1", 80.0, 30.0, 1993, 100, 3.1),
     ("test_mix_2", 150.0, 89.0, 2001, 240, 1.3),
@@ -887,6 +858,23 @@ def test_evaporate_from_crop_canopies(demand: float, canopy_water_1: float, cano
     assert pytest.approx(actual_demand) == expected_demand
     assert pytest.approx(expected_canopy_water1) == field.crops[0].data.canopy_water
     assert pytest.approx(expected_canopy_water2) == field.crops[1].data.canopy_water
+
+
+@pytest.mark.parametrize("biomasses,expected", [
+    ([30, 20, 14], 64),
+    ([22.1], 22.1),
+    ([], 0.0)
+])
+def test_determine_total_above_ground_biomass(biomasses: List[float], expected: float) -> None:
+    """Tests that total above ground biomass on the field is correctly calculated."""
+    field = Field()
+    for biomass in biomasses:
+        crop = Crop()
+        crop.data.above_ground_biomass = biomass
+        field.crops.append(crop)
+
+    actual = field._determine_total_above_ground_biomass()
+    assert actual == expected
 
 
 @pytest.mark.parametrize("extraterrestrial_radiation,max_temp,min_temp,avg_temp", [

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -516,6 +516,24 @@ def test_execute_fertilizer_application(mix_name: str, requested_n: float, reque
     field._record_fertilizer_application.assert_called_once_with(mix_name, 100, 20, 15, 10, year, day)
 
 
+@pytest.mark.parametrize("field_name,mix_name,available_mixes,expected_message", [
+    ("test_field_1", "halo_alien_mix", {}, "\"'test_field_1': expected to have fertilizer mix for 'halo_alien_mix', "
+                                           "received '{'100_0_0': {'N': 1.0, 'P': 0.0, 'K': 0.0}, '26_4_24': "
+                                           "{'N': 0.26, 'P': 0.04, 'K': 0.24}}'.\""),
+    ("test_field_2", "101_0_0", {"50_22_12": {"N": 0.5, "P": 0.22, "K": 0.12}},
+     "\"'test_field_2': expected to have fertilizer mix for '101_0_0', received '{'50_22_12': {'N': 0.5, 'P': 0.22, "
+     "'K': 0.12}, '100_0_0': {'N': 1.0, 'P': 0.0, 'K': 0.0}, '26_4_24': {'N': 0.26, 'P': 0.04, 'K': 0.24}}'.\"")
+])
+def test_execute_fertilizer_application_error(field_name: str, mix_name: str, available_mixes: Dict,
+                                              expected_message: str) -> None:
+    """Tests that errors are correctly raised when a mix is specified to be used but is not listed in the available
+        mixes."""
+    field = Field(field_data=FieldData(name=field_name), fertilizer_mixes=available_mixes)
+    with pytest.raises(KeyError) as e:
+        field._execute_fertilizer_application(mix_name, 10.0, 10.0, 1994, 120)
+    assert str(e.value) == expected_message
+
+
 @pytest.mark.parametrize("nitrogen,phosphorus,mixes,expected", [
     (100, 20, {"100_0_0": {"N": 1.0, "P": 0.0, "K": 0.0}, "26_4_24": {"N": 0.26, "P": 0.04, "K": 0.24}}, "26_4_24"),
     (50, 60, {"30_40_50": {"N": 0.3, "P": 0.4, "K": 0.5}}, "30_40_50"),

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -51,7 +51,7 @@ def test_check_crop_planting_schedule(all_events: List[PlantingEvent], events_re
     time = MagicMock(Time)
     expected_create_and_update_events_calls = [call(all_events, time)]
 
-    field.check_crop_planting_schedule(time)
+    field._check_crop_planting_schedule(time)
 
     field._filter_events.assert_has_calls(expected_create_and_update_events_calls)
     assert field._plant_crop.call_count == len(events_occurring_today)
@@ -82,7 +82,7 @@ def test_check_fertilizer_application_schedule(events: List[FertilizerEvent], re
     setattr(mocked_time, "calendar_year", 2000)
     setattr(mocked_time, "day", 100)
 
-    field.check_fertilizer_application_schedule(mocked_time)
+    field._check_fertilizer_application_schedule(mocked_time)
 
     expected_execution_calls = []
     for event in current_events:
@@ -116,7 +116,7 @@ def test_check_manure_application_schedule(events: List[ManureEvent], remaining_
     setattr(mocked_time, "calendar_year", 1991)
     setattr(mocked_time, "day", 120)
 
-    field.check_manure_application_schedule(mocked_time)
+    field._check_manure_application_schedule(mocked_time)
 
     expected_execution_calls = []
     for event in current_events:
@@ -160,7 +160,7 @@ def test_check_crop_harvest_schedule(year: int, day: int, all_harvest_events: Li
         new_call = call(event.crop_reference, event.operation, mocked_time)
         harvest_crop_calls.append(new_call)
 
-    field.check_crop_harvest_schedule(mocked_time)
+    field._check_crop_harvest_schedule(mocked_time)
 
     field._filter_events.assert_called_once_with(all_harvest_events, mocked_time)
     field._harvest_crop.assert_has_calls(harvest_crop_calls)
@@ -240,9 +240,9 @@ def test_plant_crop(crop_reference: str, heat_scheduled: bool, custom_crop_specs
     field._plant_crop(crop_reference, heat_scheduled, mocked_time)
 
     if is_supported:
-        expected_crop = field.make_supported_crop(crop_reference)
+        expected_crop = field._make_supported_crop(crop_reference)
     else:
-        expected_crop = field.make_crop_from_config_dict(custom_crop_specs.get(crop_reference))
+        expected_crop = field._make_crop_from_config_dict(custom_crop_specs.get(crop_reference))
     expected_crop.data.use_heat_scheduling = heat_scheduled
     expected_crop.data.id = crop_reference
 
@@ -422,7 +422,7 @@ def test_start_dormancy(daylength: float, threshold_daylength: float) -> None:
     crop.dormancy.enter_dormancy = MagicMock()
 
     # Run method being tested
-    field.assess_dormancy(daylength)
+    field._assess_dormancy(daylength)
 
     # Check that subroutines were called correct number of times
     if daylength <= threshold_daylength:
@@ -436,7 +436,7 @@ def test_start_dormancy(daylength: float, threshold_daylength: float) -> None:
 def test_make_supported_crop(species: str, specs: dict):
     """ensure that supported crops are properly created."""
     # check that attributes are correct
-    crop = Field.make_supported_crop(species, **specs)
+    crop = Field._make_supported_crop(species, **specs)
     assert crop.data.species == species
     for key, val in specs.items():
         assert getattr(crop.data, key) == val
@@ -448,9 +448,9 @@ def test_make_supported_crop(species: str, specs: dict):
 
     # failing cases
     with pytest.raises(Exception):
-        Field.make_supported_crop("fake_crop")
+        Field._make_supported_crop("fake_crop")
     with pytest.raises(Exception):
-        Field.make_supported_crop("corn", bad_attr=17.35)
+        Field._make_supported_crop("corn", bad_attr=17.35)
 
 
 @pytest.mark.parametrize("config", [
@@ -460,7 +460,7 @@ def test_make_supported_crop(species: str, specs: dict):
 ])
 def test_make_custom_crop(config: dict):
     """checks that custom crop attributes are set correctly"""
-    crop = Field.make_custom_crop(**config)
+    crop = Field._make_custom_crop(**config)
     for key, val in config.items():
         assert getattr(crop.data, key) == val
 
@@ -475,17 +475,17 @@ def test_make_custom_crop(config: dict):
 def test_make_crop_from_config_dict(config: dict):
     supported_crops = set(item.value for item in CropSpecies)
     has_supported_species = "species" in config.keys() and str(config["species"]) in supported_crops
-    Field.make_supported_crop = MagicMock()
-    Field.make_custom_crop = MagicMock()
+    Field._make_supported_crop = MagicMock()
+    Field._make_custom_crop = MagicMock()
 
-    Field.make_crop_from_config_dict(config)
+    Field._make_crop_from_config_dict(config)
 
     if has_supported_species:
-        Field.make_supported_crop.assert_called_once()
-        Field.make_custom_crop.assert_not_called()
+        Field._make_supported_crop.assert_called_once()
+        Field._make_custom_crop.assert_not_called()
     else:
-        Field.make_supported_crop.assert_not_called()
-        Field.make_custom_crop.assert_called_once()
+        Field._make_supported_crop.assert_not_called()
+        Field._make_custom_crop.assert_called_once()
 
 
 @pytest.mark.parametrize("mix_name,requested_n,requested_p,year,day,field_size", {
@@ -1022,7 +1022,7 @@ def test_check_tillage_schedule(events: List[TillageEvent], day: int, year: int,
     field = Field(tillage_events=events)
     todays_count = len(is_today)
     field.tiller.till_soil = MagicMock()
-    field.check_tillage_schedule(mocked_time)
+    field._check_tillage_schedule(mocked_time)
     assert field.tillage_events == not_today
 
     assert field.tiller.till_soil.call_count == todays_count

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -22,6 +22,35 @@ from RUFAS.output_manager import OutputManager
 om = OutputManager()
 
 
+def test_manage_field() -> None:
+    """Tests that all subroutines are correctly called by the main routine in field."""
+    field = Field()
+    field._check_fertilizer_application_schedule = MagicMock()
+    field._check_manure_application_schedule = MagicMock()
+    field._check_tillage_schedule = MagicMock()
+    field._execute_daily_processes = MagicMock()
+    field._assess_dormancy = MagicMock()
+    field._check_crop_planting_schedule = MagicMock()
+    field._check_crop_harvest_schedule = MagicMock()
+    field._remove_dead_crops = MagicMock()
+    field._reset_crop_field_coverage_fractions = MagicMock()
+    mocked_time = MagicMock(Time)
+    mocked_weather = MagicMock(CurrentWeather)
+    setattr(mocked_weather, "daylength", 12)
+
+    field.manage_field(mocked_time, mocked_weather)
+
+    field._check_fertilizer_application_schedule.assert_called_once_with(mocked_time)
+    field._check_manure_application_schedule.assert_called_once_with(mocked_time)
+    field._check_tillage_schedule.assert_called_once_with(mocked_time)
+    field._execute_daily_processes.assert_called_once_with(mocked_weather)
+    field._assess_dormancy.assert_called_once_with(12)
+    field._check_crop_planting_schedule.assert_called_once_with(mocked_time)
+    field._check_crop_harvest_schedule.assert_called_once_with(mocked_time)
+    field._remove_dead_crops.assert_called_once()
+    field._reset_crop_field_coverage_fractions.assert_called_once()
+
+
 @pytest.mark.parametrize("all_events,events_remaining,events_occurring_today", [
     ([PlantingEvent("test_1", 1996, 120, False), PlantingEvent("test_2", 1996, 120, False),
       PlantingEvent("test_3", 1996, 240, False), PlantingEvent("test_4", 1997, 125, False)],

--- a/SC_redesign/docs_SC/Admin/finish_line_doc.md
+++ b/SC_redesign/docs_SC/Admin/finish_line_doc.md
@@ -39,7 +39,7 @@ contribute get up to speed on the state of the module quickly.
 ## Requirements
 
 ### Field Requirements
-- [ ] Test that all the below processes have been correctly and cohesively integrated into the `Field` module.
+- [x] Test that all the below processes have been correctly and cohesively integrated into the `Field` module.
 
 #### Water
 Biophysical processes that involve the movement of water are often complex and intertwined with Crop and Soil processes,


### PR DESCRIPTION
This PR cleans and polishes the `Field` and `CropManagement` module. This includes removing all unused and placeholder methods, as well as removing some todo's and rewriting old docstrings.

- `CropManagement` has had the placeholder methods for grazing and collecting cut yields removed and replaced with TODO's. The place holder tests for these two methods have also been removed.
- `Field` has had the module and `manage_field()` docstrings rewritten to reflect their (more) finalized states. 
- Several old methods that were unused or had been replaced by new methods have been deleted, as well as all their usages and tests.
- All methods besides `manage_field()` and `perform_annual_reset()` have been made private (i.e. prefixed with an underscore)
- `_execute_fertilizer_application()` now accesses mixes in a way that will throw an error if the specified mix is not found. A test has been added to verify correct error handling.
- `manage_field()` has also had a test written, now that it is very close to being finalized.
- With the new tests, the code coverage has reached 100%
- `finish_line_doc.md` has been updated to with progress made by this PR.