### PR TITLE
Irrigation backward compatibility

### DIFF
--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -888,7 +888,7 @@ class Field:
                 crop.data.cumulative_transpiration = 0.0
                 crop.data.cumulative_potential_evapotranspiration = 0.0
 
-    def _determine_watering_amount(self, rainfall: float) -> float:
+    def _determine_watering_amount(self, rainfall: float, irrigation: float) -> float:
         """Manages watering of the field.
 
         Parameters

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -1192,6 +1192,7 @@ class Field:
         return
 
     def _record_field_watering(self, year: int, day: int, watering_amount: float):
+        """Records a watering event to the OutputManager."""
         info_map = {"class": self.__class__.__name__, "function": self._record_field_watering.__name__,
                     "prefix": f"field_name:'{self.field_data.name}'", "date": {"year": year, "day": day},
                     "field_size": self.field_data.field_size}

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -925,7 +925,6 @@ class Field:
         user-specified data provided, the hard-coded irrigation will be ignored and only uses the new method.
 
         """
-        # Old method that uses hard coded irrigation amount from the weather data
         if self.field_data.watering_occurs:
             self.field_data.current_water_deficit -= rainfall
             self.field_data.current_water_deficit = max(0.0, self.field_data.current_water_deficit)

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -122,7 +122,7 @@ class Field:
 
         # --- Whole-Field Methods ---
         # Allow non-management field processes (water/nutrient cycling) to occur
-        self._execute_daily_processes(current_weather)
+        self._execute_daily_processes(current_weather, time)
         # ... Other ...
 
         # --- Crop Management ---
@@ -766,13 +766,15 @@ class Field:
     # </editor-fold>
 
     # <editor-fold desc="--- Field-level Methods ---">
-    def _execute_daily_processes(self, current_weather: CurrentWeather) -> None:
+    def _execute_daily_processes(self, current_weather: CurrentWeather, time) -> None:
         """Executes all daily updates on this field's soil and crop objects.
 
         Parameters
         ----------
         current_weather : CurrentWeather
             Object containing the environment conditions on this day.
+        time : Time
+            Object containing the current year and day of the simulation.
 
         Notes
         -----
@@ -791,7 +793,7 @@ class Field:
                                                           snow_cover,
                                                           current_weather.annual_mean_air_temperature)
 
-        self._cycle_water(current_weather)
+        self._cycle_water(current_weather, time)
 
         for crop in self.crops:
             if crop.data.is_mature or crop.data.is_dormant:
@@ -806,12 +808,14 @@ class Field:
             crop.leaf_area_index.grow_canopy()
             crop.biomass_allocation.allocate_biomass(current_weather.incoming_light)
 
-    def _cycle_water(self, current_weather: CurrentWeather):
+    def _cycle_water(self, current_weather: CurrentWeather, time):
         """allow the water to cycle through the field.
 
         Args:
             current_weather: a CurrentWeather object, containing a collection of today's weather variables needed
                 for field processes.
+        time : Time
+            Object containing the current year and day of the simulation.
 
         Details: This method executes all water-related processes that occur within Crop and Soil objects. Having a
             separate method to handle water processes altogether is necessary because processes that effect water in the
@@ -828,7 +832,8 @@ class Field:
             of processes. This is necessary because there is not necessarily one correct order for processes to run in.
 
         """
-        watering_amount = self._determine_watering_amount(current_weather.rainfall, current_weather.irrigation)
+        watering_amount = self._determine_watering_amount(rainfall=current_weather.rainfall, year=time.year,
+                                                          day=time.day, irrigation=current_weather.irrigation)
         total_precipitation = current_weather.rainfall + watering_amount
         precipitation_reaching_soil = self._handle_water_in_crop_canopies(total_precipitation)
 
@@ -888,13 +893,18 @@ class Field:
                 crop.data.cumulative_transpiration = 0.0
                 crop.data.cumulative_potential_evapotranspiration = 0.0
 
-    def _determine_watering_amount(self, rainfall: float, irrigation=0.0) -> float:
+    def _determine_watering_amount(self, rainfall: float, year: int, day: int, irrigation=0.0) -> float:
         """Manages watering of the field.
 
         Parameters
         ----------
         rainfall : float
             Amount of rainfall that occurs on this day (mm)
+        year : int
+            Year in which this watering occurs.
+        day : int
+            Julian day on which this watering occurs.
+        irrigation
 
         Returns
         -------
@@ -916,6 +926,7 @@ class Field:
             raise ValueError("Expected to use hardcoded irrigation data or specified amount, but tried to use both")
         elif not self.field_data.watering_occurs and irrigation > 0:
             self.field_data.annual_irrigation_water_use_total += irrigation
