### PR TITLE
IM object filtering patch

### DIFF
--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -236,19 +236,21 @@ class InputManager:
         if is_nested:
             children_status: Dict[str, bool] = {}
             false_counter = 0
+            variable_properties_to_ignore = ["type", "description"]
             for nested_key in variable_properties.keys():
-                element_hierarchy.append(nested_key)
-                element_counter_and_validity = self._validate_element(element_hierarchy, properties_blob_key,
-                                                                      input_data, eager_termination)
-                is_child_valid = element_counter_and_validity["is_valid"]
-                if eager_termination and not is_child_valid:
-                    return element_counter_and_validity
-                element_path = ".".join(element_hierarchy)
-                children_status[element_path] = is_child_valid
-                if not is_child_valid:
-                    om.add_warning("Invalid nested element found", f"{element_path}", info_map)
-                    false_counter += 1
-                element_hierarchy.remove(nested_key)
+                if nested_key not in variable_properties_to_ignore:
+                    element_hierarchy.append(nested_key)
+                    element_counter_and_validity = self._validate_element(element_hierarchy, properties_blob_key,
+                                                                          input_data, eager_termination)
+                    is_child_valid = element_counter_and_validity["is_valid"]
+                    if eager_termination and not is_child_valid:
+                        return element_counter_and_validity
+                    element_path = ".".join(element_hierarchy)
+                    children_status[element_path] = is_child_valid
+                    if not is_child_valid:
+                        om.add_warning("Invalid nested element found", f"{element_path}", info_map)
+                        false_counter += 1
+                    element_hierarchy.remove(nested_key)
 
             is_valid = false_counter == 0
 

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -253,8 +253,9 @@ class InputManager:
                     element_hierarchy.remove(nested_key)
 
             is_valid = false_counter == 0
+            element_counter_and_validity["is_valid"] = is_valid
 
