### PR TITLE
CBPB manure module: Nitrogen gas emission calculations

### DIFF
--- a/RUFAS/routines/manure/gas_emissions/gas_emissions.py
+++ b/RUFAS/routines/manure/gas_emissions/gas_emissions.py
@@ -1295,3 +1295,123 @@ class GasEmissions:
             * microbial_decomp_anaerobic_conditions_effect
         )
         return total_carbon_decomposition
+
+    @classmethod
+    def _calc_nitrogen_loss_from_ammonia_emissions(
+        cls,
+        daily_nitrogen_input: float,
+        existing_nitrogen_mass: float,
+        is_bedding_tilled: bool,
+    ) -> float:
+        """Calculates the emissions of ammonia in kg.
+
+        Parameters
+        ----------
+        daily_nitrogen_input : float
+            The mass of nitrogen present in the manure excreted by animals (in kg)
+
+        existing_nitrogen_mass : float
+            The mass of nitrogen already present in the manure-bedding mixture (in kg)
+
+        is_bedding_tilled : bool
+            Indicator for if the beddint is tilled for the current simulation day.
+
+        Returns
+        -------
+        float
+            The nitrogen lost to ammonia emissions (in kg).
+
+        """
+        till_indicator = int(is_bedding_tilled)
+        total_nitrogen = daily_nitrogen_input + existing_nitrogen_mass
+        return (
+            (0.5 * total_nitrogen * till_indicator)
+            + (0.25 * total_nitrogen * (1 - till_indicator))
+        )
+
+    @classmethod
+    def _calc_nitrogen_loss_to_leaching(cls, daily_nitrogen_input: float, existing_nitrogen_mass: float) -> float:
+        """Calculates the mass of nitrogen that leaches out of the manure-bedding mixture in kg.
+
+        Parameters
+        ----------
+        daily_nitrogen_input : float
+            The mass of nitrogen present in the manure excreted by animals (in kg)
+
+        existing_nitrogen_mass : float
+            The mass of nitrogen already present in the manure-bedding mixture (in kg)
+
+        Returns
+        -------
+        float
+            The amount of nitrogen that leaches out of the bedding mixture (in kg).
+
+        """
+        return 0.035 * (daily_nitrogen_input + existing_nitrogen_mass)
+
+    @classmethod
+    def _calc_nitrogen_loss_from_nitrous_oxide_emissions(
+        cls,
+        daily_nitrogen_input: float,
+        existing_nitrogen_mass: float,
+        is_bedding_tilled: bool,
+    ) -> float:
+        """Calculates the nitrogen loss from nitrous oxide emissions in kg.
+
+        Parameters
+        ----------
+        daily_nitrogen_input : float
+            The mass of nitrogen present in the manure excreted by animals (in kg)
+
+        existing_nitrogen_mass : float
+            The mass of nitrogen already present in the manure-bedding mixture (in kg)
+
+        is_bedding_tilled : bool
+            Indicator for if the beddint is tilled for the current simulation day.
+
+        Returns
+        -------
+        float
+            The nitrogen lost to nitrous oxide emissions (in kg).
+
+        """
+        till_indicator = int(is_bedding_tilled)
+        total_nitrogen = daily_nitrogen_input + existing_nitrogen_mass
+        return (
+            0.07 * total_nitrogen * till_indicator
+            + 0.01 * total_nitrogen * (1 - till_indicator)
+        )
+
+    @classmethod
+    def calc_nitrogen_losses(
+        cls,
+        daily_nitrogen_input: float,
+        existing_nitrogen_mass: float,
+        is_bedding_tilled: bool,
+    ) -> float:
+        """Calculates the nitrogen loss from the manure_bedding mixture in kg.
+
+        Parameters
+        ----------
+        daily_nitrogen_input : float
+            The mass of nitrogen present in the manure excreted by animals (in kg)
+
+        existing_nitrogen_mass : float
+            The mass of nitrogen already present in the manure-bedding mixture (in kg)
+
+        is_bedding_tilled : bool
+            Indicator for if the beddint is tilled for the current simulation day.
+
+        Returns
+        -------
+        float
+            The nitrogen lost from the compost bedded pack barn (in kg).
+
+        """
+        return (
+            GasEmissions._calc_nitrogen_loss_from_ammonia_emissions(
+                daily_nitrogen_input, existing_nitrogen_mass, is_bedding_tilled)
+            + GasEmissions._calc_nitrogen_loss_from_nitrous_oxide_emissions(
+                daily_nitrogen_input, existing_nitrogen_mass, is_bedding_tilled)
+            + GasEmissions._calc_nitrogen_loss_to_leaching(daily_nitrogen_input, existing_nitrogen_mass)
+        )

