### PR TITLE
Add corn silage and Triticale

### DIFF
--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -838,9 +838,41 @@ class Potato(CropData):
 
 @dataclass(kw_only=True)
 class Triticale(CropData):
-    """crop data class with default values for triticale"""
-    # TODO: triticale has unknown parameters, since it is not present in SWAT database.
-    #     Durum wheat is likely the closest analog.
+    """crop data class with default values for triticale
+    Notes
+    -------
+    We use the closest analog data available which is the Durum Wheat data
+    """
+    species: str = "durum_wheat"
+    name: str = "default durum_wheat"
+    plant_code: str = "DWHT"
+    scientific_name: str = "Triticum durum"
+    plant_category: PlantCategory = PlantCategory("cool_annual")
+    is_nitrogen_fixer: bool = False
+
+    minimum_temperature: float = 0.0
+    optimal_temperature: float = 15.0
+
+    max_leaf_area_index: float = 4.0
+    first_heat_fraction_point: float = 0.15
+    first_leaf_fraction_point: float = 0.01
+    second_heat_fraction_point: float = 0.50
+    second_leaf_fraction_point: float = 0.95
+    senescent_heat_fraction: float = 0.90
+
+    light_use_efficiency: float = 30.0
+
+    emergence_nitrogen_fraction: float = 0.0600
+    half_mature_nitrogen_fraction: float = 0.0231
+    mature_nitrogen_fraction: float = 0.0130
+    emergence_phosphorus_fraction: float = 0.0084
+    half_mature_phosphorus_fraction: float = 0.0032
+    mature_phosphorus_fraction: float = 0.0019
+
+    optimal_harvest_index: float = 0.40
+    min_harvest_index: float = 0.20
+    yield_nitrogen_fraction: float = 0.0263
+    yield_phosphorus_fraction: float = 0.0057
 
 
 @dataclass(kw_only=True)
@@ -856,7 +888,7 @@ class CornSilage(CropData):
     minimum_temperature: float = 8.0
     optimal_temperature: float = 25.0
 
-    max_leaf_area_index: float = 3.0
+    max_leaf_area_index: float = 4.0
     first_heat_fraction_point: float = 0.15
     first_leaf_fraction_point: float = 0.05
     second_heat_fraction_point: float = 0.50
@@ -872,7 +904,7 @@ class CornSilage(CropData):
     half_mature_phosphorus_fraction: float = 0.0018
     mature_phosphorus_fraction: float = 0.0014
 
-    optimal_harvest_index: float = 0.50
-    min_harvest_index: float = 0.30
+    optimal_harvest_index: float = 0.90
+    min_harvest_index: float = 0.90
     yield_nitrogen_fraction: float = 0.0140
     yield_phosphorus_fraction: float = 0.0016

--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -487,6 +487,41 @@ class Corn(CropData):
 
 
 @dataclass(kw_only=True)
+class CornSilage(CropData):
+    """crop data class with default values for corn silage"""
+    species: str = "corn_silage"
+    name: str = "default corn_silage"
+    plant_code: str = "CSIL"
+    scientific_name: str = "Zea mays"
+    plant_category: PlantCategory = PlantCategory("warm_annual")
+    is_nitrogen_fixer: bool = False
+
+    minimum_temperature: float = 8.0
+    optimal_temperature: float = 25.0
+
+    max_leaf_area_index: float = 4.0
+    first_heat_fraction_point: float = 0.15
+    first_leaf_fraction_point: float = 0.05
+    second_heat_fraction_point: float = 0.50
+    second_leaf_fraction_point: float = 0.95
+    senescent_heat_fraction: float = 0.90
+
+    light_use_efficiency: float = 39.0
+
+    emergence_nitrogen_fraction: float = 0.0470
+    half_mature_nitrogen_fraction: float = 0.0177
+    mature_nitrogen_fraction: float = 0.0138
+    emergence_phosphorus_fraction: float = 0.0048
+    half_mature_phosphorus_fraction: float = 0.0018
+    mature_phosphorus_fraction: float = 0.0014
+
+    optimal_harvest_index: float = 0.90
+    min_harvest_index: float = 0.90
+    yield_nitrogen_fraction: float = 0.0140
+    yield_phosphorus_fraction: float = 0.0016
+
+
+@dataclass(kw_only=True)
 class SpringWheat(CropData):
     """crop data class with default values for spring wheat"""
     species: str = "spring_wheat"