-            return is_valid
+            return element_counter_and_validity
         else:
             var_name = element_hierarchy[-1]
             try:

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -350,6 +350,11 @@ def test_validate_element_string_type(mock_input_manager: InputManager,
 
     assert result["is_valid"] is True
 
+    input_data = {"element1": "invalid_value"}
+    result = mock_input_manager._validate_element(["element1"], "property_map_key1", input_data, True)
+
+    assert result["is_valid"] is False
+
     mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
 
 
@@ -363,6 +368,11 @@ def test_validate_element_number_type(mock_input_manager: InputManager,
     result = mock_input_manager._validate_element(["element2"], "property_map_key1", input_data, True)
 
     assert result["is_valid"] is True
+
+    input_data = {"element2": 500}
+    result = mock_input_manager._validate_element(["element2"], "property_map_key1", input_data, True)
+
+    assert result["is_valid"] is False
 
     mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
 
@@ -378,13 +388,18 @@ def test_validate_element_array_type(mock_input_manager: InputManager,
 
     assert result["is_valid"] is True
 
+    input_data = {"element3": [1, 2, 3, 6, 7, 8, 10]}
+    result = mock_input_manager._validate_element(["element3"], "property_map_key1", input_data, True)
+
+    assert result["is_valid"] is False
+
     mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
 
 
 def test_validate_element_valid_object_type(mock_input_manager: InputManager,
                                             mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
                                             input_manager_original_method_states: Dict[str, Callable], ):
-    """Unit test for nested object type input_data for _validate_element in file input_manager.py"""
+    """Unit test for valid nested object type input_data for _validate_element in file input_manager.py"""
     mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
 
     input_data = {"element4": {"nested_element1": "value1", "nested_element2": 123}}
@@ -417,7 +432,7 @@ def test_validate_element_invalid_object_type(mock_input_manager: InputManager,
 def test_validate_element_valid_nested_object_type(mock_input_manager: InputManager,
                                                    mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
                                                    input_manager_original_method_states: Dict[str, Callable], ):
-    """Unit test for object nested within another object type
+    """Unit test for valid object nested within another object type
     input_data for _validate_element in file input_manager.py"""
     mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
 

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -1080,6 +1080,18 @@ def mock_pool_for_get_data(mocker: MockerFixture) -> Dict[str, Dict[str, Any]]:
         ("module1.submodule1.nested_var", "dummyvalue2", 0),
         ("module2.submodule1.nested_module1.nested_var1", "dummyvalue3", 0),
         ("module2.submodule1.nested_module1.nested_var2", "dummyvalue4", 0),
+        ("module1", {
+            "integer_var": 5,
+            "float_var": 0.5,
+            "string_var": "dummyvalue1",
+            "boolean_var": True,
+            "integer_array_var": [1, 2, 3],
+            "float_array_var": [0.1, 0.2, 3.14159],
+            "string_array_var": ["1", "2", "3", "4", "5"],
+            "boolean_array_var": [True, False],
+            "submodule1": {
+                "nested_var": "dummyvalue2"
+            }}, 0),
     ]
 )
 def test_get_data_with_valid_key(dummy_data_path: str,

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -294,6 +294,19 @@ def mock_metadata_for_validate_element(mocker: MockerFixture) -> Dict[str, Dict[
                 "element2": {"type": "number", "minimum": 0, "maximum": 150},
                 "element3": {"type": "array",
                              "minimum_length": 1, "maximum_length": 5},
+                "element4": {"type": "object",
+                             "description": "dummy_description",
+                             "nested_element1": {
+                                 "type": "string",
+                                 "minimum_length": 1,
+                                 "maximum_length": 20
+                                },
+                             "nested_element2": {
+                                 "type": "number",
+                                 "minimum": 0,
+                                 "maximum": 250
+                                }
+                             }
             }
         }
     }
@@ -341,6 +354,20 @@ def test_validate_element_array_type(mock_input_manager: InputManager,
     mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
 
 
+def test_validate_element_object_type(mock_input_manager: InputManager,
+                                      mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
+                                      input_manager_original_method_states: Dict[str, Callable], ):
+    """Unit test for nested object type input_data for _validate_element in file input_manager.py"""
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
+    
+    input_data = {"element4": {"nested_element1": "value1", "nested_element2": 123}}
+    result = mock_input_manager._validate_element(["element4"], "property_map_key1", input_data, True)
+
+    assert result["is_valid"] is True
+
+    mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
+
+
 @pytest.mark.parametrize(
     "input_data_value, expected_result",
     [
@@ -361,21 +388,6 @@ def test_bool_type_validator(input_data_value: bool, expected_result: bool, mock
     result = mock_input_manager._bool_type_validator(variable_properties, var_name, input_data_value)
 
     assert result == expected_result
-
-
-def test_validate_element_object_type(mock_input_manager: InputManager, mocker: MockerFixture,
-                                      mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
-                                      input_manager_original_method_states: Dict[str, Callable], ):
-    """Unit test for nested object type input_data for _validate_element in file input_manager.py"""
-    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
-    mocker.patch.object(mock_input_manager, "_validate_element", return_value=True)
-    mocker.patch.object(mock_input_manager, "_fix_data", return_value=False)
-    input_data = {"element4": {"nested_element1": "value1", "nested_element2": 123}}
-    result = mock_input_manager._validate_element(["element4"], "property_map_key1", input_data)
-
-    assert result is True
-
-    mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
 
 
 def test_validate_element_invalid_var_name_raises_keyerror(mock_input_manager: InputManager,

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -306,6 +306,33 @@ def mock_metadata_for_validate_element(mocker: MockerFixture) -> Dict[str, Dict[
                                  "minimum": 0,
                                  "maximum": 250
                                 }
+                             },
+                "element5": {"type": "object",
+                             "description": "dummy_description",
+                             "nested_element1": {
+                                 "type": "string",
+                                 "minimum_length": 1,
+                                 "maximum_length": 20
+                                },
+                             "nested_element2": {
+                                 "type": "number",
+                                 "minimum": 0,
+                                 "maximum": 250
+                                },
+                             "nested_element3": {
+                                 "type": "object",
+                                 "description": "dummy_description",
+                                 "nested_sub_element1": {
+                                    "type": "string",
+                                    "minimum_length": 1,
+                                    "maximum_length": 5
+                                 },
+                                 "nested_sub_element2": {
+                                    "type": "array",
+                                    "minimum_length": 1,
+                                    "maximum_length": 5
+                                 },
+                                }
                              }
             }
         }
@@ -354,16 +381,73 @@ def test_validate_element_array_type(mock_input_manager: InputManager,
     mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
 
 
-def test_validate_element_object_type(mock_input_manager: InputManager,
-                                      mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
-                                      input_manager_original_method_states: Dict[str, Callable], ):
+def test_validate_element_valid_object_type(mock_input_manager: InputManager,
+                                            mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
+                                            input_manager_original_method_states: Dict[str, Callable], ):
     """Unit test for nested object type input_data for _validate_element in file input_manager.py"""
     mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
-    
+
     input_data = {"element4": {"nested_element1": "value1", "nested_element2": 123}}
     result = mock_input_manager._validate_element(["element4"], "property_map_key1", input_data, True)
 
     assert result["is_valid"] is True
+
+    mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
+
+
+def test_validate_element_invalid_object_type(mock_input_manager: InputManager,
+                                              mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
+                                              input_manager_original_method_states: Dict[str, Callable], ):
+    """Unit test for nested invalid object type input_data for _validate_element in file input_manager.py"""
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
+
+    input_data = {"element4": {"nested_element1": "value1", "nested_element2": 500}}
+    result = mock_input_manager._validate_element(["element4"], "property_map_key1", input_data, True)
+
+    assert result["is_valid"] is False
+
+    input_data = {"element4": {"nested_element1": "value123456789value123456789", "nested_element2": 123}}
+    result = mock_input_manager._validate_element(["element4"], "property_map_key1", input_data, True)
+
+    assert result["is_valid"] is False
+
+    mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
+
+
+def test_validate_element_valid_nested_object_type(mock_input_manager: InputManager,
+                                                   mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
+                                                   input_manager_original_method_states: Dict[str, Callable], ):
+    """Unit test for object nested within another object type
+    input_data for _validate_element in file input_manager.py"""
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
+
+    input_data = {"element5": {"nested_element1": "value1", "nested_element2": 123,
+                               "nested_element3": {"nested_sub_element1": "cows", "nested_sub_element2": [1, 2, 3]}}}
+    result = mock_input_manager._validate_element(["element5"], "property_map_key1", input_data, True)
+
+    assert result["is_valid"] is True
+
+    mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
+
+
+def test_validate_element_invalid_nested_object_type(mock_input_manager: InputManager,
+                                                     mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
+                                                     input_manager_original_method_states: Dict[str, Callable], ):
+    """Unit test for invalid object nested within another object type
+    input_data for _validate_element in file input_manager.py"""
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
+
+    input_data = {"element5": {"nested_element1": "value1", "nested_element2": 123,
+                               "nested_element3": {"nested_sub_element1": "cows", "nested_sub_element2": []}}}
+    result = mock_input_manager._validate_element(["element5"], "property_map_key1", input_data, True)
+
+    assert result["is_valid"] is False
+
+    input_data = {"element5": {"nested_element1": "value1", "nested_element2": 123,
+                               "nested_element3": {"nested_sub_element1": "invalid_cows", "nested_sub_element2": [1, 2, 3]}}}
+    result = mock_input_manager._validate_element(["element5"], "property_map_key1", input_data, True)
+
+    assert result["is_valid"] is False
 
     mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
 


### PR DESCRIPTION
This PR fixes an overlooked issue with validating nested objects in the IM's `_validate_element()` method by creating a list of keys to ignore in the nested validation loop.

Per the IM design doc, the metadata will have this structure for a nested json blob:

`"properties": {
   "<var name>": {
    "type": "object" 
    "description": "<optional description for this variable>",
     "<nested var name>": {
     "type": "<an item from list:[number, array, bool, string, –what else?-]>" 
     "description": "<optional description for this variable>",
     <data description template>
     }
   }
}`

In `_validate_element()`, if the property type is _object_, it will loop through each of the keys in the object and attempt to validate the corresponding data from the input file against them.

We don't want the IM to attempt to validate the values for the keys "type" and (optional) "description".

This PR also updates unit testing and fixes another error in the return value of the nested validation loop.