+            self._record_field_watering(year=year, day=day, watering_amount=irrigation)
             return irrigation
         elif self.field_data.watering_occurs and irrigation == 0:
             self.field_data.current_water_deficit -= rainfall
@@ -926,8 +937,8 @@ class Field:
                 water_applied_this_interval = self.field_data.current_water_deficit
                 self.field_data.current_water_deficit = self.field_data.watering_amount_in_mm
                 self.field_data.annual_irrigation_water_use_total += water_applied_this_interval
+                self._record_field_watering(year=year, day=day, watering_amount=water_applied_this_interval)
                 return water_applied_this_interval
-
             self.field_data.days_into_watering_interval += 1
             return 0.0
         else:
@@ -1179,3 +1190,10 @@ class Field:
         self.soil.data.do_annual_reset()
         self.field_data.perform_annual_field_reset()
         return
+
+    def _record_field_watering(self, year: int, day: int, watering_amount: float):
+        info_map = {"class": self.__class__.__name__, "function": self._record_manure_application.__name__,
+                    "prefix": f"field_name:'{self.field_data.name}'", "date": {"year": year, "day": day},
+                    "field_size": self.field_data.field_size}
+        value = {"watering_amount": watering_amount}
+        om.add_variable("field_watering", value, info_map)

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -893,7 +893,7 @@ class Field:
                 crop.data.cumulative_transpiration = 0.0
                 crop.data.cumulative_potential_evapotranspiration = 0.0
 
-    def _determine_watering_amount(self, rainfall: float, year: int, day: int, irrigation=0.0) -> float:
+    def _determine_watering_amount(self, rainfall: float, year: int, day: int, irrigation: float) -> float:
         """Manages watering of the field.
 
         Parameters
@@ -904,7 +904,8 @@ class Field:
             Year in which this watering occurs.
         day : int
             Julian day on which this watering occurs.
-        irrigation
+        irrigation : float
+            The amount of hard-coded irrigation in the weather data (mm)
 
         Returns
         -------
@@ -919,6 +920,9 @@ class Field:
         user). The counter that tracks how where in the interval the simulation is and the amount of water that still
         needs to be applied are reset at the end of every interval. The water that is added to the field from the farm's
         resources is tracked on an annual basis, so that water budgeting may be accurately predicted.
+
+        Old method of using hard-coded irrigation data will be used if there's no user specified data. If there's any
+        user-specified data provided, the hard-coded irrigation will be ignored and only uses the new method.
 
         """
         # Old method that uses hard coded irrigation amount from the weather data
@@ -1189,10 +1193,24 @@ class Field:
         self.field_data.perform_annual_field_reset()
         return
 
-    def _record_field_watering(self, year: int, day: int, watering_amount: float):
-        """Records a watering event to the OutputManager."""
+    def _record_field_watering(self, year: int, day: int, watering_amount: float) -> None:
+        """Record the day, year and amount of irrigation
+
+        Parameters
+        ----------
+        year : int
+            Year in which this watering occurs.
+        day : int
+            Julian day on which this watering occurs.
+        watering_amount : float
+            The amount of hard-coded irrigation in the weather data (mm)
+
+        Returns
+        -------
+        None
+        """
         info_map = {"class": self.__class__.__name__, "function": self._record_field_watering.__name__,
-                    "prefix": f"field_name:'{self.field_data.name}'", "date": {"year": year, "day": day},
-                    "field_size": self.field_data.field_size}
+                    "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day},
+                    "field_size": self.field_data.field_size, "units": "mm"}
         value = {"watering_amount": watering_amount}
         om.add_variable("field_watering", value, info_map)

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -1211,5 +1211,4 @@ class Field:
         info_map = {"class": self.__class__.__name__, "function": self._record_field_watering.__name__,
                     "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day},
                     "field_size": self.field_data.field_size, "units": "mm"}
-        value = {"watering_amount": watering_amount}
-        om.add_variable("field_watering", value, info_map)
+        om.add_variable("field_watering", watering_amount, info_map)

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -922,13 +922,7 @@ class Field:
 
         """
         # Old method that uses hard coded irrigation amount from the weather data
-        if self.field_data.watering_occurs and irrigation > 0:
-            raise ValueError("Expected to use hardcoded irrigation data or specified amount, but tried to use both")
-        elif not self.field_data.watering_occurs and irrigation > 0:
-            self.field_data.annual_irrigation_water_use_total += irrigation
-            self._record_field_watering(year=year, day=day, watering_amount=irrigation)
-            return irrigation
-        elif self.field_data.watering_occurs and irrigation == 0:
+        if self.field_data.watering_occurs:
             self.field_data.current_water_deficit -= rainfall
             self.field_data.current_water_deficit = max(0.0, self.field_data.current_water_deficit)
 
@@ -941,6 +935,10 @@ class Field:
                 return water_applied_this_interval
             self.field_data.days_into_watering_interval += 1
             return 0.0
+        elif not self.field_data.watering_occurs and irrigation > 0:
+            self.field_data.annual_irrigation_water_use_total += irrigation
+            self._record_field_watering(year=year, day=day, watering_amount=irrigation)
+            return irrigation
         else:
             return 0.0
 

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -1192,7 +1192,7 @@ class Field:
         return
 
     def _record_field_watering(self, year: int, day: int, watering_amount: float):
-        info_map = {"class": self.__class__.__name__, "function": self._record_manure_application.__name__,
+        info_map = {"class": self.__class__.__name__, "function": self._record_field_watering.__name__,
                     "prefix": f"field_name:'{self.field_data.name}'", "date": {"year": year, "day": day},
                     "field_size": self.field_data.field_size}
         value = {"watering_amount": watering_amount}

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -828,7 +828,7 @@ class Field:
             of processes. This is necessary because there is not necessarily one correct order for processes to run in.
 
         """