@@ -843,8 +878,8 @@ class Triticale(CropData):
     -------
     We use the closest analog data available which is the Durum Wheat data
     """
-    species: str = "durum_wheat"
-    name: str = "default durum_wheat"
+    species: str = "triticale"
+    name: str = "default triticale"
     plant_code: str = "DWHT"
     scientific_name: str = "Triticum durum"
     plant_category: PlantCategory = PlantCategory("cool_annual")
@@ -873,38 +908,3 @@ class Triticale(CropData):
     min_harvest_index: float = 0.20
     yield_nitrogen_fraction: float = 0.0263
     yield_phosphorus_fraction: float = 0.0057
-
-
-@dataclass(kw_only=True)
-class CornSilage(CropData):
-    """crop data class with default values for corn silage"""
-    species: str = "corn_silage"
-    name: str = "default corn_silage"
-    plant_code: str = "CSIL"
-    scientific_name: str = "Zea mays"
-    plant_category: PlantCategory = PlantCategory("warm_annual")
-    is_nitrogen_fixer: bool = False
-
-    minimum_temperature: float = 8.0
-    optimal_temperature: float = 25.0
-
-    max_leaf_area_index: float = 4.0
-    first_heat_fraction_point: float = 0.15
-    first_leaf_fraction_point: float = 0.05
-    second_heat_fraction_point: float = 0.50
-    second_leaf_fraction_point: float = 0.95
-    senescent_heat_fraction: float = 0.90
-
-    light_use_efficiency: float = 39.0
-
-    emergence_nitrogen_fraction: float = 0.0470
-    half_mature_nitrogen_fraction: float = 0.0177
-    mature_nitrogen_fraction: float = 0.0138
-    emergence_phosphorus_fraction: float = 0.0048
-    half_mature_phosphorus_fraction: float = 0.0018
-    mature_phosphorus_fraction: float = 0.0014
-
-    optimal_harvest_index: float = 0.90
-    min_harvest_index: float = 0.90
-    yield_nitrogen_fraction: float = 0.0140
-    yield_phosphorus_fraction: float = 0.0016

--- a/SC_redesign/Crop_and_Soil/crop/crop_data.py
+++ b/SC_redesign/Crop_and_Soil/crop/crop_data.py
@@ -841,3 +841,38 @@ class Triticale(CropData):
     """crop data class with default values for triticale"""
     # TODO: triticale has unknown parameters, since it is not present in SWAT database.
     #     Durum wheat is likely the closest analog.
+
+
+@dataclass(kw_only=True)
+class CornSilage(CropData):
+    """crop data class with default values for corn silage"""
+    species: str = "corn_silage"
+    name: str = "default corn_silage"
+    plant_code: str = "CSIL"
+    scientific_name: str = "Zea mays"
+    plant_category: PlantCategory = PlantCategory("warm_annual")
+    is_nitrogen_fixer: bool = False
+
+    minimum_temperature: float = 8.0
+    optimal_temperature: float = 25.0
+
+    max_leaf_area_index: float = 3.0
+    first_heat_fraction_point: float = 0.15
+    first_leaf_fraction_point: float = 0.05
+    second_heat_fraction_point: float = 0.50
+    second_leaf_fraction_point: float = 0.95
+    senescent_heat_fraction: float = 0.90
+
+    light_use_efficiency: float = 39.0
+
+    emergence_nitrogen_fraction: float = 0.0470
+    half_mature_nitrogen_fraction: float = 0.0177
+    mature_nitrogen_fraction: float = 0.0138
+    emergence_phosphorus_fraction: float = 0.0048
+    half_mature_phosphorus_fraction: float = 0.0018
+    mature_phosphorus_fraction: float = 0.0014
+
+    optimal_harvest_index: float = 0.50
+    min_harvest_index: float = 0.30
+    yield_nitrogen_fraction: float = 0.0140
+    yield_phosphorus_fraction: float = 0.0016

--- a/SC_redesign/Crop_and_Soil/crop/species_data_factory.py
+++ b/SC_redesign/Crop_and_Soil/crop/species_data_factory.py
@@ -19,7 +19,8 @@ class CropSpecies(Enum):
     SOYBEAN = "soybean"
     SUGAR_BEET = "sugar_beet"
     POTATO = "potato"
-    TRITICALE = "triticale"
+    TRITICALE = "durum_wheat"
+    CornSilage = "corn_silage"
 
 
 class CropSpeciesDataFactory:

--- a/SC_redesign/Crop_and_Soil/crop/species_data_factory.py
+++ b/SC_redesign/Crop_and_Soil/crop/species_data_factory.py
@@ -19,8 +19,8 @@ class CropSpecies(Enum):
     SOYBEAN = "soybean"
     SUGAR_BEET = "sugar_beet"
     POTATO = "potato"
-    TRITICALE = "durum_wheat"
-    CornSilage = "corn_silage"
+    TRITICALE = "triticale"
+    CORN_SILAGE = "corn_silage"
 
 
 class CropSpeciesDataFactory:

--- a/SC_redesign/Crop_and_Soil/soil/carbon_cycling/carbon_cycle.py
+++ b/SC_redesign/Crop_and_Soil/soil/carbon_cycling/carbon_cycle.py
@@ -6,7 +6,7 @@ from SC_redesign.Crop_and_Soil.crop_and_soil_constants import MEGAGRAMS_TO_KILOG
 
 
 from typing import Optional
-from SC_redesign.Crop_and_Soil.crop_and_soil_constants import HECTARES_TO_SQUARE_MILLIMETERS,\
+from SC_redesign.Crop_and_Soil.crop_and_soil_constants import HECTARES_TO_SQUARE_MILLIMETERS, \
     CUBIC_MILLIMETERS_TO_CUBIC_METERS
 
 """

