### PR TITLE
Fix newlines to be platform independent

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -320,12 +320,12 @@ def mock_output_manager(mocker) -> OutputManager:
 
 
 @pytest.mark.parametrize("data, expected_result, should_write", [
-    ({"var1": {"values": [1.0, True, "test", {"key": 1}]}}, "var1\n1.0\nTrue\ntest\n{'key': 1}\n",
+    ({"var1": {"values": [1.0, True, "test", {"key": 1}]}}, f"var1{os.linesep}1.0{os.linesep}True{os.linesep}test{os.linesep}{{'key': 1}}{os.linesep}",
      True),
     ({}, "",
      False),
     ({"var1": {"values": [1, 2, 3]}},
-     "var1\n1\n2\n3\n",
+     f"var1{os.linesep}1{os.linesep}2{os.linesep}3{os.linesep}",
      True),
     ({"var1": {"not a value": [1]}}, "",
      False),

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -633,7 +633,9 @@ def test_dump_all_pools(
     mock_output_manager.dump_logs.assert_called_once_with(path)
     mock_output_manager.dump_variables.assert_called_once_with(path, False)
     mock_output_manager.dump_variable_names_and_contexts.assert_called_once_with(path, False)
-    mock_output_manager.save_variables_to_csv_files.assert_called_once_with(f"{path}/CSVs/om/variables")
+    mock_output_manager.save_variables_to_csv_files.assert_called_once_with(
+        os.path.join(path, "CSVs", "om", "variables")
+    )
 
     mock_output_manager.dump_all_pools(path, exclude_info_maps=True)
     mock_output_manager.dump_variables.assert_called_with(path, True)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -320,7 +320,8 @@ def mock_output_manager(mocker) -> OutputManager:
 
 
 @pytest.mark.parametrize("data, expected_result, should_write", [
-    ({"var1": {"values": [1.0, True, "test", {"key": 1}]}}, f"var1{os.linesep}1.0{os.linesep}True{os.linesep}test{os.linesep}{{'key': 1}}{os.linesep}",
+    ({"var1": {"values": [1.0, True, "test", {"key": 1}]}},
+     f"var1{os.linesep}1.0{os.linesep}True{os.linesep}test{os.linesep}{{'key': 1}}{os.linesep}",
      True),
     ({}, "",
      False),


### PR DESCRIPTION
## Problem
Windows encodes newlines with 2 bytes: `\r\n`, whereas most other OSs encode it with 1 byte: `\n`

The `test_dict_to_csv` unit test in `test_misc.py` hard-coded newline as `\n`, which caused the unit test to fail when running on a windows machine.

## The Fix
Uses `os.linesep`, which encapsulates this difference.