--- a/RUFAS/routines/manure/gas_emissions/gas_emissions.py
+++ b/RUFAS/routines/manure/gas_emissions/gas_emissions.py
@@ -1308,9 +1308,9 @@ class GasEmissions:
         Parameters
         ----------
         daily_nitrogen_input : float
-            The mass of nitrogen present in the manure excreted by animals (in kg)
+            The mass of nitrogen present in the manure excreted by animals (kg)
         existing_nitrogen_mass : float
-            The mass of nitrogen already present in the manure-bedding mixture (in kg)
+            The mass of nitrogen already present in the manure-bedding mixture (kg)
         is_bedding_tilled : bool
             Indicator for if the beddint is tilled for the current simulation day.
 

--- a/RUFAS/routines/manure/gas_emissions/gas_emissions.py
+++ b/RUFAS/routines/manure/gas_emissions/gas_emissions.py
@@ -1300,7 +1300,6 @@ class GasEmissions:
     def _calc_nitrogen_loss_from_ammonia_emissions(
         cls,
         daily_nitrogen_input: float,
-        existing_nitrogen_mass: float,
         is_bedding_tilled: bool,
     ) -> float:
         """Calculates the emissions of ammonia in kg.
@@ -1309,8 +1308,6 @@ class GasEmissions:
         ----------
         daily_nitrogen_input : float
             The mass of nitrogen present in the manure excreted by animals (kg)
-        existing_nitrogen_mass : float
-            The mass of nitrogen already present in the manure-bedding mixture (kg)
         is_bedding_tilled : bool
             Indicator for if the beddint is tilled for the current simulation day.
 
@@ -1321,22 +1318,19 @@ class GasEmissions:
 
         """
         till_indicator = int(is_bedding_tilled)
-        total_nitrogen = daily_nitrogen_input + existing_nitrogen_mass
         return (
-            (0.5 * total_nitrogen * till_indicator)
-            + (0.25 * total_nitrogen * (1 - till_indicator))
+            (0.5 * daily_nitrogen_input * till_indicator)
+            + (0.25 * daily_nitrogen_input * (1 - till_indicator))
         )
 
     @classmethod
-    def _calc_nitrogen_loss_to_leaching(cls, daily_nitrogen_input: float, existing_nitrogen_mass: float) -> float:
+    def _calc_nitrogen_loss_to_leaching(cls, daily_nitrogen_input: float) -> float:
         """Calculates the mass of nitrogen that leaches out of the manure-bedding mixture in kg.
 
         Parameters
         ----------
         daily_nitrogen_input : float
             The mass of nitrogen present in the manure excreted by animals (kg)
-        existing_nitrogen_mass : float
-            The mass of nitrogen already present in the manure-bedding mixture (kg)
 
         Returns
         -------
@@ -1344,13 +1338,12 @@ class GasEmissions:
             The amount of nitrogen that leaches out of the bedding mixture (kg).
 
         """
-        return 0.035 * (daily_nitrogen_input + existing_nitrogen_mass)
+        return 0.035 * daily_nitrogen_input
 
     @classmethod
     def _calc_nitrogen_loss_from_nitrous_oxide_emissions(
         cls,
         daily_nitrogen_input: float,
-        existing_nitrogen_mass: float,
         is_bedding_tilled: bool,
     ) -> float:
         """Calculates the nitrogen loss from nitrous oxide emissions in kg.
@@ -1359,10 +1352,8 @@ class GasEmissions:
         ----------
         daily_nitrogen_input : float
             The mass of nitrogen present in the manure excreted by animals (kg)
-        existing_nitrogen_mass : float
-            The mass of nitrogen already present in the manure-bedding mixture (kg)
         is_bedding_tilled : bool
-            Indicator for if the beddint is tilled for the current simulation day.
+            Indicator for if the bedding is tilled for the current simulation day.
 
         Returns
         -------
@@ -1371,17 +1362,15 @@ class GasEmissions:
 
         """
         till_indicator = int(is_bedding_tilled)