-        watering_amount = self._determine_watering_amount(current_weather.rainfall)
+        watering_amount = self._determine_watering_amount(current_weather.rainfall, current_weather.irrigation)
         total_precipitation = current_weather.rainfall + watering_amount
         precipitation_reaching_soil = self._handle_water_in_crop_canopies(total_precipitation)
 
@@ -888,7 +888,7 @@ class Field:
                 crop.data.cumulative_transpiration = 0.0
                 crop.data.cumulative_potential_evapotranspiration = 0.0
 
-    def _determine_watering_amount(self, rainfall: float, irrigation: float) -> float:
+    def _determine_watering_amount(self, rainfall: float, irrigation=0.0) -> float:
         """Manages watering of the field.
 
         Parameters
@@ -911,21 +911,27 @@ class Field:
         resources is tracked on an annual basis, so that water budgeting may be accurately predicted.
 
         """
-        if not self.field_data.watering_occurs:
+        # Old method that uses hard coded irrigation amount from the weather data
+        if self.field_data.watering_occurs and irrigation > 0:
+            raise ValueError("Expected to use hardcoded irrigation data or specified amount, but tried to use both")
+        elif not self.field_data.watering_occurs and irrigation > 0:
+            self.field_data.annual_irrigation_water_use_total += irrigation
+            return irrigation
+        elif self.field_data.watering_occurs and irrigation == 0:
+            self.field_data.current_water_deficit -= rainfall
+            self.field_data.current_water_deficit = max(0.0, self.field_data.current_water_deficit)
+
+            if self.field_data.days_into_watering_interval == self.field_data.watering_interval:
+                self.field_data.days_into_watering_interval = 0
+                water_applied_this_interval = self.field_data.current_water_deficit
+                self.field_data.current_water_deficit = self.field_data.watering_amount_in_mm
+                self.field_data.annual_irrigation_water_use_total += water_applied_this_interval
+                return water_applied_this_interval
+
+            self.field_data.days_into_watering_interval += 1
             return 0.0
