### PR TITLE
Save simulation variables and the values into a CSV file.

### DIFF
--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -1,11 +1,13 @@
 # !/usr/bin/env python3
 
+from enum import Enum
 from pathlib import Path
 import re
 from typing import Any, Dict, List, Optional, Union
 import json
 import os
 import datetime
+import csv
 
 from RUFAS.util import Utility
 
@@ -34,6 +36,14 @@ class OutputManager(object):
 
     __instance = None
     pool_element_type = Dict[str, List[Dict[str, Any]]]
+
+    class OutputFormat(Enum):
+        """
+        Enumeration that represents valid output encodings for OutputManger pools
+        """
+        JSON = 0
+        CSV = 1
+
 
     def __new__(cls):
         if not hasattr(cls, "instance"):
@@ -307,6 +317,48 @@ class OutputManager(object):
         except Exception as e:
             raise e
 
+    def _save_variables_to_csv(self, data_dict: Dict[str, Any], path: str) -> None:
+        """Saves variables and their values to a csv file.
+
+        Parameters
+        ----------
+        data_dict : Dict[str, Any]
+            The variable dictionary to be saved
+        path : str
+            The path to the file to be saved
+
+        Raises
+        ------
+        Exception
+            If an error occurs while writting to the file
+        """
+        info_map = {"class": self.__class__.__name__,
+                    "function": self._save_variables_to_csv.__name__,
+                    }
+        self.add_log("_save_variables_to_csv", f"Attempting to save to {path}.", info_map)
+        if len(data_dict) == 0:
+            self.add_warning("_save_variables_to_csv", f"No variables in the pool to save to {path}", info_map)
+            with open(path, "w") as file:
+                file.truncate(0)
+            return
+
+        keys = list(data_dict.keys())
+        values = list(data_dict.values())
+        # Determine the maximum length of values to account for uneven lengths
+        max_length = max(len(d['values']) for d in values)
+
+        rows = []
+        for i in range(max_length):
+            row = [d['values'][i] if i < len(d['values']) else None for d in values]
+            rows.append(row)
+
+        with open(path, 'w', newline='') as file:
+            writer = csv.writer(file)
+            writer.writerow(keys)
+            writer.writerows(rows)
+
+        self.add_log("_save_variables_to_csv", f"Successfully saved to {path}.", info_map)
+
     def _list_to_file_txt(self, data_list: List[str], path: str) -> None:
         """Saves a list into a text file
 
@@ -487,7 +539,7 @@ class OutputManager(object):
             file_path = os.path.join(save_path, self._generate_file_name(f"saved_variables_{filter_file}", "json"))
             self._dict_to_file_json(filtered_pool, file_path)
 
-    def dump_variables(self, path: str, exclude_info_maps: bool = False) -> None:
+    def dump_variables(self, path: str, format: OutputFormat, exclude_info_maps: bool = False) -> None:
         """
         Dumps variables_pool into a json file in the given path to a directory.
 
@@ -504,8 +556,12 @@ class OutputManager(object):
         if exclude_info_maps:
             pool = self._exclude_info_maps(self.variables_pool)
 
-        file_path = os.path.join(path, self._generate_file_name("all_variables", "json"))
-        self._dict_to_file_json(pool, file_path)
+        file_path = os.path.join(path, self._generate_file_name("all_variables", format.name.lower()))
+        match format:
+            case OutputManager.OutputFormat.JSON:
+                self._dict_to_file_json(pool, file_path)
+            case OutputManager.OutputFormat.CSV:
+                self._save_variables_to_csv(pool, file_path)
 
     def dump_logs(self, path: str) -> None:
         """
@@ -607,7 +663,8 @@ class OutputManager(object):
         """
         dumps all pool into the given path to a directory.
         """
-        self.dump_variables(path, exclude_info_maps)
+        self.dump_variables(path, OutputManager.OutputFormat.JSON, exclude_info_maps)
+        self.dump_variables(path, OutputManager.OutputFormat.CSV, exclude_info_maps)
         self.dump_variable_names_and_contexts(path, exclude_info_maps)
         self.dump_errors(path)
         self.dump_logs(path)

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -57,14 +57,6 @@ class OutputManager(object):
                 },
             )
 
-    def _csv_output_directory(self, base_output_dir: str) -> Path:
-        """Directory where csv files are written to."""
-        return Path(base_output_dir) / "CSVs" / "om"
-
-    def _csv_variable_output_directory(self, base_output_dir: str) -> Path:
-        """Directory where variable pool's csv files are written to."""
-        return self._csv_output_directory(base_output_dir) / "variables"
-
     def _pool_element_factory(self) -> pool_element_type:
         """Factory for elements added to pools"""
         info_maps: List[Dict[str, Any]] = []
@@ -670,7 +662,7 @@ class OutputManager(object):
         """
         self.dump_variables(path, exclude_info_maps)
         self.dump_variable_names_and_contexts(path, exclude_info_maps)
-        self.save_variables_to_csv_files(str(self._csv_variable_output_directory(path)))
+        self.save_variables_to_csv_files(str(Path(path) / "CSVs" / "om" / "variables"))
         self.dump_errors(path)
         self.dump_logs(path)
         self.dump_warnings(path)

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -1,13 +1,12 @@
 # !/usr/bin/env python3
 
-from enum import Enum
 from pathlib import Path
-import re
 from typing import Any, Dict, List, Optional, Union
+import datetime
 import json
 import os
-import datetime
-import csv
+import pandas as pd
+import re
 
 from RUFAS.util import Utility
 
@@ -36,14 +35,6 @@ class OutputManager(object):
 
     __instance = None
     pool_element_type = Dict[str, List[Dict[str, Any]]]
-
-    class OutputFormat(Enum):
-        """
-        Enumeration that represents valid output encodings for OutputManger pools
-        """
-        JSON = 0
-        CSV = 1
-
 
     def __new__(cls):
         if not hasattr(cls, "instance"):
@@ -317,7 +308,7 @@ class OutputManager(object):
         except Exception as e:
             raise e
 
-    def _save_variables_to_csv(self, data_dict: Dict[str, Any], path: str) -> None:
+    def _dict_to_file_csv(self, data_dict: Dict[str, Any], path: str) -> None:
         """Saves variables and their values to a csv file.
 
         Parameters
