### PR TITLE
Injection manure applications

### DIFF
--- a/SC_redesign/Crop_and_Soil/field/fertilizer_application.py
+++ b/SC_redesign/Crop_and_Soil/field/fertilizer_application.py
@@ -111,7 +111,7 @@ class FertilizerApplication:
 
         """
         bottom_depths = self.soil.data.get_vectorized_layer_attribute("bottom_depth")
-        depth_factors = self._generate_depth_factors(application_depth, bottom_depths)
+        depth_factors = self.generate_depth_factors(application_depth, bottom_depths)
         for index, depth_factor in enumerate(depth_factors):
             self.soil.data.soil_layers[index].labile_inorganic_phosphorus_content += (phosphorus * depth_factor *
                                                                                       subsurface_fraction)
@@ -123,7 +123,7 @@ class FertilizerApplication:
                                                                                   subsurface_fraction)
 
     @staticmethod
-    def _generate_depth_factors(application_depth: float, soil_layer_bottom_depths: list[float]) -> list[float]:
+    def generate_depth_factors(application_depth: float, soil_layer_bottom_depths: list[float]) -> list[float]:
         """
         Generates a list of fractions that partitions sub-surface nutrients between the different soil layers.
 

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -173,27 +173,24 @@ class Field:
         without applying any fertilizer.
 
         """
-        info_map = {"class": self.__class__.__name__, "function": self._execute_fertilizer_application.__name__,
-                    "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day}}
         if requested_nitrogen == requested_phosphorus == 0.0:
+            info_map = {"class": self.__class__.__name__, "function": self._execute_fertilizer_application.__name__,
+                        "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day}}
             log_message = "Tried to apply fertilizer with no nitrogen or phosphorus requested."
             om.add_log("fertilizer_application_log", log_message, info_map)
             return
 
         invalid_depth_and_remainder_fraction = (application_depth == 0.0 and surface_remainder_fraction != 1.0) or \
                                                (application_depth > 0.0 and surface_remainder_fraction == 1.0)
+        error_message = "fertilizer_application_error"
         if invalid_depth_and_remainder_fraction:
-            error_message = f"Invalid application depth ({application_depth}) and surface remainder fraction " \
-                            f"({surface_remainder_fraction}). Defaulting to application depth of 0.0 mm and a surface" \
-                            f" remainder fraction of 1.0."
-            om.add_error("fertilizer_application_error", error_message, info_map)
+            self._record_nutrient_application_error(application_depth, surface_remainder_fraction, error_message, year,
+                                                    day)
             application_depth = 0.0
             surface_remainder_fraction = 1.0
 
         if application_depth > self.soil.data.soil_layers[-1].bottom_depth:
-            error_message = f"Invalid application depth ({application_depth}) is lower than the bottom depth of the " \
-                            f"soil profile, setting the application depth to be at the bottom of the soil profile."
-            om.add_error("fertilizer_application_error", error_message, info_map)
+            self._record_nutrient_application_error(application_depth, None, error_message, year, day)
             application_depth = self.soil.data.soil_layers[-1].bottom_depth
 
         try:
@@ -372,10 +369,10 @@ class Field:
         are corrected, an error is logged to the OutputManager, and execution continues with the new values.
 
         """
-        info_map = {"class": self.__class__.__name__, "function": self._execute_manure_application.__name__,
-                    "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day}}
         if requested_nitrogen == requested_phosphorus == 0.0:
-            log_message = "Tried to apply fertilizer with no nitrogen or phosphorus requested."
+            info_map = {"class": self.__class__.__name__, "function": self._execute_manure_application.__name__,
+                        "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day}}
+            log_message = "Tried to apply manure with no nitrogen or phosphorus requested."
             om.add_log("manure_application_log", log_message, info_map)
             return
 
@@ -394,19 +391,16 @@ class Field:
 
             invalid_depth_and_remainder_fraction = (application_depth == 0.0 and surface_remainder_fraction != 1.0) or \
                                                    (application_depth > 0.0 and surface_remainder_fraction == 1.0)
+
+            error_name = "manure_application_error"
             if invalid_depth_and_remainder_fraction:
-                error_message = f"Invalid application depth ({application_depth}) and surface remainder fraction " \
-                                f"({surface_remainder_fraction}). Defaulting to application depth of 0.0 mm and a " \
-                                f"surface remainder fraction of 1.0."
-                om.add_error("manure_application_error", error_message, info_map)
+                self._record_nutrient_application_error(application_depth, surface_remainder_fraction, error_name, year,
+                                                        day)
                 application_depth = 0.0
                 surface_remainder_fraction = 1.0
 
             if application_depth > self.soil.data.soil_layers[-1].bottom_depth:
-                error_message = f"Invalid application depth ({application_depth}) is lower than the bottom depth of " \
-                                f"the soil profile, setting the application depth to be at the bottom of the soil " \
-                                f"profile."
-                om.add_error("manure_application_error", error_message, info_map)
+                self._record_nutrient_application_error(application_depth, None, error_name, year, day)
                 application_depth = self.soil.data.soil_layers[-1].bottom_depth
 
             self.manure_applicator.apply_machine_manure(
@@ -488,6 +482,39 @@ class Field:
                  "phosphorus": phosphorus, "potassium": potassium}
         om.add_variable("manure_application", value, info_map)
 
+    def _record_nutrient_application_error(self, application_depth: float, surface_remainder_fraction: Optional[float],
+                                           error_name: str, year: int, day: int) -> None:
+        """
+        Logs errors to the OutputManager when attempting injection applications of manure or fertilizer.
+
+        Parameters
+        ----------
+        application_depth : float
+            Depth of the manure or fertilizer application (mm).
+        surface_remainder_fraction : Optional[float]
+            Fraction of manure or fertilizer applied that remains on the soil surface after application (unitless).
+        error_name : str
+            Name of the error, indicating whether it occurred during manure or fertilizer application.
+
+        Notes
+        -----
+        There are two possible errors that this method can log. One is an invalid combination of application depth and
+        surface remainder fraction, the other is an application depth deeper than the bottom of the soil profile. The
+        two are differentiated by what is passed for `surface_remainder_fraction`. If it is a number, it is the former,
+        and if None, then it is the latter.
+
+        """
+        info_map = {"class": self.__class__.__name__, "function": self._execute_manure_application.__name__,
+                    "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day}}
+        if surface_remainder_fraction is not None:
+            error_message = f"Invalid application depth ({application_depth}) and surface remainder fraction " \
+                            f"({surface_remainder_fraction}). Defaulting to application depth of 0.0 mm and a " \
+                            f"surface remainder fraction of 1.0."
+        else:
+            error_message = f"Invalid application depth ({application_depth}) is lower than the bottom depth of " \
+                            f"the soil profile, setting the application depth to be at the bottom of the soil " \
+                            f"profile."
+        om.add_error(error_name, error_message, info_map)
     # </editor-fold>
 
     # <editor-fold desc="--- Scheduling Methods ---">

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -389,6 +389,8 @@ class Field:
                 dry_matter_fraction=manure_supplied.dry_matter_fraction,
                 total_phosphorus_mass=manure_supplied.phosphorus,
                 field_coverage=field_coverage,
+                application_depth=application_depth,
+                surface_remainder_fraction=surface_remainder_fraction,
                 field_size=self.field_data.field_size,
                 inorganic_nitrogen_fraction=total_inorganic_nitrogen_fraction,
                 ammonium_fraction=manure_supplied.ammonium_nitrogen_fraction,
@@ -401,6 +403,8 @@ class Field:
                                             nitrogen=manure_supplied.nitrogen,
                                             phosphorus=manure_supplied.phosphorus,
                                             potassium=None,
+                                            application_depth=application_depth,
+                                            surface_remainder_fraction=surface_remainder_fraction,
                                             year=year,
                                             day=day)
         else:
@@ -420,7 +424,8 @@ class Field:
                                              application_depth, surface_remainder_fraction, year, day)
 
     def _record_manure_application(self, dry_matter_mass: float, dry_matter_fraction: float, field_coverage: float,
-                                   nitrogen: float, phosphorus: float, year: int, day: int,
+                                   nitrogen: float, phosphorus: float, application_depth: float,
+                                   surface_remainder_fraction: float, year: int, day: int,
                                    potassium: Optional[float] = None) -> None:
         """
         Records the amount of manure and related values for an individual manure application.
@@ -437,6 +442,10 @@ class Field:
             Mass of nitrogen in the manure applied (kg)
         phosphorus : float
             Mass of phosphorus in the manure applied (kg)
+        application_depth : float
+            Depth at which fertilizer is injected into the soil (mm).
+        surface_remainder_fraction : float
+            Fraction of fertilizer applied that remains on the soil surface after application (unitless).
         year : int
             Calendar year in which this manure application occurs.
         day : int
@@ -449,7 +458,9 @@ class Field:
                     "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day},
                     "field_size": self.field_data.field_size}
         value = {"dry_matter_mass": dry_matter_mass, "dry_matter_fraction": dry_matter_fraction, "field_coverage":
-                 field_coverage, "nitrogen": nitrogen, "phosphorus": phosphorus, "potassium": potassium}
+                 field_coverage, "application_depth": application_depth,
+                 "surface_remainder_fraction": surface_remainder_fraction, "nitrogen": nitrogen,
+                 "phosphorus": phosphorus, "potassium": potassium}
         om.add_variable("manure_application", value, info_map)
 
     # </editor-fold>

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -372,7 +372,11 @@ class Field:
         are corrected, an error is raised to the OutputManager, and execution continues with the new values.
 
         """
+        info_map = {"class": self.__class__.__name__, "function": self._execute_manure_application.__name__,
+                    "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day}}
         if requested_nitrogen == requested_phosphorus == 0.0:
+            log_message = "Tried to apply fertilizer with no nitrogen or phosphorus requested."
+            om.add_log("manure_application_log", log_message, info_map)
             return
 
         nutrient_request = NutrientRequest(nitrogen=requested_nitrogen, phosphorus=requested_phosphorus)
@@ -388,8 +392,6 @@ class Field:
             total_organic_nitrogen_fraction = \
                 (manure_supplied.nitrogen / manure_supplied.dry_matter) * manure_supplied.organic_nitrogen_fraction
 
-            info_map = {"class": self.__class__.__name__, "function": self._execute_manure_application.__name__,
-                        "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day}}
             invalid_depth_and_remainder_fraction = (application_depth == 0.0 and surface_remainder_fraction != 1.0) or \
                                                    (application_depth > 0.0 and surface_remainder_fraction == 1.0)
             if invalid_depth_and_remainder_fraction:

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -324,7 +324,7 @@ class Field:
         application_depth : float
             Depth at which fertilizer is injected into the soil (mm).
         surface_remainder_fraction : float
-            Fraction of fertilizer applied that remains on the soil surface after application.
+            Fraction of fertilizer applied that remains on the soil surface after application (unitless).
         year : int
             Calendar year in which the fertilizer application is occurring.
         day : int
@@ -340,7 +340,8 @@ class Field:
         om.add_variable("fertilizer_application", value, info_map)
 
     def _execute_manure_application(self, requested_nitrogen: float, requested_phosphorus: float, field_coverage: float,
-                                    year: int, day: int) -> None:
+                                    application_depth: float, surface_remainder_fraction: float, year: int,
+                                    day: int) -> None:
         """
         Builds a manure application from the requested nutrient amounts and passes that application to the
         ManureApplication module.
@@ -353,6 +354,10 @@ class Field:
             Mass of phosphorus requested to be in this manure application (kg)
         field_coverage : float
             Fraction of the field this manure is applied to (unitless)
+        application_depth : float
+            Depth at which fertilizer is injected into the soil (mm).
+        surface_remainder_fraction : float
+            Fraction of fertilizer applied that remains on the soil surface after application (unitless).
         year : int
             Calendar year in which this manure application occurs.
         day : int
@@ -411,7 +416,8 @@ class Field:
         else:
             optimal_mix = self._determine_optimal_fertilizer_mix(unmet_nitrogen_demand, unmet_phosphorus_demand,
                                                                  self.available_fertilizer_mixes)
-        self._execute_fertilizer_application(optimal_mix, unmet_nitrogen_demand, unmet_phosphorus_demand, year, day)
+        self._execute_fertilizer_application(optimal_mix, unmet_nitrogen_demand, unmet_phosphorus_demand,
+                                             application_depth, surface_remainder_fraction, year, day)
 
     def _record_manure_application(self, dry_matter_mass: float, dry_matter_fraction: float, field_coverage: float,
                                    nitrogen: float, phosphorus: float, year: int, day: int,
@@ -507,7 +513,8 @@ class Field:
         self.manure_events, todays_manure_events = self._filter_events(self.manure_events, time)
         for event in todays_manure_events:
             self._execute_manure_application(event.nitrogen_mass, event.phosphorus_mass, event.field_coverage,
-                                             event.year, event.day)
+                                             event.application_depth, event.surface_remainder_fraction, event.year,
+                                             event.day)
 
     def _check_crop_harvest_schedule(self, time) -> None:
         """

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -369,7 +369,7 @@ class Field:
         -----
         Because potassium is not currently specified in the manure request results, it is recorded as None. This method
         also checks for invalid application depths and surface remainder fractions. If invalid values are found, they
-        are corrected, an error is raised to the OutputManager, and execution continues with the new values.
+        are corrected, an error is logged to the OutputManager, and execution continues with the new values.
 
         """
         info_map = {"class": self.__class__.__name__, "function": self._execute_manure_application.__name__,

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -365,7 +365,9 @@ class Field:
 
         Notes
         -----
-        Because potassium is not currently specified in the manure request results, it is recorded as None.
+        Because potassium is not currently specified in the manure request results, it is recorded as None. This method
+        also checks for invalid application depths and surface remainder fractions. If invalid values are found, they
+        are corrected, an error is raised to the OutputManager, and execution continues with the new values.
 
         """
         if requested_nitrogen == requested_phosphorus == 0.0:
@@ -383,6 +385,25 @@ class Field:
                 (manure_supplied.nitrogen / manure_supplied.dry_matter) * manure_supplied.inorganic_nitrogen_fraction
             total_organic_nitrogen_fraction = \
                 (manure_supplied.nitrogen / manure_supplied.dry_matter) * manure_supplied.organic_nitrogen_fraction
+
+            info_map = {"class": self.__class__.__name__, "function": self._execute_manure_application.__name__,
+                        "prefix": f"field:'{self.field_data.name}'", "date": {"year": year, "day": day}}
+            invalid_depth_and_remainder_fraction = (application_depth == 0.0 and surface_remainder_fraction != 1.0) or \
+                                                   (application_depth > 0.0 and surface_remainder_fraction == 1.0)
+            if invalid_depth_and_remainder_fraction:
+                error_message = f"Invalid application depth ({application_depth}) and surface remainder fraction " \
+                                f"({surface_remainder_fraction}). Defaulting to application depth of 0.0 mm and a " \
+                                f"surface remainder fraction of 1.0."
+                om.add_error("manure_application_error", error_message, info_map)
+                application_depth = 0.0
+                surface_remainder_fraction = 1.0
+
+            if application_depth > self.soil.data.soil_layers[-1].bottom_depth:
+                error_message = f"Invalid application depth ({application_depth}) is lower than the bottom depth of " \
+                                f"the soil profile, setting the application depth to be at the bottom of the soil " \
+                                f"profile."
+                om.add_error("manure_application_error", error_message, info_map)
+                application_depth = self.soil.data.soil_layers[-1].bottom_depth
 
             self.manure_applicator.apply_machine_manure(
                 dry_matter_mass=manure_supplied.dry_matter,

--- a/SC_redesign/Crop_and_Soil/field/manure_application.py
+++ b/SC_redesign/Crop_and_Soil/field/manure_application.py
@@ -75,7 +75,8 @@ class ManureApplication:
                                          organic_nitrogen_fraction, field_size)
 
     def apply_machine_manure(self, dry_matter_mass: float, dry_matter_fraction: float,
-                             total_phosphorus_mass: float, field_coverage: float, field_size: float,
+                             total_phosphorus_mass: float, field_coverage: float, application_depth: float,
+                             surface_remainder_fraction: float, field_size: float,
                              inorganic_nitrogen_fraction: float, ammonium_fraction: float,
                              organic_nitrogen_fraction: float,
                              water_extractable_inorganic_phosphorus_fraction: float = None,
@@ -93,6 +94,10 @@ class ManureApplication:
             Total mass of phosphorus in this application of manure (kg)
         field_coverage : float
             Fraction of the field this manure is applied to (unitless)
+        application_depth : float
+            Depth at which fertilizer is injected into the soil (mm).
+        surface_remainder_fraction : float
+            Fraction of fertilizer applied that remains on the soil surface after application (unitless).
         field_size : float
             Size of the field (ha)
         inorganic_nitrogen_fraction : float

--- a/SC_redesign/Crop_and_Soil/field/manure_application.py
+++ b/SC_redesign/Crop_and_Soil/field/manure_application.py
@@ -396,16 +396,14 @@ class ManureApplication:
         bottom_depths = self.data.get_vectorized_layer_attribute("bottom_depth")
         depth_factors = FertilizerApplication.generate_depth_factors(application_depth, bottom_depths)
         water_extractable_inorganic_phosphorus = (total_phosphorus_mass *
-                                                  water_extractable_inorganic_phosphorus_fraction * subsurface_fraction)
+                                                  water_extractable_inorganic_phosphorus_fraction)
         water_extractable_organic_phosphorus = (total_phosphorus_mass * water_extractable_organic_phosphorus_fraction *
-                                                subsurface_fraction * 0.95)
-        stable_inorganic_phosphorus = (total_phosphorus_mass * stable_inorganic_phosphorus_fraction *
-                                       subsurface_fraction)
-        stable_organic_phosphorus = (total_phosphorus_mass * stable_organic_phosphorus_fraction * subsurface_fraction *
-                                     0.95)
+                                                0.95)
+        stable_inorganic_phosphorus = (total_phosphorus_mass * stable_inorganic_phosphorus_fraction)
+        stable_organic_phosphorus = (total_phosphorus_mass * stable_organic_phosphorus_fraction * 0.95)
         labile_phosphorus_addition = (water_extractable_inorganic_phosphorus + water_extractable_organic_phosphorus +
-                                      stable_organic_phosphorus)
-        active_phosphorus_addition = stable_inorganic_phosphorus
+                                      stable_organic_phosphorus) * subsurface_fraction
+        active_phosphorus_addition = stable_inorganic_phosphorus * subsurface_fraction
         for index, depth_factor in enumerate(depth_factors):
             labile_phosphorus_added_to_layer = labile_phosphorus_addition * depth_factor
             active_phosphorus_added_to_layer = active_phosphorus_addition * depth_factor