-        total_nitrogen = daily_nitrogen_input + existing_nitrogen_mass
         return (
-            0.07 * total_nitrogen * till_indicator
-            + 0.01 * total_nitrogen * (1 - till_indicator)
+            0.07 * daily_nitrogen_input * till_indicator
+            + 0.01 * daily_nitrogen_input * (1 - till_indicator)
         )
 
     @classmethod
     def calc_nitrogen_losses(
         cls,
         daily_nitrogen_input: float,
-        existing_nitrogen_mass: float,
         is_bedding_tilled: bool,
     ) -> float:
         """Calculates the nitrogen loss from the manure_bedding mixture in kg.
@@ -1390,10 +1379,8 @@ class GasEmissions:
         ----------
         daily_nitrogen_input : float
             The mass of nitrogen present in the manure excreted by animals (kg)
-        existing_nitrogen_mass : float
-            The mass of nitrogen already present in the manure-bedding mixture (kg)
         is_bedding_tilled : bool
-            Indicator for if the beddint is tilled for the current simulation day.
+            Indicator for if the bedding is tilled for the current simulation day.
 
         Returns
         -------
@@ -1401,10 +1388,13 @@ class GasEmissions:
             The nitrogen lost from the compost bedded pack barn (kg).
 
         """
+        if daily_nitrogen_input < 0.0:
+            raise ValueError(f"{daily_nitrogen_input=}. Mass must must be positive.")
+
         return (
             GasEmissions._calc_nitrogen_loss_from_ammonia_emissions(
-                daily_nitrogen_input, existing_nitrogen_mass, is_bedding_tilled)
+                daily_nitrogen_input, is_bedding_tilled)
             + GasEmissions._calc_nitrogen_loss_from_nitrous_oxide_emissions(
-                daily_nitrogen_input, existing_nitrogen_mass, is_bedding_tilled)
-            + GasEmissions._calc_nitrogen_loss_to_leaching(daily_nitrogen_input, existing_nitrogen_mass)
+                daily_nitrogen_input, is_bedding_tilled)
+            + GasEmissions._calc_nitrogen_loss_to_leaching(daily_nitrogen_input)
         )

--- a/RUFAS/routines/manure/gas_emissions/gas_emissions.py
+++ b/RUFAS/routines/manure/gas_emissions/gas_emissions.py
@@ -1309,10 +1309,8 @@ class GasEmissions:
         ----------
         daily_nitrogen_input : float
             The mass of nitrogen present in the manure excreted by animals (in kg)
-
         existing_nitrogen_mass : float
             The mass of nitrogen already present in the manure-bedding mixture (in kg)
-
         is_bedding_tilled : bool
             Indicator for if the beddint is tilled for the current simulation day.
 
@@ -1336,15 +1334,14 @@ class GasEmissions:
         Parameters
         ----------
         daily_nitrogen_input : float
-            The mass of nitrogen present in the manure excreted by animals (in kg)
-
+            The mass of nitrogen present in the manure excreted by animals (kg)
         existing_nitrogen_mass : float
-            The mass of nitrogen already present in the manure-bedding mixture (in kg)
+            The mass of nitrogen already present in the manure-bedding mixture (kg)
 
         Returns
         -------
         float
-            The amount of nitrogen that leaches out of the bedding mixture (in kg).
+            The amount of nitrogen that leaches out of the bedding mixture (kg).
 
         """
         return 0.035 * (daily_nitrogen_input + existing_nitrogen_mass)
@@ -1361,18 +1358,16 @@ class GasEmissions:
         Parameters
         ----------
         daily_nitrogen_input : float
-            The mass of nitrogen present in the manure excreted by animals (in kg)
-
+            The mass of nitrogen present in the manure excreted by animals (kg)
         existing_nitrogen_mass : float
-            The mass of nitrogen already present in the manure-bedding mixture (in kg)
-
+            The mass of nitrogen already present in the manure-bedding mixture (kg)
         is_bedding_tilled : bool
             Indicator for if the beddint is tilled for the current simulation day.
 
         Returns
         -------
         float
-            The nitrogen lost to nitrous oxide emissions (in kg).
+            The nitrogen lost to nitrous oxide emissions (kg).
 
         """
         till_indicator = int(is_bedding_tilled)