@@ -333,31 +324,21 @@ class OutputManager(object):
             If an error occurs while writting to the file
         """
         info_map = {"class": self.__class__.__name__,
-                    "function": self._save_variables_to_csv.__name__,
+                    "function": self._dict_to_file_csv.__name__,
                     }
-        self.add_log("_save_variables_to_csv", f"Attempting to save to {path}.", info_map)
-        if len(data_dict) == 0:
-            self.add_warning("_save_variables_to_csv", f"No variables in the pool to save to {path}", info_map)
-            with open(path, "w") as file:
-                file.truncate(0)
+        self.add_log("save_dict_file_try", f"Attempting to save to {path}.", info_map)
+
+        if not all("values" in v for v in data_dict.values()):
+            self.add_error("save_dict_file_try", f"Unable to save {path} due to missing values.", info_map)
             return
 
-        keys = list(data_dict.keys())
-        values = list(data_dict.values())
-        # Determine the maximum length of values to account for uneven lengths
-        max_length = max(len(d['values']) for d in values)
+        df = pd.DataFrame({k: pd.Series(v['values'], dtype=object) for k, v in data_dict.items()})
+        try:
+            df.to_csv(path, index=False)
+        except Exception as e:
+            raise e
 
-        rows = []
-        for i in range(max_length):
-            row = [d['values'][i] if i < len(d['values']) else None for d in values]
-            rows.append(row)
-
-        with open(path, 'w', newline='') as file:
-            writer = csv.writer(file)
-            writer.writerow(keys)
-            writer.writerows(rows)
-
-        self.add_log("_save_variables_to_csv", f"Successfully saved to {path}.", info_map)
+        self.add_log("save_dict_file_try", f"Successfully saved to {path}.", info_map)
 
     def _list_to_file_txt(self, data_list: List[str], path: str) -> None:
         """Saves a list into a text file
@@ -539,9 +520,9 @@ class OutputManager(object):
             file_path = os.path.join(save_path, self._generate_file_name(f"saved_variables_{filter_file}", "json"))
             self._dict_to_file_json(filtered_pool, file_path)
 
-    def dump_variables(self, path: str, format: OutputFormat, exclude_info_maps: bool = False) -> None:
+    def dump_variables(self, path: str, exclude_info_maps: bool = False) -> None:
         """
-        Dumps variables_pool into a json file in the given path to a directory.
+        Dumps variables_pool into a json file and a csv file in the given path to a directory.
 
         Parameters
         ----------
@@ -556,12 +537,10 @@ class OutputManager(object):
         if exclude_info_maps:
             pool = self._exclude_info_maps(self.variables_pool)
 
-        file_path = os.path.join(path, self._generate_file_name("all_variables", format.name.lower()))
-        match format:
-            case OutputManager.OutputFormat.JSON:
-                self._dict_to_file_json(pool, file_path)
-            case OutputManager.OutputFormat.CSV:
-                self._save_variables_to_csv(pool, file_path)
+        json_file_path = os.path.join(path, self._generate_file_name("all_variables", "json"))
+        csv_file_path = os.path.join(path, self._generate_file_name("all_variables", "csv"))
+        self._dict_to_file_json(pool, json_file_path)
+        self._dict_to_file_csv(pool, csv_file_path)
 
     def dump_logs(self, path: str) -> None:
         """
@@ -663,8 +642,7 @@ class OutputManager(object):
         """
         dumps all pool into the given path to a directory.
         """
-        self.dump_variables(path, OutputManager.OutputFormat.JSON, exclude_info_maps)
-        self.dump_variables(path, OutputManager.OutputFormat.CSV, exclude_info_maps)
+        self.dump_variables(path, exclude_info_maps)
         self.dump_variable_names_and_contexts(path, exclude_info_maps)
         self.dump_errors(path)
         self.dump_logs(path)

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -309,7 +309,7 @@ class OutputManager(object):
             raise e
 
     def _dict_to_file_csv(self, data_dict: Dict[str, Any], path: str) -> None:
-        """Saves variables and their values to a csv file.
+        """Saves a variable and its values to a csv file.
 
         Parameters
         ----------
@@ -328,7 +328,7 @@ class OutputManager(object):
                     }
         self.add_log("save_dict_file_try", f"Attempting to save to {path}.", info_map)
 
-        if not all("values" in v for v in data_dict.values()):
+        if len(data_dict) != 1 or all("values" not in v for v in data_dict.values()):
             self.add_error("save_dict_file_try", f"Unable to save {path} due to missing values.", info_map)
             return
 
@@ -520,9 +520,30 @@ class OutputManager(object):
             file_path = os.path.join(save_path, self._generate_file_name(f"saved_variables_{filter_file}", "json"))
             self._dict_to_file_json(filtered_pool, file_path)
 
+    def dump_variables_to_csv_files(self, path: str) -> None:
+        """
+        Dumps variables_pool into one csv file per variable in the given path to a directory.
+
+        Parameters
+        ----------
+        path : str
+            Path to the output directory for the OutputManager.
+
+        """
+        pool = self.variables_pool
+        variables_csv_path = Path(path) / "CSVs" / "om" / "variables"
+        try:
+            variables_csv_path.mkdir(parents=True, exist_ok=True)
+        except Exception as e:
+            raise e
+
+        for key, value in pool.items():
+            csv_file_path = os.path.join(variables_csv_path, self._generate_file_name(key, "csv"))
+            self._dict_to_file_csv({key: value}, csv_file_path)
+
     def dump_variables(self, path: str, exclude_info_maps: bool = False) -> None:
         """
-        Dumps variables_pool into a json file and a csv file in the given path to a directory.
+        Dumps variables_pool into a json file in the given path to a directory.
 
         Parameters
         ----------
@@ -538,9 +559,7 @@ class OutputManager(object):
             pool = self._exclude_info_maps(self.variables_pool)
 
         json_file_path = os.path.join(path, self._generate_file_name("all_variables", "json"))
-        csv_file_path = os.path.join(path, self._generate_file_name("all_variables", "csv"))
         self._dict_to_file_json(pool, json_file_path)
-        self._dict_to_file_csv(pool, csv_file_path)
 
     def dump_logs(self, path: str) -> None:
         """
