### PR TITLE
CBPB Manure Moduel: Methane and Carbon Emissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Testing](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml)
 [![Linting](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml)
-[![Coverage](https://img.shields.io/badge/coverage-61%25-yellow)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/coverage_pytest-cov.yml)
+[![Coverage](https://img.shields.io/badge/coverage-62%25-yellow)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/coverage_pytest-cov.yml)
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Testing](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml)
 [![Linting](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml)
-[![Coverage](https://img.shields.io/badge/coverage-62%25-yellow)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/coverage_pytest-cov.yml)
+[![Coverage](https://img.shields.io/badge/coverage-63%25-yellow)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/coverage_pytest-cov.yml)
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.
 

--- a/RUFAS/routines/manure/constants/bedding_constants.py
+++ b/RUFAS/routines/manure/constants/bedding_constants.py
@@ -1,0 +1,5 @@
+class BeddingConstants:
+    DEFAULT_CARBON_AVAILABLE_IN_BEDDING = 0.35
+    """
+    Default proportion of carbon available in bedding, (unitless, [0, 1]). Default is set to 0.35.
+    """

--- a/RUFAS/routines/manure/constants/bedding_constants.py
+++ b/RUFAS/routines/manure/constants/bedding_constants.py
@@ -1,5 +1,0 @@
-class BeddingConstants:
-    DEFAULT_CARBON_AVAILABLE_IN_BEDDING = 0.35
-    """
-    Default proportion of carbon available in bedding, (unitless, [0, 1]). Default is set to 0.35.
-    """

--- a/RUFAS/routines/manure/constants/gas_emission_constants.py
+++ b/RUFAS/routines/manure/constants/gas_emission_constants.py
@@ -12,7 +12,7 @@ class GasEmissionConstants:
 
     E = 112700.0
     """
-    Activation energy (joules per mole, J/mol). The activation energy is the 
+    Activation energy (joules per mole, J/mol). The activation energy is the
     minimum energy that must be available to molecules for a reaction to occur.
     """
 
@@ -35,7 +35,7 @@ class GasEmissionConstants:
 
     METHANE_ENERGY_DENSITY = 55.0
     """
-    Methane energy density (megajoules per kg, MJ/kg). This is the amount of energy stored per unit 
+    Methane energy density (megajoules per kg, MJ/kg). This is the amount of energy stored per unit
     mass of methane.
     """
 
@@ -45,10 +45,24 @@ class GasEmissionConstants:
     METHANE_POTENTIAL_Go = 240.0
     """Methane potential (mL/g). Default is set to 240.0."""
 
+    MCF_CONSTANT_A = 7.11
+    """
+    Parameter estimate (unitless) of a regression using IPCC data (2006) used in the
+    Methane Conversion Factor (MCF) calculation. This coefficient scales the exponential
+    function of ambient barn temperature.
+    """
+
+    MCF_CONSTANT_B = 0.0884
+    """
+    Parameter estimate (unitless) of a regression using IPCC data (2006) used in the
+    Methane Conversion Factor (MCF) calculation. This exponent coefficient determines the rate
+    at which MCF increases with ambient barn temperature.
+    """
+
     POTENTIAL_METHANE_YIELD_OF_MANURE = 0.48
     """
-    Potential methane yield of manure, (kg :math:`CH_4`/kg VS). This represents the potential 
-    amount of methane that can be produced per kilogram of volatile solids (VS) in manure. 
+    Potential methane yield of manure, (kg :math:`CH_4`/kg VS). This represents the potential
+    amount of methane that can be produced per kilogram of volatile solids (VS) in manure.
     Default is set to 0.48.
     """
 
@@ -57,25 +71,25 @@ class GasEmissionConstants:
 
     DEFAULT_VOLATILE_SOLIDS_FRACTION = 0.68
     """
-    Default volatile solids fraction, (unitless, [0, 1]). This is the fraction of 
+    Default volatile solids fraction, (unitless, [0, 1]). This is the fraction of
     total solids that are volatile Default is set to 0.68.
     """
 
     CHEN_HASHIMOTO_KINETIC_CONSTANT_KCH = 3.1
     """
-    Chen-Hashimoto kinetic constant (unitless). This constant is used in the 
+    Chen-Hashimoto kinetic constant (unitless). This constant is used in the
     Chen-Hashimoto equation to model the kinetic behaviour of the anaerobic digestion process.
     """
 
     SPECIFIC_GROWTH_RATE = 0.637
     """
-    Specific growth rate (:math:`\mu`m). This represents the rate at which the microbial population 
+    Specific growth rate (:math:`\mu`m). This represents the rate at which the microbial population
     in the anaerobic digestion process increases.
     """
 
     DEFAULT_HOUSING_SPECIFIC_CONSTANT = 260.0  # s/m
     """
-    Default housing specific constant (s/m). This constant may be used in calculations 
+    Default housing specific constant (s/m). This constant may be used in calculations
     related to the housing conditions for animals. Default is set to 260.0 s/m.
     """
 
@@ -84,3 +98,6 @@ class GasEmissionConstants:
 
     DEFAULT_PH_FOR_STORAGE_AMMONIA = 7.5
     """Default pH for storage ammonia (unitless). Default is set to 7.5."""
+
+    OXYGEN_HALF_SATURATION_CONSTANT = 0.02
+    """The half saturation constant of Oxygen gas (O2)"""

--- a/RUFAS/routines/manure/constants/gas_emission_constants.py
+++ b/RUFAS/routines/manure/constants/gas_emission_constants.py
@@ -101,3 +101,8 @@ class GasEmissionConstants:
 
     OXYGEN_HALF_SATURATION_CONSTANT = 0.02
     """The half saturation constant of Oxygen gas (O2)"""
+
+    DEFAULT_CARBON_AVAILABLE_IN_BEDDING = 0.35
+    """
+    Default proportion of carbon available in bedding, (unitless, [0, 1]). Default is set to 0.35.
+    """

--- a/RUFAS/routines/manure/constants/manure_constants.py
+++ b/RUFAS/routines/manure/constants/manure_constants.py
@@ -33,3 +33,11 @@ class ManureConstants:
     LIQUID_MANURE_DENSITY = 990.0
     SLURRY_MANURE_DENSITY = 1400
     SOLID_MANURE_DENSITY = 1250
+    DEFAULT_CARBON_AVAILABLE_IN_MANURE = 0.5
+    """
+    Default proportion of carbon available in manure, (unitless, [0, 1]). Default is set to 0.5.
+    """
+    EFFECTIVE_MICROBIAL_DECOMP_RATE = 2.37e-3
+    """The effectiveness of microbial decomposition rate (unitless)"""
+    DEFAULT_MOISTURE_EFFECT_MICROBIAL_DECOMP = 0.65
+    """The effect of moisture on microbial decomposition"""

--- a/RUFAS/routines/manure/gas_emissions/gas_emissions.py
+++ b/RUFAS/routines/manure/gas_emissions/gas_emissions.py
@@ -3,6 +3,7 @@ import math
 from RUFAS.general_constants import GeneralConstants
 from RUFAS.routines.manure.constants.gas_emission_constants import GasEmissionConstants
 from RUFAS.routines.manure.constants.manure_constants import ManureConstants
+from RUFAS.routines.manure.constants.bedding_constants import BeddingConstants
 
 
 class GasEmissions:
@@ -647,3 +648,177 @@ class GasEmissions:
         MS = GasEmissionConstants.FRACTION_OF_HANDLED_MANURE
         MF = GasEmissionConstants.METHANE_FACTOR
         return Bo * MCF * MS * MF * manure_volatile_solids
+
+    @classmethod
+    def calc_mcf(cls, ambient_barn_temp: float) -> float:
+        """
+        Calculate the Methane Conversion Factor (MCF) using the exponential function:
+        MCF(T) = MCF_CONSTANT_A * e^(MCF_CONSTANT_B * T)
+
+        Parameters
+        ----------
+        ambient_barn_temperature : float
+            The ambient barn temperature (in Celsius).
+
+        Returns
+        -------
+        float
+            The calculated Methane Conversion Factor (MCF) for the given ambient barn temperature.
+
+        """
+        return GasEmissionConstants.MCF_CONSTANT_A * math.exp(GasEmissionConstants.MCF_CONSTANT_B * ambient_barn_temp)
+
+    @classmethod
+    def calc_ifsm_methane_emission(cls, manure_volatile_solids: float, ambient_barn_temp: float) -> float:
+        """Calculates emission of methane for a day using an adaptation of the tier 2 approach
+        of the IPCC(2006), given ambient barn temperature and a methane conversion factor for the manure
+        management.
+
+        Parameters
+        ----------
+        manure_volatile_solids : float
+            The volatile solids (in kg)
+        ambient_barn_temperature : float
+            The ambient barn temperature (in Celsius)
+
+        Returns
+        -------
+        float
+            The calculated methane emissions (in kg) for the given ambient barn temperature.
+
+        """
+        if manure_volatile_solids < 0:
+            raise ValueError("Mass must be positive.")
+        methane_conversion_factor = GasEmissions.calc_mcf(ambient_barn_temp)
+        methane_emissions_in_kg = (manure_volatile_solids * GasEmissionConstants.Bo *
+                                   GasEmissionConstants.METHANE_FACTOR * methane_conversion_factor) / 100
+        return methane_emissions_in_kg
+
+    @classmethod
+    def _microbial_decomp_rate(cls, temperature: float) -> float:
+        """
+        Calculates the microbial decomposition (unitless) rate per day.
+
+
+        Parameters
+        ----------
+        temperature : float
+            The temperature of the medium (in Celsius)
+
+        Returns
+        -------
+        float
+            The microbial decomposition rate per day (unitless)
+
+        """
+        return ManureConstants.EFFECTIVE_MICROBIAL_DECOMP_RATE * \
+            (math.pow(1.066, (temperature - 10)) - math.pow(1.21, (temperature - 50)))
+
+    @classmethod
+    def _carbon_decomposition_rate(cls, days_since_last_tillage: int = 1, lag: int = 2) -> float:
+        decomposition_temp = 60
+        compost_bed_pack_temp = 30
+        decay = 0.1
+
+        max_microbial_decom_rate = cls._microbial_decomp_rate(decomposition_temp)
+        slow_decomp_rate = cls._microbial_decomp_rate(compost_bed_pack_temp)
+        exponent_coeff = decay * (days_since_last_tillage - lag)
+
+        c_decomp_rate = (
+            (max_microbial_decom_rate - slow_decomp_rate)
+            * math.exp(exponent_coeff)
+            * slow_decomp_rate
+        )
+        return c_decomp_rate
+
+    @classmethod
+    def _anaerobic_coefficient(
+        cls,
+        oxygen_mole_fraction: float = 0.15,
+        oxygen_half_saturation_constant: float = GasEmissionConstants.OXYGEN_HALF_SATURATION_CONSTANT,
+        oxygen_ambient_air_mole_fraction: float = 0.21
+    ) -> float:
+        """
+        Calculates the anaerobic coefficient.
+
+
+        Parameters
+        ----------
+        oxygen_mole_fraction : float
+            Mole fraction of oxygen in the air within the windrow
+        oxygen_half_saturation_constant : float
+            half saturation constant for oxygen gas
+        oxygen_ambient_air_mole_fraction : fot
+            mole fraction of oxygen gas in ambient air
+
+        Returns
+        -------
+        float
+            The anaerobic coefficient (unitless)
+
+        Raises
+        ------
+        ValueError
+            If oxytem_mole_fraction or oxygen_ambient_air_mole_fraction are not between [0, 1]
+
+        """
+        if not (0.0 < oxygen_mole_fraction < 1.0):
+            raise ValueError(f"{oxygen_mole_fraction=} must be in the range [0, 1]")
+        if not (0.0 < oxygen_ambient_air_mole_fraction < 1.0):
+            raise ValueError(f"{oxygen_ambient_air_mole_fraction=} must be in the range [0, 1]")
+        anaerobic_coefficient = (
+            (oxygen_mole_fraction / (oxygen_half_saturation_constant + oxygen_mole_fraction))
+            * ((oxygen_half_saturation_constant + oxygen_ambient_air_mole_fraction) / oxygen_ambient_air_mole_fraction)
+        )
+        return anaerobic_coefficient
+
+    @classmethod
+    def calc_total_carbon_decomposition(
+        cls,
+        manure_total_solids: float,
+        bedding_total_mass: float,
+        days_since_last_tillage: int,
+        lag: int,
+        moisture_effect: float = ManureConstants.DEFAULT_MOISTURE_EFFECT_MICROBIAL_DECOMP,
+        carbon_available_in_manure: float = ManureConstants.DEFAULT_CARBON_AVAILABLE_IN_MANURE,
+        carbon_available_in_bedding: float = BeddingConstants.DEFAULT_CARBON_AVAILABLE_IN_BEDDING
+    ) -> float:
+        """Calculates the carbon decomposition from the composting process of the manure-bed mixture
+        due to microbial activity (decomposition, consumption, respiration).
+
+        Parameters
+        ----------
+        manure_total_solids : float
+            The total solids from the manure (in kg)
+        bedding_total_mass : float
+            The total mass of the bedding material (in kg)
+        days_since_last_tillage : int
+            The number of days since the last tillage event
+        lag : int
+            The lag time
+        moisture_effect : float
+            The effect of moisture on microbial decomposition
+        carbon_available_in_manure : float
+            the proportion of carbon available in manure (unitless)
+        carbon_available_in_bedding : float
+            the carbon available in the bedding (unitless)
+
+        Returns
+        -------
+        float
+            The total carbon decomposition (in kg).
+
+        """
+        carbon_from_manure = manure_total_solids * carbon_available_in_manure
+        carbon_from_bedding = bedding_total_mass * carbon_available_in_bedding
+        total_carbon = carbon_from_manure + carbon_from_bedding
+
+        microbial_decomp_rate = cls._carbon_decomposition_rate(days_since_last_tillage, lag)
+        microbial_decomp_anaerobic_conditions_effect = cls._anaerobic_coefficient()
+        total_carbon_decomposition = (
+            total_carbon
+            * microbial_decomp_rate
+            * moisture_effect
+            * microbial_decomp_anaerobic_conditions_effect
+        )
+        return total_carbon_decomposition

--- a/RUFAS/routines/manure/gas_emissions/gas_emissions.py
+++ b/RUFAS/routines/manure/gas_emissions/gas_emissions.py
@@ -3,7 +3,6 @@ import math
 from RUFAS.general_constants import GeneralConstants
 from RUFAS.routines.manure.constants.gas_emission_constants import GasEmissionConstants
 from RUFAS.routines.manure.constants.manure_constants import ManureConstants
-from RUFAS.routines.manure.constants.bedding_constants import BeddingConstants
 
 
 class GasEmissions:
@@ -650,7 +649,7 @@ class GasEmissions:
         return Bo * MCF * MS * MF * manure_volatile_solids
 
     @classmethod
-    def calc_mcf(cls, ambient_barn_temp: float) -> float:
+    def _calc_methane_conversion_factor(cls, ambient_barn_temp: float) -> float:
         """
         Calculate the Methane Conversion Factor (MCF) using the exponential function:
 
@@ -670,7 +669,7 @@ class GasEmissions:
         return GasEmissionConstants.MCF_CONSTANT_A * math.exp(GasEmissionConstants.MCF_CONSTANT_B * ambient_barn_temp)
 
     @classmethod
-    def calc_ifsm_methane_emission(cls, manure_volatile_solids: float, ambient_barn_temp: float) -> float:
+    def _calc_ifsm_methane_emission(cls, manure_volatile_solids: float, ambient_barn_temp: float) -> float:
         """Calculates emission of methane for a day using an adaptation of the tier 2 approach
         of the IPCC(2006), given ambient barn temperature and a methane conversion factor for the manure
         management.
@@ -692,14 +691,14 @@ class GasEmissions:
 
         """
         if manure_volatile_solids < 0:
-            raise ValueError("Mass must be positive.")
-        methane_conversion_factor = GasEmissions.calc_mcf(ambient_barn_temp)
+            raise ValueError(f"{manure_volatile_solids=} mass must be positive.")
+        methane_conversion_factor = GasEmissions._calc_methane_conversion_factor(ambient_barn_temp)
         methane_emissions_in_kg = (manure_volatile_solids * GasEmissionConstants.Bo *
                                    GasEmissionConstants.METHANE_FACTOR * methane_conversion_factor) / 100
         return methane_emissions_in_kg
 
     @classmethod
-    def _microbial_decomp_rate(cls, temperature: float) -> float:
+    def _calc_microbial_decomp_rate(cls, temperature: float) -> float:
         """
         Calculates the microbial decomposition (unitless) rate per day:
 
@@ -720,7 +719,7 @@ class GasEmissions:
             (math.pow(1.066, (temperature - 10)) - math.pow(1.21, (temperature - 50)))
 
     @classmethod
-    def _carbon_decomposition_rate(cls, days_since_last_tillage: int = 1, lag: int = 2) -> float:
+    def _calc_carbon_decomposition_rate(cls, days_since_last_tillage: int = 1, lag: int = 2) -> float:
         """
         Calculates the carbon decomposition taking place in the composting process of
         the manure-bedding mix due to microbial activity.
@@ -746,8 +745,8 @@ class GasEmissions:
         compost_bed_pack_temp = 30
         decay = 0.1
 
-        max_microbial_decom_rate = cls._microbial_decomp_rate(decomposition_temp)
-        slow_decomp_rate = cls._microbial_decomp_rate(compost_bed_pack_temp)
+        max_microbial_decom_rate = cls._calc_microbial_decomp_rate(decomposition_temp)
+        slow_decomp_rate = cls._calc_microbial_decomp_rate(compost_bed_pack_temp)
         exponent_coeff = decay * (days_since_last_tillage - lag)
 
         c_decomp_rate = (
@@ -758,7 +757,7 @@ class GasEmissions:
         return c_decomp_rate
 
     @classmethod
-    def _anaerobic_effect(
+    def _calc_anaerobic_effect(
         cls,
         oxygen_mole_fraction: float = 0.15,
         oxygen_half_saturation_constant: float = GasEmissionConstants.OXYGEN_HALF_SATURATION_CONSTANT,
@@ -811,7 +810,7 @@ class GasEmissions:
         lag: int,
         moisture_effect: float = ManureConstants.DEFAULT_MOISTURE_EFFECT_MICROBIAL_DECOMP,
         carbon_available_in_manure: float = ManureConstants.DEFAULT_CARBON_AVAILABLE_IN_MANURE,
-        carbon_available_in_bedding: float = BeddingConstants.DEFAULT_CARBON_AVAILABLE_IN_BEDDING
+        carbon_available_in_bedding: float = GasEmissionConstants.DEFAULT_CARBON_AVAILABLE_IN_BEDDING
     ) -> float:
         """Calculates the carbon decomposition from the composting process of the manure-bed mixture
         due to microbial activity (decomposition, consumption, respiration).
@@ -843,8 +842,8 @@ class GasEmissions:
         carbon_from_bedding = bedding_total_mass * carbon_available_in_bedding
         total_carbon = carbon_from_manure + carbon_from_bedding
 
-        microbial_decomp_rate = cls._carbon_decomposition_rate(days_since_last_tillage, lag)
-        microbial_decomp_anaerobic_conditions_effect = cls._anaerobic_effect()
+        microbial_decomp_rate = cls._calc_carbon_decomposition_rate(days_since_last_tillage, lag)
+        microbial_decomp_anaerobic_conditions_effect = cls._calc_anaerobic_effect()
         total_carbon_decomposition = (
             total_carbon
             * microbial_decomp_rate

--- a/RUFAS/routines/manure/gas_emissions/gas_emissions.py
+++ b/RUFAS/routines/manure/gas_emissions/gas_emissions.py
@@ -653,11 +653,12 @@ class GasEmissions:
     def calc_mcf(cls, ambient_barn_temp: float) -> float:
         """
         Calculate the Methane Conversion Factor (MCF) using the exponential function:
-        MCF(T) = MCF_CONSTANT_A * e^(MCF_CONSTANT_B * T)
+
+        MCF(T) = 7.11 * e^(0.0884 * t)
 
         Parameters
         ----------
-        ambient_barn_temperature : float
+        ambient_barn_temp : float
             The ambient barn temperature (in Celsius).
 
         Returns
@@ -674,11 +675,14 @@ class GasEmissions:
         of the IPCC(2006), given ambient barn temperature and a methane conversion factor for the manure
         management.
 
+        CH4 emission = (VS * Bo * 0.67 * MCF) / 100
+
         Parameters
         ----------
         manure_volatile_solids : float
             The volatile solids (in kg)
-        ambient_barn_temperature : float
+
+        ambient_barn_temp : float
             The ambient barn temperature (in Celsius)
 
         Returns
@@ -697,8 +701,9 @@ class GasEmissions:
     @classmethod
     def _microbial_decomp_rate(cls, temperature: float) -> float:
         """
-        Calculates the microbial decomposition (unitless) rate per day.
+        Calculates the microbial decomposition (unitless) rate per day:
 
+        max decomp rate = eff. decomp rate * (1.066^(temp - 10) - 1.21^(temp - 50))
 
         Parameters
         ----------
@@ -716,6 +721,27 @@ class GasEmissions:
 
     @classmethod
     def _carbon_decomposition_rate(cls, days_since_last_tillage: int = 1, lag: int = 2) -> float:
+        """
+        Calculates the carbon decomposition taking place in the composting process of
+        the manure-bedding mix due to microbial activity.
+
+        Rate C Decomp = (max decomp rate - slow decomp rate) *
+        e^(decay * (days_since_last_tillage - lag)) * slow decomp rate
+
+        Parameters
+        ----------
+        days_since_last_tillage : int
+            The number of days since manure was last tilled
+
+        lag : int
+            Lag time in days.
+
+        Returns
+        -------
+        float
+            The carbon decomposition rate per day (unitless)
+
+        """
         decomposition_temp = 60
         compost_bed_pack_temp = 30
         decay = 0.1
@@ -732,29 +758,33 @@ class GasEmissions:
         return c_decomp_rate
 
     @classmethod
-    def _anaerobic_coefficient(
+    def _anaerobic_effect(
         cls,
         oxygen_mole_fraction: float = 0.15,
         oxygen_half_saturation_constant: float = GasEmissionConstants.OXYGEN_HALF_SATURATION_CONSTANT,
         oxygen_ambient_air_mole_fraction: float = 0.21
     ) -> float:
         """
-        Calculates the anaerobic coefficient.
+        Calculates the anaerobic effect.
+
+        Anaerobic effect = (O2 / (O2,hsat + O2)) * ((O2,hsat + O2,amb) / O2,amb)
 
 
         Parameters
         ----------
         oxygen_mole_fraction : float
             Mole fraction of oxygen in the air within the windrow
+
         oxygen_half_saturation_constant : float
             half saturation constant for oxygen gas
+
         oxygen_ambient_air_mole_fraction : fot
             mole fraction of oxygen gas in ambient air
 
         Returns
         -------
         float
-            The anaerobic coefficient (unitless)
+            The anaerobic effect (unitless)
 
         Raises
         ------
@@ -766,11 +796,11 @@ class GasEmissions:
             raise ValueError(f"{oxygen_mole_fraction=} must be in the range [0, 1]")
         if not (0.0 < oxygen_ambient_air_mole_fraction < 1.0):
             raise ValueError(f"{oxygen_ambient_air_mole_fraction=} must be in the range [0, 1]")
-        anaerobic_coefficient = (
+        anaerobic_effect = (
             (oxygen_mole_fraction / (oxygen_half_saturation_constant + oxygen_mole_fraction))
             * ((oxygen_half_saturation_constant + oxygen_ambient_air_mole_fraction) / oxygen_ambient_air_mole_fraction)
         )
-        return anaerobic_coefficient
+        return anaerobic_effect
 
     @classmethod
     def calc_total_carbon_decomposition(
@@ -814,7 +844,7 @@ class GasEmissions:
         total_carbon = carbon_from_manure + carbon_from_bedding
 
         microbial_decomp_rate = cls._carbon_decomposition_rate(days_since_last_tillage, lag)
-        microbial_decomp_anaerobic_conditions_effect = cls._anaerobic_coefficient()
+        microbial_decomp_anaerobic_conditions_effect = cls._anaerobic_effect()
         total_carbon_decomposition = (
             total_carbon
             * microbial_decomp_rate

--- a/tests/test_manure_module/test_gas_emissions.py
+++ b/tests/test_manure_module/test_gas_emissions.py
@@ -48,6 +48,112 @@ def test_calc_E_CH4_slurry_storage(is_enclosed: bool, mocker: MockerFixture) -> 
         assert actual == expected_E_CH4_open_air
 
 
+def test_calc_mcf() -> None:
+    """Tests calc_mcf() in gas_emissions.py."""
+    assert GasEmissions.calc_mcf(1.0) == \
+        pytest.approx((GasEmissionConstants.MCF_CONSTANT_A * math.exp(GasEmissionConstants.MCF_CONSTANT_B)))
+
+
+def test_calc_ifsm_methane_emission(mocker: MockerFixture) -> None:
+    """Tests calc_ifsm_methane_emission() in gas_emissions.py."""
+
+    # Arrange
+    ambient_barn_temp = 1.0
+    mcf = 1.0
+    patch_for_calc_ifsm_methane_emission = mocker.patch(
+        'RUFAS.routines.manure.gas_emissions.gas_emissions.GasEmissions.calc_mcf',
+        return_value=mcf
+    )
+    manure_volatile_solids = 1000.0
+    expected = (manure_volatile_solids * 0.24 * 0.67 * 1.0) / 100
+
+    # Actual
+    actual = GasEmissions.calc_ifsm_methane_emission(manure_volatile_solids, ambient_barn_temp)
+
+    # Assert
+    patch_for_calc_ifsm_methane_emission.assert_called_once_with(mcf)
+    assert actual == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("temperature", [-10.0, 0.0, 10.0])
+def test_microbial_decomp_rate(temperature: float) -> None:
+    """Tests _microbial_decomp_rate() in gas_emissions.py."""
+    assert GasEmissions._microbial_decomp_rate(temperature) == \
+        pytest.approx(2.37e-3 * (math.pow(1.066, (temperature - 10)) - math.pow(1.21, (temperature - 50))))
+
+
+@pytest.mark.parametrize("days_since_last_tillage, lag", [(1, 1), (10, 2), (1, 3)])
+def test_carbon_decomposition_rate(mocker: MockerFixture, days_since_last_tillage: int, lag: int) -> None:
+    """Tests _carbon_decomposition_rate() in gas_emissions.py."""
+
+    # Arrange
+    max_decomp_rate = 2.0
+    min_decomp_rate = 1.0
+    _ = mocker.patch(
+        'RUFAS.routines.manure.gas_emissions.gas_emissions.GasEmissions._microbial_decomp_rate',
+        side_effect=[max_decomp_rate, min_decomp_rate]
+    )
+    expected = math.exp(0.1 * (days_since_last_tillage - lag))
+
+    assert GasEmissions._carbon_decomposition_rate(days_since_last_tillage, lag) == \
+        pytest.approx(expected)
+
+
+@pytest.mark.parametrize("oxygen_mole_fraction, oxygen_ambient_air_mole_fraction, should_throw", [
+    (-1.0, 0.21, True),
+    (2.0, 0.21, True),
+    (0.15, -1.0, True),
+    (0.15, 2.0, True),
+    (0.15, 0.21, False)
+])
+def test_aneerobic_coefficient(
+    oxygen_mole_fraction: float,
+    oxygen_ambient_air_mole_fraction: float,
+    should_throw: bool
+) -> None:
+    """Tests _aneerobic_coefficient() in gas_emissions.py."""
+    if should_throw:
+        try:
+            GasEmissions._anaerobic_coefficient(
+                oxygen_mole_fraction=oxygen_mole_fraction,
+                oxygen_ambient_air_mole_fraction=oxygen_ambient_air_mole_fraction
+            )
+        except ValueError:
+            return
+        assert False
+    else:
+        expected = (
+            (oxygen_mole_fraction / (0.02 + oxygen_mole_fraction))
+            * ((0.02 + oxygen_ambient_air_mole_fraction) / oxygen_ambient_air_mole_fraction)
+        )
+        assert GasEmissions._anaerobic_coefficient(
+                oxygen_mole_fraction=oxygen_mole_fraction,
+                oxygen_ambient_air_mole_fraction=oxygen_ambient_air_mole_fraction
+            ) == pytest.approx(expected)
+
+
+def test_calc_total_carbon_decomposition(mocker: MockerFixture) -> None:
+    """Tests _aneerobic_coefficient() in gas_emissions.py."""
+    total_solids = 10.0
+    bedding_mass = 100.0
+    days_since_last_tillage = 1
+    lag = 1
+    c_decomp_rate = 1.0
+    anaerobic_effect = 1.0
+    _ = mocker.patch(
+        'RUFAS.routines.manure.gas_emissions.gas_emissions.GasEmissions._carbon_decomposition_rate',
+        return_value=c_decomp_rate
+    )
+    _ = mocker.patch(
+        'RUFAS.routines.manure.gas_emissions.gas_emissions.GasEmissions._anaerobic_coefficient',
+        return_value=anaerobic_effect
+    )
+    expected = (total_solids * 0.5 + bedding_mass * 0.35) * c_decomp_rate * 0.65 * anaerobic_effect
+
+    assert GasEmissions.calc_total_carbon_decomposition(total_solids, bedding_mass, days_since_last_tillage, lag) \
+        == pytest.approx(expected)
+
+
 @pytest.mark.parametrize('hours', [hour for hour in range(0, 24)])
 def test_calc_modified_hours(hours: float) -> None:
     """Tests _calc_modified_hours() in gas_emissions.py."""

--- a/tests/test_manure_module/test_gas_emissions.py
+++ b/tests/test_manure_module/test_gas_emissions.py
@@ -113,14 +113,11 @@ def test_aneerobic_coefficient(
 ) -> None:
     """Tests _aneerobic_coefficient() in gas_emissions.py."""
     if should_throw:
-        try:
+        with pytest.raises(ValueError):
             GasEmissions._anaerobic_coefficient(
                 oxygen_mole_fraction=oxygen_mole_fraction,
                 oxygen_ambient_air_mole_fraction=oxygen_ambient_air_mole_fraction
             )
-        except ValueError:
-            return
-        assert False
     else:
         expected = (
             (oxygen_mole_fraction / (0.02 + oxygen_mole_fraction))

--- a/tests/test_manure_module/test_gas_emissions.py
+++ b/tests/test_manure_module/test_gas_emissions.py
@@ -114,7 +114,7 @@ def test_aneerobic_coefficient(
     """Tests _aneerobic_coefficient() in gas_emissions.py."""
     if should_throw:
         with pytest.raises(ValueError):
-            GasEmissions._anaerobic_coefficient(
+            GasEmissions._anaerobic_effect(
                 oxygen_mole_fraction=oxygen_mole_fraction,
                 oxygen_ambient_air_mole_fraction=oxygen_ambient_air_mole_fraction
             )
@@ -123,7 +123,7 @@ def test_aneerobic_coefficient(
             (oxygen_mole_fraction / (0.02 + oxygen_mole_fraction))
             * ((0.02 + oxygen_ambient_air_mole_fraction) / oxygen_ambient_air_mole_fraction)
         )
-        assert GasEmissions._anaerobic_coefficient(
+        assert GasEmissions._anaerobic_effect(
                 oxygen_mole_fraction=oxygen_mole_fraction,
                 oxygen_ambient_air_mole_fraction=oxygen_ambient_air_mole_fraction
             ) == pytest.approx(expected)
@@ -142,7 +142,7 @@ def test_calc_total_carbon_decomposition(mocker: MockerFixture) -> None:
         return_value=c_decomp_rate
     )
     _ = mocker.patch(
-        'RUFAS.routines.manure.gas_emissions.gas_emissions.GasEmissions._anaerobic_coefficient',
+        'RUFAS.routines.manure.gas_emissions.gas_emissions.GasEmissions._anaerobic_effect',
         return_value=anaerobic_effect
     )
     expected = (total_solids * 0.5 + bedding_mass * 0.35) * c_decomp_rate * 0.65 * anaerobic_effect

--- a/tests/test_manure_module/test_gas_emissions.py
+++ b/tests/test_manure_module/test_gas_emissions.py
@@ -49,26 +49,26 @@ def test_calc_E_CH4_slurry_storage(is_enclosed: bool, mocker: MockerFixture) -> 
 
 
 def test_calc_mcf() -> None:
-    """Tests calc_mcf() in gas_emissions.py."""
-    assert GasEmissions.calc_mcf(1.0) == \
+    """Tests _calc_methane_conversion_factor() in gas_emissions.py."""
+    assert GasEmissions._calc_methane_conversion_factor(1.0) == \
         pytest.approx((GasEmissionConstants.MCF_CONSTANT_A * math.exp(GasEmissionConstants.MCF_CONSTANT_B)))
 
 
 def test_calc_ifsm_methane_emission(mocker: MockerFixture) -> None:
-    """Tests calc_ifsm_methane_emission() in gas_emissions.py."""
+    """Tests _calc_ifsm_methane_emission() in gas_emissions.py."""
 
     # Arrange
     ambient_barn_temp = 1.0
     mcf = 1.0
     patch_for_calc_ifsm_methane_emission = mocker.patch(
-        'RUFAS.routines.manure.gas_emissions.gas_emissions.GasEmissions.calc_mcf',
+        'RUFAS.routines.manure.gas_emissions.gas_emissions.GasEmissions._calc_methane_conversion_factor',
         return_value=mcf
     )
     manure_volatile_solids = 1000.0
     expected = (manure_volatile_solids * 0.24 * 0.67 * 1.0) / 100
 
     # Actual
-    actual = GasEmissions.calc_ifsm_methane_emission(manure_volatile_solids, ambient_barn_temp)
+    actual = GasEmissions._calc_ifsm_methane_emission(manure_volatile_solids, ambient_barn_temp)
 
     # Assert
     patch_for_calc_ifsm_methane_emission.assert_called_once_with(mcf)
@@ -77,25 +77,25 @@ def test_calc_ifsm_methane_emission(mocker: MockerFixture) -> None:
 
 @pytest.mark.parametrize("temperature", [-10.0, 0.0, 10.0])
 def test_microbial_decomp_rate(temperature: float) -> None:
-    """Tests _microbial_decomp_rate() in gas_emissions.py."""
-    assert GasEmissions._microbial_decomp_rate(temperature) == \
+    """Tests _calc_microbial_decomp_rate() in gas_emissions.py."""
+    assert GasEmissions._calc_microbial_decomp_rate(temperature) == \
         pytest.approx(2.37e-3 * (math.pow(1.066, (temperature - 10)) - math.pow(1.21, (temperature - 50))))
 
 
 @pytest.mark.parametrize("days_since_last_tillage, lag", [(1, 1), (10, 2), (1, 3)])
 def test_carbon_decomposition_rate(mocker: MockerFixture, days_since_last_tillage: int, lag: int) -> None:
-    """Tests _carbon_decomposition_rate() in gas_emissions.py."""
+    """Tests _calc_carbon_decomposition_rate() in gas_emissions.py."""
 
     # Arrange
     max_decomp_rate = 2.0
     min_decomp_rate = 1.0
-    _ = mocker.patch(
-        'RUFAS.routines.manure.gas_emissions.gas_emissions.GasEmissions._microbial_decomp_rate',
+    mocker.patch(
+        'RUFAS.routines.manure.gas_emissions.gas_emissions.GasEmissions._calc_microbial_decomp_rate',
         side_effect=[max_decomp_rate, min_decomp_rate]
     )
     expected = math.exp(0.1 * (days_since_last_tillage - lag))
 
-    assert GasEmissions._carbon_decomposition_rate(days_since_last_tillage, lag) == \
+    assert GasEmissions._calc_carbon_decomposition_rate(days_since_last_tillage, lag) == \
         pytest.approx(expected)
 
 
@@ -111,10 +111,10 @@ def test_aneerobic_coefficient(
     oxygen_ambient_air_mole_fraction: float,
     should_throw: bool
 ) -> None:
-    """Tests _aneerobic_coefficient() in gas_emissions.py."""
+    """Tests _calc_aneerobic_coefficient() in gas_emissions.py."""
     if should_throw:
         with pytest.raises(ValueError):
-            GasEmissions._anaerobic_effect(
+            GasEmissions._calc_anaerobic_effect(
                 oxygen_mole_fraction=oxygen_mole_fraction,
                 oxygen_ambient_air_mole_fraction=oxygen_ambient_air_mole_fraction
             )
@@ -123,26 +123,26 @@ def test_aneerobic_coefficient(
             (oxygen_mole_fraction / (0.02 + oxygen_mole_fraction))
             * ((0.02 + oxygen_ambient_air_mole_fraction) / oxygen_ambient_air_mole_fraction)
         )
-        assert GasEmissions._anaerobic_effect(
+        assert GasEmissions._calc_anaerobic_effect(
                 oxygen_mole_fraction=oxygen_mole_fraction,
                 oxygen_ambient_air_mole_fraction=oxygen_ambient_air_mole_fraction
             ) == pytest.approx(expected)
 
 
 def test_calc_total_carbon_decomposition(mocker: MockerFixture) -> None:
-    """Tests _aneerobic_coefficient() in gas_emissions.py."""
+    """Tests calc_total_carbon_decomposition() in gas_emissions.py."""
     total_solids = 10.0
     bedding_mass = 100.0
     days_since_last_tillage = 1
     lag = 1
     c_decomp_rate = 1.0
     anaerobic_effect = 1.0
-    _ = mocker.patch(
-        'RUFAS.routines.manure.gas_emissions.gas_emissions.GasEmissions._carbon_decomposition_rate',
+    mocker.patch(
+        'RUFAS.routines.manure.gas_emissions.gas_emissions.GasEmissions._calc_carbon_decomposition_rate',
         return_value=c_decomp_rate
     )
-    _ = mocker.patch(
-        'RUFAS.routines.manure.gas_emissions.gas_emissions.GasEmissions._anaerobic_effect',
+    mocker.patch(
+        'RUFAS.routines.manure.gas_emissions.gas_emissions.GasEmissions._calc_anaerobic_effect',
         return_value=anaerobic_effect
     )
     expected = (total_solids * 0.5 + bedding_mass * 0.35) * c_decomp_rate * 0.65 * anaerobic_effect


### PR DESCRIPTION
This PR adds the calculations for methane and carbon emissions, as specified in the Compost Bed Pack Barn (CBPB) [design doc](https://docs.google.com/document/d/1TIhbR919SXGFkIQDVzEDwxCJjopx2fkBtW_w5-TuJ00/edit?usp=sharing).

The entry point for methane emissions is `calc_ifsm_methane_emission()`.
The entry point for carbon emissions is `calc_total_carbon_decomposition()`
Both located in `gas_emissions.py`

