### PR TITLE
Injection fertilizer applications

### DIFF
--- a/SC_redesign/Crop_and_Soil/field/fertilizer_application.py
+++ b/SC_redesign/Crop_and_Soil/field/fertilizer_application.py
@@ -1,10 +1,13 @@
 from typing import Optional
 
 from SC_redesign.Crop_and_Soil.soil.soil import Soil
+from RUFAS.output_manager import OutputManager
 
 """
 This module provides a way for Field to apply fertilizer, based on SWAT Theoretical documentation section 6:1.7.
 """
+
+om = OutputManager()
 
 
 class FertilizerApplication:
@@ -60,13 +63,57 @@ class FertilizerApplication:
         """
         # TODO: move application functionality from soil/phosphorus_cycling up to this module, and increase
         #  functionality of this module - issue #492
-        self.soil.phosphorus_cycling.fertilizer.add_fertilizer_phosphorus(phosphorus_applied)
+        self.soil.phosphorus_cycling.fertilizer.add_fertilizer_phosphorus(phosphorus_applied *
+                                                                          surface_remainder_fraction)
 
         nitrates_applied = (fertilizer_mass * inorganic_nitrogen_fraction * (1 - ammonium_fraction)) / field_size
         ammonium_applied = (fertilizer_mass * inorganic_nitrogen_fraction * ammonium_fraction) / field_size
         organic_nitrogen_applied = (fertilizer_mass * organic_nitrogen_fraction * 0.5) / field_size
 
-        self.soil.data.soil_layers[0].nitrate_content += nitrates_applied
-        self.soil.data.soil_layers[0].ammonium_content += ammonium_applied
-        self.soil.data.soil_layers[0].fresh_organic_nitrogen_content += organic_nitrogen_applied
-        self.soil.data.soil_layers[0].active_organic_nitrogen_content += organic_nitrogen_applied
+        self.soil.data.soil_layers[0].nitrate_content += (nitrates_applied * surface_remainder_fraction)
+        self.soil.data.soil_layers[0].ammonium_content += (ammonium_applied * surface_remainder_fraction)
+        self.soil.data.soil_layers[0].fresh_organic_nitrogen_content += \
+            (organic_nitrogen_applied * surface_remainder_fraction)
+        self.soil.data.soil_layers[0].active_organic_nitrogen_content += \
+            (organic_nitrogen_applied * surface_remainder_fraction)
+
+    @staticmethod
+    def _generate_depth_factors(application_depth: float, soil_layer_bottom_depths: list[float]) -> list[float]:
+        """
+        Generates a list of fractions that partitions sub-surface nutrients between the different layers soil.
+
+        Parameters
+        ----------
+        application_depth : float
+            Bottom depth of nutrient application (mm).
+        soil_layer_bottom_depths : list[float]
+            List of bottom depths of soil layers in the soil profile (mm).
+
+        Returns
+        -------
+        list[float]
+            List of fractions that determine the distribution of nutrients between different soil layers when subsurface
+            nutrients are applied.
+
+        References
+        ----------
+        pseudocode_field_management [FM.3.B.3 - 5]
+
+        Notes
+        -----
+        This method of distributing nutrients between soil layers originates with Pete Vadas' SurPhos model. Its p is
+        to proportionally distribute nutrients to layers within the soil profile.
+
+        """
+        depth_factors_sum = 0.0
+        depth_factors = []
+        for depth in soil_layer_bottom_depths:
+            if depth < application_depth:
+                depth_factor = depth / application_depth
+                depth_factors_sum += depth_factor
+                depth_factors.append(depth_factor)
+            else:
+                depth_factor = 1.0 - depth_factors_sum
+                depth_factors.append(depth_factor)
+                break
+        return depth_factors

--- a/SC_redesign/Crop_and_Soil/field/fertilizer_application.py
+++ b/SC_redesign/Crop_and_Soil/field/fertilizer_application.py
@@ -1,13 +1,10 @@
 from typing import Optional
 
 from SC_redesign.Crop_and_Soil.soil.soil import Soil
-from RUFAS.output_manager import OutputManager
 
 """
 This module provides a way for Field to apply fertilizer, based on SWAT Theoretical documentation section 6:1.7.
 """
-
-om = OutputManager()
 
 
 class FertilizerApplication:

--- a/SC_redesign/Crop_and_Soil/field/fertilizer_application.py
+++ b/SC_redesign/Crop_and_Soil/field/fertilizer_application.py
@@ -44,7 +44,7 @@ class FertilizerApplication:
         application_depth : float
             Depth at which fertilizer is injected into the soil (mm).
         surface_remainder_fraction : float
-            Fraction of fertilizer applied that remains on the soil surface after application.
+            Fraction of fertilizer applied that remains on the soil surface after application (unitless).
         field_size : float
             Size of the field (ha)
 
@@ -74,7 +74,8 @@ class FertilizerApplication:
         self.soil.data.soil_layers[0].active_organic_nitrogen_content += \
             (organic_nitrogen_applied * surface_remainder_fraction)
 
-        if application_depth == 0.0 and surface_remainder_fraction == 1.0:
+        non_injection_application = application_depth == 0.0 and surface_remainder_fraction == 1.0
+        if non_injection_application:
             return
 
         subsurface_fraction = 1.0 - surface_remainder_fraction
@@ -90,17 +91,23 @@ class FertilizerApplication:
         Parameters
         ----------
         phosphorus : float
-            Amount of phosphorus applied below the surface in this application of fertilizer (kg / ha).
+            Amount of phosphorus applied in this application of fertilizer (kg / ha).
         nitrates : float
-            Amount of nitrates applied below the surface in this application of fertilizer (kg / ha).
+            Amount of nitrates applied in this application of fertilizer (kg / ha).
         ammonium : float
-            Amount of ammonium applied below the surface in this application of fertilizer (kg / ha).
+            Amount of ammonium applied in this application of fertilizer (kg / ha).
         organic_nitrogen : float
-            Amount of organic nitrogen applied below the surface in this application of fertilizer (kg / ha).
+            Amount of organic nitrogen applied in this application of fertilizer (kg / ha).
         application_depth : float
             Bottom depth of this fertilizer application (mm).
         subsurface_fraction : float
             Fraction of total fertilizer application that is applied below the soil surface (unitless).
+
+        Notes
+        -----
+        This implementation applies all nutrients from the fertilizer application to subsurface soil layers in the same
+        manner. In previous implementations of RuFaS, only phosphorus was added to layers below the surface when
+        injection applications occurred.
 
         """
         bottom_depths = self.soil.data.get_vectorized_layer_attribute("bottom_depth")
@@ -131,7 +138,7 @@ class FertilizerApplication:
         -------
         list[float]
             List of fractions that determine the distribution of nutrients between different soil layers when subsurface
-            nutrients are applied.
+            nutrients are applied (unitless).
 
         References
         ----------

--- a/SC_redesign/Crop_and_Soil/field/fertilizer_application.py
+++ b/SC_redesign/Crop_and_Soil/field/fertilizer_application.py
@@ -77,6 +77,47 @@ class FertilizerApplication:
         self.soil.data.soil_layers[0].active_organic_nitrogen_content += \
             (organic_nitrogen_applied * surface_remainder_fraction)
 
+        if surface_remainder_fraction == 1.0:
+            return
+
+        subsurface_fraction = 1.0 - surface_remainder_fraction
+        phosphorus_area_density = phosphorus_applied / field_size
+        self._apply_subsurface_fertilizer(phosphorus_area_density, nitrates_applied, ammonium_applied,
+                                          organic_nitrogen_applied, application_depth, subsurface_fraction)
+
+    def _apply_subsurface_fertilizer(self, phosphorus: float, nitrates: float, ammonium: float, organic_nitrogen: float,
+                                     application_depth: float, subsurface_fraction: float) -> None:
+        """
+        Applies subsurface nutrients to the soil profile.
+
+        Parameters
+        ----------
+        phosphorus : float
+            Amount of phosphorus applied below the surface in this application of fertilizer (kg / ha).
+        nitrates : float
+            Amount of nitrates applied below the surface in this application of fertilizer (kg / ha).
+        ammonium : float
+            Amount of ammonium applied below the surface in this application of fertilizer (kg / ha).
+        organic_nitrogen : float
+            Amount of organic nitrogen applied below the surface in this application of fertilizer (kg / ha).
+        application_depth : float
+            Bottom depth of this fertilizer application (mm).
+        subsurface_fraction : float
+            Fraction of total fertilizer application that is applied below the soil surface (unitless).
+
+        """
+        bottom_depths = self.soil.data.get_vectorized_layer_attribute("bottom_depth")
+        depth_factors = self._generate_depth_factors(application_depth, bottom_depths)
+        for index, depth_factor in enumerate(depth_factors):
+            self.soil.data.soil_layers[index].labile_inorganic_phosphorus_content += (phosphorus * depth_factor *
+                                                                                      subsurface_fraction)
+            self.soil.data.soil_layers[index].nitrate_content += (nitrates * depth_factor * subsurface_fraction)
+            self.soil.data.soil_layers[index].ammonium_content += (ammonium * depth_factor * subsurface_fraction)
+            self.soil.data.soil_layers[index].fresh_organic_nitrogen_content += (organic_nitrogen * depth_factor *
+                                                                                 subsurface_fraction)
+            self.soil.data.soil_layers[index].active_organic_nitrogen_content += (organic_nitrogen * depth_factor *
+                                                                                  subsurface_fraction)
+
     @staticmethod
     def _generate_depth_factors(application_depth: float, soil_layer_bottom_depths: list[float]) -> list[float]:
         """
@@ -101,8 +142,8 @@ class FertilizerApplication:
 
         Notes
         -----
-        This method of distributing nutrients between soil layers originates with Pete Vadas' SurPhos model. Its p is
-        to proportionally distribute nutrients to layers within the soil profile.
+        This method of distributing nutrients between soil layers originates with Pete Vadas' SurPhos model. Its purpose
+        is to proportionally distribute nutrients to layers within the soil profile.
 
         """
         depth_factors_sum = 0.0