@@ -644,6 +663,7 @@ class OutputManager(object):
         """
         self.dump_variables(path, exclude_info_maps)
         self.dump_variable_names_and_contexts(path, exclude_info_maps)
+        self.dump_variables_to_csv_files(path)
         self.dump_errors(path)
         self.dump_logs(path)
         self.dump_warnings(path)

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -62,6 +62,7 @@ class OutputManager(object):
         return Path(base_output_dir) / "CSVs" / "om"
 
     def _csv_variable_output_directory(self, base_output_dir: str) -> Path:
+        """Directory where variable pool's csv files are written to."""
         return self._csv_output_directory(base_output_dir) / "variables"
 
     def _pool_element_factory(self) -> pool_element_type:

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -57,6 +57,13 @@ class OutputManager(object):
                 },
             )
 
+    def _csv_output_directory(self, base_output_dir: str) -> Path:
+        """Directory where csv files are written to."""
+        return Path(base_output_dir) / "CSVs" / "om"
+
+    def _csv_variable_output_directory(self, base_output_dir: str) -> Path:
+        return self._csv_output_directory(base_output_dir) / "variables"
+
     def _pool_element_factory(self) -> pool_element_type:
         """Factory for elements added to pools"""
         info_maps: List[Dict[str, Any]] = []
@@ -309,12 +316,12 @@ class OutputManager(object):
             raise e
 
     def _dict_to_file_csv(self, data_dict: Dict[str, Any], path: str) -> None:
-        """Saves a variable and its values to a csv file.
+        """Saves a dictionary to a csv file.
 
         Parameters
         ----------
         data_dict : Dict[str, Any]
-            The variable dictionary to be saved
+            The dictionary to be saved
         path : str
             The path to the file to be saved
 
@@ -328,7 +335,7 @@ class OutputManager(object):
                     }
         self.add_log("save_dict_file_try", f"Attempting to save to {path}.", info_map)
 
-        if len(data_dict) != 1 or all("values" not in v for v in data_dict.values()):
+        if all("values" not in v for v in data_dict.values()):
             self.add_error("save_dict_file_try", f"Unable to save {path} due to missing values.", info_map)
             return
 
@@ -520,9 +527,9 @@ class OutputManager(object):
             file_path = os.path.join(save_path, self._generate_file_name(f"saved_variables_{filter_file}", "json"))
             self._dict_to_file_json(filtered_pool, file_path)
 
-    def dump_variables_to_csv_files(self, path: str) -> None:
+    def save_variables_to_csv_files(self, path: str) -> None:
         """
-        Dumps variables_pool into one csv file per variable in the given path to a directory.
+        Saves the variables_pool into one csv file per variable in the given path to a directory.
 
         Parameters
         ----------
@@ -531,15 +538,14 @@ class OutputManager(object):
 
         """
         pool = self.variables_pool
-        variables_csv_path = Path(path) / "CSVs" / "om" / "variables"
         try:
-            variables_csv_path.mkdir(parents=True, exist_ok=True)
+            Path(path).mkdir(parents=True, exist_ok=True)
         except Exception as e:
             raise e
 
-        for key, value in pool.items():
-            csv_file_path = os.path.join(variables_csv_path, self._generate_file_name(key, "csv"))
-            self._dict_to_file_csv({key: value}, csv_file_path)
+        for key in pool.keys():
+            csv_file_path = os.path.join(path, self._generate_file_name(key, "csv"))
+            self._dict_to_file_csv({key: pool[key]}, csv_file_path)
 
     def dump_variables(self, path: str, exclude_info_maps: bool = False) -> None:
         """
@@ -663,7 +669,7 @@ class OutputManager(object):
         """
         self.dump_variables(path, exclude_info_maps)
         self.dump_variable_names_and_contexts(path, exclude_info_maps)
-        self.dump_variables_to_csv_files(path)
+        self.save_variables_to_csv_files(str(self._csv_variable_output_directory(path)))
         self.dump_errors(path)
         self.dump_logs(path)
         self.dump_warnings(path)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -7,8 +7,7 @@ Author(s): Pooya Hekmati, sh2235@cornell.edu
 
 import re
 import os
-from typing import Callable
-from typing import Dict
+from typing import Any, Callable, Dict
 from mock import Mock, mock_open, patch
 
 import pytest
@@ -320,23 +319,30 @@ def mock_output_manager(mocker) -> OutputManager:
     return output_manager
 
 
-def test_variables_to_csv(mocker: MockerFixture) -> None:
-    """Unit test for the function _save_variables_to_csv in file output_manager.py"""
-    import tempfile
+@pytest.mark.parametrize("data, expected_result, should_write", [
+    ({"var1": {"values": [1.0, True, "test"]},
+        "var2": {"values": [{"test": 1}]}}, "var1,var2\n1.0,{'test': 1}\nTrue,\ntest,\n",
+    True),
+    ({}, "\n",
+    True),
+    ({"var1": {"values": [1]}, "var2": {"values": [1, 2]}, "var3": {"values": [1, 2, 3]}},
+     "var1,var2,var3\n1,1,1\n,2,2\n,,3\n",
+    True),
+    ({"var1": {"values": []}, "var2": {"not a value": 1}}, "",
+    False)
+])
+def test_dict_to_csv(data: Dict[str, Any], expected_result: str, should_write: bool) -> None:
+    """Unit test for the function _dict_to_file_csv in the file output_manager.py"""
     om = OutputManager()
