### PR TITLE
Fix Coverage Action

### DIFF
--- a/.github/workflows/coverage_pytest-cov.yml
+++ b/.github/workflows/coverage_pytest-cov.yml
@@ -64,9 +64,11 @@ jobs:
         URL: ${{ github.event.pull_request.comments_url }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        curl \
-          -X POST \
-          $URL \
-          -H "Content-Type: application/json" \
-          -H "Authorization: token $GITHUB_TOKEN" \
-          --data '{ "body": "Current Coverage: ${{ env.COVERAGE_PERCENTAGE }}%" }'
+        if [ ${{ env.URL }} != '' ]; then
+          curl \
+            -X POST \
+            $URL \
+            -H "Content-Type: application/json" \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            --data '{ "body": "Current Coverage: ${{ env.COVERAGE_PERCENTAGE }}%" }'
+        fi


### PR DESCRIPTION
Currently, the Coverage Action will post a comment to the PR with the current coverage status. However, if the user merges the branch into the master or if the user is pushing to the master branch directly, there will be nowhere to post such a comment. An error will then occur due to no URL set.

This PR fixes the above issue by checking if the URL is set before posing the comment.