--- a/SC_redesign/Crop_and_Soil/field/manure_application.py
+++ b/SC_redesign/Crop_and_Soil/field/manure_application.py
@@ -410,11 +410,18 @@ class ManureApplication:
         field_size : float
             Size of the field (ha).
 
+        Notes
+        -----
+        Only 95% of water extractable organic and stable organic phosphorus are put into their corresponding pools
+        because that is how SurPhos transfers organic phosphorus, as an approximation for organic phosphorus loss. This
+        practice will be changed when issue #444 is addressed.
+
         """
         bottom_depths = self.data.get_vectorized_layer_attribute("bottom_depth")
         depth_factors = FertilizerApplication.generate_depth_factors(application_depth, bottom_depths)
         water_extractable_inorganic_phosphorus = (total_phosphorus_mass *
                                                   water_extractable_inorganic_phosphorus_fraction)
+        # TODO: put subsurface organic phosphorus into corresponding soil pools - issue #444
         water_extractable_organic_phosphorus = (total_phosphorus_mass * water_extractable_organic_phosphorus_fraction *
                                                 0.95)
         stable_inorganic_phosphorus = (total_phosphorus_mass * stable_inorganic_phosphorus_fraction)

--- a/SC_redesign/Crop_and_Soil/field/manure_application.py
+++ b/SC_redesign/Crop_and_Soil/field/manure_application.py
@@ -260,6 +260,8 @@ class ManureApplication:
         the Fortran code was sent to the RuFaS team.
 
         """
+        # TODO: evaluate how to best apply subsurface liquid manure, it is likely more complicated than how this method
+        #   accomplishes it - issue #713
         surface_dry_matter_mass = dry_matter_mass * surface_remainder_fraction
         wet_rate = self._determine_wet_rate_factor(surface_dry_matter_mass, dry_matter_fraction, field_coverage,
                                                    field_size)

--- a/SC_redesign/Crop_and_Soil/field/manure_application.py
+++ b/SC_redesign/Crop_and_Soil/field/manure_application.py
@@ -1,5 +1,6 @@
 from typing import Optional, Dict
 
+from SC_redesign.Crop_and_Soil.field.fertilizer_application import FertilizerApplication
 from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 from SC_redesign.Crop_and_Soil.crop_and_soil_constants import KILOGRAMS_TO_GRAMS, SQUARE_CENTIMETERS_TO_HECTARES
 
@@ -175,28 +176,46 @@ class ManureApplication:
             Size of the field (ha)
 
         """
+        surface_dry_matter_mass = dry_matter_mass * surface_remainder_fraction
         water_extractable_organic_phosphorus_fraction = 0.05
         stable_phosphorus_fraction = 1.0 - (water_extractable_organic_phosphorus_fraction +
                                             water_extractable_inorganic_phosphorus_fraction)
         stable_inorganic_phosphorus_fraction = 0.25 * stable_phosphorus_fraction
         stable_organic_phosphorus_fraction = 0.75 * stable_phosphorus_fraction
         self.data.machine_water_extractable_inorganic_phosphorus += (total_phosphorus_mass *
-                                                                     water_extractable_inorganic_phosphorus_fraction)
+                                                                     water_extractable_inorganic_phosphorus_fraction *
+                                                                     surface_remainder_fraction)
         self.data.machine_water_extractable_organic_phosphorus += (total_phosphorus_mass *
-                                                                   water_extractable_organic_phosphorus_fraction)
-        self.data.machine_stable_inorganic_phosphorus += (total_phosphorus_mass * stable_inorganic_phosphorus_fraction)
-        self.data.machine_stable_organic_phosphorus += (total_phosphorus_mass * stable_organic_phosphorus_fraction)
+                                                                   water_extractable_organic_phosphorus_fraction *
+                                                                   surface_remainder_fraction)
+        self.data.machine_stable_inorganic_phosphorus += (total_phosphorus_mass * stable_inorganic_phosphorus_fraction *
+                                                          surface_remainder_fraction)
+        self.data.machine_stable_organic_phosphorus += (total_phosphorus_mass * stable_organic_phosphorus_fraction *
+                                                        surface_remainder_fraction)
 
         new_vals = self._determine_weighted_manure_attributes(self.data.machine_manure_dry_mass,
                                                               self.data.machine_manure_moisture_factor,
-                                                              self.data.machine_manure_field_coverage, dry_matter_mass,
-                                                              dry_matter_fraction, field_coverage)
+                                                              self.data.machine_manure_field_coverage,
+                                                              surface_dry_matter_mass, dry_matter_fraction,
+                                                              field_coverage)
         self.data.machine_manure_dry_mass = new_vals.get("new_dry_matter_mass")
         self.data.machine_manure_moisture_factor = new_vals.get("new_moisture_factor")
         self.data.machine_manure_field_coverage = new_vals.get("new_field_coverage")
 
-        self._add_nitrogen_to_soil_layer(0, dry_matter_mass, inorganic_nitrogen_fraction, ammonium_fraction,
+        self._add_nitrogen_to_soil_layer(0, surface_dry_matter_mass, inorganic_nitrogen_fraction, ammonium_fraction,
                                          organic_nitrogen_fraction, field_size)
+
+        is_not_injection_application = application_depth == 0.0 and surface_remainder_fraction == 1.0
+        if is_not_injection_application:
+            return
+
+        subsurface_fraction = 1.0 - surface_remainder_fraction
+        self._apply_subsurface_manure(total_phosphorus_mass, water_extractable_inorganic_phosphorus_fraction,
+                                      water_extractable_organic_phosphorus_fraction,
+                                      stable_inorganic_phosphorus_fraction, stable_organic_phosphorus_fraction,
+                                      dry_matter_mass, inorganic_nitrogen_fraction, ammonium_fraction,
+                                      organic_nitrogen_fraction, application_depth, subsurface_fraction,
+                                      field_size)
 
     def _apply_liquid_machine_manure(self, dry_matter_mass: float, dry_matter_fraction: float,
                                      total_phosphorus_mass: float, field_coverage: float, application_depth: float,
@@ -331,6 +350,71 @@ class ManureApplication:
         self.data.soil_layers[layer_index].ammonium_content += ammonium_added
         self.data.soil_layers[layer_index].fresh_organic_nitrogen_content += organic_nitrogen_added
         self.data.soil_layers[layer_index].active_organic_nitrogen_content += organic_nitrogen_added
+
+    def _apply_subsurface_manure(self, total_phosphorus_mass: float,
+                                 water_extractable_inorganic_phosphorus_fraction: float,
+                                 water_extractable_organic_phosphorus_fraction: float,
+                                 stable_inorganic_phosphorus_fraction: float, stable_organic_phosphorus_fraction: float,
+                                 dry_matter_mass: float, inorganic_nitrogen_fraction: float, ammonium_fraction: float,
+                                 organic_nitrogen_fraction: float, application_depth: float, subsurface_fraction: float,
+                                 field_size: float) -> None:
+        """
+        Applies subsurface nutrients to the soil profile.
+
+        Parameters
+        ----------
+        total_phosphorus_mass : float
+            Total mass of phosphorus in this application of manure (kg).
+        water_extractable_inorganic_phosphorus_fraction : float
+            Fraction of total phosphorus in this application of manure that is water extractable inorganic phosphorus,
+            in the range [0.0, 1.0] (unitless).
+        water_extractable_organic_phosphorus_fraction : float
+            Fraction of total phosphorus in this application of manure that is water extractable organic phosphorus, in
+            the range [0.0, 1.0] (unitless).
+        stable_inorganic_phosphorus_fraction : float
+            Fraction of total phosphorus in this application of manure that is stable inorganic phosphorus, in the range
+            [0.0, 1.0] (unitless).
+        stable_organic_phosphorus_fraction : float
+            Fraction of total phosphorus in this application of manure that is stable organic phosphorus, in the range
+            [0.0, 1.0] (unitless).
+        dry_matter_mass : float
+            Dry weight equivalent of the manure application (kg).
+        inorganic_nitrogen_fraction : float
+            Fraction of dry manure mass that is inorganic nitrogen (unitless).
+        ammonium_fraction : float
+            Fraction of inorganic nitrogen that is ammonium (unitless).
+        organic_nitrogen_fraction : float
+            Fraction of dry manure mass that is organic nitrogen (unitless).
+        application_depth : float
+            Depth at which fertilizer is injected into the soil (mm).
+        subsurface_fraction : float
+            Fraction of total manure application that is applied below the soil surface (unitless).
+        field_size : float
+            Size of the field (ha).
+
+        """
+        bottom_depths = self.data.get_vectorized_layer_attribute("bottom_depth")
+        depth_factors = FertilizerApplication.generate_depth_factors(application_depth, bottom_depths)
+        water_extractable_inorganic_phosphorus = (total_phosphorus_mass *
+                                                  water_extractable_inorganic_phosphorus_fraction * subsurface_fraction)
+        water_extractable_organic_phosphorus = (total_phosphorus_mass * water_extractable_organic_phosphorus_fraction *
+                                                subsurface_fraction * 0.95)
+        stable_inorganic_phosphorus = (total_phosphorus_mass * stable_inorganic_phosphorus_fraction *
+                                       subsurface_fraction)
+        stable_organic_phosphorus = (total_phosphorus_mass * stable_organic_phosphorus_fraction * subsurface_fraction *
+                                     0.95)
+        labile_phosphorus_addition = (water_extractable_inorganic_phosphorus + water_extractable_organic_phosphorus +
+                                      stable_organic_phosphorus)
+        active_phosphorus_addition = stable_inorganic_phosphorus
+        for index, depth_factor in enumerate(depth_factors):
+            labile_phosphorus_added_to_layer = labile_phosphorus_addition * depth_factor
+            active_phosphorus_added_to_layer = active_phosphorus_addition * depth_factor
+            self.data.soil_layers[index].add_to_labile_phosphorus(labile_phosphorus_added_to_layer, field_size)
+            self.data.soil_layers[index].add_to_active_phosphorus(active_phosphorus_added_to_layer, field_size)
+
+            dry_matter_added_to_layer = dry_matter_mass * subsurface_fraction * depth_factor
+            self._add_nitrogen_to_soil_layer(index, dry_matter_added_to_layer, inorganic_nitrogen_fraction,
+                                             ammonium_fraction, organic_nitrogen_fraction, field_size)
 
     # --- Static Methods ---
     @staticmethod

--- a/SC_redesign/Crop_and_Soil/field/manure_application.py
+++ b/SC_redesign/Crop_and_Soil/field/manure_application.py
@@ -22,7 +22,7 @@ class ManureApplication:
             provided.
         field_size : float, optional
             Used to initialize a SoilData object for this module to work with, if a pre-configured SoilData object is
-            not provided (ha)
+            not provided (ha).
 
         """
         self.data = soil_data or SoilData(field_size=field_size)