--- a/SC_redesign/Crop_and_Soil/field/fertilizer_application.py
+++ b/SC_redesign/Crop_and_Soil/field/fertilizer_application.py
@@ -24,7 +24,8 @@ class FertilizerApplication:
         self.soil = soil or Soil(field_size=field_size)
 
     def apply_fertilizer(self, phosphorus_applied: float, fertilizer_mass: float, inorganic_nitrogen_fraction: float,
-                         ammonium_fraction: float, organic_nitrogen_fraction: float, field_size: float) -> None:
+                         ammonium_fraction: float, organic_nitrogen_fraction: float, application_depth: float,
+                         surface_remainder_fraction: float, field_size: float) -> None:
         """
         Applies nutrients to the soil through fertilizer.
 
@@ -40,6 +41,10 @@ class FertilizerApplication:
             Fraction of inorganic nitrogen mass applied that is ammonium (unitless)
         organic_nitrogen_fraction : float
             Fraction of fertilizer mass applied that is organic nitrogen (unitless)
+        application_depth : float
+            Depth at which fertilizer is injected into the soil (mm).
+        surface_remainder_fraction : float
+            Fraction of fertilizer applied that remains on the soil surface after application.
         field_size : float
             Size of the field (ha)
 

--- a/SC_redesign/Crop_and_Soil/field/fertilizer_application.py
+++ b/SC_redesign/Crop_and_Soil/field/fertilizer_application.py
@@ -38,9 +38,9 @@ class FertilizerApplication:
         inorganic_nitrogen_fraction : float
             Fraction of fertilizer mass applied that is inorganic nitrogen (unitless)
         ammonium_fraction : float
-            Fraction of inorganic nitrogen mass applied that is ammonium (unitless)
+            Fraction of inorganic nitrogen mass applied that is ammonium (unitless).
         organic_nitrogen_fraction : float
-            Fraction of fertilizer mass applied that is organic nitrogen (unitless)
+            Fraction of fertilizer mass applied that is organic nitrogen (unitless).
         application_depth : float
             Depth at which fertilizer is injected into the soil (mm).
         surface_remainder_fraction : float
@@ -125,7 +125,7 @@ class FertilizerApplication:
     @staticmethod
     def _generate_depth_factors(application_depth: float, soil_layer_bottom_depths: list[float]) -> list[float]:
         """
-        Generates a list of fractions that partitions sub-surface nutrients between the different layers soil.
+        Generates a list of fractions that partitions sub-surface nutrients between the different soil layers.
 
         Parameters
         ----------

--- a/SC_redesign/Crop_and_Soil/field/fertilizer_application.py
+++ b/SC_redesign/Crop_and_Soil/field/fertilizer_application.py
@@ -32,11 +32,11 @@ class FertilizerApplication:
         Parameters
         ----------
         phosphorus_applied : float
-            Mass of phosphorus applied to the soil (kg)
+            Mass of phosphorus applied to the soil (kg).
         fertilizer_mass : float
-            Total mass of fertilizer application (kg)
+            Total mass of fertilizer application (kg).
         inorganic_nitrogen_fraction : float
-            Fraction of fertilizer mass applied that is inorganic nitrogen (unitless)
+            Fraction of fertilizer mass applied that is inorganic nitrogen (unitless).
         ammonium_fraction : float
             Fraction of inorganic nitrogen mass applied that is ammonium (unitless).
         organic_nitrogen_fraction : float
@@ -46,11 +46,11 @@ class FertilizerApplication:
         surface_remainder_fraction : float
             Fraction of fertilizer applied that remains on the soil surface after application (unitless).
         field_size : float
-            Size of the field (ha)
+            Size of the field (ha).
 
         References
         ----------
-        SWAT Theoretical documentation section 6:1.7
+        SWAT Theoretical documentation section 6:1.7.
 
         Notes
         -----

--- a/SC_redesign/Crop_and_Soil/field/fertilizer_application.py
+++ b/SC_redesign/Crop_and_Soil/field/fertilizer_application.py
@@ -77,7 +77,7 @@ class FertilizerApplication:
         self.soil.data.soil_layers[0].active_organic_nitrogen_content += \
             (organic_nitrogen_applied * surface_remainder_fraction)
 
-        if surface_remainder_fraction == 1.0:
+        if application_depth == 0.0 and surface_remainder_fraction == 1.0:
             return
 
         subsurface_fraction = 1.0 - surface_remainder_fraction

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -153,7 +153,7 @@ class Field:
         application_depth : float
             Depth at which fertilizer is injected into the soil (mm).
         surface_remainder_fraction : float
-            Fraction of fertilizer applied that remains on the soil surface after application.
+            Fraction of fertilizer applied that remains on the soil surface after application (unitless).
         year : int
             Calendar year in which the fertilizer application is occurring.
         day : int
@@ -176,11 +176,11 @@ class Field:
         if requested_nitrogen == requested_phosphorus == 0.0:
             return
 