@@ -1394,18 +1389,16 @@ class GasEmissions:
         Parameters
         ----------
         daily_nitrogen_input : float
-            The mass of nitrogen present in the manure excreted by animals (in kg)
-
+            The mass of nitrogen present in the manure excreted by animals (kg)
         existing_nitrogen_mass : float
-            The mass of nitrogen already present in the manure-bedding mixture (in kg)
-
+            The mass of nitrogen already present in the manure-bedding mixture (kg)
         is_bedding_tilled : bool
             Indicator for if the beddint is tilled for the current simulation day.
 
         Returns
         -------
         float
-            The nitrogen lost from the compost bedded pack barn (in kg).
+            The nitrogen lost from the compost bedded pack barn (kg).
 
         """
         return (

--- a/tests/test_manure_module/test_gas_emissions.py
+++ b/tests/test_manure_module/test_gas_emissions.py
@@ -76,6 +76,57 @@ def test_calc_ifsm_methane_emission(mocker: MockerFixture) -> None:
     assert actual == pytest.approx(expected)
 
 
+def test_calc_nitrogen_loss_from_ammonia_emissions() -> None:
+    """Tests _calc_nitrogen_loss_from_ammonia_emissions() in gas_emissions.py"""
+    additional_n = 1.0
+    existing_n = 0.5
+    assert GasEmissions._calc_nitrogen_loss_from_ammonia_emissions(additional_n, existing_n, False) \
+        == pytest.approx(0.375)
+    assert GasEmissions._calc_nitrogen_loss_from_ammonia_emissions(additional_n, existing_n, True) \
+        == pytest.approx(0.75)
+
+
+def test_calc_nitrogen_loss_to_leaching() -> None:
+    """Tests _calc_nitrogen_loss_to_leaching() in gas_emissions.py"""
+    additional_n = 1.0
+    existing_n = 0.5
+    assert GasEmissions._calc_nitrogen_loss_to_leaching(additional_n, existing_n) \
+        == pytest.approx(0.0525)
+
+
+def test_calc_nitrogen_loss_from_nitrous_oxide_emissions() -> None:
+    """Tests _calc_nitrogen_loss_from_nitrous_oxide_emissions() in gas_emissions.py"""
+    additional_n = 1.0
+    existing_n = 0.5
+    assert GasEmissions._calc_nitrogen_loss_from_nitrous_oxide_emissions(additional_n, existing_n, False) \
+        == pytest.approx(0.015)
+    assert GasEmissions._calc_nitrogen_loss_from_nitrous_oxide_emissions(additional_n, existing_n, True) \
+        == pytest.approx(0.105)
+
+
+def test_calc_nitrogen_losses(mocker: MockerFixture) -> None:
+    """Tests calc_nitrogen_losses() in gas_emissions.py"""
+    ammonia_loss = 1.0
+    leaching_loss = 2.0
+    nitrous_oxide_loss = 3.0
+    mocker.patch(
+        'RUFAS.routines.manure.gas_emissions.gas_emissions.GasEmissions._calc_nitrogen_loss_from_ammonia_emissions',
+        return_value=ammonia_loss
+    )
+    mocker.patch(
+        'RUFAS.routines.manure.gas_emissions.gas_emissions.GasEmissions._calc_nitrogen_loss_to_leaching',
+        return_value=leaching_loss
+    )
+    mocker.patch(
+        'RUFAS.routines.manure.gas_emissions.gas_emissions.'
+        'GasEmissions._calc_nitrogen_loss_from_nitrous_oxide_emissions',
+        return_value=nitrous_oxide_loss
+    )
+    expected = ammonia_loss + leaching_loss + nitrous_oxide_loss
+
+    assert GasEmissions.calc_nitrogen_losses(1.0, 1.0, True) == pytest.approx(expected)
+
+
 @pytest.mark.parametrize("temperature", [-10.0, 0.0, 10.0])
 def test_microbial_decomp_rate(temperature: float) -> None:
     """Tests _calc_microbial_decomp_rate() in gas_emissions.py."""

--- a/tests/test_manure_module/test_gas_emissions.py
+++ b/tests/test_manure_module/test_gas_emissions.py
@@ -78,29 +78,26 @@ def test_calc_ifsm_methane_emission(mocker: MockerFixture) -> None:
 
 def test_calc_nitrogen_loss_from_ammonia_emissions() -> None:
     """Tests _calc_nitrogen_loss_from_ammonia_emissions() in gas_emissions.py"""
-    additional_n = 1.0
-    existing_n = 0.5
-    assert GasEmissions._calc_nitrogen_loss_from_ammonia_emissions(additional_n, existing_n, False) \
+    additional_n = 1.5
+    assert GasEmissions._calc_nitrogen_loss_from_ammonia_emissions(additional_n, False) \
         == pytest.approx(0.375)
-    assert GasEmissions._calc_nitrogen_loss_from_ammonia_emissions(additional_n, existing_n, True) \
+    assert GasEmissions._calc_nitrogen_loss_from_ammonia_emissions(additional_n, True) \
         == pytest.approx(0.75)
 
 
 def test_calc_nitrogen_loss_to_leaching() -> None:
     """Tests _calc_nitrogen_loss_to_leaching() in gas_emissions.py"""
-    additional_n = 1.0
-    existing_n = 0.5
-    assert GasEmissions._calc_nitrogen_loss_to_leaching(additional_n, existing_n) \
+    additional_n = 1.5
+    assert GasEmissions._calc_nitrogen_loss_to_leaching(additional_n) \
         == pytest.approx(0.0525)
 
 
 def test_calc_nitrogen_loss_from_nitrous_oxide_emissions() -> None:
     """Tests _calc_nitrogen_loss_from_nitrous_oxide_emissions() in gas_emissions.py"""
-    additional_n = 1.0
-    existing_n = 0.5
-    assert GasEmissions._calc_nitrogen_loss_from_nitrous_oxide_emissions(additional_n, existing_n, False) \
+    additional_n = 1.5
+    assert GasEmissions._calc_nitrogen_loss_from_nitrous_oxide_emissions(additional_n, False) \
         == pytest.approx(0.015)
-    assert GasEmissions._calc_nitrogen_loss_from_nitrous_oxide_emissions(additional_n, existing_n, True) \
+    assert GasEmissions._calc_nitrogen_loss_from_nitrous_oxide_emissions(additional_n, True) \
         == pytest.approx(0.105)
 
 
@@ -124,7 +121,27 @@ def test_calc_nitrogen_losses(mocker: MockerFixture) -> None:
     )
     expected = ammonia_loss + leaching_loss + nitrous_oxide_loss
 
-    assert GasEmissions.calc_nitrogen_losses(1.0, 1.0, True) == pytest.approx(expected)
+    assert GasEmissions.calc_nitrogen_losses(1.0, True) == pytest.approx(expected)
+
+
+def test_calc_nitrogen_losses_invalid_mass(mocker: MockerFixture) -> None:
+    """Tests calc_nitrogen_losses() in gas_emissions.py"""
+    mocker.patch(
+        'RUFAS.routines.manure.gas_emissions.gas_emissions.GasEmissions._calc_nitrogen_loss_from_ammonia_emissions',
+        return_value=0.0
+    )
+    mocker.patch(
+        'RUFAS.routines.manure.gas_emissions.gas_emissions.GasEmissions._calc_nitrogen_loss_to_leaching',
+        return_value=0.0
+    )
+    mocker.patch(
+        'RUFAS.routines.manure.gas_emissions.gas_emissions.'
+        'GasEmissions._calc_nitrogen_loss_from_nitrous_oxide_emissions',
+        return_value=0.0
+    )
+    invalid_negative_mass = -1.0
+    with pytest.raises(ValueError):
+        GasEmissions.calc_nitrogen_losses(invalid_negative_mass, True)
 
 
 @pytest.mark.parametrize("temperature", [-10.0, 0.0, 10.0])


### PR DESCRIPTION
Implements the 3 gas calculations that combine to calculate the total loss of nitrogen in the manure-bedding mixture for the CBPB manure module.

This PR introduces 4 functions:
1. `_calc_nitrogen_loss_from_ammonia_emissions()`: M.3.A.1
2. `_calc_nitrogen_loss_to_leaching()`: M.3.B.1
3. `_calc_nitrogen_loss_from_nitrous_oxide_emissions()`: M.3.C.1
4. `calc_nitrogen_losses()`: M.3.D.1. This only includes the losses. I will add the additional N inside the CBPB class.

Please refer to the CBPB design doc for the equations.