--- a/SC_redesign/Crop_and_Soil/tests_SC/crop_tests/test_crop_data_and_species_factory.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/crop_tests/test_crop_data_and_species_factory.py
@@ -17,7 +17,8 @@ from dataclasses import asdict
     ("soybean", CropSpecies.SOYBEAN),
     ("sugar_beet", CropSpecies.SUGAR_BEET),
     ("potato", CropSpecies.POTATO),
-    ("triticale", CropSpecies.TRITICALE),
+    ("durum_wheat", CropSpecies.TRITICALE),
+    ("corn_silage", CropSpecies.CornSilage)
 ])
 def test_crop_species_enum(species, expected):
     """ensure that CropSpecies correctly enumerates the accepted species names"""

--- a/SC_redesign/Crop_and_Soil/tests_SC/crop_tests/test_crop_data_and_species_factory.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/crop_tests/test_crop_data_and_species_factory.py
@@ -17,8 +17,8 @@ from dataclasses import asdict
     ("soybean", CropSpecies.SOYBEAN),
     ("sugar_beet", CropSpecies.SUGAR_BEET),
     ("potato", CropSpecies.POTATO),
-    ("durum_wheat", CropSpecies.TRITICALE),
-    ("corn_silage", CropSpecies.CornSilage)
+    ("triticale", CropSpecies.TRITICALE),
+    ("corn_silage", CropSpecies.CORN_SILAGE)
 ])
 def test_crop_species_enum(species, expected):
     """ensure that CropSpecies correctly enumerates the accepted species names"""

--- a/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/carbon_cycling_tests/test_carbon_cycle.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/soil_tests/carbon_cycling_tests/test_carbon_cycle.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 from SC_redesign.Crop_and_Soil.soil.carbon_cycling.carbon_cycle import CarbonCycling
 from SC_redesign.Crop_and_Soil.soil.layer_data import LayerData
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
-from SC_redesign.Crop_and_Soil.crop_and_soil_constants import HECTARES_TO_SQUARE_MILLIMETERS,\
+from SC_redesign.Crop_and_Soil.crop_and_soil_constants import HECTARES_TO_SQUARE_MILLIMETERS, \
     CUBIC_MILLIMETERS_TO_CUBIC_METERS
 
 


### PR DESCRIPTION
### Summary
This PR aims to complete the V1 requirements to support corn silage and Triticale.

### Changes
- In `crop_data.py`, two children classes of `CropData`, `Triticale`, and `CornSilage` was created and will assign the correct values according to SWAT.
- In `species_data_factory.py`, both classes were added `CropSpecies` to enumerate
- The test was updated to reflect this change.

### Notes
- We use the closest analog data available for triticale which is the Durum Wheat data
- Not sure where to determine this `is_nitrogen_fixer` field, the current value is according to **chatGPT**.