-
-        self.field_data.current_water_deficit -= rainfall
-        self.field_data.current_water_deficit = max(0.0, self.field_data.current_water_deficit)
-
-        if self.field_data.days_into_watering_interval == self.field_data.watering_interval:
-            self.field_data.days_into_watering_interval = 0
-            water_applied_this_interval = self.field_data.current_water_deficit
-            self.field_data.current_water_deficit = self.field_data.watering_amount_in_mm
-            self.field_data.annual_irrigation_water_use_total += water_applied_this_interval
-            return water_applied_this_interval
-
-        self.field_data.days_into_watering_interval += 1
-        return 0.0
+        else:
+            return 0.0
 
     def _handle_water_in_crop_canopies(self, precipitation_total: float) -> float:
         """Adds water to canopies of all the crops in the field and removes any excess water from them.

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -920,7 +920,7 @@ def test_cycle_water(field_size: float, rainfall: float, runoff: float, high_wat
 
 
 @pytest.mark.parametrize("rainfall,days_into_interval,water_deficit,watering_occurs,irrigation,should_fail,old_method",
-                         [
+                        [
                         (3.4, 3, 1.5, False, 0, False, False),  # No watering because water_occurs is False
                         (3.1, 5, 2.3, True, 0, False, False),  # No watering because rainfall takes care of watering
                         (0.2, 5, 3.6, True, 0, False, False),  # Watering occurs because water deficit has not been met

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -921,16 +921,16 @@ def test_cycle_water(field_size: float, rainfall: float, runoff: float, high_wat
 
 @pytest.mark.parametrize("rainfall,days_into_interval,water_deficit,watering_occurs,irrigation,should_fail,old_method",
                          [
-    (3.4, 3, 1.5, False, 0, False, False),  # No watering because water_occurs is False
-    (3.1, 5, 2.3, True, 0, False, False),  # No watering because rainfall takes care of watering
-    (0.2, 5, 3.6, True, 0, False, False),  # Watering occurs because water deficit has not been met
-    (0.19, 4, 2.8, True, 0, False, False), # No watering occurs because interval has not been met
-    (0.2, 5, 3.6, True, 9.24, True, False),
-    (0.2, 5, 3.6, False, 77.7, False, True)
-])
+                        (3.4, 3, 1.5, False, 0, False, False),  # No watering because water_occurs is False
+                        (3.1, 5, 2.3, True, 0, False, False),  # No watering because rainfall takes care of watering
+                        (0.2, 5, 3.6, True, 0, False, False),  # Watering occurs because water deficit has not been met
+                        (0.19, 4, 2.8, True, 0, False, False),  # No watering occurs because interval has not been met
+                        (0.2, 5, 3.6, True, 9.24, True, False),
+                        (0.2, 5, 3.6, False, 77.7, False, True)
+                        ])
 def test_determine_watering_amount(rainfall: float, days_into_interval: int, water_deficit: float,
                                    watering_occurs: float, irrigation: float, should_fail: bool,
-                                   old_method: bool)-> None:
+                                   old_method: bool) -> None:
     """Tests that the correct amount of water to be used to water is field is calculated, and that the counters and
         totals are updated correctly."""
     data = FieldData(watering_amount_in_liters=50_000, watering_interval=5,

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -60,7 +60,7 @@ def test_manage_field() -> None:
     field._check_fertilizer_application_schedule.assert_called_once_with(mocked_time)
     field._check_manure_application_schedule.assert_called_once_with(mocked_time)
     field._check_tillage_schedule.assert_called_once_with(mocked_time)
-    field._execute_daily_processes.assert_called_once_with(mocked_weather)
+    field._execute_daily_processes.assert_called_once_with(mocked_weather, mocked_time)
     field._assess_dormancy.assert_called_once_with(12)
     field._check_crop_planting_schedule.assert_called_once_with(mocked_time)
     field._check_crop_harvest_schedule.assert_called_once_with(mocked_time)

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -807,14 +807,16 @@ def test_execute_daily_processes(field_size: float, crops_growing: bool, residue
             crop.growth_constraints.constrain_growth = MagicMock()
             crop.leaf_area_index.grow_canopy = MagicMock()
             crop.biomass_allocation.allocate_biomass = MagicMock()
-
-        incorp._execute_daily_processes(current_weather)
+        mocked_time = MagicMock(Time)
+        setattr(mocked_time, "year", 2023)
+        setattr(mocked_time, "day", 178)
+        incorp._execute_daily_processes(current_weather, mocked_time)
 
         incorp._determine_total_above_ground_biomass.assert_called_once()
         incorp.soil.soil_temp.daily_soil_temperature_update.assert_called_once_with(light, mean_temp, min_temp,
                                                                                     max_temp, 89 + residue, 0,
                                                                                     annual_mean_temp)
-        incorp._cycle_water.assert_called_once_with(current_weather)
+        incorp._cycle_water.assert_called_once_with(current_weather, mocked_time)
         for crop in incorp.crops:
             if crops_growing:
                 crop.heat_units.absorb_heat_units.assert_called_once_with(mean_temp, min_temp, max_temp)
@@ -884,12 +886,16 @@ def test_cycle_water(field_size: float, rainfall: float, runoff: float, high_wat
         crop_2.water_dynamics.set_maximum_transpiration = MagicMock()
         crop_2.water_dynamics.cycle_water = MagicMock()
         crop_2.water_uptake.uptake_water = MagicMock()
+        mocked_time = MagicMock(Time)
+        setattr(mocked_time, "year", 2023)
+        setattr(mocked_time, "day", 178)
 
-        incorp._cycle_water(current_weather)
-
-        incorp._determine_watering_amount.assert_called_once_with(rainfall, 0.0)
+        incorp._cycle_water(current_weather, mocked_time)
+        incorp._determine_watering_amount.assert_called_once_with(rainfall=rainfall, year=mocked_time.year,
+                                                                  day=mocked_time.day, irrigation=0.0)
         incorp._handle_water_in_crop_canopies.assert_called_once_with(rainfall)
-        incorp._determine_potential_evapotranspiration.assert_called_once_with(light, max_temp, min_temp, mean_temp)
+        incorp._determine_potential_evapotranspiration.assert_called_once_with(light, max_temp, min_temp,
+                                                                               mean_temp)
         incorp._evaporate_from_crop_canopies.assert_called_once_with(33.5)
         incorp.soil.infiltration.infiltrate.assert_called_once_with(2.0, 1, 33.5)
         incorp.soil.percolation.percolate.assert_called_once_with(high_water_table)
@@ -936,6 +942,9 @@ def test_determine_watering_amount(rainfall: float, days_into_interval: int, wat
                                    old_method: bool) -> None:
     """Tests that the correct amount of water to be used to water is field is calculated, and that the counters and
         totals are updated correctly."""
+    mocked_time = MagicMock(Time)
+    setattr(mocked_time, "year", 2023)
+    setattr(mocked_time, "day", 178)
     data = FieldData(watering_amount_in_liters=50_000, watering_interval=5,
                      days_into_watering_interval=days_into_interval)
     data.watering_amount_in_mm = 5.0
@@ -945,10 +954,10 @@ def test_determine_watering_amount(rainfall: float, days_into_interval: int, wat
 
     if should_fail:
         with pytest.raises(ValueError) as e:
-            incorp._determine_watering_amount(rainfall, irrigation)
+            incorp._determine_watering_amount(rainfall, mocked_time.year, mocked_time.day, irrigation)
             assert str(e) == "Expected to use hardcoded irrigation data or specified amount, but tried to use both"
     else:
-        actual = incorp._determine_watering_amount(rainfall, irrigation)
+        actual = incorp._determine_watering_amount(rainfall, mocked_time.year, mocked_time.day, irrigation)
         if old_method:
             assert actual == irrigation
         else:

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -1244,14 +1244,11 @@ def test_error_field_data_initialization(watering_amount: float, interval: int) 
 
 @pytest.mark.parametrize("field_name,field_size,day,year,watering_amount,expected_info_map,expected_value", [
     ("name_1", 100, 120, 1993, 135.6,
-     {"prefix": "field:'name_1'", "date": {"year": 1993, "day": 120}, "field_size": 100, "units": "mm"},
-     {"watering_amount": 135.6}),
+     {"prefix": "field:'name_1'", "date": {"year": 1993, "day": 120}, "field_size": 100, "units": "mm"}, 135.6),
     ("name_2", 14.65, 3, 1996, 1.2,
-     {"prefix": "field:'name_2'", "date": {"year": 1996, "day": 3}, "field_size": 14.65, "units": "mm"},
-     {"watering_amount": 1.2}),
+     {"prefix": "field:'name_2'", "date": {"year": 1996, "day": 3}, "field_size": 14.65, "units": "mm"}, 1.2),
     ("name_2", 14.65, 48, 2023, 1.2,
-     {"prefix": "field:'name_2'", "date": {"year": 2023, "day": 48}, "field_size": 14.65, "units": "mm"},
-     {"watering_amount": 1.2})
+     {"prefix": "field:'name_2'", "date": {"year": 2023, "day": 48}, "field_size": 14.65, "units": "mm"}, 1.2)
 ])
 def test_record_field_watering(field_name: str, field_size: float, day: int, year: int, watering_amount: float,
                                expected_info_map: Dict, expected_value: Dict) -> None:

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -1247,6 +1247,7 @@ def test_error_field_data_initialization(watering_amount: float, interval: int) 
     elif interval < 0:
         assert f"Expected watering interval to be >= 0, received '{interval}'." == str(e.value)
 
+
 @pytest.mark.parametrize("field_name,field_size,day,year,watering_amount,expected_info_map,expected_value", [
     ("name_1", 100, 120, 1993, 135.6,
      {"prefix": "field_name:'name_1'", "date": {"year": 1993, "day": 120}, "field_size": 100},

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -887,7 +887,7 @@ def test_cycle_water(field_size: float, rainfall: float, runoff: float, high_wat
 
         incorp._cycle_water(current_weather)
 
-        incorp._determine_watering_amount.assert_called_once_with(rainfall)
+        incorp._determine_watering_amount.assert_called_once_with(rainfall, 0.0)
         incorp._handle_water_in_crop_canopies.assert_called_once_with(rainfall)
         incorp._determine_potential_evapotranspiration.assert_called_once_with(light, max_temp, min_temp, mean_temp)
         incorp._evaporate_from_crop_canopies.assert_called_once_with(33.5)
@@ -919,14 +919,18 @@ def test_cycle_water(field_size: float, rainfall: float, runoff: float, high_wat
             assert crop_2.data.cumulative_potential_evapotranspiration == 0
 
 
-@pytest.mark.parametrize("rainfall,days_into_interval,water_deficit,watering_occurs", [
-    (3.4, 3, 1.5, False),  # No watering because water_occurs is False
-    (3.1, 5, 2.3, True),  # No watering because rainfall takes care of watering
-    (0.2, 5, 3.6, True),  # Watering occurs because water deficit has not been met
-    (0.19, 4, 2.8, True)  # No watering occurs because interval has not been met
+@pytest.mark.parametrize("rainfall,days_into_interval,water_deficit,watering_occurs,irrigation,should_fail,old_method",
+                         [
+    (3.4, 3, 1.5, False, 0, False, False),  # No watering because water_occurs is False
+    (3.1, 5, 2.3, True, 0, False, False),  # No watering because rainfall takes care of watering
+    (0.2, 5, 3.6, True, 0, False, False),  # Watering occurs because water deficit has not been met
+    (0.19, 4, 2.8, True, 0, False, False), # No watering occurs because interval has not been met
+    (0.2, 5, 3.6, True, 9.24, True, False),
+    (0.2, 5, 3.6, False, 77.7, False, True)
 ])
 def test_determine_watering_amount(rainfall: float, days_into_interval: int, water_deficit: float,
-                                   watering_occurs: float) -> None:
+                                   watering_occurs: float, irrigation: float, should_fail: bool,
+                                   old_method: bool)-> None:
     """Tests that the correct amount of water to be used to water is field is calculated, and that the counters and
         totals are updated correctly."""
     data = FieldData(watering_amount_in_liters=50_000, watering_interval=5,
@@ -936,22 +940,29 @@ def test_determine_watering_amount(rainfall: float, days_into_interval: int, wat
     data.current_water_deficit = water_deficit
     incorp = Field(field_data=data, manure_manager=MagicMock(ManureManager))
 
-    actual = incorp._determine_watering_amount(rainfall)
-
-    if not watering_occurs:
-        assert actual == 0.0
-        assert incorp.field_data.days_into_watering_interval == days_into_interval
-        assert incorp.field_data.annual_irrigation_water_use_total == 0
-    elif days_into_interval == incorp.field_data.watering_interval:
-        assert actual == max(0.0, water_deficit - rainfall)
-        assert incorp.field_data.days_into_watering_interval == 0
-        assert incorp.field_data.current_water_deficit == 5.0
-        assert incorp.field_data.annual_irrigation_water_use_total == actual
+    if should_fail:
+        with pytest.raises(ValueError) as e:
+            incorp._determine_watering_amount(rainfall, irrigation)
+            assert str(e) == "Expected to use hardcoded irrigation data or specified amount, but tried to use both"
     else:
-        assert actual == 0.0
-        assert incorp.field_data.days_into_watering_interval == days_into_interval + 1
-        assert incorp.field_data.current_water_deficit == max(0.0, water_deficit - rainfall)
-        assert incorp.field_data.annual_irrigation_water_use_total == 0
+        actual = incorp._determine_watering_amount(rainfall, irrigation)
+        if old_method:
+            assert actual == irrigation
+        else:
+            if not watering_occurs:
+                assert actual == 0.0
+                assert incorp.field_data.days_into_watering_interval == days_into_interval
+                assert incorp.field_data.annual_irrigation_water_use_total == 0
+            elif days_into_interval == incorp.field_data.watering_interval:
+                assert actual == max(0.0, water_deficit - rainfall)
+                assert incorp.field_data.days_into_watering_interval == 0
+                assert incorp.field_data.current_water_deficit == 5.0
+                assert incorp.field_data.annual_irrigation_water_use_total == actual
+            else:
+                assert actual == 0.0
+                assert incorp.field_data.days_into_watering_interval == days_into_interval + 1
+                assert incorp.field_data.current_water_deficit == max(0.0, water_deficit - rainfall)
+                assert incorp.field_data.annual_irrigation_water_use_total == 0
 
 
 @pytest.mark.parametrize("precipitation,canopy_capacity,first_canopy_amount,second_canopy_amount,expected_return,"

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -925,21 +925,20 @@ def test_cycle_water(field_size: float, rainfall: float, runoff: float, high_wat
             assert crop_2.data.cumulative_potential_evapotranspiration == 0
 
 
-@pytest.mark.parametrize("rainfall,days_into_interval,water_deficit,watering_occurs,irrigation,should_fail,old_method",
+@pytest.mark.parametrize("rainfall,days_into_interval,water_deficit,watering_occurs,irrigation,old_method",
                          [
-                             (3.4, 3, 1.5, False, 0, False, False),  # No watering because water_occurs is False
-                             (3.1, 5, 2.3, True, 0, False, False),
+                             (3.4, 3, 1.5, False, 0, False),  # No watering because water_occurs is False
+                             (3.1, 5, 2.3, True, 0, False),
                              # No watering because rainfall takes care of watering
-                             (0.2, 5, 3.6, True, 0, False, False),
+                             (0.2, 5, 3.6, True, 0, False),
                              # Watering occurs because water deficit has not been met
-                             (0.19, 4, 2.8, True, 0, False, False),
+                             (0.19, 4, 2.8, True, 0, False),
                              # No watering occurs because interval has not been met
-                             (0.2, 5, 3.6, True, 9.24, True, False),
-                             (0.2, 5, 3.6, False, 77.7, False, True)
+                             (0.2, 5, 3.6, True, 9.24, False),
+                             (0.2, 5, 3.6, False, 77.7, True)
                          ])
 def test_determine_watering_amount(rainfall: float, days_into_interval: int, water_deficit: float,
-                                   watering_occurs: float, irrigation: float, should_fail: bool,
-                                   old_method: bool) -> None:
+                                   watering_occurs: float, irrigation: float, old_method: bool) -> None:
     """Tests that the correct amount of water to be used to water is field is calculated, and that the counters and
         totals are updated correctly."""
     mocked_time = MagicMock(Time)
@@ -952,29 +951,24 @@ def test_determine_watering_amount(rainfall: float, days_into_interval: int, wat
     data.current_water_deficit = water_deficit
     incorp = Field(field_data=data, manure_manager=MagicMock(ManureManager))
 
-    if should_fail:
-        with pytest.raises(ValueError) as e:
-            incorp._determine_watering_amount(rainfall, mocked_time.year, mocked_time.day, irrigation)
-            assert str(e) == "Expected to use hardcoded irrigation data or specified amount, but tried to use both"
+    actual = incorp._determine_watering_amount(rainfall, mocked_time.year, mocked_time.day, irrigation)
+    if old_method:
+        assert actual == irrigation
     else:
-        actual = incorp._determine_watering_amount(rainfall, mocked_time.year, mocked_time.day, irrigation)
-        if old_method:
-            assert actual == irrigation
+        if not watering_occurs:
+            assert actual == 0.0
+            assert incorp.field_data.days_into_watering_interval == days_into_interval
+            assert incorp.field_data.annual_irrigation_water_use_total == 0
+        elif days_into_interval == incorp.field_data.watering_interval:
+            assert actual == max(0.0, water_deficit - rainfall)
+            assert incorp.field_data.days_into_watering_interval == 0
+            assert incorp.field_data.current_water_deficit == 5.0
+            assert incorp.field_data.annual_irrigation_water_use_total == actual
         else:
-            if not watering_occurs:
-                assert actual == 0.0
-                assert incorp.field_data.days_into_watering_interval == days_into_interval
-                assert incorp.field_data.annual_irrigation_water_use_total == 0
-            elif days_into_interval == incorp.field_data.watering_interval:
-                assert actual == max(0.0, water_deficit - rainfall)
-                assert incorp.field_data.days_into_watering_interval == 0
-                assert incorp.field_data.current_water_deficit == 5.0
-                assert incorp.field_data.annual_irrigation_water_use_total == actual
-            else:
-                assert actual == 0.0
-                assert incorp.field_data.days_into_watering_interval == days_into_interval + 1
-                assert incorp.field_data.current_water_deficit == max(0.0, water_deficit - rainfall)
-                assert incorp.field_data.annual_irrigation_water_use_total == 0
+            assert actual == 0.0
+            assert incorp.field_data.days_into_watering_interval == days_into_interval + 1
+            assert incorp.field_data.current_water_deficit == max(0.0, water_deficit - rainfall)
+            assert incorp.field_data.annual_irrigation_water_use_total == 0
 
 
 @pytest.mark.parametrize("precipitation,canopy_capacity,first_canopy_amount,second_canopy_amount,expected_return,"

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -1246,3 +1246,23 @@ def test_error_field_data_initialization(watering_amount: float, interval: int) 
         assert f"Expected watering amount to be >= 0, received '{watering_amount}'." == str(e.value)
     elif interval < 0:
         assert f"Expected watering interval to be >= 0, received '{interval}'." == str(e.value)
+
+@pytest.mark.parametrize("field_name,field_size,day,year,watering_amount,expected_info_map,expected_value", [
+    ("name_1", 100, 120, 1993, 135.6,
+     {"prefix": "field_name:'name_1'", "date": {"year": 1993, "day": 120}, "field_size": 100},
+     {"watering_amount": 135.6}),
+    ("name_2", 14.65, 3, 1996, 1.2,
+     {"prefix": "field_name:'name_2'", "date": {"year": 1996, "day": 3}, "field_size": 14.65},
+     {"watering_amount": 1.2}),
+    ("name_2", 14.65, 48, 2023, 1.2,
+     {"prefix": "field_name:'name_2'", "date": {"year": 2023, "day": 48}, "field_size": 14.65},
+     {"watering_amount": 1.2})
+])
+def test_record_field_watering(field_name: str, field_size: float, day: int, year: int, watering_amount: float,
+                               expected_info_map: Dict, expected_value: Dict) -> None:
+    field = Field(field_data=FieldData(name=field_name, field_size=field_size), manure_manager=MagicMock(ManureManager))
+    field._record_field_watering(year=year, day=day, watering_amount=watering_amount)
+
+    actual = om.variables_pool[f"field_name:'{field_name}'.field_watering"]
+    assert actual["info_maps"].__contains__(expected_info_map)
+    assert actual["values"].__contains__(expected_value)

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -920,14 +920,17 @@ def test_cycle_water(field_size: float, rainfall: float, runoff: float, high_wat
 
 
 @pytest.mark.parametrize("rainfall,days_into_interval,water_deficit,watering_occurs,irrigation,should_fail,old_method",
-                        [
-                        (3.4, 3, 1.5, False, 0, False, False),  # No watering because water_occurs is False
-                        (3.1, 5, 2.3, True, 0, False, False),  # No watering because rainfall takes care of watering
-                        (0.2, 5, 3.6, True, 0, False, False),  # Watering occurs because water deficit has not been met
-                        (0.19, 4, 2.8, True, 0, False, False),  # No watering occurs because interval has not been met
-                        (0.2, 5, 3.6, True, 9.24, True, False),
-                        (0.2, 5, 3.6, False, 77.7, False, True)
-                        ])
+                         [
+                             (3.4, 3, 1.5, False, 0, False, False),  # No watering because water_occurs is False
+                             (3.1, 5, 2.3, True, 0, False, False),
+                             # No watering because rainfall takes care of watering
+                             (0.2, 5, 3.6, True, 0, False, False),
+                             # Watering occurs because water deficit has not been met
+                             (0.19, 4, 2.8, True, 0, False, False),
+                             # No watering occurs because interval has not been met
+                             (0.2, 5, 3.6, True, 9.24, True, False),
+                             (0.2, 5, 3.6, False, 77.7, False, True)
+                         ])
 def test_determine_watering_amount(rainfall: float, days_into_interval: int, water_deficit: float,
                                    watering_occurs: float, irrigation: float, should_fail: bool,
                                    old_method: bool) -> None:

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -1242,16 +1242,15 @@ def test_error_field_data_initialization(watering_amount: float, interval: int) 
         assert f"Expected watering interval to be >= 0, received '{interval}'." == str(e.value)
 
 
-
 @pytest.mark.parametrize("field_name,field_size,day,year,watering_amount,expected_info_map,expected_value", [
     ("name_1", 100, 120, 1993, 135.6,
-     {"prefix": "field_name:'name_1'", "date": {"year": 1993, "day": 120}, "field_size": 100},
+     {"prefix": "field:'name_1'", "date": {"year": 1993, "day": 120}, "field_size": 100, "units": "mm"},
      {"watering_amount": 135.6}),
     ("name_2", 14.65, 3, 1996, 1.2,
-     {"prefix": "field_name:'name_2'", "date": {"year": 1996, "day": 3}, "field_size": 14.65},
+     {"prefix": "field:'name_2'", "date": {"year": 1996, "day": 3}, "field_size": 14.65, "units": "mm"},
      {"watering_amount": 1.2}),
     ("name_2", 14.65, 48, 2023, 1.2,
-     {"prefix": "field_name:'name_2'", "date": {"year": 2023, "day": 48}, "field_size": 14.65},
+     {"prefix": "field:'name_2'", "date": {"year": 2023, "day": 48}, "field_size": 14.65, "units": "mm"},
      {"watering_amount": 1.2})
 ])
 def test_record_field_watering(field_name: str, field_size: float, day: int, year: int, watering_amount: float,
@@ -1259,7 +1258,7 @@ def test_record_field_watering(field_name: str, field_size: float, day: int, yea
     field = Field(field_data=FieldData(name=field_name, field_size=field_size), manure_manager=MagicMock(ManureManager))
     field._record_field_watering(year=year, day=day, watering_amount=watering_amount)
 
-    actual = om.variables_pool[f"field_name:'{field_name}'.field_watering"]
+    actual = om.variables_pool[f"field:'{field_name}'.field_watering"]
     assert actual["info_maps"].__contains__(expected_info_map)
     assert actual["values"].__contains__(expected_value)
 


### PR DESCRIPTION
### Summary
This draft is to make the method `_determine_watering_amount()` backward compatible with the hard-coded irrigation in weather data. With this PR, it will add a condition to simply return the irrigation data straight from the provided weather data. Also, there is a method added to record the amount and time. All changes are tested to ensure full coverage. 

### Changes
- In `field.py`, `_determine_watering_amount` has added a field to take in irrigation, if the new irrigation field is provided it will simply use that as the watering amount
-  In `field.py`, `_determine_watering_amount` will now record the time and amount of watering when the old or new method is used.
- In `field.py`,  `_execute_daily_processes` and `_cycle_water` will now take in extra time parameters to help record the watering amount.
-  In `field.py`,  `_record_field_watering` is created to record the time and amount of watering occurrences..
- All changes are covered and tested