@@ -36,19 +36,19 @@ class ManureApplication:
         Parameters
         ----------
         dry_matter_mass : float
-            Dry weight equivalent of this application (kg)
+            Dry weight equivalent of this application (kg).
         dry_matter_fraction : float
-            Fraction of this manure application that is dry matter, in the range (0.0, 1.0] (unitless)
+            Fraction of this manure application that is dry matter, in the range (0.0, 1.0] (unitless).
         total_phosphorus_mass : float
-            Total mass of phosphorus in this application of manure (kg)
+            Total mass of phosphorus in this application of manure (kg).
         inorganic_nitrogen_fraction : float
-            Fraction of dry manure mass that is inorganic nitrogen (unitless)
+            Fraction of dry manure mass that is inorganic nitrogen (unitless).
         ammonium_fraction : float
-            Fraction of inorganic nitrogen that is ammonium (unitless)
+            Fraction of inorganic nitrogen that is ammonium (unitless).
         organic_nitrogen_fraction : float
-            Fraction of dry manure mass that is organic nitrogen (unitless)
+            Fraction of dry manure mass that is organic nitrogen (unitless).
         field_size : float
-            Size of the field (ha)
+            Size of the field (ha).
 
         Notes
         -----
@@ -88,11 +88,11 @@ class ManureApplication:
         Parameters
         ----------
         dry_matter_mass : float
-            Dry weight equivalent of this application (kg)
+            Dry weight equivalent of this application (kg).
         dry_matter_fraction : float
-            Fraction of this manure application that is dry matter, in the range (0.0, 1.0] (unitless)
+            Fraction of this manure application that is dry matter, in the range (0.0, 1.0] (unitless).
         total_phosphorus_mass : float
-            Total mass of phosphorus in this application of manure (kg)
+            Total mass of phosphorus in this application of manure (kg).
         field_coverage : float
             Fraction of the field this manure is applied to (unitless).
         application_depth : float
@@ -100,23 +100,23 @@ class ManureApplication:
         surface_remainder_fraction : float
             Fraction of fertilizer applied that remains on the soil surface after application (unitless).
         field_size : float
-            Size of the field (ha)
+            Size of the field (ha).
         inorganic_nitrogen_fraction : float
-            Fraction of dry manure mass that is inorganic nitrogen (unitless)
+            Fraction of dry manure mass that is inorganic nitrogen (unitless).
         ammonium_fraction : float
-            Fraction of inorganic nitrogen that is ammonium (unitless)
+            Fraction of inorganic nitrogen that is ammonium (unitless).
         organic_nitrogen_fraction : float
-            Fraction of dry manure mass that is organic nitrogen (unitless)
+            Fraction of dry manure mass that is organic nitrogen (unitless).
         water_extractable_inorganic_phosphorus_fraction : float, default=None
             Fraction of total phosphorus in this application of manure that is water extractable inorganic phosphorus,
-            in the range [0.0, 1.0] (unitless)
+            in the range [0.0, 1.0] (unitless).
         source_animal : str, default=None
-            Type of animal that produced this manure (options are "CATTLE", "SWINE", or "POULTRY") (unitless)
+            Type of animal that produced this manure (options are "CATTLE", "SWINE", or "POULTRY") (unitless).
 
         Raises
         ------
         ValueError
-            If the water extractable inorganic phosphorus fraction is not inside the range [0.0, 0.95]
+            If the water extractable inorganic phosphorus fraction is not inside the range [0.0, 0.95].
 
         """
         if water_extractable_inorganic_phosphorus_fraction is not None:
@@ -152,28 +152,28 @@ class ManureApplication:
         Parameters
         ----------
         dry_matter_mass : float
-            Dry weight equivalent of this application (kg)
+            Dry weight equivalent of this application (kg).
         dry_matter_fraction : float
-            Fraction of this manure application that is dry matter, in the range (0.0, 1.0] (unitless)
+            Fraction of this manure application that is dry matter, in the range (0.0, 1.0] (unitless).
         total_phosphorus_mass : float
             Total mass of phosphorus in this application of manure (kg).
         field_coverage : float
-            Fraction of the field this manure is applied to (unitless)
+            Fraction of the field this manure is applied to (unitless).
         application_depth : float
             Depth at which fertilizer is injected into the soil (mm).
         surface_remainder_fraction : float
             Fraction of fertilizer applied that remains on the soil surface after application (unitless).
         water_extractable_inorganic_phosphorus_fraction : float
             Fraction of total phosphorus in this application of manure that is water extractable inorganic phosphorus,
-            in the range [0.0, 1.0] (unitless)
+            in the range [0.0, 1.0] (unitless).
         inorganic_nitrogen_fraction : float
-            Fraction of dry manure mass that is inorganic nitrogen (unitless)
+            Fraction of dry manure mass that is inorganic nitrogen (unitless).
         ammonium_fraction : float
-            Fraction of inorganic nitrogen that is ammonium (unitless)
+            Fraction of inorganic nitrogen that is ammonium (unitless).
         organic_nitrogen_fraction : float
-            Fraction of dry manure mass that is organic nitrogen (unitless)
+            Fraction of dry manure mass that is organic nitrogen (unitless).
         field_size : float
-            Size of the field (ha)
+            Size of the field (ha).
 
         """
         surface_dry_matter_mass = dry_matter_mass * surface_remainder_fraction
@@ -228,11 +228,11 @@ class ManureApplication:
         Parameters
         ----------
         dry_matter_mass : float
-            Dry weight equivalent of this application (kg)
+            Dry weight equivalent of this application (kg).
         dry_matter_fraction : float
-            Fraction of this manure application that is dry matter, in the range (0.0, 1.0] (unitless)
+            Fraction of this manure application that is dry matter, in the range (0.0, 1.0] (unitless).
         total_phosphorus_mass : float
-            Total mass of phosphorus in this application of manure (kg)
+            Total mass of phosphorus in this application of manure (kg).
         field_coverage : float
             Fraction of the field this manure is applied to (unitless).
         application_depth : float
@@ -240,16 +240,16 @@ class ManureApplication:
         surface_remainder_fraction : float
             Fraction of fertilizer applied that remains on the soil surface after application (unitless).
         field_size : float
-            Size of the field (ha)
+            Size of the field (ha).
         water_extractable_inorganic_phosphorus_fraction : float
             Fraction of total phosphorus in this application of manure that is water extractable inorganic phosphorus,
-            in the range [0.0, 1.0] (unitless)
+            in the range [0.0, 1.0] (unitless).
         inorganic_nitrogen_fraction : float
-            Fraction of dry manure mass that is inorganic nitrogen (unitless)
+            Fraction of dry manure mass that is inorganic nitrogen (unitless).
         ammonium_fraction : float
-            Fraction of inorganic nitrogen that is ammonium (unitless)
+            Fraction of inorganic nitrogen that is ammonium (unitless).
         organic_nitrogen_fraction : float
-            Fraction of dry manure mass that is organic nitrogen (unitless)
+            Fraction of dry manure mass that is organic nitrogen (unitless).
 
         Notes
         -----
@@ -338,17 +338,17 @@ class ManureApplication:
         Parameters
         ----------
         layer_index : int
-            Index of the soil layer to be added to (unitless)
+            Index of the soil layer to be added to (unitless).
         dry_matter_mass : float
-            Dry weight equivalent of this application (kg)
+            Dry weight equivalent of this application (kg).
         inorganic_nitrogen_fraction : float
-            Fraction of dry manure mass that is inorganic nitrogen (unitless)
+            Fraction of dry manure mass that is inorganic nitrogen (unitless).
         ammonium_fraction : float
-            Fraction of inorganic nitrogen that is ammonium (unitless)
+            Fraction of inorganic nitrogen that is ammonium (unitless).
         organic_nitrogen_fraction : float
-            Fraction of dry manure mass that is organic nitrogen (unitless)
+            Fraction of dry manure mass that is organic nitrogen (unitless).
         field_size : float
-            Size of the field (ha)
+            Size of the field (ha).
 
         References
         ----------

--- a/SC_redesign/Crop_and_Soil/field/manure_application.py
+++ b/SC_redesign/Crop_and_Soil/field/manure_application.py
@@ -128,18 +128,20 @@ class ManureApplication:
 
         if dry_matter_fraction <= 0.15:
             self._apply_liquid_machine_manure(dry_matter_mass, dry_matter_fraction, total_phosphorus_mass,
-                                              field_coverage, field_size,
+                                              field_coverage, application_depth, surface_remainder_fraction, field_size,
                                               water_extractable_inorganic_phosphorus_fraction,
                                               inorganic_nitrogen_fraction, ammonium_fraction, organic_nitrogen_fraction)
         else:
             self._apply_solid_machine_manure(dry_matter_mass, dry_matter_fraction, total_phosphorus_mass,
-                                             field_coverage, water_extractable_inorganic_phosphorus_fraction,
+                                             field_coverage, application_depth, surface_remainder_fraction,
+                                             water_extractable_inorganic_phosphorus_fraction,
                                              inorganic_nitrogen_fraction, ammonium_fraction, organic_nitrogen_fraction,
                                              field_size)
         self.data.machine_manure_applied_mass = dry_matter_mass
 
     def _apply_solid_machine_manure(self, dry_matter_mass: float, dry_matter_fraction: float,
-                                    total_phosphorus_mass: float, field_coverage: float,
+                                    total_phosphorus_mass: float, field_coverage: float, application_depth: float,
+                                    surface_remainder_fraction: float,
                                     water_extractable_inorganic_phosphorus_fraction: float,
                                     inorganic_nitrogen_fraction: float, ammonium_fraction: float,
                                     organic_nitrogen_fraction: float, field_size: float) -> None:
@@ -156,6 +158,10 @@ class ManureApplication:
             Total mass of phosphorus in this application of manure (kg)
         field_coverage : float
             Fraction of the field this manure is applied to (unitless)
+        application_depth : float
+            Depth at which fertilizer is injected into the soil (mm).
+        surface_remainder_fraction : float
+            Fraction of fertilizer applied that remains on the soil surface after application (unitless).
         water_extractable_inorganic_phosphorus_fraction : float
             Fraction of total phosphorus in this application of manure that is water extractable inorganic phosphorus,
             in the range [0.0, 1.0] (unitless)
@@ -193,7 +199,8 @@ class ManureApplication:
                                          organic_nitrogen_fraction, field_size)
 
     def _apply_liquid_machine_manure(self, dry_matter_mass: float, dry_matter_fraction: float,
-                                     total_phosphorus_mass: float, field_coverage: float, field_size: float,
+                                     total_phosphorus_mass: float, field_coverage: float, application_depth: float,
+                                     surface_remainder_fraction: float, field_size: float,
                                      water_extractable_inorganic_phosphorus_fraction: float,
                                      inorganic_nitrogen_fraction: float, ammonium_fraction: float,
                                      organic_nitrogen_fraction: float) -> None:
@@ -209,6 +216,10 @@ class ManureApplication:
             Total mass of phosphorus in this application of manure (kg)
         field_coverage : float
             Fraction of the field this manure is applied to (unitless)
+        application_depth : float
+            Depth at which fertilizer is injected into the soil (mm).
+        surface_remainder_fraction : float
+            Fraction of fertilizer applied that remains on the soil surface after application (unitless).
         field_size : float
             Size of the field (ha)
         water_extractable_inorganic_phosphorus_fraction : float

