### PR TITLE
Create Input Manager file and class

### DIFF
--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -7,7 +7,7 @@ class InputManager:
     """
     Input Manager class responsible for loading, validating, and providing access to input data.
     """
-    __instance = Optional['InputManager'] = None
+    __instance = None
 
     def __new__(cls):
         if not hasattr(cls, "instance"):
@@ -17,5 +17,3 @@ class InputManager:
     def __init__(self) -> None:
         if InputManager.__instance is None:
             InputManager.__instance = self
-        self.__pool: Dict[str, Any] = {}
-        self.__metadata: Dict[str, Any] = {}

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -1,0 +1,21 @@
+# !/usr/bin/env python3
+
+from typing import Any, Dict, Optional
+
+
+class InputManager:
+    """
+    Input Manager class responsible for loading, validating, and providing access to input data.
+    """
+    __instance = Optional['InputManager'] = None
+
+    def __new__(cls):
+        if not hasattr(cls, "instance"):
+            cls.instance = super(InputManager, cls).__new__(cls)
+        return cls.instance
+
+    def __init__(self) -> None:
+        if InputManager.__instance is None:
+            InputManager.__instance = self
+        self.__pool: Dict[str, Any] = {}
+        self.__metadata: Dict[str, Any] = {}

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -14,6 +14,7 @@ import pytest
 from mock.mock import MagicMock
 from pytest import approx, raises
 from pytest_mock.plugin import MockerFixture
+from RUFAS.input_manager import InputManager
 
 from RUFAS.general_constants import GeneralConstants
 from RUFAS.output_manager import OutputManager
@@ -1223,6 +1224,19 @@ def test_save_variables(
     mock_output_manager.save_variables = output_manager_original_method_states[
         "save_variables"
     ]
+
+
+@pytest.fixture
+def mock_input_manager(mocker) -> InputManager:
+    input_manager = InputManager()
+    return input_manager
+
+
+def test_input_manager_singleton(mocker: MockerFixture) -> None:
+    im1 = InputManager()
+    im2 = InputManager()
+
+    assert im1 is im2
 
 
 class DummyClass:


### PR DESCRIPTION
This PR seeks to address issue #603 to create an input_manager.py file and declare the InputManager class in it.

Unit testing has been added to ensure it is a singleton.

This is the starting point for the Input Manager.