-    variable_data = {"var1": {"values": [1.0, True, "test"]},
-                "var2": {"values": [{"test": 1}]}}
-    empty_data = dict()
-    with tempfile.TemporaryDirectory() as temp_dir:
-        file_path = os.path.join(temp_dir, "test.csv")
-        om._save_variables_to_csv(variable_data, file_path)
-        with open(file_path, 'r') as file:
-            assert file.read() == "var1,var2\n1.0,{'test': 1}\nTrue,\ntest,\n"
-        om._save_variables_to_csv(empty_data, file_path)
-        with open(file_path, 'r') as file:
-            assert file.read() == ""
+    open_mock = mock_open()
 
-    assert os.path.exists(file_path) == False
+    with patch("builtins.open", open_mock):
+        om._dict_to_file_csv(data, "test")
+
+    if should_write:
+        open_mock.assert_called_with("test", "w", encoding="utf-8", errors="strict", newline='')
+    written_data = ''.join(call[1][0] for call in open_mock().write.mock_calls)
+    assert written_data == expected_result
 
 def test_generate_key(mocker: MockerFixture) -> None:
     """Unit test for function _generate_key in file output_manager.py"""
@@ -576,7 +582,7 @@ def output_manager_original_method_states(
         "_generate_file_name": mock_output_manager._generate_file_name,
         "_generate_key": mock_output_manager._generate_key,
         "_dict_to_file_json": mock_output_manager._dict_to_file_json,
-        "_save_variables_to_csv": mock_output_manager._save_variables_to_csv,
+        "_dict_to_file_csv": mock_output_manager._dict_to_file_csv,
         "_list_to_file_txt": mock_output_manager._list_to_file_txt,
         "_add_to_pool": mock_output_manager._add_to_pool,
         "_exclude_info_maps": mock_output_manager._exclude_info_maps,
@@ -613,24 +619,16 @@ def test_dump_all_pools(
     mock_output_manager.dump_errors.assert_called_once_with(path)
     mock_output_manager.dump_warnings.assert_called_once_with(path)
     mock_output_manager.dump_logs.assert_called_once_with(path)
-    mock_output_manager.dump_variables.assert_has_calls([
-        call.dump_variables(path, OutputManager.OutputFormat.JSON, False),
-        call.dump_variables(path, OutputManager.OutputFormat.CSV, False)
-        ])
+    mock_output_manager.dump_variables.assert_called_once_with(path, False)
     mock_output_manager.dump_variable_names_and_contexts.assert_called_once_with(path, False)
 
     mock_output_manager.dump_all_pools(path, exclude_info_maps=True)
-    mock_output_manager.dump_variables.assert_has_calls([
-        call.dump_variables(path, OutputManager.OutputFormat.JSON, False),
-        call.dump_variables(path, OutputManager.OutputFormat.CSV, False),
-        call.dump_variables(path, OutputManager.OutputFormat.JSON, True),
-        call.dump_variables(path, OutputManager.OutputFormat.CSV, True)
-        ])
+    mock_output_manager.dump_variables.assert_called_with(path, True)
     mock_output_manager.dump_variable_names_and_contexts.assert_called_with(path, True)
     assert mock_output_manager.dump_logs.call_count == 2
     assert mock_output_manager.dump_warnings.call_count == 2
     assert mock_output_manager.dump_errors.call_count == 2
-    assert mock_output_manager.dump_variables.call_count == 4
+    assert mock_output_manager.dump_variables.call_count == 2
 
     # Restore original methods
     mock_output_manager.dump_variables = output_manager_original_method_states[
@@ -668,20 +666,21 @@ def test_dump_variables(
     """Test case for function dump_variables in output_manager.py"""
     mock_output_manager._generate_file_name = MagicMock(return_value="dummy_name")
     mock_output_manager._dict_to_file_json = MagicMock()
-    mock_output_manager._save_variables_to_csv = MagicMock()
+    mock_output_manager._dict_to_file_csv = MagicMock()
 
-    mock_output_manager.dump_variables("dummy_path", OutputManager.OutputFormat.JSON)
+    mock_output_manager.dump_variables("dummy_path")
 
-    mock_output_manager._generate_file_name.assert_called_once_with("all_variables", "json")
+    mock_output_manager._generate_file_name.assert_has_calls([
+        call.generate_file_name("all_variables", "json"),
+        call.generate_file_name("all_variables", "csv"),
+    ])
     mock_output_manager._dict_to_file_json.assert_called_once_with(
         mock_output_manager.variables_pool, os.path.join("dummy_path", "dummy_name")
     )
-
-    mock_output_manager.dump_variables("dummy_path", OutputManager.OutputFormat.CSV)
-    mock_output_manager._generate_file_name.assert_called_with("all_variables", "csv")
-    mock_output_manager._save_variables_to_csv.assert_called_once_with(
+    mock_output_manager._dict_to_file_csv.assert_called_once_with(
         mock_output_manager.variables_pool, os.path.join("dummy_path", "dummy_name")
     )
+
 
     # Restore original methods
     mock_output_manager._generate_file_name = output_manager_original_method_states[
@@ -689,6 +688,9 @@ def test_dump_variables(
     ]
     mock_output_manager._dict_to_file_json = output_manager_original_method_states[
         "_dict_to_file_json"
+    ]
+    mock_output_manager._dict_to_file_csv = output_manager_original_method_states[
+        "_dict_to_file_csv"
     ]
 
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -12,7 +12,7 @@ from typing import Dict
 from mock import Mock, mock_open, patch
 
 import pytest
-from mock.mock import MagicMock
+from mock.mock import MagicMock, call
 from pytest import approx, raises
 from pytest_mock.plugin import MockerFixture
 
@@ -320,6 +320,24 @@ def mock_output_manager(mocker) -> OutputManager:
     return output_manager
 
 
+def test_variables_to_csv(mocker: MockerFixture) -> None:
+    """Unit test for the function _save_variables_to_csv in file output_manager.py"""
+    import tempfile
+    om = OutputManager()
+    variable_data = {"var1": {"values": [1.0, True, "test"]},
+                "var2": {"values": [{"test": 1}]}}
+    empty_data = dict()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file_path = os.path.join(temp_dir, "test.csv")
+        om._save_variables_to_csv(variable_data, file_path)
+        with open(file_path, 'r') as file:
+            assert file.read() == "var1,var2\n1.0,{'test': 1}\nTrue,\ntest,\n"
+        om._save_variables_to_csv(empty_data, file_path)
+        with open(file_path, 'r') as file:
+            assert file.read() == ""
+
+    assert os.path.exists(file_path) == False
+
 def test_generate_key(mocker: MockerFixture) -> None:
     """Unit test for function _generate_key in file output_manager.py"""
     om = OutputManager()
@@ -558,6 +576,7 @@ def output_manager_original_method_states(
         "_generate_file_name": mock_output_manager._generate_file_name,
         "_generate_key": mock_output_manager._generate_key,
         "_dict_to_file_json": mock_output_manager._dict_to_file_json,
+        "_save_variables_to_csv": mock_output_manager._save_variables_to_csv,
         "_list_to_file_txt": mock_output_manager._list_to_file_txt,
         "_add_to_pool": mock_output_manager._add_to_pool,
         "_exclude_info_maps": mock_output_manager._exclude_info_maps,
@@ -594,17 +613,24 @@ def test_dump_all_pools(
     mock_output_manager.dump_errors.assert_called_once_with(path)
     mock_output_manager.dump_warnings.assert_called_once_with(path)
     mock_output_manager.dump_logs.assert_called_once_with(path)
-    mock_output_manager.dump_variables.assert_called_once_with(
-        path, False
-    )
+    mock_output_manager.dump_variables.assert_has_calls([
+        call.dump_variables(path, OutputManager.OutputFormat.JSON, False),
+        call.dump_variables(path, OutputManager.OutputFormat.CSV, False)
+        ])
     mock_output_manager.dump_variable_names_and_contexts.assert_called_once_with(path, False)
 
     mock_output_manager.dump_all_pools(path, exclude_info_maps=True)
-    mock_output_manager.dump_variables.assert_called_with(path, True)
+    mock_output_manager.dump_variables.assert_has_calls([
+        call.dump_variables(path, OutputManager.OutputFormat.JSON, False),
+        call.dump_variables(path, OutputManager.OutputFormat.CSV, False),
+        call.dump_variables(path, OutputManager.OutputFormat.JSON, True),
+        call.dump_variables(path, OutputManager.OutputFormat.CSV, True)
+        ])
     mock_output_manager.dump_variable_names_and_contexts.assert_called_with(path, True)
     assert mock_output_manager.dump_logs.call_count == 2
     assert mock_output_manager.dump_warnings.call_count == 2
     assert mock_output_manager.dump_errors.call_count == 2
+    assert mock_output_manager.dump_variables.call_count == 4
 
     # Restore original methods
     mock_output_manager.dump_variables = output_manager_original_method_states[
@@ -642,11 +668,18 @@ def test_dump_variables(
     """Test case for function dump_variables in output_manager.py"""
     mock_output_manager._generate_file_name = MagicMock(return_value="dummy_name")
     mock_output_manager._dict_to_file_json = MagicMock()
+    mock_output_manager._save_variables_to_csv = MagicMock()
 
-    mock_output_manager.dump_variables("dummy_path")
+    mock_output_manager.dump_variables("dummy_path", OutputManager.OutputFormat.JSON)
 
     mock_output_manager._generate_file_name.assert_called_once_with("all_variables", "json")
     mock_output_manager._dict_to_file_json.assert_called_once_with(
+        mock_output_manager.variables_pool, os.path.join("dummy_path", "dummy_name")
+    )
+
+    mock_output_manager.dump_variables("dummy_path", OutputManager.OutputFormat.CSV)
+    mock_output_manager._generate_file_name.assert_called_with("all_variables", "csv")
+    mock_output_manager._save_variables_to_csv.assert_called_once_with(
         mock_output_manager.variables_pool, os.path.join("dummy_path", "dummy_name")
     )
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -313,16 +313,6 @@ def test_get_prefix() -> None:
     om = OutputManager()
     assert om._get_prefix("class", "func") == "class.func"
 
-def test_csv_output_dir() -> None:
-    """Unit test for function _csv_output_directory in file output_manager.py"""
-    om = OutputManager()
-    assert om._csv_output_directory("test") == Path("test/CSVs/om/")
-
-def test_csv_variable_output_dir() -> None:
-    """Unit test for function _csv_variable_output_directory in file output_manager.py"""
-    om = OutputManager()
-    assert om._csv_variable_output_directory("test") == Path("test/CSVs/om/variables/")
-
 @pytest.fixture
 def mock_output_manager(mocker) -> OutputManager:
     output_manager = OutputManager()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -320,16 +320,17 @@ def mock_output_manager(mocker) -> OutputManager:
 
 
 @pytest.mark.parametrize("data, expected_result, should_write", [
-    ({"var1": {"values": [1.0, True, "test"]},
-        "var2": {"values": [{"test": 1}]}}, "var1,var2\n1.0,{'test': 1}\nTrue,\ntest,\n",
-    True),
-    ({}, "\n",
-    True),
-    ({"var1": {"values": [1]}, "var2": {"values": [1, 2]}, "var3": {"values": [1, 2, 3]}},
-     "var1,var2,var3\n1,1,1\n,2,2\n,,3\n",
-    True),
+    ({"var1": {"values": [1.0, True, "test", {"key": 1}]}}, "var1\n1.0\nTrue\ntest\n{'key': 1}\n",
+     True),
+    ({}, "",
+     False),
+    ({"var1": {"values": [1,2,3]}},
+     "var1\n1\n2\n3\n",
+     True),
+    ({"var1": {"not a value": [1]}}, "",
+     False),
     ({"var1": {"values": []}, "var2": {"not a value": 1}}, "",
-    False)
+     False)
 ])
 def test_dict_to_csv(data: Dict[str, Any], expected_result: str, should_write: bool) -> None:
     """Unit test for the function _dict_to_file_csv in the file output_manager.py"""
@@ -599,6 +600,7 @@ def output_manager_original_method_states(
         "dump_warnings": mock_output_manager.dump_warnings,
         "dump_errors": mock_output_manager.dump_errors,
         "dump_variable_names_and_contexts": mock_output_manager.dump_variable_names_and_contexts,
+        "dump_variables_to_csv_files ": mock_output_manager.dump_variables_to_csv_files,
     }
 
 
@@ -613,6 +615,7 @@ def test_dump_all_pools(
     mock_output_manager.dump_logs = MagicMock()
     mock_output_manager.dump_variables = MagicMock()
     mock_output_manager.dump_variable_names_and_contexts = MagicMock()
+    mock_output_manager.dump_variables_to_csv_files = MagicMock()
 
     mock_output_manager.dump_all_pools(path, exclude_info_maps=False)
 
@@ -621,6 +624,7 @@ def test_dump_all_pools(
     mock_output_manager.dump_logs.assert_called_once_with(path)
     mock_output_manager.dump_variables.assert_called_once_with(path, False)
     mock_output_manager.dump_variable_names_and_contexts.assert_called_once_with(path, False)
+    mock_output_manager.dump_variables_to_csv_files.assert_called_once_with(path)
 
     mock_output_manager.dump_all_pools(path, exclude_info_maps=True)
     mock_output_manager.dump_variables.assert_called_with(path, True)
@@ -629,6 +633,7 @@ def test_dump_all_pools(
     assert mock_output_manager.dump_warnings.call_count == 2
     assert mock_output_manager.dump_errors.call_count == 2
     assert mock_output_manager.dump_variables.call_count == 2
+    assert mock_output_manager.dump_variables_to_csv_files.call_count == 2
 
     # Restore original methods
     mock_output_manager.dump_variables = output_manager_original_method_states[
@@ -643,6 +648,9 @@ def test_dump_all_pools(
     ]
     mock_output_manager.dump_variable_names_and_contexts = output_manager_original_method_states[
         "dump_variable_names_and_contexts"
+    ]
+    mock_output_manager.dump_variables_to_csv_files = output_manager_original_method_states[
+        "dump_variables_to_csv_files "
     ]
 
 def test_generate_file_name(mocker: MockerFixture) -> None:
@@ -666,21 +674,13 @@ def test_dump_variables(
     """Test case for function dump_variables in output_manager.py"""
     mock_output_manager._generate_file_name = MagicMock(return_value="dummy_name")
     mock_output_manager._dict_to_file_json = MagicMock()
-    mock_output_manager._dict_to_file_csv = MagicMock()
 
     mock_output_manager.dump_variables("dummy_path")
 
-    mock_output_manager._generate_file_name.assert_has_calls([
-        call.generate_file_name("all_variables", "json"),
-        call.generate_file_name("all_variables", "csv"),
-    ])
+    mock_output_manager._generate_file_name.assert_called_once_with("all_variables", "json")
     mock_output_manager._dict_to_file_json.assert_called_once_with(
         mock_output_manager.variables_pool, os.path.join("dummy_path", "dummy_name")
     )
-    mock_output_manager._dict_to_file_csv.assert_called_once_with(
-        mock_output_manager.variables_pool, os.path.join("dummy_path", "dummy_name")
-    )
-
 
     # Restore original methods
     mock_output_manager._generate_file_name = output_manager_original_method_states[
@@ -689,10 +689,35 @@ def test_dump_variables(
     mock_output_manager._dict_to_file_json = output_manager_original_method_states[
         "_dict_to_file_json"
     ]
+
+def test_dump_variables_to_csv_files(
+    mock_output_manager: OutputManager,
+    output_manager_original_method_states: Dict[str, Callable],
+) -> None:
+    """Test case for function dump_variable_names_and_contexts in output_manager.py"""
+    mock_output_manager._generate_file_name = MagicMock(return_value="dummy_name")
+    mock_output_manager._dict_to_file_csv = MagicMock()
+    original_variables_pool = mock_output_manager.variables_pool
+    mock_output_manager.variables_pool = {"var1": {"values": [1]}}
+
+    with patch('pathlib.Path.mkdir') as mock_mkdir:
+        mock_mkdir.return_value = None
+        mock_output_manager.dump_variables_to_csv_files("dummy_path")
+
+    mock_mkdir.assert_called_with(parents=True, exist_ok=True)
+    mock_output_manager._generate_file_name.assert_called_once_with("var1", "csv")
+    mock_output_manager._dict_to_file_csv.assert_called_once_with(
+        mock_output_manager.variables_pool, os.path.join("dummy_path", "CSVs", "om", "variables", "dummy_name")
+    )
+
+    mock_output_manager.variables_pool = original_variables_pool
+    # Restore original methods
+    mock_output_manager._generate_file_name = output_manager_original_method_states[
+        "_generate_file_name"
+    ]
     mock_output_manager._dict_to_file_csv = output_manager_original_method_states[
         "_dict_to_file_csv"
     ]
-
 
 def test_dump_logs(
     mock_output_manager: OutputManager,
@@ -789,6 +814,8 @@ def test_dump_variable_names_and_contexts(
     mock_output_manager._list_to_file_txt = output_manager_original_method_states[
         "_list_to_file_txt"
     ]
+
+
 
 
 def test_list_to_file_txt(

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -5,10 +5,11 @@ Description: Implements test cases
 Author(s): Pooya Hekmati, sh2235@cornell.edu
 """
 
-import re
 import os
+import re
 from typing import Any, Callable, Dict
 from mock import Mock, mock_open, patch
+from pathlib import Path
 
 import pytest
 from mock.mock import MagicMock, call
@@ -312,6 +313,15 @@ def test_get_prefix() -> None:
     om = OutputManager()
     assert om._get_prefix("class", "func") == "class.func"
 
+def test_csv_output_dir() -> None:
+    """Unit test for function _csv_output_directory in file output_manager.py"""
+    om = OutputManager()
+    assert str(om._csv_output_directory("test")) == Path("test/CSVs/om/")
+
+def test_csv_output_dir() -> None:
+    """Unit test for function _csv_output_directory in file output_manager.py"""
+    om = OutputManager()
+    assert om._csv_variable_output_directory("test") == Path("test/CSVs/om/variables/")
 
 @pytest.fixture
 def mock_output_manager(mocker) -> OutputManager:
@@ -329,8 +339,6 @@ def mock_output_manager(mocker) -> OutputManager:
      True),
     ({"var1": {"not a value": [1]}}, "",
      False),
-    ({"var1": {"values": []}, "var2": {"not a value": 1}}, "",
-     False)
 ])
 def test_dict_to_csv(data: Dict[str, Any], expected_result: str, should_write: bool) -> None:
     """Unit test for the function _dict_to_file_csv in the file output_manager.py"""
@@ -600,7 +608,7 @@ def output_manager_original_method_states(
         "dump_warnings": mock_output_manager.dump_warnings,
         "dump_errors": mock_output_manager.dump_errors,
         "dump_variable_names_and_contexts": mock_output_manager.dump_variable_names_and_contexts,
-        "dump_variables_to_csv_files ": mock_output_manager.dump_variables_to_csv_files,
+        "save_variables_to_csv_files ": mock_output_manager.save_variables_to_csv_files,
     }
 
 
@@ -615,7 +623,7 @@ def test_dump_all_pools(
     mock_output_manager.dump_logs = MagicMock()
     mock_output_manager.dump_variables = MagicMock()
     mock_output_manager.dump_variable_names_and_contexts = MagicMock()
-    mock_output_manager.dump_variables_to_csv_files = MagicMock()
+    mock_output_manager.save_variables_to_csv_files = MagicMock()
 
     mock_output_manager.dump_all_pools(path, exclude_info_maps=False)
 
@@ -624,7 +632,7 @@ def test_dump_all_pools(
     mock_output_manager.dump_logs.assert_called_once_with(path)
     mock_output_manager.dump_variables.assert_called_once_with(path, False)
     mock_output_manager.dump_variable_names_and_contexts.assert_called_once_with(path, False)
-    mock_output_manager.dump_variables_to_csv_files.assert_called_once_with(path)
+    mock_output_manager.save_variables_to_csv_files.assert_called_once_with(f"{path}/CSVs/om/variables")
 
     mock_output_manager.dump_all_pools(path, exclude_info_maps=True)
     mock_output_manager.dump_variables.assert_called_with(path, True)
@@ -633,7 +641,7 @@ def test_dump_all_pools(
     assert mock_output_manager.dump_warnings.call_count == 2
     assert mock_output_manager.dump_errors.call_count == 2
     assert mock_output_manager.dump_variables.call_count == 2
-    assert mock_output_manager.dump_variables_to_csv_files.call_count == 2
+    assert mock_output_manager.save_variables_to_csv_files.call_count == 2
 
     # Restore original methods
     mock_output_manager.dump_variables = output_manager_original_method_states[
@@ -649,8 +657,8 @@ def test_dump_all_pools(
     mock_output_manager.dump_variable_names_and_contexts = output_manager_original_method_states[
         "dump_variable_names_and_contexts"
     ]
-    mock_output_manager.dump_variables_to_csv_files = output_manager_original_method_states[
-        "dump_variables_to_csv_files "
+    mock_output_manager.save_variables_to_csv_files = output_manager_original_method_states[
+        "save_variables_to_csv_files "
     ]
 
 def test_generate_file_name(mocker: MockerFixture) -> None:
@@ -690,7 +698,7 @@ def test_dump_variables(
         "_dict_to_file_json"
     ]
 
-def test_dump_variables_to_csv_files(
+def test_save_variables_to_csv_files(
     mock_output_manager: OutputManager,
     output_manager_original_method_states: Dict[str, Callable],
 ) -> None:
@@ -702,12 +710,12 @@ def test_dump_variables_to_csv_files(
 
     with patch('pathlib.Path.mkdir') as mock_mkdir:
         mock_mkdir.return_value = None
-        mock_output_manager.dump_variables_to_csv_files("dummy_path")
+        mock_output_manager.save_variables_to_csv_files("dummy_path")
 
     mock_mkdir.assert_called_with(parents=True, exist_ok=True)
     mock_output_manager._generate_file_name.assert_called_once_with("var1", "csv")
     mock_output_manager._dict_to_file_csv.assert_called_once_with(
-        mock_output_manager.variables_pool, os.path.join("dummy_path", "CSVs", "om", "variables", "dummy_name")
+        mock_output_manager.variables_pool, os.path.join("dummy_path", "dummy_name")
     )
 
     mock_output_manager.variables_pool = original_variables_pool

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -316,10 +316,10 @@ def test_get_prefix() -> None:
 def test_csv_output_dir() -> None:
     """Unit test for function _csv_output_directory in file output_manager.py"""
     om = OutputManager()
-    assert str(om._csv_output_directory("test")) == Path("test/CSVs/om/")
+    assert om._csv_output_directory("test") == Path("test/CSVs/om/")
 
-def test_csv_output_dir() -> None:
-    """Unit test for function _csv_output_directory in file output_manager.py"""
+def test_csv_variable_output_dir() -> None:
+    """Unit test for function _csv_variable_output_directory in file output_manager.py"""
     om = OutputManager()
     assert om._csv_variable_output_directory("test") == Path("test/CSVs/om/variables/")
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -9,10 +9,9 @@ import os
 import re
 from typing import Any, Callable, Dict
 from mock import Mock, mock_open, patch
-from pathlib import Path
 
 import pytest
-from mock.mock import MagicMock, call
+from mock.mock import MagicMock
 from pytest import approx, raises
 from pytest_mock.plugin import MockerFixture
 
@@ -313,6 +312,7 @@ def test_get_prefix() -> None:
     om = OutputManager()
     assert om._get_prefix("class", "func") == "class.func"
 
+
 @pytest.fixture
 def mock_output_manager(mocker) -> OutputManager:
     output_manager = OutputManager()
@@ -324,24 +324,29 @@ def mock_output_manager(mocker) -> OutputManager:
      True),
     ({}, "",
      False),
-    ({"var1": {"values": [1,2,3]}},
+    ({"var1": {"values": [1, 2, 3]}},
      "var1\n1\n2\n3\n",
      True),
     ({"var1": {"not a value": [1]}}, "",
      False),
 ])
-def test_dict_to_csv(data: Dict[str, Any], expected_result: str, should_write: bool) -> None:
+def test_dict_to_csv(
+    mock_output_manager: OutputManager,
+    data: Dict[str, Any],
+    expected_result: str,
+    should_write: bool
+) -> None:
     """Unit test for the function _dict_to_file_csv in the file output_manager.py"""
-    om = OutputManager()
     open_mock = mock_open()
 
     with patch("builtins.open", open_mock):
-        om._dict_to_file_csv(data, "test")
+        mock_output_manager._dict_to_file_csv(data, "test")
 
     if should_write:
         open_mock.assert_called_with("test", "w", encoding="utf-8", errors="strict", newline='')
     written_data = ''.join(call[1][0] for call in open_mock().write.mock_calls)
     assert written_data == expected_result
+
 
 def test_generate_key(mocker: MockerFixture) -> None:
     """Unit test for function _generate_key in file output_manager.py"""
@@ -376,6 +381,7 @@ def test_generate_key(mocker: MockerFixture) -> None:
     key = om._generate_key("key_name", info_map)
     assert key == "dummy_prefix.key_name.dummy_suffix"
 
+
 def test_get_timestamp(mocker: MockerFixture) -> None:
     """Unit test for the function _get_timestamp in file output_manager.py"""
     om = OutputManager()
@@ -386,6 +392,7 @@ def test_get_timestamp(mocker: MockerFixture) -> None:
 
     assert re.match(timestamp_with_millis_pattern, om._get_timestamp(include_millis=True))
     assert re.match(timestamp_without_millis_pattern, om._get_timestamp(include_millis=False))
+
 
 def test_add_error(
     mock_output_manager: OutputManager,
@@ -420,6 +427,7 @@ def test_add_error(
         "_get_timestamp"
     ]
 
+
 def test_add_warning(
     mock_output_manager: OutputManager,
     output_manager_original_method_states: Dict[str, Callable],
@@ -453,6 +461,7 @@ def test_add_warning(
         "_get_timestamp"
     ]
 
+
 def test_add_log(
     mock_output_manager: OutputManager,
     output_manager_original_method_states: Dict[str, Callable],
@@ -485,6 +494,7 @@ def test_add_log(
     mock_output_manager._get_timestamp = output_manager_original_method_states[
         "_get_timestamp"
     ]
+
 
 def test_add_variable(
     mock_output_manager: OutputManager,
@@ -651,6 +661,7 @@ def test_dump_all_pools(
         "save_variables_to_csv_files "
     ]
 
+
 def test_generate_file_name(mocker: MockerFixture) -> None:
     """Unit test for function _generate_file_name in file output_manager.py"""
     timestamp = "18-Jan-2023_Wed_22-38-14"
@@ -664,6 +675,7 @@ def test_generate_file_name(mocker: MockerFixture) -> None:
             om._generate_file_name(base_name, extension)
             == f"{base_name}_{timestamp}.{extension}"
         )
+
 
 def test_dump_variables(
     mock_output_manager: OutputManager,
@@ -688,11 +700,12 @@ def test_dump_variables(
         "_dict_to_file_json"
     ]
 
+
 def test_save_variables_to_csv_files(
     mock_output_manager: OutputManager,
     output_manager_original_method_states: Dict[str, Callable],
 ) -> None:
-    """Test case for function dump_variable_names_and_contexts in output_manager.py"""
+    """Test case for function save_variables_to_csv_files in output_manager.py"""
     mock_output_manager._generate_file_name = MagicMock(return_value="dummy_name")
     mock_output_manager._dict_to_file_csv = MagicMock()
     original_variables_pool = mock_output_manager.variables_pool
@@ -716,6 +729,7 @@ def test_save_variables_to_csv_files(
     mock_output_manager._dict_to_file_csv = output_manager_original_method_states[
         "_dict_to_file_csv"
     ]
+
 
 def test_dump_logs(
     mock_output_manager: OutputManager,
@@ -812,8 +826,6 @@ def test_dump_variable_names_and_contexts(
     mock_output_manager._list_to_file_txt = output_manager_original_method_states[
         "_list_to_file_txt"
     ]
-
-
 
 
 def test_list_to_file_txt(
@@ -1135,6 +1147,7 @@ def test_filter_variables_pool_exclude_duplicate_patterns(
     ]
     mock_output_manager.variables_pool = {}
 
+
 @pytest.fixture
 def mock_variables_pool() -> Dict[str, str]:
     dummy_variables_pool = {
@@ -1366,7 +1379,7 @@ def test_make_serializable_recursive(
 ) -> None:
     """Unit test for function _make_serializable() in file util.py"""
     # Arrange
-    patch_for_get_str = mocker.patch.object(
+    _ = mocker.patch.object(
         Utility, "_get_str", side_effect=lambda x: str(x)
     )
 


### PR DESCRIPTION
This address part 1 of the CSV generation for the OutputManager: issue #641.

It pads the values with None, which are inserted into the csv file as nothing instead of the string "None".