-        impossible_depth_and_remainder_fraction = (application_depth == 0.0 and surface_remainder_fraction != 1.0) or \
-                                                  (application_depth > 0.0 and surface_remainder_fraction == 1.0)
-        if impossible_depth_and_remainder_fraction:
-            info_map = {"class": self.__class__.__name__, "function": self._execute_fertilizer_application.__name__,
-                        "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day}}
+        info_map = {"class": self.__class__.__name__, "function": self._execute_fertilizer_application.__name__,
+                    "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day}}
+        invalid_depth_and_remainder_fraction = (application_depth == 0.0 and surface_remainder_fraction != 1.0) or \
+                                               (application_depth > 0.0 and surface_remainder_fraction == 1.0)
+        if invalid_depth_and_remainder_fraction:
             error_message = f"Invalid application depth ({application_depth}) and surface remainder fraction " \
                             f"({surface_remainder_fraction}). Defaulting to application depth of 0.0 mm and a surface" \
                             f" remainder fraction of 1.0."
@@ -189,8 +189,6 @@ class Field:
             surface_remainder_fraction = 1.0
 
         if application_depth > self.soil.data.soil_layers[-1].bottom_depth:
-            info_map = {"class": self.__class__.__name__, "function": self._execute_fertilizer_application.__name__,
-                        "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day}}
             error_message = f"Invalid application depth ({application_depth}) is lower than the bottom depth of the " \
                             f"soil profile, setting the application depth to be at the bottom of the soil profile."
             om.add_error("fertilizer_application_error", error_message, info_map)

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -173,11 +173,13 @@ class Field:
         without applying any fertilizer.
 
         """
-        if requested_nitrogen == requested_phosphorus == 0.0:
-            return
-
         info_map = {"class": self.__class__.__name__, "function": self._execute_fertilizer_application.__name__,
                     "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day}}
+        if requested_nitrogen == requested_phosphorus == 0.0:
+            log_message = "Tried to apply fertilizer with no nitrogen or phosphorus requested."
+            om.add_log("fertilizer_application_log", log_message, info_map)
+            return
+
         invalid_depth_and_remainder_fraction = (application_depth == 0.0 and surface_remainder_fraction != 1.0) or \
                                                (application_depth > 0.0 and surface_remainder_fraction == 1.0)
         if invalid_depth_and_remainder_fraction:

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -314,13 +314,13 @@ class Field:
         mix_name : str
             The name of the mix this fertilizer application is composed of.
         total_mass : float
-            The total mass of phosphorus applied (kg)
+            The total mass of phosphorus applied (kg).
         nitrogen_mass : float
-            The mass of nitrogen applied (kg)
+            The mass of nitrogen applied (kg).
         phosphorus_mass : float
-            The mass of phosphorus applied (kg)
+            The mass of phosphorus applied (kg).
         potassium_mass : float
-            The mass of potassium applied (kg)
+            The mass of potassium applied (kg).
         application_depth : float
             Depth at which fertilizer is injected into the soil (mm).
         surface_remainder_fraction : float

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -188,6 +188,14 @@ class Field:
             application_depth = 0.0
             surface_remainder_fraction = 1.0
 
+        if application_depth > self.soil.data.soil_layers[-1].bottom_depth:
+            info_map = {"class": self.__class__.__name__, "function": self._execute_fertilizer_application.__name__,
+                        "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day}}
+            error_message = f"Invalid application depth ({application_depth}) is lower than the bottom depth of the " \
+                            f"soil profile, setting the application depth to be at the bottom of the soil profile."
+            om.add_error("fertilizer_application_error", error_message, info_map)
+            application_depth = self.soil.data.soil_layers[-1].bottom_depth
+
         try:
             fertilizer_mix = self.available_fertilizer_mixes[mix_name]
         except KeyError:

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -179,9 +179,9 @@ class Field:
         impossible_depth_and_remainder_fraction = (application_depth == 0.0 and surface_remainder_fraction != 1.0) or \
                                                   (application_depth > 0.0 and surface_remainder_fraction == 1.0)
         if impossible_depth_and_remainder_fraction:
-            info_map = {"class": self.__class__.__name__, "function": self._record_fertilizer_application.__name__,
+            info_map = {"class": self.__class__.__name__, "function": self._execute_fertilizer_application.__name__,
                         "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day}}
-            error_message = f"Invalid application depth ({application_depth}) and surface remainder fraction" \
+            error_message = f"Invalid application depth ({application_depth}) and surface remainder fraction " \
                             f"({surface_remainder_fraction}). Defaulting to application depth of 0.0 mm and a surface" \
                             f" remainder fraction of 1.0."
             om.add_error("fertilizer_application_error", error_message, info_map)

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -137,7 +137,8 @@ class Field:
 
     # <editor-fold desc="--- Soil Management Methods ---">
     def _execute_fertilizer_application(self, mix_name: str, requested_nitrogen: float, requested_phosphorus: float,
-                                        year: int, day: int) -> None:
+                                        application_depth: float, surface_remainder_fraction: float, year: int,
+                                        day: int) -> None:
         """
         Executes a fertilizer application based on the requested amounts of nutrients.
 
@@ -146,9 +147,13 @@ class Field:
         mix_name : str
             The name of the mix this fertilizer application should be composed of.
         requested_nitrogen : float
-            Minimum amount of nitrogen to be included in this fertilizer application.
+            Minimum amount of nitrogen to be included in this fertilizer application (kg).
         requested_phosphorus : float
-            Minimum amount of phosphorus to be included in this fertilizer application.
+            Minimum amount of phosphorus to be included in this fertilizer application (kg).
+        application_depth : float
+            Depth at which fertilizer is injected into the soil (mm).
+        surface_remainder_fraction : float
+            Fraction of fertilizer applied that remains on the soil surface after application.
         year : int
             Calendar year in which the fertilizer application is occurring.
         day : int
@@ -170,6 +175,18 @@ class Field:
         """
         if requested_nitrogen == requested_phosphorus == 0.0:
             return
+
+        impossible_depth_and_remainder_fraction = (application_depth == 0.0 and surface_remainder_fraction != 1.0) or \
+                                                  (application_depth > 0.0 and surface_remainder_fraction == 1.0)
+        if impossible_depth_and_remainder_fraction:
+            info_map = {"class": self.__class__.__name__, "function": self._record_fertilizer_application.__name__,
+                        "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day}}
+            error_message = f"Invalid application depth ({application_depth}) and surface remainder fraction" \
+                            f"({surface_remainder_fraction}). Defaulting to application depth of 0.0 mm and a surface" \
+                            f" remainder fraction of 1.0."
+            om.add_error("fertilizer_application_error", error_message, info_map)
+            application_depth = 0.0
+            surface_remainder_fraction = 1.0
 
         try:
             fertilizer_mix = self.available_fertilizer_mixes[mix_name]
@@ -194,11 +211,11 @@ class Field:
         organic_nitrogen_fraction = 0.0
 
         self.fertilizer_applicator.apply_fertilizer(phosphorus_applied, total_mass_applied, inorganic_nitrogen_fraction,
-                                                    ammonium_fraction, organic_nitrogen_fraction,
-                                                    self.field_data.field_size)
+                                                    ammonium_fraction, organic_nitrogen_fraction, application_depth,
+                                                    surface_remainder_fraction, self.field_data.field_size)
 
         self._record_fertilizer_application(mix_name, total_mass_applied, nitrogen_applied, phosphorus_applied,
-                                            potassium_applied, year, day)
+                                            potassium_applied, application_depth, surface_remainder_fraction, year, day)
 
     @staticmethod
     def _determine_optimal_fertilizer_mix(requested_nitrogen: float, requested_phosphorus: float,
@@ -281,7 +298,8 @@ class Field:
                 "potassium_mass": potassium_mass}
 
     def _record_fertilizer_application(self, mix_name: str, total_mass: float, nitrogen_mass: float,
-                                       phosphorus_mass: float, potassium_mass: float, year: int, day: int) -> None:
+                                       phosphorus_mass: float, potassium_mass: float, application_depth: float,
+                                       surface_remainder_fraction: float, year: int, day: int) -> None:
         """
         Records a fertilizer application and saves it to the Output manager.
 
@@ -297,6 +315,10 @@ class Field:
             The mass of phosphorus applied (kg)
         potassium_mass : float
             The mass of potassium applied (kg)
+        application_depth : float
+            Depth at which fertilizer is injected into the soil (mm).
+        surface_remainder_fraction : float
+            Fraction of fertilizer applied that remains on the soil surface after application.
         year : int
             Calendar year in which the fertilizer application is occurring.
         day : int
@@ -307,7 +329,8 @@ class Field:
                     "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day},
                     "mix_name": mix_name, "field_size": self.field_data.field_size}
         value = {"mass": total_mass, "nitrogen": nitrogen_mass, "phosphorus": phosphorus_mass,
-                 "potassium": potassium_mass}
+                 "potassium": potassium_mass, "application_depth": application_depth,
+                 "surface_remainder_fraction": surface_remainder_fraction}
         om.add_variable("fertilizer_application", value, info_map)
 
     def _execute_manure_application(self, requested_nitrogen: float, requested_phosphorus: float, field_coverage: float,
@@ -447,8 +470,8 @@ class Field:
         """
         self.fertilizer_events, todays_fertilizer_events = self._filter_events(self.fertilizer_events, time)
         for event in todays_fertilizer_events:
-            self._execute_fertilizer_application(event.mix_name, event.nitrogen_mass, event.phosphorus_mass, event.year,
-                                                 event.day)
+            self._execute_fertilizer_application(event.mix_name, event.nitrogen_mass, event.phosphorus_mass,
+                                                 event.depth, event.surface_remainder_fraction, event.year, event.day)
 
     def _check_tillage_schedule(self, time) -> None:
         """

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_fertilizer_application.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_fertilizer_application.py
@@ -1,8 +1,11 @@
 import pytest
 from typing import List
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from SC_redesign.Crop_and_Soil.field.fertilizer_application import FertilizerApplication
+from SC_redesign.Crop_and_Soil.soil.layer_data import LayerData
+from SC_redesign.Crop_and_Soil.soil.soil import Soil
+from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 
 
 @pytest.mark.parametrize("depth,bottom_depths,expected",[
@@ -17,6 +20,41 @@ def test_generate_depth_factors(depth: float, bottom_depths: list[float], expect
     """Tests that the depth factors are correctly calculated for subsurface nutrient applications."""
     actual = FertilizerApplication._generate_depth_factors(depth, bottom_depths)
     assert pytest.approx(actual) == expected
+
+
+@pytest.mark.parametrize("nutrient_amounts,depth,subsurface_frac,expected", [
+    (100.0, 50.0, 0.6, [6.0, 24.0, 30.0, 0.0]),
+    (45.0, 120.0, 0.89, [4.005, 16.02, 20.025, 0.0])
+])
+def test_apply_subsurface_fertilizer(nutrient_amounts: float, depth: float, subsurface_frac: float,
+                                     expected: list[float]) -> None:
+    """Tests that subsurface nutrients from fertilizer are applied correctly."""
+    field_size = 1.3
+    soil_layers = [LayerData(top_depth=0.0, bottom_depth=20.0, field_size=field_size),
+                   LayerData(top_depth=20.0, bottom_depth=70.0, field_size=field_size),
+                   LayerData(top_depth=70.0, bottom_depth=200.0, field_size=field_size),
+                   LayerData(top_depth=200.0, bottom_depth=400.0, field_size=field_size)]
+    for layer in soil_layers:
+        layer.labile_inorganic_phosphorus_content = 0.0
+        layer.nitrate_content = 0.0
+        layer.ammonium_content = 0.0
+        layer.fresh_organic_nitrogen_content = 0.0
+        layer.active_organic_nitrogen_content = 0.0
+    soil = Soil(soil_data=SoilData(soil_layers=soil_layers, field_size=field_size))
+    fert_app = FertilizerApplication(soil=soil)
+
+    with patch("SC_redesign.Crop_and_Soil.field.fertilizer_application.FertilizerApplication._generate_depth_factors",
+               new_callable=MagicMock, return_value=[0.1, 0.4, 0.5]) as patched_depth_factor_generator:
+        fert_app._apply_subsurface_fertilizer(nutrient_amounts, nutrient_amounts, nutrient_amounts, nutrient_amounts,
+                                              depth, subsurface_frac)
+
+        patched_depth_factor_generator.assert_called_once_with(depth, [20.0, 70.0, 200.0, 400.0])
+        for index, expected_result in enumerate(expected):
+            assert fert_app.soil.data.soil_layers[index].labile_inorganic_phosphorus_content == expected_result
+            assert fert_app.soil.data.soil_layers[index].nitrate_content == expected_result
+            assert fert_app.soil.data.soil_layers[index].ammonium_content == expected_result
+            assert fert_app.soil.data.soil_layers[index].fresh_organic_nitrogen_content == expected_result
+            assert fert_app.soil.data.soil_layers[index].active_organic_nitrogen_content == expected_result
 
 
 @pytest.mark.parametrize("phosphorus,fertilizer,inorganic_nitrogen_frac,ammonium_frac,organic_nitrogen_frac,depth,"

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_fertilizer_application.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_fertilizer_application.py
@@ -5,6 +5,20 @@ from unittest.mock import MagicMock
 from SC_redesign.Crop_and_Soil.field.fertilizer_application import FertilizerApplication
 
 
+@pytest.mark.parametrize("depth,bottom_depths,expected",[
+    (15.0, [20.0, 70.0, 200.0], [1.0]),
+    (0.0, [20.0, 70.0, 200.0], [1.0]),
+    (40.0, [20.0, 70.0, 200.0], [0.5, 0.5]),
+    (65.0, [20.0, 70.0, 200.0], [0.30769231, 0.69230769]),
+    (70.0, [20.0, 70.0, 200.0], [0.28571429, 0.71428571]),
+    (120.0, [20.0, 70.0, 200.0], [0.16666667, 0.58333333, 0.25]),
+])
+def test_generate_depth_factors(depth: float, bottom_depths: list[float], expected: list[float]) -> None:
+    """Tests that the depth factors are correctly calculated for subsurface nutrient applications."""
+    actual = FertilizerApplication._generate_depth_factors(depth, bottom_depths)
+    assert pytest.approx(actual) == expected
+
+
 @pytest.mark.parametrize("phosphorus,fertilizer,inorganic_nitrogen_frac,ammonium_frac,organic_nitrogen_frac,depth,"
                          "remainder,expected", [
                              (15, 90, 0.15, 0.44, 0.09, 0.0, 1.0, [7.56, 5.94, 4.05]),

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_fertilizer_application.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_fertilizer_application.py
@@ -5,13 +5,14 @@ from unittest.mock import MagicMock
 from SC_redesign.Crop_and_Soil.field.fertilizer_application import FertilizerApplication
 
 
-@pytest.mark.parametrize("phosphorus,fertilizer,inorganic_nitrogen_frac,ammonium_frac,organic_nitrogen_frac,expected", [
-    (15, 90, 0.15, 0.44, 0.09, [7.56, 5.94, 4.05]),
-    (22.1, 144, 0.33, 0.2, 0.06, [38.016, 9.504, 4.32]),
-    (0, 0, 0, 0, 0, [0, 0, 0])
-])
+@pytest.mark.parametrize("phosphorus,fertilizer,inorganic_nitrogen_frac,ammonium_frac,organic_nitrogen_frac,depth,"
+                         "remainder,expected", [
+                             (15, 90, 0.15, 0.44, 0.09, 0.0, 1.0, [7.56, 5.94, 4.05]),
+                             (22.1, 144, 0.33, 0.2, 0.06, 40.0, 0.88, [38.016, 9.504, 4.32]),
+                             (0, 0, 0, 0, 0, 0.0, 1.0, [0, 0, 0])
+                         ])
 def test_apply_fertilizer(phosphorus: float, fertilizer: float, inorganic_nitrogen_frac: float, ammonium_frac: float,
-                          organic_nitrogen_frac: float, expected: List[float]) -> None:
+                          organic_nitrogen_frac: float, depth: float, remainder: float, expected: List[float]) -> None:
     """Tests that fertilizer is applied correctly."""
     field_size = 1.7
     fert_app = FertilizerApplication(field_size=field_size)
@@ -23,7 +24,7 @@ def test_apply_fertilizer(phosphorus: float, fertilizer: float, inorganic_nitrog
     fert_app.soil.phosphorus_cycling.fertilizer.add_fertilizer_phosphorus = MagicMock()
 
     fert_app.apply_fertilizer(phosphorus, fertilizer, inorganic_nitrogen_frac, ammonium_frac, organic_nitrogen_frac,
-                              field_size)
+                              depth, remainder, field_size)
 
     fert_app.soil.phosphorus_cycling.fertilizer.add_fertilizer_phosphorus.assert_called_once_with(phosphorus)
     assert pytest.approx(fert_app.soil.data.soil_layers[0].nitrate_content) == expected[0] / field_size

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_fertilizer_application.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_fertilizer_application.py
@@ -1,6 +1,6 @@
 import pytest
 from typing import List
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 from SC_redesign.Crop_and_Soil.field.fertilizer_application import FertilizerApplication
 from SC_redesign.Crop_and_Soil.soil.layer_data import LayerData

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_fertilizer_application.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_fertilizer_application.py
@@ -1,6 +1,6 @@
 import pytest
 from typing import List
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, call
 
 from SC_redesign.Crop_and_Soil.field.fertilizer_application import FertilizerApplication
 from SC_redesign.Crop_and_Soil.soil.layer_data import LayerData
@@ -8,7 +8,7 @@ from SC_redesign.Crop_and_Soil.soil.soil import Soil
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 
 
-@pytest.mark.parametrize("depth,bottom_depths,expected",[
+@pytest.mark.parametrize("depth,bottom_depths,expected", [
     (15.0, [20.0, 70.0, 200.0], [1.0]),
     (0.0, [20.0, 70.0, 200.0], [1.0]),
     (40.0, [20.0, 70.0, 200.0], [0.5, 0.5]),
@@ -58,13 +58,15 @@ def test_apply_subsurface_fertilizer(nutrient_amounts: float, depth: float, subs
 
 
 @pytest.mark.parametrize("phosphorus,fertilizer,inorganic_nitrogen_frac,ammonium_frac,organic_nitrogen_frac,depth,"
-                         "remainder,expected", [
-                             (15, 90, 0.15, 0.44, 0.09, 0.0, 1.0, [7.56, 5.94, 4.05]),
-                             (22.1, 144, 0.33, 0.2, 0.06, 40.0, 0.88, [38.016, 9.504, 4.32]),
-                             (0, 0, 0, 0, 0, 0.0, 1.0, [0, 0, 0])
+                         "remainder,expected,subsurface_app_call", [
+                             (15, 90, 0.15, 0.44, 0.09, 0.0, 1.0, [15, 4.44705882, 3.49411765, 2.38235294], None),
+                             (22.1, 144, 0.33, 0.2, 0.06, 40.0, 0.88, [19.448, 19.6788706, 4.91971765, 2.23623529],
+                              (13, 22.3623529, 5.5905882, 2.5411764, 40.0, 0.12)),
+                             (0, 0, 0, 0, 0, 0.0, 1.0, [0, 0, 0, 0], None)
                          ])
 def test_apply_fertilizer(phosphorus: float, fertilizer: float, inorganic_nitrogen_frac: float, ammonium_frac: float,
-                          organic_nitrogen_frac: float, depth: float, remainder: float, expected: List[float]) -> None:
+                          organic_nitrogen_frac: float, depth: float, remainder: float, expected: List[float],
+                          subsurface_app_call: tuple[float]) -> None:
     """Tests that fertilizer is applied correctly."""
     field_size = 1.7
     fert_app = FertilizerApplication(field_size=field_size)
@@ -73,13 +75,24 @@ def test_apply_fertilizer(phosphorus: float, fertilizer: float, inorganic_nitrog
     fert_app.soil.data.soil_layers[0].fresh_organic_nitrogen_content = 0
     fert_app.soil.data.soil_layers[0].active_organic_nitrogen_content = 0
 
-    fert_app.soil.phosphorus_cycling.fertilizer.add_fertilizer_phosphorus = MagicMock()
+    with patch(
+            "SC_redesign.Crop_and_Soil.field.fertilizer_application.FertilizerApplication._apply_subsurface_fertilizer",
+            new_callable=MagicMock) as patched_subsurface_applicator, \
+        patch("SC_redesign.Crop_and_Soil.soil.phosphorus_cycling.fertilizer.Fertilizer.add_fertilizer_phosphorus",
+              new_callable=MagicMock) as patched_phosphorus_applicator:
+        fert_app.apply_fertilizer(phosphorus, fertilizer, inorganic_nitrogen_frac, ammonium_frac, organic_nitrogen_frac,
+                                  depth, remainder, field_size)
 
-    fert_app.apply_fertilizer(phosphorus, fertilizer, inorganic_nitrogen_frac, ammonium_frac, organic_nitrogen_frac,
-                              depth, remainder, field_size)
-
-    fert_app.soil.phosphorus_cycling.fertilizer.add_fertilizer_phosphorus.assert_called_once_with(phosphorus)
-    assert pytest.approx(fert_app.soil.data.soil_layers[0].nitrate_content) == expected[0] / field_size
-    assert pytest.approx(fert_app.soil.data.soil_layers[0].ammonium_content) == expected[1] / field_size
-    assert pytest.approx(fert_app.soil.data.soil_layers[0].fresh_organic_nitrogen_content) == expected[2] / field_size
-    assert pytest.approx(fert_app.soil.data.soil_layers[0].active_organic_nitrogen_content) == expected[2] / field_size
+        patched_phosphorus_applicator.assert_called_once_with(expected[0])
+        assert pytest.approx(fert_app.soil.data.soil_layers[0].nitrate_content) == expected[1]
+        assert pytest.approx(fert_app.soil.data.soil_layers[0].ammonium_content) == expected[2]
+        assert pytest.approx(fert_app.soil.data.soil_layers[0].fresh_organic_nitrogen_content) == expected[3]
+        assert pytest.approx(fert_app.soil.data.soil_layers[0].active_organic_nitrogen_content) == expected[3]
+        if subsurface_app_call is not None:
+            patched_subsurface_applicator.assert_called_once_with(pytest.approx(subsurface_app_call[0]),
+                                                                  pytest.approx(subsurface_app_call[1]),
+                                                                  pytest.approx(subsurface_app_call[2]),
+                                                                  pytest.approx(subsurface_app_call[3]),
+                                                                  subsurface_app_call[4], subsurface_app_call[5])
+        else:
+            patched_subsurface_applicator.assert_not_called()

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -544,15 +544,15 @@ def test_make_crop_from_config_dict(config: dict):
 
 @pytest.mark.parametrize("mix_name,requested_n,requested_p,depth,remainder,year,day,field_size,fertilizer_applied,"
                          "invalid_depth_fraction", {
-    ("test_mix_1", 80.0, 30.0, 0.0, 1.0, 1993, 100, 3.1, True, False),
-    ("test_mix_2", 150.0, 89.0, 25.0, 0.89, 2001, 240, 1.3, True, False),
-    ("test_mix_3", 10.0, 90.33, 100.0, 0.5, 1992, 30, 2.44, True, False),
-    ("test_mix_4", 0.0, 50.0, 0.0, 1.0, 1996, 60, 1.45, True, False),
-    ("test_mix_5", 67.5, 0.0, 0.0, 1.0, 1998, 200, 2.3, True, False),
-    ("test_mix_6", 0.0, 0.0, 0.0, 1.0, 1988, 120, 0.5, False, False),
-    ("test_mix_7", 50.0, 50.0, 20.0, 1.0, 1988, 125, 0.8, True, True),
-    ("test_mix_8", 70.0, 70.0, 0.0, 0.85, 1998, 130, 0.95, True, True),
-})
+                             ("test_mix_1", 80.0, 30.0, 0.0, 1.0, 1993, 100, 3.1, True, False),
+                             ("test_mix_2", 150.0, 89.0, 25.0, 0.89, 2001, 240, 1.3, True, False),
+                             ("test_mix_3", 10.0, 90.33, 100.0, 0.5, 1992, 30, 2.44, True, False),
+                             ("test_mix_4", 0.0, 50.0, 0.0, 1.0, 1996, 60, 1.45, True, False),
+                             ("test_mix_5", 67.5, 0.0, 0.0, 1.0, 1998, 200, 2.3, True, False),
+                             ("test_mix_6", 0.0, 0.0, 0.0, 1.0, 1988, 120, 0.5, False, False),
+                             ("test_mix_7", 50.0, 50.0, 20.0, 1.0, 1988, 125, 0.8, True, True),
+                             ("test_mix_8", 70.0, 70.0, 0.0, 0.85, 1998, 130, 0.95, True, True),
+                         })
 def test_execute_fertilizer_application(mix_name: str, requested_n: float, requested_p: float, depth: float,
                                         remainder: float, year: int, day: int, field_size: float,
                                         fertilizer_applied: bool, invalid_depth_fraction: bool) -> None:
@@ -573,12 +573,12 @@ def test_execute_fertilizer_application(mix_name: str, requested_n: float, reque
         if invalid_depth_fraction:
             expected_depth = 0.0
             expected_remainder = 1.0
-            expected_info_map = {"prefix": f"field:'test'", "date": {"year": year, "day": day},
+            expected_info_map = {"prefix": "field:'test'", "date": {"year": year, "day": day},
                                  "timestamp": "00-Jan-1970_Thu_00-00-00"}
             expected_error_message = f"Invalid application depth ({depth}) and surface remainder fraction " \
                                      f"({remainder}). Defaulting to application depth of 0.0 mm and a surface " \
                                      f"remainder fraction of 1.0."
-            actual = om.errors_pool[f"field:'test'.fertilizer_application_error"]
+            actual = om.errors_pool["field:'test'.fertilizer_application_error"]
             assert actual["info_maps"].__contains__(expected_info_map)
             assert actual["values"].__contains__(expected_error_message)
         else:
@@ -588,9 +588,9 @@ def test_execute_fertilizer_application(mix_name: str, requested_n: float, reque
         if fertilizer_applied:
             expected_nitrogen_fraction = 0.2
             field._formulate_fertilizer_required.assert_called_once_with(0.3, 0.2, 0.5, requested_n, requested_p)
-            field.fertilizer_applicator.apply_fertilizer.assert_called_once_with(15, 100, expected_nitrogen_fraction, 0.0,
-                                                                                 0.0, expected_depth, expected_remainder,
-                                                                                 field_size)
+            field.fertilizer_applicator.apply_fertilizer.assert_called_once_with(15, 100, expected_nitrogen_fraction,
+                                                                                 0.0, 0.0, expected_depth,
+                                                                                 expected_remainder, field_size)
             field._record_fertilizer_application.assert_called_once_with(mix_name, 100, 20, 15, 10, expected_depth,
                                                                          expected_remainder, year, day)
         else:

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -670,25 +670,25 @@ def test_formulate_fertilizer_required(nitrogen_frac: float, phosphorus_frac: fl
     assert actual == expected
 
 
-@pytest.mark.parametrize("mix_name,total_mass,nitrogen_mass,phosphorus_mass,potassium_mass,year,day,field_name,"
-                         "field_size", [
-                             ("mix_1", 100, 20, 20, 20, 1992, 90, "field_1", 1.4),
-                             ("mix_2", 30, 10, 3, 3, 1994, 120, "field_2", 4.3)
+@pytest.mark.parametrize("mix_name,total_mass,nitrogen_mass,phosphorus_mass,potassium_mass,depth,remainder,year,day,"
+                         "field_name,field_size", [
+                             ("mix_1", 100, 20, 20, 20, 35.0, 0.8, 1992, 90, "field_1", 1.4),
+                             ("mix_2", 30, 10, 3, 3, 0.0, 1.0, 1994, 120, "field_2", 4.3)
                          ])
 def test_record_fertilizer_application(mix_name: str, total_mass: float, nitrogen_mass: float, phosphorus_mass: float,
-                                       potassium_mass: float, year: int, day: int, field_name: str,
-                                       field_size: float) -> None:
+                                       potassium_mass: float, depth: float, remainder: float, year: int, day: int,
+                                       field_name: str, field_size: float) -> None:
     """Tests that fertilizer applications are correctly recorded in the OutputManager."""
     field = Field(field_data=FieldData(name=field_name, field_size=field_size),
                   manure_manager=MagicMock(ManureManager))
 
-    field._record_fertilizer_application(mix_name, total_mass, nitrogen_mass, phosphorus_mass, potassium_mass, year,
-                                         day)
+    field._record_fertilizer_application(mix_name, total_mass, nitrogen_mass, phosphorus_mass, potassium_mass, depth,
+                                         remainder, year, day)
 
     expected_info_map = {"prefix": f"field:'{field_name}'", "date": {"year": year, "day": day},
                          "mix_name": mix_name, "field_size": field_size}
     expected_value = {"mass": total_mass, "nitrogen": nitrogen_mass, "phosphorus": phosphorus_mass,
-                      "potassium": potassium_mass}
+                      "potassium": potassium_mass, "application_depth": depth, "surface_remainder_fraction": remainder}
     actual = om.variables_pool[f"field:'{field_name}'.fertilizer_application"]
     assert actual["info_maps"].__contains__(expected_info_map)
     assert actual["values"].__contains__(expected_value)

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -544,61 +544,40 @@ def test_make_crop_from_config_dict(config: dict):
         Field._make_custom_crop.assert_called_once()
 
 
-@pytest.mark.parametrize("mix_name,requested_n,requested_p,depth,remainder,year,day,field_size,fertilizer_applied,"
-                         "invalid_depth_fraction", {
-                             ("test_mix_1", 80.0, 30.0, 0.0, 1.0, 1993, 100, 3.1, True, False),
-                             ("test_mix_2", 150.0, 89.0, 25.0, 0.89, 2001, 240, 1.3, True, False),
-                             ("test_mix_3", 10.0, 90.33, 100.0, 0.5, 1992, 30, 2.44, True, False),
-                             ("test_mix_4", 0.0, 50.0, 0.0, 1.0, 1996, 60, 1.45, True, False),
-                             ("test_mix_5", 67.5, 0.0, 0.0, 1.0, 1998, 200, 2.3, True, False),
-                             ("test_mix_6", 0.0, 0.0, 0.0, 1.0, 1988, 120, 0.5, False, False),
-                             ("test_mix_7", 50.0, 50.0, 20.0, 1.0, 1988, 125, 0.8, True, True),
-                             ("test_mix_8", 70.0, 70.0, 0.0, 0.85, 1998, 130, 0.95, True, True),
+@pytest.mark.parametrize("mix_name,requested_n,requested_p,depth,remainder,year,day,field_size,fertilizer_applied", {
+                             ("test_mix_1", 80.0, 30.0, 0.0, 1.0, 1993, 100, 3.1, True),
+                             ("test_mix_2", 150.0, 89.0, 25.0, 0.89, 2001, 240, 1.3, True),
+                             ("test_mix_3", 10.0, 90.33, 100.0, 0.5, 1992, 30, 2.44, True),
+                             ("test_mix_4", 0.0, 50.0, 0.0, 1.0, 1996, 60, 1.45, True),
+                             ("test_mix_5", 67.5, 0.0, 0.0, 1.0, 1998, 200, 2.3, True),
+                             ("test_mix_6", 0.0, 0.0, 0.0, 1.0, 1988, 120, 0.5, False),
                          })
 def test_execute_fertilizer_application(mix_name: str, requested_n: float, requested_p: float, depth: float,
                                         remainder: float, year: int, day: int, field_size: float,
-                                        fertilizer_applied: bool, invalid_depth_fraction: bool) -> None:
+                                        fertilizer_applied: bool) -> None:
     """Tests that fertilizer applications are being correctly executed and recorded."""
-    with patch("RUFAS.output_manager.OutputManager._get_timestamp", new_callable=MagicMock,
-               return_value="00-Jan-1970_Thu_00-00-00"):
-        field_data = FieldData(name="test", field_size=field_size)
-        field = Field(field_data=field_data, fertilizer_mixes={mix_name: {"N": 0.3, "P": 0.2, "K": 0.5}},
-                      manure_manager=MagicMock(ManureManager))
-        field._formulate_fertilizer_required = MagicMock(return_value={"total_mass": 100, "nitrogen_mass": 20,
-                                                                       "phosphorus_mass": 15,
-                                                                       "potassium_mass": 10})
-        field.fertilizer_applicator.apply_fertilizer = MagicMock()
-        field._record_fertilizer_application = MagicMock()
+    field_data = FieldData(name="test", field_size=field_size)
+    field = Field(field_data=field_data, fertilizer_mixes={mix_name: {"N": 0.3, "P": 0.2, "K": 0.5}},
+                  manure_manager=MagicMock(ManureManager))
+    field._formulate_fertilizer_required = MagicMock(return_value={"total_mass": 100, "nitrogen_mass": 20,
+                                                                   "phosphorus_mass": 15,
+                                                                   "potassium_mass": 10})
+    field.fertilizer_applicator.apply_fertilizer = MagicMock()
+    field._record_fertilizer_application = MagicMock()
 
-        field._execute_fertilizer_application(mix_name, requested_n, requested_p, depth, remainder, year, day)
+    field._execute_fertilizer_application(mix_name, requested_n, requested_p, depth, remainder, year, day)
 
-        if invalid_depth_fraction:
-            expected_depth = 0.0
-            expected_remainder = 1.0
-            expected_info_map = {"prefix": "field:'test'", "date": {"year": year, "day": day},
-                                 "timestamp": "00-Jan-1970_Thu_00-00-00"}
-            expected_error_message = f"Invalid application depth ({depth}) and surface remainder fraction " \
-                                     f"({remainder}). Defaulting to application depth of 0.0 mm and a surface " \
-                                     f"remainder fraction of 1.0."
-            actual = om.errors_pool["field:'test'.fertilizer_application_error"]
-            assert actual["info_maps"].__contains__(expected_info_map)
-            assert actual["values"].__contains__(expected_error_message)
-        else:
-            expected_depth = depth
-            expected_remainder = remainder
-
-        if fertilizer_applied:
-            expected_nitrogen_fraction = 0.2
-            field._formulate_fertilizer_required.assert_called_once_with(0.3, 0.2, 0.5, requested_n, requested_p)
-            field.fertilizer_applicator.apply_fertilizer.assert_called_once_with(15, 100, expected_nitrogen_fraction,
-                                                                                 0.0, 0.0, expected_depth,
-                                                                                 expected_remainder, field_size)
-            field._record_fertilizer_application.assert_called_once_with(mix_name, 100, 20, 15, 10, expected_depth,
-                                                                         expected_remainder, year, day)
-        else:
-            field._formulate_fertilizer_required.assert_not_called()
-            field.fertilizer_applicator.apply_fertilizer.assert_not_called()
-            field._record_fertilizer_application.assert_not_called()
+    if fertilizer_applied:
+        expected_nitrogen_fraction = 0.2
+        field._formulate_fertilizer_required.assert_called_once_with(0.3, 0.2, 0.5, requested_n, requested_p)
+        field.fertilizer_applicator.apply_fertilizer.assert_called_once_with(15, 100, expected_nitrogen_fraction,
+                                                                             0.0, 0.0, depth, remainder, field_size)
+        field._record_fertilizer_application.assert_called_once_with(mix_name, 100, 20, 15, 10, depth, remainder, year,
+                                                                     day)
+    else:
+        field._formulate_fertilizer_required.assert_not_called()
+        field.fertilizer_applicator.apply_fertilizer.assert_not_called()
+        field._record_fertilizer_application.assert_not_called()
 
 
 @pytest.mark.parametrize("field_name,mix_name,available_mixes,expected_message", [
@@ -618,6 +597,47 @@ def test_execute_fertilizer_application_error(field_name: str, mix_name: str, av
     with pytest.raises(KeyError) as e:
         field._execute_fertilizer_application(mix_name, 10.0, 10.0, 0.0, 1.0, 1994, 120)
     assert str(e.value) == expected_message
+
+
+@pytest.mark.parametrize("depth,remainder,expected_depth,expected_remainder,expected_info_map,expected_error_message", [
+    (1000.0, 0.1, 950.0, 0.1,
+     {"prefix": "field:'test'", "date": {"year": 1994, "day": 200}, "timestamp": "00-Jan-1970_Thu_00-00-00"},
+     "Invalid application depth (1000.0) is lower than the bottom depth of the soil profile, setting the application "
+     "depth to be at the bottom of the soil profile."),
+    (100.0, 1.0, 0.0, 1.0,
+     {"prefix": "field:'test'", "date": {"year": 1994, "day": 200}, "timestamp": "00-Jan-1970_Thu_00-00-00"},
+     "Invalid application depth (100.0) and surface remainder fraction (1.0). Defaulting to application depth of 0.0 "
+     "mm and a surface remainder fraction of 1.0."),
+    (0.0, 0.9, 0.0, 1.0,
+     {"prefix": "field:'test'", "date": {"year": 1994, "day": 200}, "timestamp": "00-Jan-1970_Thu_00-00-00"},
+     "Invalid application depth (0.0) and surface remainder fraction (0.9). Defaulting to application depth of 0.0 mm "
+     "and a surface remainder fraction of 1.0.")
+])
+def test_execute_fertilizer_application_with_invalid_args(depth: float, remainder: float, expected_depth: float,
+                                                          expected_remainder: float, expected_info_map: dict,
+                                                          expected_error_message: str) -> None:
+    """Tests that fertilizer applications with invalid arguments are caught, recorded in the OutputManager and execution
+        with corrected values takes place."""
+    field = Field(field_data=FieldData(name="test", field_size=1.2), manure_manager=MagicMock(ManureManager))
+    field.soil.data.soil_layers[-1].bottom_depth = 950.0
+    with patch("RUFAS.output_manager.OutputManager._get_timestamp", new_callable=MagicMock,
+               return_value="00-Jan-1970_Thu_00-00-00"), \
+            patch("SC_redesign.Crop_and_Soil.field.field.Field._formulate_fertilizer_required", new_callable=MagicMock,
+                  return_value={"total_mass": 100.0, "phosphorus_mass": 50.0, "nitrogen_mass": 50.0,
+                                "potassium_mass": 0.0}) as patched_formulator, \
+            patch("SC_redesign.Crop_and_Soil.field.fertilizer_application.FertilizerApplication.apply_fertilizer",
+                  new_callable=MagicMock) as patched_applicator, \
+            patch("SC_redesign.Crop_and_Soil.field.field.Field._record_fertilizer_application",
+                  new_callable=MagicMock) as patched_recorder:
+        field._execute_fertilizer_application("26_4_24", 50.0, 50.0, depth, remainder, 1994, 200)
+
+        actual = om.errors_pool["field:'test'.fertilizer_application_error"]
+        assert actual["info_maps"].__contains__(expected_info_map)
+        assert actual["values"].__contains__(expected_error_message)
+        patched_formulator.assert_called_once_with(0.26, 0.04, 0.24, 50.0, 50.0)
+        patched_applicator.assert_called_once_with(50.0, 100.0, 0.5, 0.0, 0.0, expected_depth, expected_remainder, 1.2)
+        patched_recorder.assert_called_once_with("26_4_24", 100.0, 50.0, 50.0, 0.0, expected_depth, expected_remainder,
+                                                 1994, 200)
 
 
 @pytest.mark.parametrize("nitrogen,phosphorus,mixes,expected", [

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -132,8 +132,8 @@ def test_check_fertilizer_application_schedule(events: List[FertilizerEvent], re
 
     expected_execution_calls = []
     for event in current_events:
-        expected_execution_calls.append(call(event.mix_name, event.nitrogen_mass, event.phosphorus_mass, event.year,
-                                             event.day))
+        expected_execution_calls.append(call(event.mix_name, event.nitrogen_mass, event.phosphorus_mass, event.depth,
+                                             event.surface_remainder_fraction, event.year, event.day))
     field._filter_events.assert_called_once_with(events, mocked_time)
     field._execute_fertilizer_application.assert_has_calls(expected_execution_calls)
 
@@ -542,16 +542,17 @@ def test_make_crop_from_config_dict(config: dict):
         Field._make_custom_crop.assert_called_once()
 
 
-@pytest.mark.parametrize("mix_name,requested_n,requested_p,year,day,field_size,fertilizer_applied", {
-    ("test_mix_1", 80.0, 30.0, 1993, 100, 3.1, True),
-    ("test_mix_2", 150.0, 89.0, 2001, 240, 1.3, True),
-    ("test_mix_3", 10.0, 90.33, 1992, 30, 2.44, True),
-    ("test_mix_4", 0.0, 50.0, 1996, 60, 1.45, True),
-    ("test_mix_5", 67.5, 0.0, 1998, 200, 2.3, True),
-    ("test_mix_6", 0.0, 0.0, 1988, 120, 0.5, False)
+@pytest.mark.parametrize("mix_name,requested_n,requested_p,depth,remainder,year,day,field_size,fertilizer_applied", {
+    ("test_mix_1", 80.0, 30.0, 0.0, 1.0, 1993, 100, 3.1, True),
+    ("test_mix_2", 150.0, 89.0, 25.0, 0.89, 2001, 240, 1.3, True),
+    ("test_mix_3", 10.0, 90.33, 100.0, 0.5, 1992, 30, 2.44, True),
+    ("test_mix_4", 0.0, 50.0, 0.0, 1.0, 1996, 60, 1.45, True),
+    ("test_mix_5", 67.5, 0.0, 0.0, 1.0, 1998, 200, 2.3, True),
+    ("test_mix_6", 0.0, 0.0, 0.0, 1.0, 1988, 120, 0.5, False)
 })
-def test_execute_fertilizer_application(mix_name: str, requested_n: float, requested_p: float,
-                                        year: int, day: int, field_size: float, fertilizer_applied: bool) -> None:
+def test_execute_fertilizer_application(mix_name: str, requested_n: float, requested_p: float, depth: float,
+                                        remainder: float, year: int, day: int, field_size: float,
+                                        fertilizer_applied: bool) -> None:
     """Tests that fertilizer applications are being correctly executed and recorded."""
     field_data = FieldData(name="test", field_size=field_size)
     field = Field(field_data=field_data, fertilizer_mixes={mix_name: {"N": 0.3, "P": 0.2, "K": 0.5}},
@@ -562,14 +563,15 @@ def test_execute_fertilizer_application(mix_name: str, requested_n: float, reque
     field.fertilizer_applicator.apply_fertilizer = MagicMock()
     field._record_fertilizer_application = MagicMock()
 
-    field._execute_fertilizer_application(mix_name, requested_n, requested_p, year, day)
+    field._execute_fertilizer_application(mix_name, requested_n, requested_p, depth, remainder, year, day)
 
     if fertilizer_applied:
         expected_nitrogen_fraction = 0.2
         field._formulate_fertilizer_required.assert_called_once_with(0.3, 0.2, 0.5, requested_n, requested_p)
         field.fertilizer_applicator.apply_fertilizer.assert_called_once_with(15, 100, expected_nitrogen_fraction, 0.0,
-                                                                             0.0, field_size)
-        field._record_fertilizer_application.assert_called_once_with(mix_name, 100, 20, 15, 10, year, day)
+                                                                             0.0, depth, remainder, field_size)
+        field._record_fertilizer_application.assert_called_once_with(mix_name, 100, 20, 15, 10, depth, remainder, year,
+                                                                     day)
     else:
         field._formulate_fertilizer_required.assert_not_called()
         field.fertilizer_applicator.apply_fertilizer.assert_not_called()
@@ -591,8 +593,47 @@ def test_execute_fertilizer_application_error(field_name: str, mix_name: str, av
     field = Field(field_data=FieldData(name=field_name), fertilizer_mixes=available_mixes,
                   manure_manager=MagicMock(ManureManager))
     with pytest.raises(KeyError) as e:
-        field._execute_fertilizer_application(mix_name, 10.0, 10.0, 1994, 120)
+        field._execute_fertilizer_application(mix_name, 10.0, 10.0, 0.0, 1.0, 1994, 120)
     assert str(e.value) == expected_message
+
+
+@pytest.mark.parametrize("depth,remainder,expected_error_message,expected_info_map", [
+    (0.0, 0.8, "Invalid application depth (0.0) and surface remainder fraction (0.8). Defaulting to application depth "
+               "of 0.0 mm and a surface remainder fraction of 1.0.",
+     {"class": "Field", "function": "_record_fertilizer_application", "prefix": f"field:'test'",
+      "date": {"year": 1999, "day": 100}}),
+    (50.0, 1.0, "Invalid application depth (50.0) and surface remainder fraction (1.0). Defaulting to application "
+                "depth of 0.0 mm and a surface remainder fraction of 1.0.",
+     {"class": "Field", "function": "_record_fertilizer_application", "prefix": f"field:'test'",
+      "date": {"year": 1999, "day": 100}})
+])
+def test_execute_fertilizer_application_with_invalid_parameters(depth: float, remainder: float,
+                                                                expected_error_message: str,
+                                                                expected_info_map: dict) -> None:
+    """Tests that errors are correctly raised to the OutputManager and execution continues when invalid application
+        depths and surface remainder fraction combinations are given."""
+    field_data = FieldData(name="test", field_size=1.4)
+    field = Field(field_data=field_data, fertilizer_mixes={"mix_name": {"N": 0.3, "P": 0.2, "K": 0.5}},
+                  manure_manager=MagicMock(ManureManager))
+    field._formulate_fertilizer_required = MagicMock(return_value={"total_mass": 100, "nitrogen_mass": 20,
+                                                                   "phosphorus_mass": 15, "potassium_mass": 10})
+    field.fertilizer_applicator.apply_fertilizer = MagicMock()
+    field._record_fertilizer_application = MagicMock()
+
+    field._execute_fertilizer_application("mix_name", 50, 50, depth, remainder, 1999, 100)
+
+    expected_depth = 0.0
+    expected_remainder = 1.0
+    expected_nitrogen_fraction = 0.2
+    field._formulate_fertilizer_required.assert_called_once_with(0.3, 0.2, 0.5, 50, 50)
+    field.fertilizer_applicator.apply_fertilizer.assert_called_once_with(15, 100, expected_nitrogen_fraction, 0.0,
+                                                                         0.0, expected_depth, expected_remainder, 1.4)
+    field._record_fertilizer_application.assert_called_once_with("mix_name", 100, 20, 15, 10, expected_depth,
+                                                                 expected_remainder, 1999, 100)
+
+    actual = om.errors_pool[f"field:'test'.fertilizer_application_error"]
+    assert actual["info_maps"].__contains__(expected_info_map)
+    assert actual["values"].__contains__(expected_error_message)
 
 
 @pytest.mark.parametrize("nitrogen,phosphorus,mixes,expected", [

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -565,19 +565,27 @@ def test_execute_fertilizer_application(mix_name: str, requested_n: float, reque
     field.fertilizer_applicator.apply_fertilizer = MagicMock()
     field._record_fertilizer_application = MagicMock()
 
-    field._execute_fertilizer_application(mix_name, requested_n, requested_p, depth, remainder, year, day)
+    with patch("RUFAS.output_manager.OutputManager._get_timestamp", new_callable=MagicMock,
+               return_value="00-Jan-1970_Thu_00-00-00"):
+        field._execute_fertilizer_application(mix_name, requested_n, requested_p, depth, remainder, year, day)
 
-    if fertilizer_applied:
-        expected_nitrogen_fraction = 0.2
-        field._formulate_fertilizer_required.assert_called_once_with(0.3, 0.2, 0.5, requested_n, requested_p)
-        field.fertilizer_applicator.apply_fertilizer.assert_called_once_with(15, 100, expected_nitrogen_fraction,
-                                                                             0.0, 0.0, depth, remainder, field_size)
-        field._record_fertilizer_application.assert_called_once_with(mix_name, 100, 20, 15, 10, depth, remainder, year,
-                                                                     day)
-    else:
-        field._formulate_fertilizer_required.assert_not_called()
-        field.fertilizer_applicator.apply_fertilizer.assert_not_called()
-        field._record_fertilizer_application.assert_not_called()
+        if fertilizer_applied:
+            expected_nitrogen_fraction = 0.2
+            field._formulate_fertilizer_required.assert_called_once_with(0.3, 0.2, 0.5, requested_n, requested_p)
+            field.fertilizer_applicator.apply_fertilizer.assert_called_once_with(15, 100, expected_nitrogen_fraction,
+                                                                                 0.0, 0.0, depth, remainder, field_size)
+            field._record_fertilizer_application.assert_called_once_with(mix_name, 100, 20, 15, 10, depth, remainder,
+                                                                         year, day)
+        else:
+            expected_info_map = {"prefix": "field:'test'", "date": {"year": year, "day": day},
+                                 "timestamp": "00-Jan-1970_Thu_00-00-00"}
+            expected_log_message = "Tried to apply fertilizer with no nitrogen or phosphorus requested."
+            actual = om.logs_pool["field:'test'.fertilizer_application_log"]
+            assert actual["info_maps"].__contains__(expected_info_map)
+            assert actual["values"].__contains__(expected_log_message)
+            field._formulate_fertilizer_required.assert_not_called()
+            field.fertilizer_applicator.apply_fertilizer.assert_not_called()
+            field._record_fertilizer_application.assert_not_called()
 
 
 @pytest.mark.parametrize("field_name,mix_name,available_mixes,expected_message", [

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -542,40 +542,61 @@ def test_make_crop_from_config_dict(config: dict):
         Field._make_custom_crop.assert_called_once()
 
 
-@pytest.mark.parametrize("mix_name,requested_n,requested_p,depth,remainder,year,day,field_size,fertilizer_applied", {
-    ("test_mix_1", 80.0, 30.0, 0.0, 1.0, 1993, 100, 3.1, True),
-    ("test_mix_2", 150.0, 89.0, 25.0, 0.89, 2001, 240, 1.3, True),
-    ("test_mix_3", 10.0, 90.33, 100.0, 0.5, 1992, 30, 2.44, True),
-    ("test_mix_4", 0.0, 50.0, 0.0, 1.0, 1996, 60, 1.45, True),
-    ("test_mix_5", 67.5, 0.0, 0.0, 1.0, 1998, 200, 2.3, True),
-    ("test_mix_6", 0.0, 0.0, 0.0, 1.0, 1988, 120, 0.5, False)
+@pytest.mark.parametrize("mix_name,requested_n,requested_p,depth,remainder,year,day,field_size,fertilizer_applied,"
+                         "invalid_depth_fraction", {
+    ("test_mix_1", 80.0, 30.0, 0.0, 1.0, 1993, 100, 3.1, True, False),
+    ("test_mix_2", 150.0, 89.0, 25.0, 0.89, 2001, 240, 1.3, True, False),
+    ("test_mix_3", 10.0, 90.33, 100.0, 0.5, 1992, 30, 2.44, True, False),
+    ("test_mix_4", 0.0, 50.0, 0.0, 1.0, 1996, 60, 1.45, True, False),
+    ("test_mix_5", 67.5, 0.0, 0.0, 1.0, 1998, 200, 2.3, True, False),
+    ("test_mix_6", 0.0, 0.0, 0.0, 1.0, 1988, 120, 0.5, False, False),
+    ("test_mix_7", 50.0, 50.0, 20.0, 1.0, 1988, 125, 0.8, True, True),
+    ("test_mix_8", 70.0, 70.0, 0.0, 0.85, 1998, 130, 0.95, True, True),
 })
 def test_execute_fertilizer_application(mix_name: str, requested_n: float, requested_p: float, depth: float,
                                         remainder: float, year: int, day: int, field_size: float,
-                                        fertilizer_applied: bool) -> None:
+                                        fertilizer_applied: bool, invalid_depth_fraction: bool) -> None:
     """Tests that fertilizer applications are being correctly executed and recorded."""
-    field_data = FieldData(name="test", field_size=field_size)
-    field = Field(field_data=field_data, fertilizer_mixes={mix_name: {"N": 0.3, "P": 0.2, "K": 0.5}},
-                  manure_manager=MagicMock(ManureManager))
-    field._formulate_fertilizer_required = MagicMock(return_value={"total_mass": 100, "nitrogen_mass": 20,
-                                                                   "phosphorus_mass": 15,
-                                                                   "potassium_mass": 10})
-    field.fertilizer_applicator.apply_fertilizer = MagicMock()
-    field._record_fertilizer_application = MagicMock()
+    with patch("RUFAS.output_manager.OutputManager._get_timestamp", new_callable=MagicMock,
+               return_value="00-Jan-1970_Thu_00-00-00"):
+        field_data = FieldData(name="test", field_size=field_size)
+        field = Field(field_data=field_data, fertilizer_mixes={mix_name: {"N": 0.3, "P": 0.2, "K": 0.5}},
+                      manure_manager=MagicMock(ManureManager))
+        field._formulate_fertilizer_required = MagicMock(return_value={"total_mass": 100, "nitrogen_mass": 20,
+                                                                       "phosphorus_mass": 15,
+                                                                       "potassium_mass": 10})
+        field.fertilizer_applicator.apply_fertilizer = MagicMock()
+        field._record_fertilizer_application = MagicMock()
 
-    field._execute_fertilizer_application(mix_name, requested_n, requested_p, depth, remainder, year, day)
+        field._execute_fertilizer_application(mix_name, requested_n, requested_p, depth, remainder, year, day)
 
-    if fertilizer_applied:
-        expected_nitrogen_fraction = 0.2
-        field._formulate_fertilizer_required.assert_called_once_with(0.3, 0.2, 0.5, requested_n, requested_p)
-        field.fertilizer_applicator.apply_fertilizer.assert_called_once_with(15, 100, expected_nitrogen_fraction, 0.0,
-                                                                             0.0, depth, remainder, field_size)
-        field._record_fertilizer_application.assert_called_once_with(mix_name, 100, 20, 15, 10, depth, remainder, year,
-                                                                     day)
-    else:
-        field._formulate_fertilizer_required.assert_not_called()
-        field.fertilizer_applicator.apply_fertilizer.assert_not_called()
-        field._record_fertilizer_application.assert_not_called()
+        if invalid_depth_fraction:
+            expected_depth = 0.0
+            expected_remainder = 1.0
+            expected_info_map = {"prefix": f"field:'test'", "date": {"year": year, "day": day},
+                                 "timestamp": "00-Jan-1970_Thu_00-00-00"}
+            expected_error_message = f"Invalid application depth ({depth}) and surface remainder fraction " \
+                                     f"({remainder}). Defaulting to application depth of 0.0 mm and a surface " \
+                                     f"remainder fraction of 1.0."
+            actual = om.errors_pool[f"field:'test'.fertilizer_application_error"]
+            assert actual["info_maps"].__contains__(expected_info_map)
+            assert actual["values"].__contains__(expected_error_message)
+        else:
+            expected_depth = depth
+            expected_remainder = remainder
+
+        if fertilizer_applied:
+            expected_nitrogen_fraction = 0.2
+            field._formulate_fertilizer_required.assert_called_once_with(0.3, 0.2, 0.5, requested_n, requested_p)
+            field.fertilizer_applicator.apply_fertilizer.assert_called_once_with(15, 100, expected_nitrogen_fraction, 0.0,
+                                                                                 0.0, expected_depth, expected_remainder,
+                                                                                 field_size)
+            field._record_fertilizer_application.assert_called_once_with(mix_name, 100, 20, 15, 10, expected_depth,
+                                                                         expected_remainder, year, day)
+        else:
+            field._formulate_fertilizer_required.assert_not_called()
+            field.fertilizer_applicator.apply_fertilizer.assert_not_called()
+            field._record_fertilizer_application.assert_not_called()
 
 
 @pytest.mark.parametrize("field_name,mix_name,available_mixes,expected_message", [
@@ -595,45 +616,6 @@ def test_execute_fertilizer_application_error(field_name: str, mix_name: str, av
     with pytest.raises(KeyError) as e:
         field._execute_fertilizer_application(mix_name, 10.0, 10.0, 0.0, 1.0, 1994, 120)
     assert str(e.value) == expected_message
-
-
-@pytest.mark.parametrize("depth,remainder,expected_error_message,expected_info_map", [
-    (0.0, 0.8, "Invalid application depth (0.0) and surface remainder fraction (0.8). Defaulting to application depth "
-               "of 0.0 mm and a surface remainder fraction of 1.0.",
-     {"class": "Field", "function": "_record_fertilizer_application", "prefix": f"field:'test'",
-      "date": {"year": 1999, "day": 100}}),
-    (50.0, 1.0, "Invalid application depth (50.0) and surface remainder fraction (1.0). Defaulting to application "
-                "depth of 0.0 mm and a surface remainder fraction of 1.0.",
-     {"class": "Field", "function": "_record_fertilizer_application", "prefix": f"field:'test'",
-      "date": {"year": 1999, "day": 100}})
-])
-def test_execute_fertilizer_application_with_invalid_parameters(depth: float, remainder: float,
-                                                                expected_error_message: str,
-                                                                expected_info_map: dict) -> None:
-    """Tests that errors are correctly raised to the OutputManager and execution continues when invalid application
-        depths and surface remainder fraction combinations are given."""
-    field_data = FieldData(name="test", field_size=1.4)
-    field = Field(field_data=field_data, fertilizer_mixes={"mix_name": {"N": 0.3, "P": 0.2, "K": 0.5}},
-                  manure_manager=MagicMock(ManureManager))
-    field._formulate_fertilizer_required = MagicMock(return_value={"total_mass": 100, "nitrogen_mass": 20,
-                                                                   "phosphorus_mass": 15, "potassium_mass": 10})
-    field.fertilizer_applicator.apply_fertilizer = MagicMock()
-    field._record_fertilizer_application = MagicMock()
-
-    field._execute_fertilizer_application("mix_name", 50, 50, depth, remainder, 1999, 100)
-
-    expected_depth = 0.0
-    expected_remainder = 1.0
-    expected_nitrogen_fraction = 0.2
-    field._formulate_fertilizer_required.assert_called_once_with(0.3, 0.2, 0.5, 50, 50)
-    field.fertilizer_applicator.apply_fertilizer.assert_called_once_with(15, 100, expected_nitrogen_fraction, 0.0,
-                                                                         0.0, expected_depth, expected_remainder, 1.4)
-    field._record_fertilizer_application.assert_called_once_with("mix_name", 100, 20, 15, 10, expected_depth,
-                                                                 expected_remainder, 1999, 100)
-
-    actual = om.errors_pool[f"field:'test'.fertilizer_application_error"]
-    assert actual["info_maps"].__contains__(expected_info_map)
-    assert actual["values"].__contains__(expected_error_message)
 
 
 @pytest.mark.parametrize("nitrogen,phosphorus,mixes,expected", [
@@ -743,8 +725,8 @@ def test_execute_manure_application(nitrogen: float, phosphorus: float, coverage
         field._determine_optimal_fertilizer_mix.assert_not_called()
         field._execute_fertilizer_application.assert_not_called()
     else:
-        expected_total_inorganic_fraction = 0.14    # equal to (50.0 / 250.0) * 0.7
-        expected_total_organic_fraction = 0.06      # equal to (50.0 / 250.0) * 0.3
+        expected_total_inorganic_fraction = 0.14  # equal to (50.0 / 250.0) * 0.7
+        expected_total_organic_fraction = 0.06  # equal to (50.0 / 250.0) * 0.3
 
         if supplied_manure is not None:
             mocked_manure_manager.request_nutrients.assert_called_once_with(expected_request)
@@ -1268,7 +1250,7 @@ def test_error_field_data_initialization(watering_amount: float, interval: int) 
 
 @pytest.mark.parametrize("annual_irrigation_water_use_total,expected", [
     (1500, 0),
-    (063.25,  0),
+    (063.25, 0),
     (0, 0)
 ])
 def test_field_data_perform_annual_field_reset(annual_irrigation_water_use_total: float, expected: float) -> None:


### PR DESCRIPTION
This PR implements the functionality for injection fertilizer applications.

- Two new methods have been introduced in `FertilizerApplication`, `_generate_depth_factors()` calculates the distribution of nutrients between soil layers, and `_apply_subsurface_fertilizer()` applies nutrients to the soil layers.
- `apply_fertilizer()` now takes the depth and surface remainder fractions of fertilizer applications, and uses them to apply subsurface applications when specified.
- `_execute_fertilizer_application()` in `Field` now accepts the depth and surface remainder fractions of fertilizer applications. It checks them for errors and passes them along to other methods that record and execute applications.
- `_record_fertilizer_application()` records the depth and surface remainder fractions as well.
- `_check_fertilizer_application_schedule()` passes the depth and surface remainder fractions to be executed.
- All changes are tested.