### PR TITLE
Negative water evaporation bug draft

### DIFF
--- a/SC_redesign/Crop_and_Soil/crop/water_uptake.py
+++ b/SC_redesign/Crop_and_Soil/crop/water_uptake.py
@@ -196,7 +196,7 @@ class WaterUptake:
     @staticmethod
     def _adjust_water_uptakes(potential_uptakes: List[float], unmet_demands: List[float],
                               uptake_compensation: float) -> List[float]:
-        """adjusts the potential water uptakes from each layer based by drawing from deeper layers when possible.
+        """Adjusts the potential water uptakes for each layer based on drawing from deeper layers when possible.
 
         References
         ----------

--- a/SC_redesign/Crop_and_Soil/crop/water_uptake.py
+++ b/SC_redesign/Crop_and_Soil/crop/water_uptake.py
@@ -196,7 +196,7 @@ class WaterUptake:
     @staticmethod
     def _adjust_water_uptakes(potential_uptakes: List[float], unmet_demands: List[float],
                               uptake_compensation: float) -> List[float]:
-        """adjusts the potential water uptakes from each layer based by drawing from deeper layeres when possible.
+        """adjusts the potential water uptakes from each layer based by drawing from deeper layers when possible.
 
         References
         ----------

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -1113,8 +1113,10 @@ class Field:
         for crop in self.crops:
             amount_evaporated = crop.water_dynamics.evaporate_from_canopy(remaining_evapotranspirative_demand)
             remaining_evapotranspirative_demand -= amount_evaporated
-            if remaining_evapotranspirative_demand == 0.0:
+            if remaining_evapotranspirative_demand - amount_evaporated <= 0.0:
                 break
+            else:
+                remaining_evapotranspirative_demand -= amount_evaporated
         return remaining_evapotranspirative_demand
 
     def _determine_total_above_ground_biomass(self) -> float:

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -1153,20 +1153,22 @@ class Field:
         Notes
         -----
         This method calculates the evapotranspirative demand for the entire field on any given day using the Hargreaves
-        method.This method will also cap the minimum to zero if negative average values were inputted, which causes
-        nonsense negative evapotranspirative demand.
+        method.This method lower-bounds the potential evapotranspiration at 0.0 mm.
         """
-        if max_air_temp - min_air_temp < 0:
-            raise Exception
         if avg_air_temp is None:
             calculated_avg_air_temp = (max_air_temp + min_air_temp) / 2
             latent_heat_vaporization = Field._determine_latent_heat_vaporization(calculated_avg_air_temp)
-            return max(0, (0.0023 * extra_terrestrial_radiation * ((max_air_temp - min_air_temp) ** (-0.5))
-                           * (calculated_avg_air_temp + 17.8)) / latent_heat_vaporization)
+            potential_evapotranspiration = (0.0023 *
+                                            extra_terrestrial_radiation * ((max_air_temp - min_air_temp) ** (-0.5))
+                                            * (calculated_avg_air_temp + 17.8)) / latent_heat_vaporization
+            return max(0, potential_evapotranspiration)
+
         else:
             latent_heat_vaporization = Field._determine_latent_heat_vaporization(avg_air_temp)
-            return max(0, (0.0023 * extra_terrestrial_radiation * ((max_air_temp - min_air_temp) ** (-0.5))
-                           * (avg_air_temp + 17.8)) / latent_heat_vaporization)
+            potential_evapotranspiration = (0.0023 *
+                                            extra_terrestrial_radiation * ((max_air_temp - min_air_temp) ** (-0.5))
+                                            * (avg_air_temp + 17.8)) / latent_heat_vaporization
+            return max(0, potential_evapotranspiration)
 
     @staticmethod
     def _determine_latent_heat_vaporization(avg_air_temp: float) -> float:

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -1153,18 +1153,20 @@ class Field:
         Notes
         -----
         This method calculates the evapotranspirative demand for the entire field on any given day using the Hargreaves
-        method.
-
+        method.This method will also cap the minimum to zero if negative average values were inputted, which causes
+        nonsense negative evapotranspirative demand.
         """
+        if max_air_temp - min_air_temp < 0:
+            raise Exception
         if avg_air_temp is None:
             calculated_avg_air_temp = (max_air_temp + min_air_temp) / 2
             latent_heat_vaporization = Field._determine_latent_heat_vaporization(calculated_avg_air_temp)
-            return (0.0023 * extra_terrestrial_radiation * ((max_air_temp - min_air_temp) ** (-0.5))
-                    * (calculated_avg_air_temp + 17.8)) / latent_heat_vaporization
+            return max(0, (0.0023 * extra_terrestrial_radiation * ((max_air_temp - min_air_temp) ** (-0.5))
+                           * (calculated_avg_air_temp + 17.8)) / latent_heat_vaporization)
         else:
             latent_heat_vaporization = Field._determine_latent_heat_vaporization(avg_air_temp)
-            return (0.0023 * extra_terrestrial_radiation * ((max_air_temp - min_air_temp) ** (-0.5))
-                    * (avg_air_temp + 17.8)) / latent_heat_vaporization
+            return max(0, (0.0023 * extra_terrestrial_radiation * ((max_air_temp - min_air_temp) ** (-0.5))
+                           * (avg_air_temp + 17.8)) / latent_heat_vaporization)
 
     @staticmethod
     def _determine_latent_heat_vaporization(avg_air_temp: float) -> float:

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -1153,7 +1153,7 @@ class Field:
         Notes
         -----
         This method calculates the evapotranspirative demand for the entire field on any given day using the Hargreaves