--- a/SC_redesign/Crop_and_Soil/field/manure_application.py
+++ b/SC_redesign/Crop_and_Soil/field/manure_application.py
@@ -260,7 +260,9 @@ class ManureApplication:
         the Fortran code was sent to the RuFaS team.
 
         """
-        wet_rate = self._determine_wet_rate_factor(dry_matter_mass, dry_matter_fraction, field_coverage, field_size)
+        surface_dry_matter_mass = dry_matter_mass * surface_remainder_fraction
+        wet_rate = self._determine_wet_rate_factor(surface_dry_matter_mass, dry_matter_fraction, field_coverage,
+                                                   field_size)
         soil_infiltration = self._determine_infiltration_factor(wet_rate)
         surface_retention = (1.0 - soil_infiltration)
         water_extractable_organic_phosphorus_fraction = 0.05
@@ -270,13 +272,13 @@ class ManureApplication:
         stable_organic_phosphorus_fraction = 0.75 * stable_phosphorus_fraction
 
         self.data.machine_water_extractable_inorganic_phosphorus += total_phosphorus_mass * \
-            water_extractable_inorganic_phosphorus_fraction * surface_retention
+            water_extractable_inorganic_phosphorus_fraction * surface_retention * surface_remainder_fraction
         self.data.machine_water_extractable_organic_phosphorus += total_phosphorus_mass * \
-            water_extractable_organic_phosphorus_fraction * surface_retention
+            water_extractable_organic_phosphorus_fraction * surface_retention * surface_remainder_fraction
         self.data.machine_stable_inorganic_phosphorus += total_phosphorus_mass * \
-            stable_inorganic_phosphorus_fraction * surface_retention
+            stable_inorganic_phosphorus_fraction * surface_retention * surface_remainder_fraction
         self.data.machine_stable_organic_phosphorus += total_phosphorus_mass * \
-            stable_organic_phosphorus_fraction * surface_retention
+            stable_organic_phosphorus_fraction * surface_retention * surface_remainder_fraction
 
         # TODO: put infiltrated organic phosphorus into corresponding soil pools - issue #444
         mass_to_add_to_labile_P = total_phosphorus_mass * water_extractable_inorganic_phosphorus_fraction * \
@@ -284,13 +286,15 @@ class ManureApplication:
         mass_to_add_to_labile_P += total_phosphorus_mass * water_extractable_organic_phosphorus_fraction * \
             soil_infiltration * 0.95
         mass_to_add_to_labile_P += total_phosphorus_mass * stable_organic_phosphorus_fraction * soil_infiltration * 0.95
+        mass_to_add_to_labile_P *= surface_remainder_fraction
         self.data.soil_layers[0].add_to_labile_phosphorus(mass_to_add_to_labile_P, field_size)
 
-        mass_to_add_to_active_P = total_phosphorus_mass * stable_inorganic_phosphorus_fraction * soil_infiltration
+        mass_to_add_to_active_P = total_phosphorus_mass * stable_inorganic_phosphorus_fraction * soil_infiltration * \
+            surface_remainder_fraction
         self.data.soil_layers[0].add_to_active_phosphorus(mass_to_add_to_active_P, field_size)
 
         adjusted_field_coverage = field_coverage * 0.5
-        adjusted_dry_matter_mass = dry_matter_mass * 0.8
+        adjusted_dry_matter_mass = surface_dry_matter_mass * 0.8
         new_vals = self._determine_weighted_manure_attributes(self.data.machine_manure_dry_mass,
                                                               self.data.machine_manure_moisture_factor,
                                                               self.data.machine_manure_field_coverage,
@@ -300,16 +304,28 @@ class ManureApplication:
         self.data.machine_manure_moisture_factor = new_vals.get("new_moisture_factor")
         self.data.machine_manure_field_coverage = new_vals.get("new_field_coverage")
 
-        top_layer_mass = surface_retention * dry_matter_mass
+        top_layer_mass = surface_retention * surface_dry_matter_mass
         top_layer_inorganic_nitrogen_fraction = surface_retention * inorganic_nitrogen_fraction
         top_layer_organic_nitrogen_fraction = surface_retention * organic_nitrogen_fraction
         self._add_nitrogen_to_soil_layer(0, top_layer_mass, top_layer_inorganic_nitrogen_fraction, ammonium_fraction,
                                          top_layer_organic_nitrogen_fraction, field_size)
-        second_layer_mass = soil_infiltration * dry_matter_mass
+        second_layer_mass = soil_infiltration * surface_dry_matter_mass
         second_layer_inorganic_nitrogen_fraction = soil_infiltration * inorganic_nitrogen_fraction
         second_layer_organic_nitrogen_fraction = soil_infiltration * organic_nitrogen_fraction
         self._add_nitrogen_to_soil_layer(1, second_layer_mass, second_layer_inorganic_nitrogen_fraction,
                                          ammonium_fraction, second_layer_organic_nitrogen_fraction, field_size)
+
+        is_not_subsurface_application = application_depth == 0.0 and surface_remainder_fraction == 1.0
+        if is_not_subsurface_application:
+            return
+
+        subsurface_fraction = 1.0 - surface_remainder_fraction
+        self._apply_subsurface_manure(total_phosphorus_mass, water_extractable_inorganic_phosphorus_fraction,
+                                      water_extractable_organic_phosphorus_fraction,
+                                      stable_inorganic_phosphorus_fraction, stable_organic_phosphorus_fraction,
+                                      dry_matter_mass, inorganic_nitrogen_fraction, ammonium_fraction,
+                                      organic_nitrogen_fraction, application_depth, subsurface_fraction,
+                                      field_size)
 
     def _add_nitrogen_to_soil_layer(self, layer_index: int, dry_matter_mass: float, inorganic_nitrogen_fraction: float,
                                     ammonium_fraction: float, organic_nitrogen_fraction: float,

--- a/SC_redesign/Crop_and_Soil/field/manure_application.py
+++ b/SC_redesign/Crop_and_Soil/field/manure_application.py
@@ -94,7 +94,7 @@ class ManureApplication:
         total_phosphorus_mass : float
             Total mass of phosphorus in this application of manure (kg)
         field_coverage : float
-            Fraction of the field this manure is applied to (unitless)
+            Fraction of the field this manure is applied to (unitless).
         application_depth : float
             Depth at which fertilizer is injected into the soil (mm).
         surface_remainder_fraction : float
@@ -156,7 +156,7 @@ class ManureApplication:
         dry_matter_fraction : float
             Fraction of this manure application that is dry matter, in the range (0.0, 1.0] (unitless)
         total_phosphorus_mass : float
-            Total mass of phosphorus in this application of manure (kg)
+            Total mass of phosphorus in this application of manure (kg).
         field_coverage : float
             Fraction of the field this manure is applied to (unitless)
         application_depth : float
@@ -234,7 +234,7 @@ class ManureApplication:
         total_phosphorus_mass : float
             Total mass of phosphorus in this application of manure (kg)
         field_coverage : float
-            Fraction of the field this manure is applied to (unitless)
+            Fraction of the field this manure is applied to (unitless).
         application_depth : float
             Depth at which fertilizer is injected into the soil (mm).
         surface_remainder_fraction : float

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_fertilizer_application.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_fertilizer_application.py
@@ -18,7 +18,7 @@ from SC_redesign.Crop_and_Soil.soil.soil_data import SoilData
 ])
 def test_generate_depth_factors(depth: float, bottom_depths: list[float], expected: list[float]) -> None:
     """Tests that the depth factors are correctly calculated for subsurface nutrient applications."""
-    actual = FertilizerApplication._generate_depth_factors(depth, bottom_depths)
+    actual = FertilizerApplication.generate_depth_factors(depth, bottom_depths)
     assert pytest.approx(actual) == expected
 
 

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_fertilizer_application.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_fertilizer_application.py
@@ -43,7 +43,7 @@ def test_apply_subsurface_fertilizer(nutrient_amounts: float, depth: float, subs
     soil = Soil(soil_data=SoilData(soil_layers=soil_layers, field_size=field_size))
     fert_app = FertilizerApplication(soil=soil)
 
-    with patch("SC_redesign.Crop_and_Soil.field.fertilizer_application.FertilizerApplication._generate_depth_factors",
+    with patch("SC_redesign.Crop_and_Soil.field.fertilizer_application.FertilizerApplication.generate_depth_factors",
                new_callable=MagicMock, return_value=[0.1, 0.4, 0.5]) as patched_depth_factor_generator:
         fert_app._apply_subsurface_fertilizer(nutrient_amounts, nutrient_amounts, nutrient_amounts, nutrient_amounts,
                                               depth, subsurface_frac)

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -608,29 +608,19 @@ def test_execute_fertilizer_application_error(field_name: str, mix_name: str, av
     assert str(e.value) == expected_message
 
 
-@pytest.mark.parametrize("depth,remainder,expected_depth,expected_remainder,expected_info_map,expected_error_message", [
-    (1000.0, 0.1, 950.0, 0.1,
-     {"prefix": "field:'test'", "date": {"year": 1994, "day": 200}, "timestamp": "00-Jan-1970_Thu_00-00-00"},
-     "Invalid application depth (1000.0) is lower than the bottom depth of the soil profile, setting the application "
-     "depth to be at the bottom of the soil profile."),
-    (100.0, 1.0, 0.0, 1.0,
-     {"prefix": "field:'test'", "date": {"year": 1994, "day": 200}, "timestamp": "00-Jan-1970_Thu_00-00-00"},
-     "Invalid application depth (100.0) and surface remainder fraction (1.0). Defaulting to application depth of 0.0 "
-     "mm and a surface remainder fraction of 1.0."),
-    (0.0, 0.9, 0.0, 1.0,
-     {"prefix": "field:'test'", "date": {"year": 1994, "day": 200}, "timestamp": "00-Jan-1970_Thu_00-00-00"},
-     "Invalid application depth (0.0) and surface remainder fraction (0.9). Defaulting to application depth of 0.0 mm "
-     "and a surface remainder fraction of 1.0.")
+@pytest.mark.parametrize("depth,remainder,expected_depth,expected_remainder,invalid_combination", [
+    (1000.0, 0.1, 950.0, 0.1, False),
+    (100.0, 1.0, 0.0, 1.0, True),
+    (0.0, 0.9, 0.0, 1.0, True)
 ])
 def test_execute_fertilizer_application_with_invalid_args(depth: float, remainder: float, expected_depth: float,
-                                                          expected_remainder: float, expected_info_map: dict,
-                                                          expected_error_message: str) -> None:
+                                                          expected_remainder: float, invalid_combination: bool) -> None:
     """Tests that fertilizer applications with invalid arguments are caught, recorded in the OutputManager and execution
         with corrected values takes place."""
     field = Field(field_data=FieldData(name="test", field_size=1.2), manure_manager=MagicMock(ManureManager))
     field.soil.data.soil_layers[-1].bottom_depth = 950.0
-    with patch("RUFAS.output_manager.OutputManager._get_timestamp", new_callable=MagicMock,
-               return_value="00-Jan-1970_Thu_00-00-00"), \
+    with patch("SC_redesign.Crop_and_Soil.field.field.Field._record_nutrient_application_error",
+               new_callable=MagicMock) as patched_error, \
             patch("SC_redesign.Crop_and_Soil.field.field.Field._formulate_fertilizer_required", new_callable=MagicMock,
                   return_value={"total_mass": 100.0, "phosphorus_mass": 50.0, "nitrogen_mass": 50.0,
                                 "potassium_mass": 0.0}) as patched_formulator, \
@@ -640,9 +630,10 @@ def test_execute_fertilizer_application_with_invalid_args(depth: float, remainde
                   new_callable=MagicMock) as patched_recorder:
         field._execute_fertilizer_application("26_4_24", 50.0, 50.0, depth, remainder, 1994, 200)
 
-        actual = om.errors_pool["field:'test'.fertilizer_application_error"]
-        assert actual["info_maps"].__contains__(expected_info_map)
-        assert actual["values"].__contains__(expected_error_message)
+        if invalid_combination:
+            patched_error.assert_called_once_with(depth, remainder, "fertilizer_application_error", 1994, 200)
+        else:
+            patched_error.assert_called_once_with(depth, None, "fertilizer_application_error", 1994, 200)
         patched_formulator.assert_called_once_with(0.26, 0.04, 0.24, 50.0, 50.0)
         patched_applicator.assert_called_once_with(50.0, 100.0, 0.5, 0.0, 0.0, expected_depth, expected_remainder, 1.2)
         patched_recorder.assert_called_once_with("26_4_24", 100.0, 50.0, 50.0, 0.0, expected_depth, expected_remainder,
@@ -754,7 +745,7 @@ def test_execute_manure_application(nitrogen: float, phosphorus: float, coverage
         if nitrogen == phosphorus == 0.0:
             expected_info_map = {"prefix": "field:'test'", "date": {"year": year, "day": day},
                                  "timestamp": "00-Jan-1970_Thu_00-00-00"}
-            expected_log_message = "Tried to apply fertilizer with no nitrogen or phosphorus requested."
+            expected_log_message = "Tried to apply manure with no nitrogen or phosphorus requested."
             actual = om.logs_pool["field:'test'.manure_application_log"]
             assert actual["info_maps"].__contains__(expected_info_map)
             assert actual["values"].__contains__(expected_log_message)
@@ -812,23 +803,13 @@ def test_execute_manure_application(nitrogen: float, phosphorus: float, coverage
                 field._execute_fertilizer_application.assert_not_called()
 
 
-@pytest.mark.parametrize("depth,remainder,expected_depth,expected_remainder,expected_info_map,expected_error_message", [
-    (100.0, 1.0, 0.0, 1.0,
-     {"prefix": "field:'test'", "date": {"year": 2000, "day": 133}, "timestamp": "00-Jan-1970_Thu_00-00-00"},
-     "Invalid application depth (100.0) and surface remainder fraction (1.0). Defaulting to application depth of 0.0 "
-     "mm and a surface remainder fraction of 1.0."),
-    (0.0, 0.76, 0.0, 1.0,
-     {"prefix": "field:'test'", "date": {"year": 2000, "day": 133}, "timestamp": "00-Jan-1970_Thu_00-00-00"},
-     "Invalid application depth (0.0) and surface remainder fraction (0.76). Defaulting to application depth of 0.0 "
-     "mm and a surface remainder fraction of 1.0."),
-    (1000.0, 0.2, 950.0, 0.2,
-     {"prefix": "field:'test'", "date": {"year": 2000, "day": 133}, "timestamp": "00-Jan-1970_Thu_00-00-00"},
-     "Invalid application depth (1000.0) is lower than the bottom depth of the soil profile, setting the application "
-     "depth to be at the bottom of the soil profile.")
+@pytest.mark.parametrize("depth,remainder,expected_depth,expected_remainder,invalid_combination", [
+    (100.0, 1.0, 0.0, 1.0, True),
+    (0.0, 0.76, 0.0, 1.0, True),
+    (1000.0, 0.2, 950.0, 0.2, False)
 ])
 def test_execute_manure_application_with_invalid_args(depth: float, remainder: float, expected_depth: float,
-                                                      expected_remainder: float, expected_info_map: dict,
-                                                      expected_error_message: str) -> None:
+                                                      expected_remainder: float, invalid_combination: bool) -> None:
     """Tests that the manure application executor raises errors and runs correctly when invalid arguments are passed."""
     mocked_manure_manager = MagicMock(ManureManager)
     mocked_manure_manager.request_nutrients = MagicMock(return_value=NutrientRequestResults(nitrogen=50.0,
@@ -838,8 +819,8 @@ def test_execute_manure_application_with_invalid_args(depth: float, remainder: f
                                                                                             dry_matter_fraction=0.66))
     field = Field(field_data=FieldData(name="test", field_size=1.89), manure_manager=mocked_manure_manager)
     field.soil.data.soil_layers[-1].bottom_depth = 950.0
-    with patch("RUFAS.output_manager.OutputManager._get_timestamp", new_callable=MagicMock,
-               return_value="00-Jan-1970_Thu_00-00-00"), \
+    with patch("SC_redesign.Crop_and_Soil.field.field.Field._record_nutrient_application_error",
+               new_callable=MagicMock) as patched_error, \
             patch("SC_redesign.Crop_and_Soil.field.manure_application.ManureApplication.apply_machine_manure",
                   new_callable=MagicMock) as patched_manure_applicator, \
             patch("SC_redesign.Crop_and_Soil.field.field.Field._record_manure_application",
@@ -850,9 +831,10 @@ def test_execute_manure_application_with_invalid_args(depth: float, remainder: f
                   new_callable=MagicMock) as patched_fertilizer_applicator:
         field._execute_manure_application(50.0, 50.0, 0.8, depth, remainder, 2000, 133)
 
-        actual = om.errors_pool["field:'test'.manure_application_error"]
-        assert actual["info_maps"].__contains__(expected_info_map)
-        assert actual["values"].__contains__(expected_error_message)
+        if invalid_combination:
+            patched_error.assert_called_once_with(depth, remainder, "manure_application_error", 2000, 133)
+        else:
+            patched_error.assert_called_once_with(depth, None, "manure_application_error", 2000, 133)
         mocked_manure_manager.request_nutrients.assert_called_once_with(NutrientRequest(nitrogen=50.0, phosphorus=50.0))
         patched_manure_applicator.assert_called_once_with(
             dry_matter_mass=100.0,
@@ -911,6 +893,30 @@ def test_record_manure_application(field_name: str, field_size: float, dry_mass:
     actual = om.variables_pool[f"field:'{field_name}'.manure_application"]
     assert actual["info_maps"].__contains__(expected_info)
     assert actual["values"].__contains__(expected_values)
+
+
+@pytest.mark.parametrize("depth,remainder,name,year,day,expected_info_map,expected_error_message", [
+    (100.0, 1.0, "manure_application_error", 1998, 200,
+     {"prefix": "field:'test'", "date": {"year": 1998, "day": 200}, "timestamp": "00-Jan-1970_Thu_00-00-00"},
+     "Invalid application depth (100.0) and surface remainder fraction (1.0). Defaulting to application depth of 0.0 "
+     "mm and a surface remainder fraction of 1.0."),
+    (800.0, None, "fertilizer_application_error", 2005, 100,
+     {"prefix": "field:'test'", "date": {"year": 2005, "day": 100}, "timestamp": "00-Jan-1970_Thu_00-00-00"},
+     "Invalid application depth (800.0) is lower than the bottom depth of the soil profile, setting the application "
+     "depth to be at the bottom of the soil profile.")
+])
+def test_record_nutrient_application_error(depth: float, remainder: float, name: str, year: int, day: int,
+                                           expected_info_map: dict, expected_error_message: str) -> None:
+    """Tests that manure and fertilizer application errors are correctly recorded to the OutputManager."""
+    with patch("RUFAS.output_manager.OutputManager._get_timestamp", new_callable=MagicMock,
+               return_value="00-Jan-1970_Thu_00-00-00"):
+        field = Field(field_data=FieldData(name="test"), manure_manager=MagicMock(ManureManager))
+        field._record_nutrient_application_error(depth, remainder, name, year, day)
+
+        expected_error_name = expected_info_map["prefix"] + "." + name
+        actual = om.errors_pool[expected_error_name]
+        assert actual["info_maps"].__contains__(expected_info_map)
+        assert actual["values"].__contains__(expected_error_message)
 
 
 @pytest.mark.parametrize("field_size,crops_growing,residue,light,mean_temp,min_temp,max_temp,annual_mean_temp,"

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -789,29 +789,33 @@ def test_execute_manure_application(nitrogen: float, phosphorus: float, coverage
             field._execute_fertilizer_application.assert_not_called()
 
 
-@pytest.mark.parametrize("field_name,field_size,dry_mass,dry_fraction,coverage,nitrogen,phosphorus,year,day,"
-                         "expected_info,expected_values,potassium", [
-                             ("test_1", 1.3, 100, 0.1, 0.8, 10, 15, 1991, 75,
+@pytest.mark.parametrize("field_name,field_size,dry_mass,dry_fraction,coverage,nitrogen,phosphorus,depth,remainder,"
+                         "year,day,expected_info,expected_values,potassium", [
+                             ("test_1", 1.3, 100, 0.1, 0.8, 10, 15, 0.0, 1.0, 1991, 75,
                               {"prefix": "field:'test_1'", "date": {"year": 1991, "day": 75}, "field_size": 1.3},
-                              {"dry_matter_mass": 100, "dry_matter_fraction": 0.1, "field_coverage": 0.8,
-                               "nitrogen": 10, "phosphorus": 15, "potassium": 12.5}, 12.5),
-                             ("test_2", 2.4, 144.6, 0.3, 0.92, 40, 43.1, 1994, 200,
+                              {"dry_matter_mass": 100, "dry_matter_fraction": 0.1, "application_depth": 0.0,
+                               "surface_remainder_fraction": 1.0, "field_coverage": 0.8, "nitrogen": 10,
+                               "phosphorus": 15, "potassium": 12.5}, 12.5),
+                             ("test_2", 2.4, 144.6, 0.3, 0.92, 40, 43.1, 45.0, 0.85, 1994, 200,
                               {"prefix": "field:'test_2'", "date": {"year": 1994, "day": 200}, "field_size": 2.4},
-                              {"dry_matter_mass": 144.6, "dry_matter_fraction": 0.3, "field_coverage": 0.92,
-                               "nitrogen": 40, "phosphorus": 43.1, "potassium": 14.55}, 14.55),
-                             ("test_3", 0.66, 266.5, 0.44, 0.95, 100.5, 78.0, 2009, 150,
+                              {"dry_matter_mass": 144.6, "dry_matter_fraction": 0.3, "application_depth": 45.0,
+                               "surface_remainder_fraction": 0.85,  "field_coverage": 0.92, "nitrogen": 40,
+                               "phosphorus": 43.1, "potassium": 14.55}, 14.55),
+                             ("test_3", 0.66, 266.5, 0.44, 0.95, 100.5, 78.0, 120.0, 0.7, 2009, 150,
                               {"prefix": "field:'test_3'", "date": {"year": 2009, "day": 150}, "field_size": 0.66},
-                              {"dry_matter_mass": 266.5, "dry_matter_fraction": 0.44, "field_coverage": 0.95,
+                              {"dry_matter_mass": 266.5, "dry_matter_fraction": 0.44, "application_depth": 120.0,
+                               "surface_remainder_fraction": 0.7, "field_coverage": 0.95,
                                "nitrogen": 100.5, "phosphorus": 78.0, "potassium": None}, None)
                          ])
 def test_record_manure_application(field_name: str, field_size: float, dry_mass: float, dry_fraction: float,
-                                   coverage: float, nitrogen: float, phosphorus: float, year: int, day: int,
-                                   expected_info: Dict, expected_values: Dict,
+                                   coverage: float, nitrogen: float, phosphorus: float, depth: float, remainder: float,
+                                   year: int, day: int, expected_info: Dict, expected_values: Dict,
                                    potassium: float) -> None:
     """Tests that manure applications are recorded correctly."""
     field = Field(field_data=FieldData(name=field_name, field_size=field_size), manure_manager=MagicMock(ManureManager))
 
-    field._record_manure_application(dry_mass, dry_fraction, coverage, nitrogen, phosphorus, year, day, potassium)
+    field._record_manure_application(dry_mass, dry_fraction, coverage, nitrogen, phosphorus, depth, remainder, year,
+                                     day, potassium)
 
     actual = om.variables_pool[f"field:'{field_name}'.manure_application"]
     assert actual["info_maps"].__contains__(expected_info)

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -741,66 +741,75 @@ def test_execute_manure_application(nitrogen: float, phosphorus: float, coverage
     """Tests that manure is applied to the soil correctly."""
     mocked_manure_manager = MagicMock(ManureManager)
     mocked_manure_manager.request_nutrients = MagicMock(return_value=supplied_manure)
-    field = Field(field_data=FieldData(field_size=1.4), manure_manager=mocked_manure_manager)
+    field = Field(field_data=FieldData(name="test", field_size=1.4), manure_manager=mocked_manure_manager)
     field.manure_applicator.apply_machine_manure = MagicMock()
     field._record_manure_application = MagicMock()
     field._determine_optimal_fertilizer_mix = MagicMock(return_value="expected_optimal_mix")
     field._execute_fertilizer_application = MagicMock()
 
-    field._execute_manure_application(nitrogen, phosphorus, coverage, depth, remainder, year, day)
+    with patch("RUFAS.output_manager.OutputManager._get_timestamp", new_callable=MagicMock,
+               return_value="00-Jan-1970_Thu_00-00-00"):
+        field._execute_manure_application(nitrogen, phosphorus, coverage, depth, remainder, year, day)
 
-    if nitrogen == phosphorus == 0.0:
-        mocked_manure_manager.request_nutrients.assert_not_called()
-        field.manure_applicator.apply_machine_manure.assert_not_called()
-        field._record_manure_application.assert_not_called()
-        field._determine_optimal_fertilizer_mix.assert_not_called()
-        field._execute_fertilizer_application.assert_not_called()
-    else:
-        expected_total_inorganic_fraction = 0.14  # equal to (50.0 / 250.0) * 0.7
-        expected_total_organic_fraction = 0.06  # equal to (50.0 / 250.0) * 0.3
+        if nitrogen == phosphorus == 0.0:
+            expected_info_map = {"prefix": "field:'test'", "date": {"year": year, "day": day},
+                                 "timestamp": "00-Jan-1970_Thu_00-00-00"}
+            expected_log_message = "Tried to apply fertilizer with no nitrogen or phosphorus requested."
+            actual = om.logs_pool["field:'test'.manure_application_log"]
+            assert actual["info_maps"].__contains__(expected_info_map)
+            assert actual["values"].__contains__(expected_log_message)
 
-        if supplied_manure is not None:
-            mocked_manure_manager.request_nutrients.assert_called_once_with(expected_request)
-            field.manure_applicator.apply_machine_manure.assert_called_once_with(
-                dry_matter_mass=supplied_manure.dry_matter,
-                dry_matter_fraction=supplied_manure.dry_matter_fraction,
-                total_phosphorus_mass=supplied_manure.phosphorus,
-                field_coverage=coverage,
-                application_depth=depth,
-                surface_remainder_fraction=remainder,
-                field_size=1.4,
-                inorganic_nitrogen_fraction=pytest.approx(expected_total_inorganic_fraction),
-                ammonium_fraction=supplied_manure.ammonium_nitrogen_fraction,
-                organic_nitrogen_fraction=pytest.approx(expected_total_organic_fraction),
-                water_extractable_inorganic_phosphorus_fraction=supplied_manure.inorganic_phosphorus_fraction)
-            field._record_manure_application.assert_called_once_with(
-                dry_matter_mass=supplied_manure.dry_matter,
-                dry_matter_fraction=supplied_manure.dry_matter_fraction,
-                field_coverage=coverage,
-                nitrogen=supplied_manure.nitrogen,
-                phosphorus=supplied_manure.phosphorus,
-                potassium=None,
-                application_depth=depth,
-                surface_remainder_fraction=remainder,
-                year=year,
-                day=day)
-
-        if fertilizer_applied and only_nitrogen_unmet:
-            field._determine_optimal_fertilizer_mix.assert_not_called()
-            field._execute_fertilizer_application.assert_called_once_with("100_0_0", expected_unmet_nitrogen,
-                                                                          expected_unmet_phosphorus, depth, remainder,
-                                                                          year, day)
-        elif fertilizer_applied and not only_nitrogen_unmet:
-            field._determine_optimal_fertilizer_mix.assert_called_once_with(expected_unmet_nitrogen,
-                                                                            expected_unmet_phosphorus,
-                                                                            field.available_fertilizer_mixes)
-            field._execute_fertilizer_application.assert_called_once_with("expected_optimal_mix",
-                                                                          expected_unmet_nitrogen,
-                                                                          expected_unmet_phosphorus, depth, remainder,
-                                                                          year, day)
-        else:
+            mocked_manure_manager.request_nutrients.assert_not_called()
+            field.manure_applicator.apply_machine_manure.assert_not_called()
+            field._record_manure_application.assert_not_called()
             field._determine_optimal_fertilizer_mix.assert_not_called()
             field._execute_fertilizer_application.assert_not_called()
+        else:
+            expected_total_inorganic_fraction = 0.14  # equal to (50.0 / 250.0) * 0.7
+            expected_total_organic_fraction = 0.06  # equal to (50.0 / 250.0) * 0.3
+
+            if supplied_manure is not None:
+                mocked_manure_manager.request_nutrients.assert_called_once_with(expected_request)
+                field.manure_applicator.apply_machine_manure.assert_called_once_with(
+                    dry_matter_mass=supplied_manure.dry_matter,
+                    dry_matter_fraction=supplied_manure.dry_matter_fraction,
+                    total_phosphorus_mass=supplied_manure.phosphorus,
+                    field_coverage=coverage,
+                    application_depth=depth,
+                    surface_remainder_fraction=remainder,
+                    field_size=1.4,
+                    inorganic_nitrogen_fraction=pytest.approx(expected_total_inorganic_fraction),
+                    ammonium_fraction=supplied_manure.ammonium_nitrogen_fraction,
+                    organic_nitrogen_fraction=pytest.approx(expected_total_organic_fraction),
+                    water_extractable_inorganic_phosphorus_fraction=supplied_manure.inorganic_phosphorus_fraction)
+                field._record_manure_application.assert_called_once_with(
+                    dry_matter_mass=supplied_manure.dry_matter,
+                    dry_matter_fraction=supplied_manure.dry_matter_fraction,
+                    field_coverage=coverage,
+                    nitrogen=supplied_manure.nitrogen,
+                    phosphorus=supplied_manure.phosphorus,
+                    potassium=None,
+                    application_depth=depth,
+                    surface_remainder_fraction=remainder,
+                    year=year,
+                    day=day)
+
+            if fertilizer_applied and only_nitrogen_unmet:
+                field._determine_optimal_fertilizer_mix.assert_not_called()
+                field._execute_fertilizer_application.assert_called_once_with("100_0_0", expected_unmet_nitrogen,
+                                                                              expected_unmet_phosphorus, depth,
+                                                                              remainder, year, day)
+            elif fertilizer_applied and not only_nitrogen_unmet:
+                field._determine_optimal_fertilizer_mix.assert_called_once_with(expected_unmet_nitrogen,
+                                                                                expected_unmet_phosphorus,
+                                                                                field.available_fertilizer_mixes)
+                field._execute_fertilizer_application.assert_called_once_with("expected_optimal_mix",
+                                                                              expected_unmet_nitrogen,
+                                                                              expected_unmet_phosphorus, depth,
+                                                                              remainder, year, day)
+            else:
+                field._determine_optimal_fertilizer_mix.assert_not_called()
+                field._execute_fertilizer_application.assert_not_called()
 
 
 @pytest.mark.parametrize("depth,remainder,expected_depth,expected_remainder,expected_info_map,expected_error_message", [

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -167,7 +167,8 @@ def test_check_manure_application_schedule(events: List[ManureEvent], remaining_
     expected_execution_calls = []
     for event in current_events:
         expected_execution_calls.append(call(event.nitrogen_mass, event.phosphorus_mass, event.field_coverage,
-                                             event.year, event.day))
+                                             event.application_depth, event.surface_remainder_fraction, event.year,
+                                             event.day))
     field._filter_events.assert_called_once_with(events, mocked_time)
     assert field.manure_events == remaining_events
     field._execute_manure_application.assert_has_calls(expected_execution_calls)

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -546,13 +546,13 @@ def test_make_crop_from_config_dict(config: dict):
 
 
 @pytest.mark.parametrize("mix_name,requested_n,requested_p,depth,remainder,year,day,field_size,fertilizer_applied", {
-                             ("test_mix_1", 80.0, 30.0, 0.0, 1.0, 1993, 100, 3.1, True),
-                             ("test_mix_2", 150.0, 89.0, 25.0, 0.89, 2001, 240, 1.3, True),
-                             ("test_mix_3", 10.0, 90.33, 100.0, 0.5, 1992, 30, 2.44, True),
-                             ("test_mix_4", 0.0, 50.0, 0.0, 1.0, 1996, 60, 1.45, True),
-                             ("test_mix_5", 67.5, 0.0, 0.0, 1.0, 1998, 200, 2.3, True),
-                             ("test_mix_6", 0.0, 0.0, 0.0, 1.0, 1988, 120, 0.5, False),
-                         })
+    ("test_mix_1", 80.0, 30.0, 0.0, 1.0, 1993, 100, 3.1, True),
+    ("test_mix_2", 150.0, 89.0, 25.0, 0.89, 2001, 240, 1.3, True),
+    ("test_mix_3", 10.0, 90.33, 100.0, 0.5, 1992, 30, 2.44, True),
+    ("test_mix_4", 0.0, 50.0, 0.0, 1.0, 1996, 60, 1.45, True),
+    ("test_mix_5", 67.5, 0.0, 0.0, 1.0, 1998, 200, 2.3, True),
+    ("test_mix_6", 0.0, 0.0, 0.0, 1.0, 1988, 120, 0.5, False),
+})
 def test_execute_fertilizer_application(mix_name: str, requested_n: float, requested_p: float, depth: float,
                                         remainder: float, year: int, day: int, field_size: float,
                                         fertilizer_applied: bool) -> None:
@@ -795,6 +795,74 @@ def test_execute_manure_application(nitrogen: float, phosphorus: float, coverage
             field._execute_fertilizer_application.assert_not_called()
 
 
+@pytest.mark.parametrize("depth,remainder,expected_depth,expected_remainder,expected_info_map,expected_error_message", [
+    (100.0, 1.0, 0.0, 1.0,
+     {"prefix": "field:'test'", "date": {"year": 2000, "day": 133}, "timestamp": "00-Jan-1970_Thu_00-00-00"},
+     "Invalid application depth (100.0) and surface remainder fraction (1.0). Defaulting to application depth of 0.0 "
+     "mm and a surface remainder fraction of 1.0."),
+    (0.0, 0.76, 0.0, 1.0,
+     {"prefix": "field:'test'", "date": {"year": 2000, "day": 133}, "timestamp": "00-Jan-1970_Thu_00-00-00"},
+     "Invalid application depth (0.0) and surface remainder fraction (0.76). Defaulting to application depth of 0.0 "
+     "mm and a surface remainder fraction of 1.0."),
+    (1000.0, 0.2, 950.0, 0.2,
+     {"prefix": "field:'test'", "date": {"year": 2000, "day": 133}, "timestamp": "00-Jan-1970_Thu_00-00-00"},
+     "Invalid application depth (1000.0) is lower than the bottom depth of the soil profile, setting the application "
+     "depth to be at the bottom of the soil profile.")
+])
+def test_execute_manure_application_with_invalid_args(depth: float, remainder: float, expected_depth: float,
+                                                      expected_remainder: float, expected_info_map: dict,
+                                                      expected_error_message: str) -> None:
+    """Tests that the manure application executor raises errors and runs correctly when invalid arguments are passed."""
+    mocked_manure_manager = MagicMock(ManureManager)
+    mocked_manure_manager.request_nutrients = MagicMock(return_value=NutrientRequestResults(nitrogen=50.0,
+                                                                                            phosphorus=50.0,
+                                                                                            total_manure_mass=150.0,
+                                                                                            dry_matter=100.0,
+                                                                                            dry_matter_fraction=0.66))
+    field = Field(field_data=FieldData(name="test", field_size=1.89), manure_manager=mocked_manure_manager)
+    field.soil.data.soil_layers[-1].bottom_depth = 950.0
+    with patch("RUFAS.output_manager.OutputManager._get_timestamp", new_callable=MagicMock,
+               return_value="00-Jan-1970_Thu_00-00-00"), \
+            patch("SC_redesign.Crop_and_Soil.field.manure_application.ManureApplication.apply_machine_manure",
+                  new_callable=MagicMock) as patched_manure_applicator, \
+            patch("SC_redesign.Crop_and_Soil.field.field.Field._record_manure_application",
+                  new_callable=MagicMock) as patched_recorder, \
+            patch("SC_redesign.Crop_and_Soil.field.field.Field._determine_optimal_fertilizer_mix",
+                  new_callable=MagicMock, return_value="26_4_24") as patched_optimizer, \
+            patch("SC_redesign.Crop_and_Soil.field.field.Field._execute_fertilizer_application",
+                  new_callable=MagicMock) as patched_fertilizer_applicator:
+        field._execute_manure_application(50.0, 50.0, 0.8, depth, remainder, 2000, 133)
+
+        actual = om.errors_pool["field:'test'.manure_application_error"]
+        assert actual["info_maps"].__contains__(expected_info_map)
+        assert actual["values"].__contains__(expected_error_message)
+        mocked_manure_manager.request_nutrients.assert_called_once_with(NutrientRequest(nitrogen=50.0, phosphorus=50.0))
+        patched_manure_applicator.assert_called_once_with(
+            dry_matter_mass=100.0,
+            dry_matter_fraction=0.66,
+            total_phosphorus_mass=50.0,
+            field_coverage=0.8,
+            application_depth=expected_depth,
+            surface_remainder_fraction=expected_remainder,
+            field_size=1.89,
+            inorganic_nitrogen_fraction=0.3,
+            ammonium_fraction=0.3,
+            organic_nitrogen_fraction=0.2,
+            water_extractable_inorganic_phosphorus_fraction=0.5)
+        patched_recorder.assert_called_once_with(dry_matter_mass=100.0,
+                                                 dry_matter_fraction=0.66,
+                                                 field_coverage=0.8,
+                                                 nitrogen=50.0,
+                                                 phosphorus=50.0,
+                                                 potassium=None,
+                                                 application_depth=expected_depth,
+                                                 surface_remainder_fraction=expected_remainder,
+                                                 year=2000,
+                                                 day=133)
+        patched_optimizer.assert_not_called()
+        patched_fertilizer_applicator.assert_not_called()
+
+
 @pytest.mark.parametrize("field_name,field_size,dry_mass,dry_fraction,coverage,nitrogen,phosphorus,depth,remainder,"
                          "year,day,expected_info,expected_values,potassium", [
                              ("test_1", 1.3, 100, 0.1, 0.8, 10, 15, 0.0, 1.0, 1991, 75,
@@ -805,7 +873,7 @@ def test_execute_manure_application(nitrogen: float, phosphorus: float, coverage
                              ("test_2", 2.4, 144.6, 0.3, 0.92, 40, 43.1, 45.0, 0.85, 1994, 200,
                               {"prefix": "field:'test_2'", "date": {"year": 1994, "day": 200}, "field_size": 2.4},
                               {"dry_matter_mass": 144.6, "dry_matter_fraction": 0.3, "application_depth": 45.0,
-                               "surface_remainder_fraction": 0.85,  "field_coverage": 0.92, "nitrogen": 40,
+                               "surface_remainder_fraction": 0.85, "field_coverage": 0.92, "nitrogen": 40,
                                "phosphorus": 43.1, "potassium": 14.55}, 14.55),
                              ("test_3", 0.66, 266.5, 0.44, 0.95, 100.5, 78.0, 120.0, 0.7, 2009, 150,
                               {"prefix": "field:'test_3'", "date": {"year": 2009, "day": 150}, "field_size": 0.66},

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -699,35 +699,35 @@ def test_record_fertilizer_application(mix_name: str, total_mass: float, nitroge
     assert actual["values"].__contains__(expected_value)
 
 
-@pytest.mark.parametrize("nitrogen,phosphorus,coverage,year,day,fertilizer_applied,only_nitrogen_unmet,"
+@pytest.mark.parametrize("nitrogen,phosphorus,coverage,depth,remainder,year,day,fertilizer_applied,only_nitrogen_unmet,"
                          "supplied_manure,expected_request,expected_unmet_nitrogen,expected_unmet_phosphorus", [
-                             (75.0, 75.0, 0.9, 1993, 175, True, False,
+                             (75.0, 75.0, 0.9, 0.0, 1.0, 1993, 175, True, False,
                               NutrientRequestResults(nitrogen=50.0, phosphorus=50.0, dry_matter=250.0,
                                                      dry_matter_fraction=0.33, organic_nitrogen_fraction=0.3,
                                                      inorganic_nitrogen_fraction=0.7, ammonium_nitrogen_fraction=0.25,
                                                      organic_phosphorus_fraction=0.5,
                                                      inorganic_phosphorus_fraction=0.5),
                               NutrientRequest(nitrogen=75.0, phosphorus=75.0), 25.0, 25.0),
-                             (100.0, 0.0, 0.88, 2003, 200, True, True,
+                             (100.0, 0.0, 0.88, 120.0, 0.7, 2003, 200, True, True,
                               NutrientRequestResults(nitrogen=50.0, phosphorus=50.0, dry_matter=250.0,
                                                      dry_matter_fraction=0.33, organic_nitrogen_fraction=0.3,
                                                      inorganic_nitrogen_fraction=0.7, ammonium_nitrogen_fraction=0.25,
                                                      organic_phosphorus_fraction=0.4,
                                                      inorganic_phosphorus_fraction=0.6),
                               NutrientRequest(nitrogen=100.0, phosphorus=0.0), 50.0, 0.0),
-                             (50.0, 50.0, 0.91, 1998, 155, False, False,
+                             (50.0, 50.0, 0.91, 200.0, 0.45, 1998, 155, False, False,
                               NutrientRequestResults(nitrogen=50.0, phosphorus=50.0, dry_matter=250.0,
                                                      dry_matter_fraction=0.33, organic_nitrogen_fraction=0.3,
                                                      inorganic_nitrogen_fraction=0.7, ammonium_nitrogen_fraction=0.25,
                                                      organic_phosphorus_fraction=0.544,
                                                      inorganic_phosphorus_fraction=0.456),
                               NutrientRequest(nitrogen=50.0, phosphorus=50.0), 0.0, 0.0),
-                             (65.0, 40.0, 0.77, 1999, 160, True, False, None,
+                             (65.0, 40.0, 0.77, 75.0, 0.78, 1999, 160, True, False, None,
                               NutrientRequest(nitrogen=65.0, phosphorus=40.0), 65.0, 40.0),
-                             (0, 0, 0.5, 1996, 155, False, False, None, None, 0.0, 0.0)
+                             (0, 0, 0.5, 0.0, 1.0, 1996, 155, False, False, None, None, 0.0, 0.0)
                          ])
-def test_execute_manure_application(nitrogen: float, phosphorus: float, coverage: float, year: int, day: int,
-                                    fertilizer_applied: bool, only_nitrogen_unmet: bool,
+def test_execute_manure_application(nitrogen: float, phosphorus: float, coverage: float, depth: float, remainder: float,
+                                    year: int, day: int, fertilizer_applied: bool, only_nitrogen_unmet: bool,
                                     supplied_manure: NutrientRequestResults, expected_request: NutrientRequest,
                                     expected_unmet_nitrogen: float, expected_unmet_phosphorus: float) -> None:
     """Tests that manure is applied to the soil correctly."""
@@ -739,7 +739,7 @@ def test_execute_manure_application(nitrogen: float, phosphorus: float, coverage
     field._determine_optimal_fertilizer_mix = MagicMock(return_value="expected_optimal_mix")
     field._execute_fertilizer_application = MagicMock()
 
-    field._execute_manure_application(nitrogen, phosphorus, coverage, year, day)
+    field._execute_manure_application(nitrogen, phosphorus, coverage, depth, remainder, year, day)
 
     if nitrogen == phosphorus == 0.0:
         mocked_manure_manager.request_nutrients.assert_not_called()
@@ -758,6 +758,8 @@ def test_execute_manure_application(nitrogen: float, phosphorus: float, coverage
                 dry_matter_fraction=supplied_manure.dry_matter_fraction,
                 total_phosphorus_mass=supplied_manure.phosphorus,
                 field_coverage=coverage,
+                application_depth=depth,
+                surface_remainder_fraction=remainder,
                 field_size=1.4,
                 inorganic_nitrogen_fraction=pytest.approx(expected_total_inorganic_fraction),
                 ammonium_fraction=supplied_manure.ammonium_nitrogen_fraction,
@@ -770,20 +772,24 @@ def test_execute_manure_application(nitrogen: float, phosphorus: float, coverage
                 nitrogen=supplied_manure.nitrogen,
                 phosphorus=supplied_manure.phosphorus,
                 potassium=None,
+                application_depth=depth,
+                surface_remainder_fraction=remainder,
                 year=year,
                 day=day)
 
         if fertilizer_applied and only_nitrogen_unmet:
             field._determine_optimal_fertilizer_mix.assert_not_called()
             field._execute_fertilizer_application.assert_called_once_with("100_0_0", expected_unmet_nitrogen,
-                                                                          expected_unmet_phosphorus, year, day)
+                                                                          expected_unmet_phosphorus, depth, remainder,
+                                                                          year, day)
         elif fertilizer_applied and not only_nitrogen_unmet:
             field._determine_optimal_fertilizer_mix.assert_called_once_with(expected_unmet_nitrogen,
                                                                             expected_unmet_phosphorus,
                                                                             field.available_fertilizer_mixes)
             field._execute_fertilizer_application.assert_called_once_with("expected_optimal_mix",
                                                                           expected_unmet_nitrogen,
-                                                                          expected_unmet_phosphorus, year, day)
+                                                                          expected_unmet_phosphorus, depth, remainder,
+                                                                          year, day)
         else:
             field._determine_optimal_fertilizer_mix.assert_not_called()
             field._execute_fertilizer_application.assert_not_called()

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_manure_application.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_manure_application.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest import approx
 from unittest.mock import MagicMock, patch, call
 from typing import List
 
@@ -162,10 +163,10 @@ def test_apply_solid_machine_manure(dry_mass: float, dry_fraction: float, phosph
 
 @pytest.mark.parametrize("dry_mass,dry_frac,phosphorus_mass,coverage,area,weiP_frac,inorganic_frac,ammonium_frac,"
                          "organic_frac", [
-                            (1000, 0.15, 122, 0.88, 1.94, 0.4, 0.3, 0.39, 0.044),
-                            (1230, 0.115, 180, 0.97, 2.45, 0.356, 0.14, 0.5, 0.018),
-                            (2015, 0.0911, 233.2, 0.66, 4.8, 0.22, 0.2, 0.51, 0.023),
-                            (1780, 0.056, 345, 0.93, 3.81, 0.623, 0.18, 0.6, 0.033),
+                             (1000, 0.15, 122, 0.88, 1.94, 0.4, 0.3, 0.39, 0.044),
+                             (1230, 0.115, 180, 0.97, 2.45, 0.356, 0.14, 0.5, 0.018),
+                             (2015, 0.0911, 233.2, 0.66, 4.8, 0.22, 0.2, 0.51, 0.023),
+                             (1780, 0.056, 345, 0.93, 3.81, 0.623, 0.18, 0.6, 0.033),
                          ])
 def test_apply_liquid_machine_manure(dry_mass: float, dry_frac: float, phosphorus_mass: float, coverage: float,
                                      area: float, weiP_frac: float, inorganic_frac: float, ammonium_frac: float,
@@ -221,6 +222,47 @@ def test_apply_liquid_machine_manure(dry_mass: float, dry_frac: float, phosphoru
     assert incorp.data.machine_water_extractable_organic_phosphorus == expect_water_extractable_organic
     assert incorp.data.machine_stable_inorganic_phosphorus == expect_stable_inorganic
     assert incorp.data.machine_stable_organic_phosphorus == expect_stable_organic
+
+
+@pytest.mark.parametrize("total_phosphorus,wip_frac,wop_frap,sip_frac,sop_frac,dry_matter,inorganic_frac,ammonium_frac,"
+                         "organic_frac,depth,subsurface_frac,area,expected_labile_calls,expected_active_calls,"
+                         "expected_nitrogen_calls", [
+                             (50.0, 0.5, 0.05, 0.33, 0.12, 100.0, 0.4, 0.5, 0.1, 65.0, 0.5, 1.5,
+                              [call(approx(0.826875), 1.5), call(approx(5.788125), 1.5), call(approx(9.9225), 1.5)],
+                              [call(approx(0.4125), 1.5), call(approx(2.8875), 1.5), call(approx(4.95), 1.5)],
+                              [call(0, 2.5, 0.4, 0.5, 0.1, 1.5), call(1, 17.5, 0.4, 0.5, 0.1, 1.5),
+                               call(2, 30, 0.4, 0.5, 0.1, 1.5)]),
+                             (70.0, 0.6, 0.03, 0.28, 0.09, 125.0, 0.5, 0.3, 0.08, 100.0, 0.8, 2.1,
+                              [call(approx(1.9992), 2.1), call(approx(13.9944), 2.1), call(approx(23.9904), 2.1)],
+                              [call(approx(0.784), 2.1), call(approx(5.488), 2.1), call(approx(9.408), 2.1)],
+                              [call(0, 5, 0.5, 0.3, 0.08, 2.1), call(1, 35, 0.5, 0.3, 0.08, 2.1),
+                               call(2, 60, 0.5, 0.3, 0.08, 2.1)])
+                         ])
+def test_apply_subsurface_manure(total_phosphorus: float, wip_frac: float, wop_frap: float, sip_frac: float,
+                                 sop_frac: float, dry_matter: float, inorganic_frac: float, ammonium_frac: float,
+                                 organic_frac: float, depth: float, subsurface_frac: float, area: float,
+                                 expected_labile_calls: list, expected_active_calls: list,
+                                 expected_nitrogen_calls: list) -> None:
+    """Tests that nutrients from injection manure applications are correctly distributed between soil layers."""
+    manure_app = ManureApplication(field_size=area)
+    with patch("SC_redesign.Crop_and_Soil.soil.soil_data.SoilData.get_vectorized_layer_attribute",
+               new_callable=MagicMock, return_value=[20.0, 50.0, 200.0, 400.0]) as layer, \
+            patch("SC_redesign.Crop_and_Soil.field.fertilizer_application.FertilizerApplication.generate_depth_factors",
+                  new_callable=MagicMock, return_value=[0.05, 0.35, 0.6]) as depth_factors, \
+            patch("SC_redesign.Crop_and_Soil.soil.layer_data.LayerData.add_to_labile_phosphorus",
+                  new_callable=MagicMock) as labile, \
+            patch("SC_redesign.Crop_and_Soil.soil.layer_data.LayerData.add_to_active_phosphorus",
+                  new_callable=MagicMock) as active, \
+            patch("SC_redesign.Crop_and_Soil.field.manure_application.ManureApplication._add_nitrogen_to_soil_layer",
+                  new_callable=MagicMock) as nitrogen:
+        manure_app._apply_subsurface_manure(total_phosphorus, wip_frac, wop_frap, sip_frac, sop_frac, dry_matter,
+                                            inorganic_frac, ammonium_frac, organic_frac, depth, subsurface_frac, area)
+
+        layer.assert_called_once_with("bottom_depth")
+        depth_factors.assert_called_once_with(depth, [20.0, 50.0, 200.0, 400.0])
+        labile.assert_has_calls(expected_labile_calls)
+        active.assert_has_calls(expected_active_calls)
+        nitrogen.assert_has_calls(expected_nitrogen_calls)
 
 
 @pytest.mark.parametrize("index,mass,inorganic_frac,ammonium_frac,organic_frac,field_size,expected", [
@@ -287,11 +329,11 @@ def test_apply_grazing_manure(dry_mass: float, dry_fraction: float, phosphorus_m
 
 @pytest.mark.parametrize("dry_mass,dry_fraction,total_phosphorus_mass,coverage,depth,remainder,area,inorganic_frac,"
                          "ammonium_frac,organic_frac,weiP_frac,source_animal,should_fail", [
-                            (1000, 0.75, 200, 0.85, 0.0, 1.0, 1.835, 0.11, 0.55, 0.01, 0.5, None, False),
-                            (3000, 0.10, 150, 0.975, 150.0, 0.55, 2.2254, 0.2, 0.6, 0.03, None, "CATTLE", False),
-                            (2000, 0.44, 103.5, 0.88, 0.0, 1.0, 0.8898, 0.14, 0.44, 0.06, 0.25, "SWINE", False),
-                            (2500, 0.08, 175, 0.79, 0.0, 1.0, 3.4453, 0.33, 0.39, 0.09, None, None, False),
-                            (2500, 0.08, 175, 0.79, 50.0, 0.92, 3.4453, 0.33, 0.39, 0.09, 1.8, None, True),
+                             (1000, 0.75, 200, 0.85, 0.0, 1.0, 1.835, 0.11, 0.55, 0.01, 0.5, None, False),
+                             (3000, 0.10, 150, 0.975, 150.0, 0.55, 2.2254, 0.2, 0.6, 0.03, None, "CATTLE", False),
+                             (2000, 0.44, 103.5, 0.88, 0.0, 1.0, 0.8898, 0.14, 0.44, 0.06, 0.25, "SWINE", False),
+                             (2500, 0.08, 175, 0.79, 0.0, 1.0, 3.4453, 0.33, 0.39, 0.09, None, None, False),
+                             (2500, 0.08, 175, 0.79, 50.0, 0.92, 3.4453, 0.33, 0.39, 0.09, 1.8, None, True),
                          ])
 def test_apply_machine_manure(dry_mass: float, dry_fraction: float, total_phosphorus_mass: float, coverage: float,
                               depth: float, remainder: float, area: float, inorganic_frac: float, ammonium_frac: float,

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_manure_application.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_manure_application.py
@@ -125,15 +125,15 @@ def test_error_determine_water_extractable_inorganic_phosphorus_fraction_by_anim
 
 
 # ---- Helper function tests
-@pytest.mark.parametrize("dry_mass,dry_fraction,phosphorus_mass,field_coverage,weiP_frac,inorganic_frac,ammonium_frac,"
-                         "organic_frac", [
-                             (1000, 0.18, 200, 0.89, 0.5, 0.33, 0.51, 0.05),
-                             (955, 0.44, 100, 0.76, 0.47, 0.2, 0.45, 0.03),
-                             (2500, 0.411, 350, 0.96, 0.33, 0.15, 0.42, 0.045),
+@pytest.mark.parametrize("dry_mass,dry_fraction,phosphorus_mass,field_coverage,depth,remainder,weiP_frac,"
+                         "inorganic_frac,ammonium_frac,organic_frac,subsurface_app", [
+                             (1000, 0.18, 200, 0.89, 0.0, 1.0, 0.5, 0.33, 0.51, 0.05, False),
+                             (955, 0.44, 100, 0.76, 100.0, 0.5, 0.47, 0.2, 0.45, 0.03, True),
+                             (2500, 0.411, 350, 0.96, 250.0, 0.15, 0.33, 0.15, 0.42, 0.045, True),
                          ])
 def test_apply_solid_machine_manure(dry_mass: float, dry_fraction: float, phosphorus_mass: float, field_coverage: float,
-                                    weiP_frac: float, inorganic_frac: float, ammonium_frac: float,
-                                    organic_frac: float) -> None:
+                                    depth: float, remainder: float, weiP_frac: float, inorganic_frac: float,
+                                    ammonium_frac: float, organic_frac: float, subsurface_app: bool) -> None:
     """Tests that manure with greater than 15% solid matter content is added to the field correctly."""
     data = SoilData(machine_manure_dry_mass=3000, machine_manure_moisture_factor=0.65,
                     machine_manure_field_coverage=0.77, field_size=1.1)
@@ -142,23 +142,34 @@ def test_apply_solid_machine_manure(dry_mass: float, dry_fraction: float, phosph
                                                                            "new_moisture_factor": 0.83,
                                                                            "new_field_coverage": 0.93})
     incorp._add_nitrogen_to_soil_layer = MagicMock()
+    incorp._apply_subsurface_manure = MagicMock()
 
-    incorp._apply_solid_machine_manure(dry_mass, dry_fraction, phosphorus_mass, field_coverage, weiP_frac,
-                                       inorganic_frac, ammonium_frac, organic_frac, 1.1)
+    incorp._apply_solid_machine_manure(dry_mass, dry_fraction, phosphorus_mass, field_coverage, depth, remainder,
+                                       weiP_frac, inorganic_frac, ammonium_frac, organic_frac, 1.1)
 
-    incorp._determine_weighted_manure_attributes.assert_called_once_with(3000, 0.65, 0.77, dry_mass, dry_fraction,
-                                                                         field_coverage)
-    incorp._add_nitrogen_to_soil_layer.assert_called_once_with(0, dry_mass, inorganic_frac, ammonium_frac,
+    expected_dry_mass = dry_mass * remainder
+    expected_stable_inorganic_frac = (1 - (weiP_frac + 0.05)) * 0.25
+    expected_stable_organic_frac = (1 - (weiP_frac + 0.05)) * 0.75
+    expected_subsurface_frac = 1.0 - remainder
+    incorp._determine_weighted_manure_attributes.assert_called_once_with(3000, 0.65, 0.77, expected_dry_mass,
+                                                                         dry_fraction, field_coverage)
+    incorp._add_nitrogen_to_soil_layer.assert_called_once_with(0, expected_dry_mass, inorganic_frac, ammonium_frac,
                                                                organic_frac, 1.1)
-    assert incorp.data.machine_water_extractable_inorganic_phosphorus == phosphorus_mass * weiP_frac
-    assert incorp.data.machine_water_extractable_organic_phosphorus == phosphorus_mass * 0.05
-    assert incorp.data.machine_stable_inorganic_phosphorus == \
-           (phosphorus_mass * (1 - (weiP_frac + 0.05))) * 0.25
-    assert pytest.approx(incorp.data.machine_stable_organic_phosphorus) == \
-           (phosphorus_mass * (1 - (weiP_frac + 0.05))) * 0.75
+    assert incorp.data.machine_water_extractable_inorganic_phosphorus == phosphorus_mass * weiP_frac * remainder
+    assert incorp.data.machine_water_extractable_organic_phosphorus == phosphorus_mass * 0.05 * remainder
+    assert incorp.data.machine_stable_inorganic_phosphorus == phosphorus_mass * expected_stable_inorganic_frac * \
+           remainder
+    assert pytest.approx(incorp.data.machine_stable_organic_phosphorus) == phosphorus_mass * \
+           expected_stable_organic_frac * remainder
     assert incorp.data.machine_manure_dry_mass == 4000
     assert incorp.data.machine_manure_moisture_factor == 0.83
     assert incorp.data.machine_manure_field_coverage == 0.93
+    if subsurface_app:
+        incorp._apply_subsurface_manure.assert_called_once_with(phosphorus_mass, weiP_frac, 0.05,
+                                                                expected_stable_inorganic_frac,
+                                                                expected_stable_organic_frac, dry_mass, inorganic_frac,
+                                                                ammonium_frac, organic_frac, depth,
+                                                                expected_subsurface_frac, 1.1)
 
 
 @pytest.mark.parametrize("dry_mass,dry_frac,phosphorus_mass,coverage,area,weiP_frac,inorganic_frac,ammonium_frac,"

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_manure_application.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_manure_application.py
@@ -285,17 +285,17 @@ def test_apply_grazing_manure(dry_mass: float, dry_fraction: float, phosphorus_m
     assert incorp.data.grazing_manure_applied_mass == dry_mass
 
 
-@pytest.mark.parametrize("dry_mass,dry_fraction,total_phosphorus_mass,coverage,area,inorganic_frac,ammonium_frac,"
-                         "organic_frac,weiP_frac,source_animal,should_fail", [
-                            (1000, 0.75, 200, 0.85, 1.835, 0.11, 0.55, 0.01, 0.5, None, False),
-                            (3000, 0.10, 150, 0.975, 2.2254, 0.2, 0.6, 0.03, None, "CATTLE", False),
-                            (2000, 0.44, 103.5, 0.88, 0.8898, 0.14, 0.44, 0.06, 0.25, "SWINE", False),
-                            (2500, 0.08, 175, 0.79, 3.4453, 0.33, 0.39, 0.09, None, None, False),
-                            (2500, 0.08, 175, 0.79, 3.4453, 0.33, 0.39, 0.09, 1.8, None, True),
+@pytest.mark.parametrize("dry_mass,dry_fraction,total_phosphorus_mass,coverage,depth,remainder,area,inorganic_frac,"
+                         "ammonium_frac,organic_frac,weiP_frac,source_animal,should_fail", [
+                            (1000, 0.75, 200, 0.85, 0.0, 1.0, 1.835, 0.11, 0.55, 0.01, 0.5, None, False),
+                            (3000, 0.10, 150, 0.975, 150.0, 0.55, 2.2254, 0.2, 0.6, 0.03, None, "CATTLE", False),
+                            (2000, 0.44, 103.5, 0.88, 0.0, 1.0, 0.8898, 0.14, 0.44, 0.06, 0.25, "SWINE", False),
+                            (2500, 0.08, 175, 0.79, 0.0, 1.0, 3.4453, 0.33, 0.39, 0.09, None, None, False),
+                            (2500, 0.08, 175, 0.79, 50.0, 0.92,3.4453, 0.33, 0.39, 0.09, 1.8, None, True),
                          ])
 def test_apply_machine_manure(dry_mass: float, dry_fraction: float, total_phosphorus_mass: float, coverage: float,
-                              area: float, inorganic_frac: float, ammonium_frac: float, organic_frac: float,
-                              weiP_frac: float, source_animal: str, should_fail: bool) -> None:
+                              depth: float, remainder: float, area: float, inorganic_frac: float, ammonium_frac: float,
+                              organic_frac: float, weiP_frac: float, source_animal: str, should_fail: bool) -> None:
     """Tests that the machine-applied manure is correctly added into existing manure on the field."""
     data = SoilData(field_size=area)
     incorp = ManureApplication(data)
@@ -303,16 +303,16 @@ def test_apply_machine_manure(dry_mass: float, dry_fraction: float, total_phosph
     if should_fail:
         with pytest.raises(ValueError) as e:
 
-            incorp.apply_machine_manure(dry_mass, dry_fraction, total_phosphorus_mass, coverage, area, inorganic_frac,
-                                        ammonium_frac, organic_frac, weiP_frac, source_animal)
+            incorp.apply_machine_manure(dry_mass, dry_fraction, total_phosphorus_mass, coverage, depth, remainder, area,
+                                        inorganic_frac, ammonium_frac, organic_frac, weiP_frac, source_animal)
         assert str(e.value) == f"Water extractable inorganic phosphorus fraction must be in the range [0.0, 0.95]," \
                                f" received '{weiP_frac}'."
     else:
         incorp._determine_water_extractable_inorganic_phosphorus_fraction_by_animal = MagicMock(return_value=0.25)
         incorp._apply_liquid_machine_manure = MagicMock()
         incorp._apply_solid_machine_manure = MagicMock()
-        incorp.apply_machine_manure(dry_mass, dry_fraction, total_phosphorus_mass, coverage, area, inorganic_frac,
-                                    ammonium_frac, organic_frac, weiP_frac, source_animal)
+        incorp.apply_machine_manure(dry_mass, dry_fraction, total_phosphorus_mass, coverage, depth, remainder, area,
+                                    inorganic_frac, ammonium_frac, organic_frac, weiP_frac, source_animal)
 
         expected_weiP_frac = weiP_frac
         if weiP_frac is None:
@@ -324,10 +324,12 @@ def test_apply_machine_manure(dry_mass: float, dry_fraction: float, total_phosph
 
         if dry_fraction <= 0.15:
             incorp._apply_liquid_machine_manure.assert_called_once_with(dry_mass, dry_fraction, total_phosphorus_mass,
-                                                                        coverage, area, expected_weiP_frac,
-                                                                        inorganic_frac, ammonium_frac, organic_frac)
+                                                                        coverage, depth, remainder, area,
+                                                                        expected_weiP_frac, inorganic_frac,
+                                                                        ammonium_frac, organic_frac)
         else:
             incorp._apply_solid_machine_manure.assert_called_once_with(dry_mass, dry_fraction, total_phosphorus_mass,
-                                                                       coverage, expected_weiP_frac, inorganic_frac,
-                                                                       ammonium_frac, organic_frac, area)
+                                                                       coverage, depth, remainder, expected_weiP_frac,
+                                                                       inorganic_frac, ammonium_frac, organic_frac,
+                                                                       area)
         assert incorp.data.machine_manure_applied_mass == dry_mass

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_manure_application.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_manure_application.py
@@ -291,7 +291,7 @@ def test_apply_grazing_manure(dry_mass: float, dry_fraction: float, phosphorus_m
                             (3000, 0.10, 150, 0.975, 150.0, 0.55, 2.2254, 0.2, 0.6, 0.03, None, "CATTLE", False),
                             (2000, 0.44, 103.5, 0.88, 0.0, 1.0, 0.8898, 0.14, 0.44, 0.06, 0.25, "SWINE", False),
                             (2500, 0.08, 175, 0.79, 0.0, 1.0, 3.4453, 0.33, 0.39, 0.09, None, None, False),
-                            (2500, 0.08, 175, 0.79, 50.0, 0.92,3.4453, 0.33, 0.39, 0.09, 1.8, None, True),
+                            (2500, 0.08, 175, 0.79, 50.0, 0.92, 3.4453, 0.33, 0.39, 0.09, 1.8, None, True),
                          ])
 def test_apply_machine_manure(dry_mass: float, dry_fraction: float, total_phosphorus_mass: float, coverage: float,
                               depth: float, remainder: float, area: float, inorganic_frac: float, ammonium_frac: float,

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_manure_application.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_manure_application.py
@@ -170,23 +170,26 @@ def test_apply_solid_machine_manure(dry_mass: float, dry_fraction: float, phosph
                                                                 expected_stable_organic_frac, dry_mass, inorganic_frac,
                                                                 ammonium_frac, organic_frac, depth,
                                                                 expected_subsurface_frac, 1.1)
+    else:
+        incorp._apply_subsurface_manure.assert_not_called()
 
 
-@pytest.mark.parametrize("dry_mass,dry_frac,phosphorus_mass,coverage,area,weiP_frac,inorganic_frac,ammonium_frac,"
-                         "organic_frac", [
-                             (1000, 0.15, 122, 0.88, 1.94, 0.4, 0.3, 0.39, 0.044),
-                             (1230, 0.115, 180, 0.97, 2.45, 0.356, 0.14, 0.5, 0.018),
-                             (2015, 0.0911, 233.2, 0.66, 4.8, 0.22, 0.2, 0.51, 0.023),
-                             (1780, 0.056, 345, 0.93, 3.81, 0.623, 0.18, 0.6, 0.033),
+@pytest.mark.parametrize("dry_mass,dry_frac,phosphorus_mass,coverage,depth,remainder,area,weiP_frac,inorganic_frac,"
+                         "ammonium_frac,organic_frac,subsurface_app", [
+                             (1000, 0.15, 122, 0.88, 0.0, 1.0, 1.94, 0.4, 0.3, 0.39, 0.044, False),
+                             (1230, 0.115, 180, 0.97, 0.0, 1.0, 2.45, 0.356, 0.14, 0.5, 0.018, False),
+                             (2015, 0.0911, 233.2, 0.66, 100.0, 0.2, 4.8, 0.22, 0.2, 0.51, 0.023, True),
+                             (1780, 0.056, 345, 0.93, 80.0, 0.44, 3.81, 0.623, 0.18, 0.6, 0.033, True)
                          ])
 def test_apply_liquid_machine_manure(dry_mass: float, dry_frac: float, phosphorus_mass: float, coverage: float,
-                                     area: float, weiP_frac: float, inorganic_frac: float, ammonium_frac: float,
-                                     organic_frac: float) -> None:
+                                     depth: float, remainder: float, area: float, weiP_frac: float,
+                                     inorganic_frac: float, ammonium_frac: float, organic_frac: float,
+                                     subsurface_app: bool) -> None:
     """Tests that when manure slurry is added it correctly adds phosphorus to soil surface and subsurface pools, and
         sets surface pool characteristics.
     """
     data = SoilData(machine_manure_dry_mass=1000, machine_manure_moisture_factor=0.8, machine_manure_field_coverage=0.9,
-                    field_size=1.1)
+                    field_size=area)
     incorp = ManureApplication(data)
     incorp._determine_wet_rate_factor = MagicMock(return_value=2000)
     incorp._determine_infiltration_factor = MagicMock(return_value=0.5)
@@ -196,29 +199,35 @@ def test_apply_liquid_machine_manure(dry_mass: float, dry_frac: float, phosphoru
                                                                            "new_moisture_factor": 0.93,
                                                                            "new_field_coverage": 0.98})
     incorp._add_nitrogen_to_soil_layer = MagicMock()
+    incorp._apply_subsurface_manure = MagicMock()
 
-    incorp._apply_liquid_machine_manure(dry_mass, dry_frac, phosphorus_mass, coverage, area, weiP_frac, inorganic_frac,
-                                        ammonium_frac, organic_frac)
+    incorp._apply_liquid_machine_manure(dry_mass, dry_frac, phosphorus_mass, coverage, depth, remainder, area,
+                                        weiP_frac, inorganic_frac, ammonium_frac, organic_frac)
 
-    expect_adjusted_dry_mass = dry_mass * 0.8
+    expect_surface_dry_mass = dry_mass * remainder
+    expect_adjusted_dry_mass = expect_surface_dry_mass * 0.8
     expect_adjusted_coverage = coverage * 0.5
-    expect_water_extractable_inorganic = phosphorus_mass * weiP_frac * 0.5
-    expect_water_extractable_organic = phosphorus_mass * 0.05 * 0.5
-    expect_stable_inorganic = phosphorus_mass * (1 - (weiP_frac + 0.05)) * 0.25 * 0.5
-    expect_stable_organic = phosphorus_mass * (1 - (weiP_frac + 0.05)) * 0.75 * 0.5
+    expect_water_extractable_inorganic = phosphorus_mass * weiP_frac * 0.5 * remainder
+    expect_water_extractable_organic = phosphorus_mass * 0.05 * 0.5 * remainder
+    expect_stable_inorganic_frac = (1 - (weiP_frac + 0.05)) * 0.25
+    expect_stable_inorganic = phosphorus_mass * expect_stable_inorganic_frac * 0.5 * remainder
+    expect_stable_organic_frac = (1 - (weiP_frac + 0.05)) * 0.75
+    expect_stable_organic = phosphorus_mass * expect_stable_organic_frac * 0.5 * remainder
     expect_labile = phosphorus_mass * weiP_frac * 0.5
     expect_labile += phosphorus_mass * 0.05 * 0.5 * 0.95
     expect_labile += phosphorus_mass * (1 - (weiP_frac + 0.05)) * 0.75 * 0.5 * 0.95
-    expect_active = phosphorus_mass * (1 - (weiP_frac + 0.05)) * 0.25 * 0.5
+    expect_labile *= remainder
+    expect_active = phosphorus_mass * (1 - (weiP_frac + 0.05)) * 0.25 * 0.5 * remainder
 
-    expected_mass = dry_mass * 0.5
+    expected_mass = expect_surface_dry_mass * 0.5
     expected_inorganic_frac = inorganic_frac * 0.5
     expected_organic_frac = organic_frac * 0.5
     expected_nitrogen_calls = [
         call(0, expected_mass, expected_inorganic_frac, ammonium_frac, expected_organic_frac, area),
         call(1, expected_mass, expected_inorganic_frac, ammonium_frac, expected_organic_frac, area)]
+    expected_subsurface_frac = 1.0 - remainder
 
-    incorp._determine_wet_rate_factor.assert_called_once_with(dry_mass, dry_frac, coverage, area)
+    incorp._determine_wet_rate_factor.assert_called_once_with(expect_surface_dry_mass, dry_frac, coverage, area)
     incorp._determine_infiltration_factor.assert_called_once_with(2000)
     incorp._determine_weighted_manure_attributes.assert_called_once_with(1000, 0.8, 0.9, expect_adjusted_dry_mass,
                                                                          dry_frac, expect_adjusted_coverage)
@@ -233,6 +242,14 @@ def test_apply_liquid_machine_manure(dry_mass: float, dry_frac: float, phosphoru
     assert incorp.data.machine_water_extractable_organic_phosphorus == expect_water_extractable_organic
     assert incorp.data.machine_stable_inorganic_phosphorus == expect_stable_inorganic
     assert incorp.data.machine_stable_organic_phosphorus == expect_stable_organic
+    if subsurface_app:
+        incorp._apply_subsurface_manure.assert_called_once_with(phosphorus_mass, weiP_frac, 0.05,
+                                                                expect_stable_inorganic_frac,
+                                                                expect_stable_organic_frac, dry_mass, inorganic_frac,
+                                                                ammonium_frac, organic_frac, depth,
+                                                                expected_subsurface_frac, area)
+    else:
+        incorp._apply_subsurface_manure.assert_not_called()
 
 
 @pytest.mark.parametrize("total_phosphorus,wip_frac,wop_frap,sip_frac,sop_frac,dry_matter,inorganic_frac,ammonium_frac,"


### PR DESCRIPTION
This PR implements the functionality for injection manure applications, and completes the v1 functionality requirements for the Crop and Soil module.

- `generate_depth_factors()` has been made public in `FertilizerApplication`, because it is used in `ManureApplication`. All previous uses have been changed to account for this.
- `Field` now passes the application depth and surface remainder fraction to the various manure application and recording methods.
- `Field._execute_manure_application()` now checks for invalid args and raises errors to the `OutputManager` if they are found.
- `ManureApplication` has had `_apply_subsurface_manure()` added, which handles applying all the subsurface nutrients to the soil layers when injection manure applications are executed. Both `_apply_solid_machine_manure()` and `_apply_liquid_machine_manure()` use this method.
- Both `_apply_solid_machine_manure()` and `_apply_liquid_machine_manure()` have been modified to only apply some of the manure to the surface when injection applications of manure occur.
- All changes and additions are tested, and this PR has the same coverage as the base branch `SC_redesign`.