-        method.This method lower-bounds the potential evapotranspiration at 0.0 mm.
+        method. This method lower-bounds the potential evapotranspiration at 0.0 mm.
         """
         if avg_air_temp is None:
             calculated_avg_air_temp = (max_air_temp + min_air_temp) / 2

--- a/SC_redesign/Crop_and_Soil/field/field.py
+++ b/SC_redesign/Crop_and_Soil/field/field.py
@@ -1113,10 +1113,8 @@ class Field:
         for crop in self.crops:
             amount_evaporated = crop.water_dynamics.evaporate_from_canopy(remaining_evapotranspirative_demand)
             remaining_evapotranspirative_demand -= amount_evaporated
-            if remaining_evapotranspirative_demand - amount_evaporated <= 0.0:
+            if remaining_evapotranspirative_demand == 0.0:
                 break
-            else:
-                remaining_evapotranspirative_demand -= amount_evaporated
         return remaining_evapotranspirative_demand
 
     def _determine_total_above_ground_biomass(self) -> float:

--- a/SC_redesign/Crop_and_Soil/soil/evaporation.py
+++ b/SC_redesign/Crop_and_Soil/soil/evaporation.py
@@ -52,7 +52,7 @@ class Evaporation:
             amount_water_removed = min(amount_water_removed, amount_available_for_evaporation)
             layer.water_content -= amount_water_removed
             amount_available_for_evaporation -= amount_water_removed
-            if amount_available_for_evaporation == 0:
+            if amount_available_for_evaporation <= 0:
                 break
 
         total_evaporation_from_soil = maximum_soil_water_evaporation - amount_available_for_evaporation

--- a/SC_redesign/Crop_and_Soil/soil/evaporation.py
+++ b/SC_redesign/Crop_and_Soil/soil/evaporation.py
@@ -52,7 +52,7 @@ class Evaporation:
             amount_water_removed = min(amount_water_removed, amount_available_for_evaporation)
             layer.water_content -= amount_water_removed
             amount_available_for_evaporation -= amount_water_removed
-            if amount_available_for_evaporation <= 0:
+            if amount_available_for_evaporation == 0:
                 break
 
         total_evaporation_from_soil = maximum_soil_water_evaporation - amount_available_for_evaporation

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -1201,10 +1201,10 @@ def test_potential_evapotranspiration(extraterrestrial_radiation, max_temp, min_
         actual = Field._determine_potential_evapotranspiration(extraterrestrial_radiation, max_temp, min_temp, avg_temp)
         if avg_temp is not None:
             expect = max(0, (0.0023 * extraterrestrial_radiation * ((max_temp - min_temp) ** (-0.5)) *
-                      (avg_temp + 17.8)) / 1.3)
+                             (avg_temp + 17.8)) / 1.3)
         else:
             expect = max(0, (0.0023 * extraterrestrial_radiation * ((max_temp - min_temp) ** (-0.5)) *
-                      (((max_temp + min_temp) / 2) + 17.8)) / 1.3)
+                             (((max_temp + min_temp) / 2) + 17.8)) / 1.3)
 
         if avg_temp is not None:
             mocked_latent_heat.assert_called_once_with(avg_temp)

--- a/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
+++ b/SC_redesign/Crop_and_Soil/tests_SC/field_tests/test_field.py
@@ -1193,17 +1193,18 @@ def test_determine_total_above_ground_biomass(biomasses: List[float], expected: 
     (568, 20, 14, None),
     (80, 14, 0, 8),
     (678.0098, 26.8896, 10.3339, 18.3345),
+    (678.0098, 26.8896, 10.3339, -100000)
 ])
 def test_potential_evapotranspiration(extraterrestrial_radiation, max_temp, min_temp, avg_temp):
     with patch("SC_redesign.Crop_and_Soil.field.field.Field._determine_latent_heat_vaporization",
                new_callable=MagicMock, return_value=1.3) as mocked_latent_heat:
         actual = Field._determine_potential_evapotranspiration(extraterrestrial_radiation, max_temp, min_temp, avg_temp)
         if avg_temp is not None:
-            expect = (0.0023 * extraterrestrial_radiation * ((max_temp - min_temp) ** (-0.5)) *
-                      (avg_temp + 17.8)) / 1.3
+            expect = max(0, (0.0023 * extraterrestrial_radiation * ((max_temp - min_temp) ** (-0.5)) *
+                      (avg_temp + 17.8)) / 1.3)
         else:
-            expect = (0.0023 * extraterrestrial_radiation * ((max_temp - min_temp) ** (-0.5)) *
-                      (((max_temp + min_temp) / 2) + 17.8)) / 1.3
+            expect = max(0, (0.0023 * extraterrestrial_radiation * ((max_temp - min_temp) ** (-0.5)) *
+                      (((max_temp + min_temp) / 2) + 17.8)) / 1.3)
 
         if avg_temp is not None:
             mocked_latent_heat.assert_called_once_with(avg_temp)


### PR DESCRIPTION
### Summary
This small PR is to find out what causing the negative water_evporation value in the output and fix it. This will solve issue #643.

### Changes

- In `field.py`, `_determine_potential_evapotranspiration` will now set a minimum return value to 0.0 if `avg_air_temp` was too small.
- A few changes to condition statements in `evaporation.py`.
### Notes
These values might need to be re-evaluated again by science experts.