### PR TITLE
IM Validate CSV Input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Testing](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml)
 [![Linting](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml)
-[![Coverage](https://img.shields.io/badge/coverage-84%25-yellowgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/coverage_pytest-cov.yml)
+[![Coverage](https://img.shields.io/badge/coverage-85%25-yellowgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/coverage_pytest-cov.yml)
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.
 

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -473,7 +473,7 @@ class InputManager:
         """Validates an input data bool element."""
         return input_data_value in (True, False)
 
-    def _fix_data(self, variable_properties: Dict[str, Any], element_hierarchy: list,
+    def _fix_data(self, variable_properties: Dict[str, Any], element_hierarchy: List[Union[str, int]],
                   input_data: Dict[str, Any]) -> bool:
         """
         Attempt to fix the invalid data.

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -199,41 +199,99 @@ class InputManager:
         om.add_log("Total Invalid Items", f"{invalid_elements_counter=}", info_map)
         return invalid_elements_counter == 0
 
-    def _get_validity(self, variable_properties: Dict[str, Any], var_name: str, input_data_value: Any,
-                      var_type: str) -> bool:
-        """Helper function to route arguments to correct type-validator function.
+    def _validate_input_type_dynamic(self, variable_properties: Dict[str, Any], var_name: str, input_data_value: Any):
+        """
+        Validates the input data value based on its specified dynamic type.
 
         Parameters
         ----------
         variable_properties : Dict[str, Any]
-            The metadata properties of the variable being validated.
+            A dictionary containing properties relevant to the validation.
         var_name : str
             The name of the variable being validated.
         input_data_value : Any
-            The value of the variable being validated.
-        var_type : str
-            The type of the variable being validated.
+            The input data value to be validated.
+
         Returns
         -------
         bool
-            True if element is valid.
+            True if the input data value is valid for the specified type, False otherwise.
+
         Raises
         ------
         KeyError
-            Raised if the variable type is not one of the 4 currently supported for validation.
+            If an invalid type is provided in the variable_properties or if "type" key is missing.
+
+        Notes
+        ------
+        This function determines the type of validation needed based on the 'type' property in variable_properties.
+        It dynamically selects the appropriate validator based on the determined type and delegates the validation
+        process to that validator function. If the determined type is not recognized or if "type" key is missing,
+        a KeyError is raised.
+
+        Example
+        --------
+        variable_properties = {"type": "string", "min_length": 3, "max_length": 10}
+        var_name = "name"
+        input_data_value = "John Doe"
+        is_valid = validate_input_type_dynamic(variable_properties, var_name, input_data_value)
+        if is_valid:
+            print(f"{var_name} is a valid {variable_properties['type']}.")
+        else:
+            print(f"{var_name} is not a valid {variable_properties['type']}.")
         """
-        data_type_to_validator_map = {"string": self._string_type_validator,
-                                      "number": self._num_type_validator,
-                                      "array": self._array_type_validator,
-                                      "bool": self._bool_type_validator, }
+        if "type" not in variable_properties:
+            raise KeyError("Missing 'type' key in variable_properties")
+        var_type = variable_properties["type"]
+        data_type_to_validator_map = {
+            "string": self._string_type_validator,
+            "number": self._num_type_validator,
+            "array": self._array_type_validator,
+            "bool": self._bool_type_validator,
+        }
         try:
             validator = data_type_to_validator_map[var_type]
         except KeyError:
-            raise KeyError(f"Invalid type {var_type}: Element must be type {data_type_to_validator_map.keys()}")
-
+            raise KeyError(
+                f"Invalid type {var_type}: Element must be type {data_type_to_validator_map.keys()}"
+            )
         return validator(variable_properties, var_name, input_data_value)
 
-    def _validate_csv_element(self, property: str, properties_blob_key: str, input_data: Dict[str, Any],
+    # def _get_validity(self, variable_properties: Dict[str, Any], var_name: str, input_data_value: Any,
+    #                   var_type: str) -> bool:
+    #     """Helper function to route arguments to correct type-validator function.
+
+    #     Parameters
+    #     ----------
+    #     variable_properties : Dict[str, Any]
+    #         The metadata properties of the variable being validated.
+    #     var_name : str
+    #         The name of the variable being validated.
+    #     input_data_value : Any
+    #         The value of the variable being validated.
+    #     var_type : str
+    #         The type of the variable being validated.
+    #     Returns
+    #     -------
+    #     bool
+    #         True if element is valid.
+    #     Raises
+    #     ------
+    #     KeyError
+    #         Raised if the variable type is not one of the 4 currently supported for validation.
+    #     """
+    #     data_type_to_validator_map = {"string": self._string_type_validator,
+    #                                   "number": self._num_type_validator,
+    #                                   "array": self._array_type_validator,
+    #                                   "bool": self._bool_type_validator, }
+    #     try:
+    #         validator = data_type_to_validator_map[var_type]
+    #     except KeyError:
+    #         raise KeyError(f"Invalid type {var_type}: Element must be type {data_type_to_validator_map.keys()}")
+
+    #     return validator(variable_properties, var_name, input_data_value)
+
+    def _validate_csv_element(self, var_name: str, properties_blob_key: str, input_data: Dict[str, Any],
                               eager_termination: bool) -> dict:
         """
         Receives data loaded from csv input file and the validates each row element in the csv column it's sent.
@@ -242,7 +300,7 @@ class InputManager:
 
         Parameters
         ----------
-        property : str
+        var_name : str
             The name of the csv data element being validated.
         properties_blob_key : str
             The metadata properties section keyword for the data input file being checked.
@@ -260,18 +318,19 @@ class InputManager:
         """
         element_counter_and_validity = {"fixed_elements": 0, "total_elements": 0, "valid_elements": 0,
                                         "invalid_elements": 0, "is_valid": True}
-        property_data = input_data[property]
-        variable_properties = reduce(lambda d, key: d[key], [property],
+        property_data = input_data[var_name]
+        variable_properties = reduce(lambda d, key: d[key], [var_name],
                                      self.__metadata["properties"][properties_blob_key])
-        var_type = variable_properties["type"]
+        # var_type = variable_properties["type"]
 
         for element_num in range(len(property_data)):
             element_counter_and_validity["total_elements"] += 1
-            is_valid = self._get_validity(variable_properties, property, property_data[element_num], var_type)
+            # is_valid = self._get_validity(variable_properties, property, property_data[element_num], var_type)
+            is_valid = self._validate_input_type_dynamic(variable_properties, var_name, property_data[element_num])
             if is_valid:
                 element_counter_and_validity["valid_elements"] += 1
             else:
-                is_fixed = self._fix_data(variable_properties, [property, element_num], input_data)
+                is_fixed = self._fix_data(variable_properties, [var_name, element_num], input_data)
                 if is_fixed:
                     element_counter_and_validity["fixed_elements"] += 1
                 else:
@@ -323,8 +382,9 @@ class InputManager:
         except KeyError as e:
             raise KeyError(f"{str(e)} not found in input data")
 
-        var_type = variable_properties["type"]
-        is_nested = var_type == "object"
+        if "type" not in variable_properties:
+            raise KeyError("Missing 'type' key in variable_properties")
+        is_nested = variable_properties["type"] == "object"
         if is_nested:
             children_status: Dict[str, bool] = {}
             false_counter = 0
@@ -356,7 +416,9 @@ class InputManager:
             except KeyError:
                 raise KeyError(f"Key {var_name} not found in input data")
 
-            is_valid = self._get_validity(variable_properties, var_name, input_data_value, var_type)
+            is_valid = self._validate_input_type_dynamic(variable_properties, var_name, input_data_value)
+
+            # is_valid = self._get_validity(variable_properties, var_name, input_data_value, var_type)
 
             element_counter_and_validity["total_elements"] += 1
             if is_valid:

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -165,18 +165,22 @@ class InputManager:
             file_path = file_details["path"]
 
             try:
+                file_type = file_details["type"]
                 data_loader = data_type_to_loader_map[file_details["type"]]
                 data = data_loader(file_path)
             except KeyError:
                 raise KeyError(f"Faulty data type in {file_blob_key},"
                                f"supported types are: {data_type_to_loader_map.keys()}")
 
-            # counter_dict = {"fixed_elements": 0, "total_elements": 0, "valid_elements": 0, "invalid_elements": 0}
             properties_blob_key = file_details["properties"]
             properties = self.__metadata["properties"][properties_blob_key]
             for property in properties.keys():
-                element_counter_and_validity = self._validate_element([property], properties_blob_key, data,
-                                                                      eager_termination)
+                if file_type == "json":
+                    element_counter_and_validity = self._validate_json_element([property], properties_blob_key, data,
+                                                                               eager_termination)
+                if file_type == "csv":
+                    pass
+
                 fixed_elements_counter += element_counter_and_validity["fixed_elements"]
                 valid_elements_counter += element_counter_and_validity["valid_elements"]
                 total_elements_counter += element_counter_and_validity["total_elements"]
@@ -194,10 +198,10 @@ class InputManager:
         om.add_log("Total Invalid Items", f"{invalid_elements_counter=}", info_map)
         return invalid_elements_counter == 0
 
-    def _validate_element(self, element_hierarchy: List[str], properties_blob_key: str,
-                          input_data: Dict[str, Any], eager_termination: bool, ) -> dict:
+    def _validate_json_element(self, element_hierarchy: List[str], properties_blob_key: str,
+                               input_data: Dict[str, Any], eager_termination: bool, ) -> dict:
         """
-        Receives data loaded from input file, recursively finds and then validates nested elements,
+        Receives data loaded from json input file, recursively finds and then validates nested elements,
         attempts to fix any invalid elements, and tracks the number of how many valid, invalid, fixed,
         and total elements from the input data are checked.
 
@@ -225,7 +229,7 @@ class InputManager:
 
         """
         info_map = {"class": self.__class__.__name__,
-                    "function": self._validate_element.__name__,
+                    "function": self._validate_json_element.__name__,
                     }
         element_counter_and_validity = {"fixed_elements": 0, "total_elements": 0, "valid_elements": 0,
                                         "invalid_elements": 0, "is_valid": True}
@@ -240,8 +244,8 @@ class InputManager:
             for nested_key in variable_properties.keys():
                 if nested_key not in variable_properties_to_ignore:
                     element_hierarchy.append(nested_key)
-                    element_counter_and_validity = self._validate_element(element_hierarchy, properties_blob_key,
-                                                                          input_data, eager_termination)
+                    element_counter_and_validity = self._validate_json_element(element_hierarchy, properties_blob_key,
+                                                                               input_data, eager_termination)
                     is_child_valid = element_counter_and_validity["is_valid"]
                     if eager_termination and not is_child_valid:
                         return element_counter_and_validity

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -179,7 +179,8 @@ class InputManager:
                     element_counter_and_validity = self._validate_json_element([property], properties_blob_key, data,
                                                                                eager_termination)
                 if file_type == "csv":
-                    pass
+                    element_counter_and_validity = self._validate_csv_element(property, properties_blob_key, data,
+                                                                              eager_termination)
 
                 fixed_elements_counter += element_counter_and_validity["fixed_elements"]
                 valid_elements_counter += element_counter_and_validity["valid_elements"]
@@ -198,12 +199,71 @@ class InputManager:
         om.add_log("Total Invalid Items", f"{invalid_elements_counter=}", info_map)
         return invalid_elements_counter == 0
 
+    def _validate_csv_element(self, property: str, properties_blob_key: str, input_data: Dict[str, Any],
+                              eager_termination: bool) -> dict:
+        """
+        Receives data loaded from csv input file and the validates each row element in the csv column it's sent.
+        It attempts to fix any invalid elements and tracks the number of valid, invalid, fixed,
+        and total elements from the input file are checked.
+
+        Parameters
+        ----------
+        property : str
+            The name of the csv data element being validated.
+        properties_blob_key : str
+            The metadata properties section keyword for the data input file being checked.
+        input_data : Dict[str, Any]
+            A buffer dictionary that holds the input data for validation and fixing.
+        eager_termination : bool
+            If true, the process will be terminated upon finding invalid data.
+
+        Returns
+        -------
+        dict
+            A dictionary that collects the counts of total elements checked,
+            invalid elements, valid elements, and fixed elements as well as a boolean
+            which is True if the data is valid, False otherwise.
+        """
+        # property = column header/key in csv data dict ("diesel_cost_gal")
+        # input_data = {"diesel_cost_gal": [5, 10], "electricity_cost_kwh": [0.15], etc}
+        info_map = {"class": self.__class__.__name__,
+                    "function": self._validate_csv_element.__name__,
+                    }
+        element_counter_and_validity = {"fixed_elements": 0, "total_elements": 0, "valid_elements": 0,
+                                        "invalid_elements": 0, "is_valid": True}
+        property_data = input_data["property"]  # get array of data to validate
+        variable_properties = reduce(lambda d, key: d[key], [property],
+                                     self.__metadata["properties"][properties_blob_key])
+        var_type = variable_properties["type"]
+        data_type_to_validator_map = {"string": self._string_type_validator,
+                                      "number": self._num_type_validator,
+                                      "array": self._array_type_validator,
+                                      "bool": self._bool_type_validator, }
+        try:
+            validator = data_type_to_validator_map[var_type]
+        except KeyError:
+            raise KeyError(f"Invalid type {var_type}: Element must be type {data_type_to_validator_map.keys()}")
+
+        for element in property_data:
+            element_counter_and_validity["total_elements"] += 1
+            is_valid = validator(variable_properties, property, element)
+            if is_valid:
+                element_counter_and_validity["valid_elements"] += 1
+            else:
+                is_fixed = self._fix_data(variable_properties, [property], input_data)
+                if is_fixed:
+                    element_counter_and_validity["fixed_elements"] += 1
+                else:
+                    element_counter_and_validity["invalid_elements"] += 1
+                    element_counter_and_validity["is_valid"] = False
+        return element_counter_and_validity
+
     def _validate_json_element(self, element_hierarchy: List[str], properties_blob_key: str,
                                input_data: Dict[str, Any], eager_termination: bool, ) -> dict:
         """
         Receives data loaded from json input file, recursively finds and then validates nested elements,
-        attempts to fix any invalid elements, and tracks the number of how many valid, invalid, fixed,
-        and total elements from the input data are checked.
+        attempts to fix any invalid elements, and tracks the number of valid, invalid, fixed,
+        and total elements from the input file are checked.
 
         Parameters
         ----------

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -257,40 +257,6 @@ class InputManager:
             )
         return validator(variable_properties, var_name, input_data_value)
 
-    # def _get_validity(self, variable_properties: Dict[str, Any], var_name: str, input_data_value: Any,
-    #                   var_type: str) -> bool:
-    #     """Helper function to route arguments to correct type-validator function.
-
-    #     Parameters
-    #     ----------
-    #     variable_properties : Dict[str, Any]
-    #         The metadata properties of the variable being validated.
-    #     var_name : str
-    #         The name of the variable being validated.
-    #     input_data_value : Any
-    #         The value of the variable being validated.
-    #     var_type : str
-    #         The type of the variable being validated.
-    #     Returns
-    #     -------
-    #     bool
-    #         True if element is valid.
-    #     Raises
-    #     ------
-    #     KeyError
-    #         Raised if the variable type is not one of the 4 currently supported for validation.
-    #     """
-    #     data_type_to_validator_map = {"string": self._string_type_validator,
-    #                                   "number": self._num_type_validator,
-    #                                   "array": self._array_type_validator,
-    #                                   "bool": self._bool_type_validator, }
-    #     try:
-    #         validator = data_type_to_validator_map[var_type]
-    #     except KeyError:
-    #         raise KeyError(f"Invalid type {var_type}: Element must be type {data_type_to_validator_map.keys()}")
-
-    #     return validator(variable_properties, var_name, input_data_value)
-
     def _validate_csv_element(self, var_name: str, properties_blob_key: str, input_data: Dict[str, Any],
                               eager_termination: bool) -> dict:
         """
@@ -321,11 +287,9 @@ class InputManager:
         property_data = input_data[var_name]
         variable_properties = reduce(lambda d, key: d[key], [var_name],
                                      self.__metadata["properties"][properties_blob_key])
-        # var_type = variable_properties["type"]
 
         for element_num in range(len(property_data)):
             element_counter_and_validity["total_elements"] += 1
-            # is_valid = self._get_validity(variable_properties, property, property_data[element_num], var_type)
             is_valid = self._validate_input_type_dynamic(variable_properties, var_name, property_data[element_num])
             if is_valid:
                 element_counter_and_validity["valid_elements"] += 1
@@ -417,8 +381,6 @@ class InputManager:
                 raise KeyError(f"Key {var_name} not found in input data")
 
             is_valid = self._validate_input_type_dynamic(variable_properties, var_name, input_data_value)
-
-            # is_valid = self._get_validity(variable_properties, var_name, input_data_value, var_type)
 
             element_counter_and_validity["total_elements"] += 1
             if is_valid:

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -201,7 +201,7 @@ class InputManager:
 
     def _get_validity(self, variable_properties: Dict[str, Any], var_name: str, input_data_value: Any,
                       var_type: str) -> bool:
-        """Helper function to route correct arguments to type-validator functions.
+        """Helper function to route arguments to correct type-validator function.
 
         Parameters
         ----------
@@ -265,13 +265,13 @@ class InputManager:
                                      self.__metadata["properties"][properties_blob_key])
         var_type = variable_properties["type"]
 
-        for element in property_data:
+        for element_num in range(len(property_data)):
             element_counter_and_validity["total_elements"] += 1
-            is_valid = self._get_validity(variable_properties, property, element, var_type)
+            is_valid = self._get_validity(variable_properties, property, property_data[element_num], var_type)
             if is_valid:
                 element_counter_and_validity["valid_elements"] += 1
             else:
-                is_fixed = self._fix_data(variable_properties, [property], input_data)
+                is_fixed = self._fix_data(variable_properties, [property, element_num], input_data)
                 if is_fixed:
                     element_counter_and_validity["fixed_elements"] += 1
                 else:
@@ -351,16 +351,6 @@ class InputManager:
             except KeyError:
                 raise KeyError(f"Key {var_name} not found in input data")
 
-            # data_type_to_validator_map = {"string": self._string_type_validator,
-            #                               "number": self._num_type_validator,
-            #                               "array": self._array_type_validator,
-            #                               "bool": self._bool_type_validator, }
-            # try:
-            #     validator = data_type_to_validator_map[var_type]
-            # except KeyError:
-            #     raise KeyError(f"Invalid type {var_type}: Element must be type {data_type_to_validator_map.keys()}")
-
-            # is_valid = validator(variable_properties, var_name, input_data_value)
             is_valid = self._get_validity(variable_properties, var_name, input_data_value, var_type)
 
             element_counter_and_validity["total_elements"] += 1
@@ -454,8 +444,8 @@ class InputManager:
         """Validates an input data bool element."""
         return input_data_value in (True, False)
 
-    def _fix_data(self, variable_properties: dict[str, Any], element_hierarchy: List[str],
-                  input_data: dict[str, Any]) -> bool:
+    def _fix_data(self, variable_properties: Dict[str, Any], element_hierarchy: list,
+                  input_data: Dict[str, Any]) -> bool:
         """
         Attempt to fix the invalid data.
 
@@ -464,8 +454,8 @@ class InputManager:
         variable_properties : dict[str, Any]
             The properties for the variable of interest.
 
-        element_hierarchy: List[str]
-            A list of strings indicating the path to reach the variable of interest in self.__metadata and self.__pool.
+        element_hierarchy: list
+            A list indicating the path to reach the variable of interest in self.__metadata and self.__pool.
 
         input_data: dict[str, Any]
             A buffer dictionary that holds the input data for validation and fixing.

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -199,6 +199,40 @@ class InputManager:
         om.add_log("Total Invalid Items", f"{invalid_elements_counter=}", info_map)
         return invalid_elements_counter == 0
 
+    def _get_validity(self, variable_properties: Dict[str, Any], var_name: str, input_data_value: Any,
+                      var_type: str) -> bool:
+        """Helper function to route correct arguments to type-validator functions.
+
+        Parameters
+        ----------
+        variable_properties : Dict[str, Any]
+            The metadata properties of the variable being validated.
+        var_name : str
+            The name of the variable being validated.
+        input_data_value : Any
+            The value of the variable being validated.
+        var_type : str
+            The type of the variable being validated.
+        Returns
+        -------
+        bool
+            True if element is valid.
+        Raises
+        ------
+        KeyError
+            Raised if the variable type is not one of the 4 currently supported for validation.
+        """
+        data_type_to_validator_map = {"string": self._string_type_validator,
+                                      "number": self._num_type_validator,
+                                      "array": self._array_type_validator,
+                                      "bool": self._bool_type_validator, }
+        try:
+            validator = data_type_to_validator_map[var_type]
+        except KeyError:
+            raise KeyError(f"Invalid type {var_type}: Element must be type {data_type_to_validator_map.keys()}")
+
+        return validator(variable_properties, var_name, input_data_value)
+
     def _validate_csv_element(self, property: str, properties_blob_key: str, input_data: Dict[str, Any],
                               eager_termination: bool) -> dict:
         """
@@ -226,27 +260,25 @@ class InputManager:
         """
         # property = column header/key in csv data dict ("diesel_cost_gal")
         # input_data = {"diesel_cost_gal": [5, 10], "electricity_cost_kwh": [0.15], etc}
-        info_map = {"class": self.__class__.__name__,
-                    "function": self._validate_csv_element.__name__,
-                    }
         element_counter_and_validity = {"fixed_elements": 0, "total_elements": 0, "valid_elements": 0,
                                         "invalid_elements": 0, "is_valid": True}
-        property_data = input_data["property"]  # get array of data to validate
+        property_data = input_data[property]  # get array of data to validate
         variable_properties = reduce(lambda d, key: d[key], [property],
                                      self.__metadata["properties"][properties_blob_key])
         var_type = variable_properties["type"]
-        data_type_to_validator_map = {"string": self._string_type_validator,
-                                      "number": self._num_type_validator,
-                                      "array": self._array_type_validator,
-                                      "bool": self._bool_type_validator, }
-        try:
-            validator = data_type_to_validator_map[var_type]
-        except KeyError:
-            raise KeyError(f"Invalid type {var_type}: Element must be type {data_type_to_validator_map.keys()}")
+        # data_type_to_validator_map = {"string": self._string_type_validator,
+        #                               "number": self._num_type_validator,
+        #                               "array": self._array_type_validator,
+        #                               "bool": self._bool_type_validator, }
+        # try:
+        #     validator = data_type_to_validator_map[var_type]
+        # except KeyError:
+        #     raise KeyError(f"Invalid type {var_type}: Element must be type {data_type_to_validator_map.keys()}")
 
         for element in property_data:
             element_counter_and_validity["total_elements"] += 1
-            is_valid = validator(variable_properties, property, element)
+            # is_valid = validator(variable_properties, property, element)
+            is_valid = self._get_validity(variable_properties, property, element, var_type)
             if is_valid:
                 element_counter_and_validity["valid_elements"] += 1
             else:
@@ -254,6 +286,8 @@ class InputManager:
                 if is_fixed:
                     element_counter_and_validity["fixed_elements"] += 1
                 else:
+                    if eager_termination:
+                        return element_counter_and_validity
                     element_counter_and_validity["invalid_elements"] += 1
                     element_counter_and_validity["is_valid"] = False
         return element_counter_and_validity
@@ -327,16 +361,17 @@ class InputManager:
             except KeyError:
                 raise KeyError(f"Key {var_name} not found in input data")
 
-            data_type_to_validator_map = {"string": self._string_type_validator,
-                                          "number": self._num_type_validator,
-                                          "array": self._array_type_validator,
-                                          "bool": self._bool_type_validator, }
-            try:
-                validator = data_type_to_validator_map[var_type]
-            except KeyError:
-                raise KeyError(f"Invalid type {var_type}: Element must be type {data_type_to_validator_map.keys()}")
+            # data_type_to_validator_map = {"string": self._string_type_validator,
+            #                               "number": self._num_type_validator,
+            #                               "array": self._array_type_validator,
+            #                               "bool": self._bool_type_validator, }
+            # try:
+            #     validator = data_type_to_validator_map[var_type]
+            # except KeyError:
+            #     raise KeyError(f"Invalid type {var_type}: Element must be type {data_type_to_validator_map.keys()}")
 
-            is_valid = validator(variable_properties, var_name, input_data_value)
+            # is_valid = validator(variable_properties, var_name, input_data_value)
+            is_valid = self._get_validity(variable_properties, var_name, input_data_value, var_type)
 
             element_counter_and_validity["total_elements"] += 1
             if is_valid:

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -258,26 +258,15 @@ class InputManager:
             invalid elements, valid elements, and fixed elements as well as a boolean
             which is True if the data is valid, False otherwise.
         """
-        # property = column header/key in csv data dict ("diesel_cost_gal")
-        # input_data = {"diesel_cost_gal": [5, 10], "electricity_cost_kwh": [0.15], etc}
         element_counter_and_validity = {"fixed_elements": 0, "total_elements": 0, "valid_elements": 0,
                                         "invalid_elements": 0, "is_valid": True}
-        property_data = input_data[property]  # get array of data to validate
+        property_data = input_data[property]
         variable_properties = reduce(lambda d, key: d[key], [property],
                                      self.__metadata["properties"][properties_blob_key])
         var_type = variable_properties["type"]
-        # data_type_to_validator_map = {"string": self._string_type_validator,
-        #                               "number": self._num_type_validator,
-        #                               "array": self._array_type_validator,
-        #                               "bool": self._bool_type_validator, }
-        # try:
-        #     validator = data_type_to_validator_map[var_type]
-        # except KeyError:
-        #     raise KeyError(f"Invalid type {var_type}: Element must be type {data_type_to_validator_map.keys()}")
 
         for element in property_data:
             element_counter_and_validity["total_elements"] += 1
-            # is_valid = validator(variable_properties, property, element)
             is_valid = self._get_validity(variable_properties, property, element, var_type)
             if is_valid:
                 element_counter_and_validity["valid_elements"] += 1
@@ -286,10 +275,11 @@ class InputManager:
                 if is_fixed:
                     element_counter_and_validity["fixed_elements"] += 1
                 else:
-                    if eager_termination:
-                        return element_counter_and_validity
                     element_counter_and_validity["invalid_elements"] += 1
                     element_counter_and_validity["is_valid"] = False
+                    if eager_termination:
+                        return element_counter_and_validity
+
         return element_counter_and_validity
 
     def _validate_json_element(self, element_hierarchy: List[str], properties_blob_key: str,

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -48,6 +48,7 @@ def input_manager_original_method_states(
         "_fix_data": mock_input_manager._fix_data,
         "get_data": mock_input_manager.get_data,
         "get_metadata": mock_input_manager.get_metadata,
+        "get_validity": mock_input_manager._get_validity
     }
 
 
@@ -173,7 +174,7 @@ def mock_metadata(mocker: MockerFixture) -> Dict[str, Dict[str, Any]]:
 
 
 def test_populate_pool_valid(mock_input_manager: InputManager, mock_metadata: Dict[str, Dict[str, Any]],
-                             input_manager_original_method_states: Dict[str, Callable], ):
+                             input_manager_original_method_states: Dict[str, Callable], ) -> None:
     """Unit test for valid data for function _populate_pool in file input_manager.py"""
     mock_input_manager._InputManager__metadata = mock_metadata
     mock_input_manager._load_data_from_json = lambda _: {"element1": "value1", "element2": "value2"}
@@ -272,7 +273,7 @@ def test_populate_pool_eager_termination(mock_input_manager: InputManager, mock_
 
 
 def test_populate_pool_raises_keyerror(mock_input_manager: InputManager,
-                                       input_manager_original_method_states: Dict[str, Callable], ):
+                                       input_manager_original_method_states: Dict[str, Callable], ) -> None:
     """Unit test for invalid data file type for function _populate_pool in file input_manager.py"""
     mock_input_manager._InputManager__metadata = {"files": {"dummy_file_key": {"type": "invalid_data_type",
                                                                                "path": "/path/to/your/file",
@@ -289,6 +290,42 @@ def test_populate_pool_raises_keyerror(mock_input_manager: InputManager,
     mock_input_manager._populate_pool = \
         input_manager_original_method_states["_populate_pool"]
     mock_input_manager._validate_json_element = input_manager_original_method_states["_validate_json_element"]
+
+
+@pytest.mark.parametrize(
+        "variable_properties, input_data_value, var_type",
+        [
+            ({"dummy_property": "dummy_value"}, "dummy_value", "string"),
+            ({"dummy_property": 10}, 10, "number"),
+            ({"dummy_property": True}, True, "bool"),
+            ({"dummy_property": []}, [], "array"),
+        ]
+)
+def test_get_validity_valid_data(mock_input_manager: InputManager,
+                                 input_manager_original_method_states: Dict[str, Callable],
+                                 variable_properties: Dict[str, Any], input_data_value: Any, var_type: str) -> None:
+    """Unit test for valid data type for function _get_validity in file input_manager.py"""
+    var_name = "dummy_var"
+
+    result = mock_input_manager._get_validity(variable_properties, var_name, input_data_value, var_type)
+    assert result is True
+
+    mock_input_manager._get_validity = input_manager_original_method_states["_get_validity"]
+
+
+def test_get_validity_invalid_type_raises_keyerror(mock_input_manager: InputManager,
+                                                   input_manager_original_method_states: Dict[str, Callable],
+                                                   ) -> None:
+    """Unit test for invalid data type raising a KeyError for function _get_validity in file input_manager.py"""
+    variable_properties = {"dummy_property": "dummy_value"}
+    var_name = "dummy_var"
+    input_data_value = "dummy_value"
+    var_type = "invalid_type"
+
+    with pytest.raises(KeyError, match="Invalid type invalid_type"):
+        mock_input_manager._get_validity(variable_properties, var_name, input_data_value, var_type)
+
+        mock_input_manager._get_validity = input_manager_original_method_states["_get_validity"]
 
 
 @pytest.fixture
@@ -354,7 +391,7 @@ def mock_metadata_for_validate_json_element(mocker: MockerFixture) -> Dict[str, 
 
 def test_validate_json_element_string_type(mock_input_manager: InputManager,
                                            mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
-                                           input_manager_original_method_states: Dict[str, Callable], ):
+                                           input_manager_original_method_states: Dict[str, Callable], ) -> None:
     """Unit test for string type input_data for _validate_json_element in file input_manager.py"""
     mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element
 
@@ -373,7 +410,7 @@ def test_validate_json_element_string_type(mock_input_manager: InputManager,
 
 def test_validate_json_element_number_type(mock_input_manager: InputManager,
                                            mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
-                                           input_manager_original_method_states: Dict[str, Callable], ):
+                                           input_manager_original_method_states: Dict[str, Callable], ) -> None:
     """Unit test for number type input_data for _validate_json_element in file input_manager.py"""
     mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element
 
@@ -392,7 +429,7 @@ def test_validate_json_element_number_type(mock_input_manager: InputManager,
 
 def test_validate_json_element_array_type(mock_input_manager: InputManager,
                                           mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
-                                          input_manager_original_method_states: Dict[str, Callable], ):
+                                          input_manager_original_method_states: Dict[str, Callable], ) -> None:
     """Unit test for array type input_data for _validate_json_element in file input_manager.py"""
     mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element
 
@@ -411,7 +448,7 @@ def test_validate_json_element_array_type(mock_input_manager: InputManager,
 
 def test_validate_json_element_valid_object_type(mock_input_manager: InputManager,
                                                  mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
-                                                 input_manager_original_method_states: Dict[str, Callable], ):
+                                                 input_manager_original_method_states: Dict[str, Callable], ) -> None:
     """Unit test for valid nested object type input_data for _validate_json_element in file input_manager.py"""
     mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element
 
@@ -425,7 +462,7 @@ def test_validate_json_element_valid_object_type(mock_input_manager: InputManage
 
 def test_validate_json_element_invalid_object_type(mock_input_manager: InputManager,
                                                    mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
-                                                   input_manager_original_method_states: Dict[str, Callable], ):
+                                                   input_manager_original_method_states: Dict[str, Callable], ) -> None:
     """Unit test for nested invalid object type input_data for _validate_json_element in file input_manager.py"""
     mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element
 
@@ -444,7 +481,7 @@ def test_validate_json_element_invalid_object_type(mock_input_manager: InputMana
 
 def test_validate_element_valid_nested_object_type(mock_input_manager: InputManager,
                                                    mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
-                                                   input_manager_original_method_states: Dict[str, Callable], ):
+                                                   input_manager_original_method_states: Dict[str, Callable], ) -> None:
     """Unit test for valid object nested within another object type
     input_data for _validate_json_element in file input_manager.py"""
     mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element
@@ -460,7 +497,7 @@ def test_validate_element_valid_nested_object_type(mock_input_manager: InputMana
 
 def test_validate_element_invalid_nested_object_type(mock_input_manager: InputManager,
                                                      mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
-                                                     input_manager_original_method_states: Dict[str, Callable], ):
+                                                     input_manager_original_method_states: Dict[str, Callable], ) -> None:
     """Unit test for invalid object nested within another object type
     input_data for _validate_json_element in file input_manager.py"""
     mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -96,7 +96,7 @@ def test_load_data_from_json_missing_file_raises_error(mock_input_manager: Input
         with patch("RUFAS.output_manager.OutputManager.add_log") as add_log:
             with pytest.raises(FileNotFoundError):
                 mock_input_manager._load_data_from_json("non_existent_file.json")
-                assert add_log.call_count == 1
+            assert add_log.call_count == 1
 
 
 def test_load_data_from_json_invalid_data_raises_error(mock_input_manager: InputManager, ) -> None:
@@ -105,7 +105,7 @@ def test_load_data_from_json_invalid_data_raises_error(mock_input_manager: Input
         with patch("RUFAS.output_manager.OutputManager.add_log") as add_log:
             with pytest.raises(json.JSONDecodeError):
                 mock_input_manager._load_data_from_json("dummy_file.json")
-                assert add_log.call_count == 1
+            assert add_log.call_count == 1
 
 
 def test_load_data_from_csv(mock_input_manager: InputManager, ) -> None:
@@ -122,12 +122,12 @@ def test_load_data_from_csv(mock_input_manager: InputManager, ) -> None:
 
 
 def test_load_data_from_csv_missing_file_raises_error(mock_input_manager: InputManager, ) -> None:
-    """Unit test for function _load_data_from_json with missing json file in file input_manager.py"""
+    """Unit test for function _load_data_from_csv with missing csv file in file input_manager.py"""
     with patch("builtins.open", side_effect=FileNotFoundError):
         with patch("RUFAS.output_manager.OutputManager.add_log") as add_log:
             with pytest.raises(FileNotFoundError):
                 mock_input_manager._load_data_from_csv("non_existent_file.csv")
-                assert add_log.call_count == 2
+            assert add_log.call_count == 1
 
 
 def test_load_data_from_csv_invalid_data_raises_error(mock_input_manager: InputManager, ) -> None:
@@ -137,7 +137,7 @@ def test_load_data_from_csv_invalid_data_raises_error(mock_input_manager: InputM
             with patch("pandas.read_csv", side_effect=pd.errors.ParserError("Invalid CSV")):
                 with pytest.raises(pd.errors.ParserError):
                     mock_input_manager._load_data_from_csv("dummy_file.csv")
-                    assert add_log.call_count == 1
+                assert add_log.call_count == 1
 
 
 def test_start_data_processing(mock_input_manager: InputManager,
@@ -197,11 +197,11 @@ def test_populate_pool_valid(mock_input_manager: InputManager, mock_metadata: Di
         with patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning:
             result = mock_input_manager._populate_pool(eager_termination=True)
 
-            assert result is True
-            assert add_log.call_count == 4
-            assert add_warning.call_count == 0
-            assert "file1" in mock_input_manager._InputManager__pool
-            assert "file2" in mock_input_manager._InputManager__pool
+        assert result is True
+        assert add_log.call_count == 4
+        assert add_warning.call_count == 0
+        assert "file1" in mock_input_manager._InputManager__pool
+        assert "file2" in mock_input_manager._InputManager__pool
 
     mock_input_manager._populate_pool = \
         input_manager_original_method_states["_populate_pool"]
@@ -219,13 +219,13 @@ def test_populate_pool_invalid(mock_input_manager: InputManager, mock_metadata: 
     mock_input_manager._validate_json_element = lambda *args, **kwargs: {"fixed_elements": 1,
                                                                          "valid_elements": 1,
                                                                          "total_elements": 1,
-                                                                         "invalid_elements": 0,
+                                                                         "invalid_elements": 1,
                                                                          "is_valid": False
                                                                          }
     mock_input_manager._validate_csv_element = lambda *args, **kwargs: {"fixed_elements": 1,
                                                                         "valid_elements": 1,
                                                                         "total_elements": 1,
-                                                                        "invalid_elements": 0,
+                                                                        "invalid_elements": 1,
                                                                         "is_valid": False
                                                                         }
 
@@ -233,11 +233,12 @@ def test_populate_pool_invalid(mock_input_manager: InputManager, mock_metadata: 
         with patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning:
 
             result = mock_input_manager._populate_pool(eager_termination=True)
-            assert result is False
-            assert add_log.call_count == 0
-            assert add_warning.call_count == 0
-            assert "file1" not in mock_input_manager._InputManager__pool
-            assert "file2" not in mock_input_manager._InputManager__pool
+
+        assert result is False
+        assert add_log.call_count == 0
+        assert add_warning.call_count == 0
+        assert "file1" not in mock_input_manager._InputManager__pool
+        assert "file2" not in mock_input_manager._InputManager__pool
 
     mock_input_manager._populate_pool = \
         input_manager_original_method_states["_populate_pool"]
@@ -391,6 +392,24 @@ def mock_metadata_for_validate_element(mocker: MockerFixture) -> Dict[str, Dict[
             }
         }
     }
+
+
+def test_validate_element_fixable_data(mock_input_manager: InputManager,
+                                       mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
+                                       input_manager_original_method_states: Dict[str, Callable], ) -> None:
+    """Unit test for a fixable number type input_data for _validate_json_element in file input_manager.py"""
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
+    mock_input_manager._num_type_validator = MagicMock(return_value=False)
+    mock_input_manager._fix_data = MagicMock(return_value=True)
+
+    input_data = {"element2": 123}
+    result = mock_input_manager._validate_json_element(["element2"], "property_map_key1", input_data, True)
+
+    assert result["is_valid"] is True
+
+    mock_input_manager._validate_json_element = input_manager_original_method_states["_validate_json_element"]
+    mock_input_manager._num_type_validator = input_manager_original_method_states["_num_type_validator"]
+    mock_input_manager._fix_data = input_manager_original_method_states["_fix_data"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -2,7 +2,7 @@
 RUFAS: Ruminant Farm Systems Model
 File name: test_input_manager.py
 Description: Implements test cases for Input Manager
-Author(s): Niko Tomlinson, ndt2@cornell.edu
+Author(s): Niko Tomlinson, ndt2@cornell.edu; Allister Liu, al25632@cornell.edu; Michael Richards, mr2372@cornell.edu
 """
 from functools import reduce
 import json
@@ -232,10 +232,10 @@ def test_populate_pool_invalid(mock_input_manager: InputManager, mock_metadata: 
     with patch("RUFAS.output_manager.OutputManager.add_log") as add_log:
         with patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning:
 
-            result = mock_input_manager._populate_pool(eager_termination=True)
+            result = mock_input_manager._populate_pool(eager_termination=False)
 
         assert result is False
-        assert add_log.call_count == 0
+        assert add_log.call_count == 4
         assert add_warning.call_count == 0
         assert "file1" not in mock_input_manager._InputManager__pool
         assert "file2" not in mock_input_manager._InputManager__pool
@@ -388,7 +388,9 @@ def mock_metadata_for_validate_element(mocker: MockerFixture) -> Dict[str, Dict[
                                  },
                                 }
                              },
-                "element6": {"type": "bool"}
+                "element6": {"type": "bool"},
+                "element7": {"type": "number", "maximum": 10, "default": 5},
+                "element8": {"type": "object", "nested_element": {"type": "number", "maximum": 10}},
             }
         }
     }
@@ -445,26 +447,28 @@ def test_validate_csv_element_valid_data(mock_input_manager: InputManager,
 
 
 @pytest.mark.parametrize(
-        "property, input_data, total_elements, valid_elements, invalid_elements, fixed_elements, eager_termination",
+        "property, input_data, total_elements, valid_elements, invalid_elements, fixed_elements, is_valid,"
+        " eager_termination",
         [
-            ("element1", {"element1": ["invalid1", "invalid2", "invalid3"]}, 3, 0, 3, 0, False),
-            ("element2", {"element2": [-6, 1149, 955, -22]}, 1, 0, 1, 0, True),
+            ("element1", {"element1": ["invalid1", "invalid2", "invalid3"]}, 3, 0, 3, 0, False, False),
+            ("element2", {"element2": [-6, 1149, 955, -22]}, 1, 0, 1, 0, False, True),
+            ("element7", {"element7": [50]}, 1, 0, 0, 1, True, False),
         ]
 )
 def test_validate_csv_element_invalid_data(mock_input_manager: InputManager,
                                            mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
-                                           property: str, input_data: list, total_elements: int,
+                                           property: str, input_data: list, total_elements: int, is_valid: bool,
                                            valid_elements: int, invalid_elements: int, fixed_elements: int,
                                            input_manager_original_method_states: Dict[str, Callable],
                                            eager_termination: bool,
                                            ) -> None:
     mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
-    mock_input_manager._fix_data = MagicMock(return_value=False)
+    mock_input_manager._fix_data = MagicMock(return_value=is_valid)
     properties_blob_key = "property_map_key1"
 
     result = mock_input_manager._validate_csv_element(property, properties_blob_key,
                                                       input_data, eager_termination)
-    assert result["is_valid"] is False
+    assert result["is_valid"] is is_valid
     assert result["total_elements"] == total_elements
     assert result["valid_elements"] == valid_elements
     assert result["invalid_elements"] == invalid_elements
@@ -489,6 +493,14 @@ def test_validate_json_element_string_type(mock_input_manager: InputManager,
     result = mock_input_manager._validate_json_element(["element1"], "property_map_key1", input_data, True)
 
     assert result["is_valid"] is False
+
+    input_data = {"element8": {"nested_element": 750}}
+    with patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning:
+        result = mock_input_manager._validate_json_element(["element8"], "property_map_key1", input_data, False)
+
+        assert add_warning.call_count == 2
+        assert result["is_valid"] is False
+        assert result["invalid_elements"] == 1
 
     mock_input_manager._validate_json_element = input_manager_original_method_states["_validate_json_element"]
 
@@ -626,12 +638,33 @@ def test_bool_type_validator(input_data_value: bool, expected_result: bool, mock
     assert result == expected_result
 
 
-def test_validate_json_element_invalid_var_name_raises_keyerror(mock_input_manager: InputManager,
-                                                                input_manager_original_method_states:
-                                                                Dict[str, Callable],
-                                                                ) -> None:
+def test_validate_json_element_invalid_var_name_raises_metadata_keyerror(mock_input_manager: InputManager,
+                                                                         input_manager_original_method_states:
+                                                                         Dict[str, Callable],
+                                                                         ) -> None:
     """Unit test for keyerror raised for invalid var name for _validate_json_element in file input_manager.py"""
     element_hierarchy = ["valid_key", "invalid_key"]
+    properties_blob_key = "dummy_properties_blob_key"
+    input_data = {"valid_key": {"another_valid_key": "value"}}
+    eager_termination = False
+
+    with pytest.raises(KeyError):
+        mock_input_manager._validate_json_element(element_hierarchy, properties_blob_key, input_data,
+                                                  eager_termination)
+
+    mock_input_manager._validate_json_element = input_manager_original_method_states["_validate_json_element"]
+
+
+def test_validate_json_element_invalid_var_name_raises_input_data_keyerror(mock_input_manager: InputManager,
+                                                                           input_manager_original_method_states:
+                                                                           Dict[str, Callable],
+                                                                           ) -> None:
+    """Unit test for keyerror raised for invalid var name for _validate_json_element in file input_manager.py"""
+    mock_input_manager._InputManager__metadata = {"properties": {"dummy_properties_blob_key":
+                                                                 {"valid_key":
+                                                                  {"type": "object", "secondary_key":
+                                                                   {"type": "string"}}}}}
+    element_hierarchy = ["valid_key", "secondary_key"]
     properties_blob_key = "dummy_properties_blob_key"
     input_data = {"valid_key": {"another_valid_key": "value"}}
     eager_termination = False

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -48,7 +48,8 @@ def input_manager_original_method_states(
         "_fix_data": mock_input_manager._fix_data,
         "get_data": mock_input_manager.get_data,
         "get_metadata": mock_input_manager.get_metadata,
-        "get_validity": mock_input_manager._get_validity
+        "_get_validity": mock_input_manager._get_validity,
+        "_validate_csv_element": mock_input_manager._validate_csv_element,
     }
 
 
@@ -205,6 +206,7 @@ def test_populate_pool_valid(mock_input_manager: InputManager, mock_metadata: Di
     mock_input_manager._populate_pool = \
         input_manager_original_method_states["_populate_pool"]
     mock_input_manager._validate_json_element = input_manager_original_method_states["_validate_json_element"]
+    mock_input_manager._validate_csv_element = input_manager_original_method_states["_validate_csv_element"]
 
 
 def test_populate_pool_invalid(mock_input_manager: InputManager, mock_metadata: Dict[str, Dict[str, Any]],
@@ -240,6 +242,7 @@ def test_populate_pool_invalid(mock_input_manager: InputManager, mock_metadata: 
     mock_input_manager._populate_pool = \
         input_manager_original_method_states["_populate_pool"]
     mock_input_manager._validate_json_element = input_manager_original_method_states["_validate_json_element"]
+    mock_input_manager._validate_csv_element = input_manager_original_method_states["_validate_csv_element"]
 
 
 def test_populate_pool_eager_termination(mock_input_manager: InputManager, mock_metadata: Dict[str, Dict[str, Any]],
@@ -325,11 +328,11 @@ def test_get_validity_invalid_type_raises_keyerror(mock_input_manager: InputMana
     with pytest.raises(KeyError, match="Invalid type invalid_type"):
         mock_input_manager._get_validity(variable_properties, var_name, input_data_value, var_type)
 
-        mock_input_manager._get_validity = input_manager_original_method_states["_get_validity"]
+    mock_input_manager._get_validity = input_manager_original_method_states["_get_validity"]
 
 
 @pytest.fixture
-def mock_metadata_for_validate_json_element(mocker: MockerFixture) -> Dict[str, Dict[str, Any]]:
+def mock_metadata_for_validate_element(mocker: MockerFixture) -> Dict[str, Dict[str, Any]]:
     return {
         "files": {
             "file1": {
@@ -383,17 +386,49 @@ def mock_metadata_for_validate_json_element(mocker: MockerFixture) -> Dict[str, 
                                     "maximum_length": 5
                                  },
                                 }
-                             }
+                             },
+                "element6": {"type": "bool"}
             }
         }
     }
 
 
+@pytest.mark.parametrize(
+        "property, input_data, total_elements, valid_elements, invalid_elements, fixed_elements",
+        [
+            ("element1", {"element1": ["123-45-6789", "000-11-6123", "555-55-5555"]}, 3, 3, 0, 0),
+            ("element2", {"element2": [6, 149, 55, 22]}, 4, 4, 0, 0),
+            ("element6", {"element6": [True, False, True]}, 3, 3, 0, 0),
+        ]
+)
+def test_validate_csv_element_valid_data(mock_input_manager: InputManager,
+                                         mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
+                                         property: str, input_data: list, total_elements: int,
+                                         valid_elements: int, invalid_elements: int, fixed_elements: int,
+                                         input_manager_original_method_states: Dict[str, Callable],
+                                         ) -> None:
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
+    dummy_property = property
+    properties_blob_key = "property_map_key1"
+    dummy_input_data = input_data
+    eager_termination = True
+
+    result = mock_input_manager._validate_csv_element(dummy_property, properties_blob_key,
+                                                      dummy_input_data, eager_termination)
+    assert result["is_valid"] is True
+    assert result["total_elements"] == total_elements
+    assert result["valid_elements"] == valid_elements
+    assert result["invalid_elements"] == invalid_elements
+    assert result["fixed_elements"] == fixed_elements
+
+    mock_input_manager._validate_csv_element = input_manager_original_method_states["_validate_csv_element"]
+
+
 def test_validate_json_element_string_type(mock_input_manager: InputManager,
-                                           mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
+                                           mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
                                            input_manager_original_method_states: Dict[str, Callable], ) -> None:
     """Unit test for string type input_data for _validate_json_element in file input_manager.py"""
-    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
 
     input_data = {"element1": "123-45-6789"}
     result = mock_input_manager._validate_json_element(["element1"], "property_map_key1", input_data, True)
@@ -409,10 +444,10 @@ def test_validate_json_element_string_type(mock_input_manager: InputManager,
 
 
 def test_validate_json_element_number_type(mock_input_manager: InputManager,
-                                           mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
+                                           mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
                                            input_manager_original_method_states: Dict[str, Callable], ) -> None:
     """Unit test for number type input_data for _validate_json_element in file input_manager.py"""
-    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
 
     input_data = {"element2": 123}
     result = mock_input_manager._validate_json_element(["element2"], "property_map_key1", input_data, True)
@@ -428,10 +463,10 @@ def test_validate_json_element_number_type(mock_input_manager: InputManager,
 
 
 def test_validate_json_element_array_type(mock_input_manager: InputManager,
-                                          mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
+                                          mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
                                           input_manager_original_method_states: Dict[str, Callable], ) -> None:
     """Unit test for array type input_data for _validate_json_element in file input_manager.py"""
-    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
 
     input_data = {"element3": [1, 2, 3]}
     result = mock_input_manager._validate_json_element(["element3"], "property_map_key1", input_data, True)
@@ -447,10 +482,10 @@ def test_validate_json_element_array_type(mock_input_manager: InputManager,
 
 
 def test_validate_json_element_valid_object_type(mock_input_manager: InputManager,
-                                                 mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
+                                                 mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
                                                  input_manager_original_method_states: Dict[str, Callable], ) -> None:
     """Unit test for valid nested object type input_data for _validate_json_element in file input_manager.py"""
-    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
 
     input_data = {"element4": {"nested_element1": "value1", "nested_element2": 123}}
     result = mock_input_manager._validate_json_element(["element4"], "property_map_key1", input_data, True)
@@ -461,10 +496,10 @@ def test_validate_json_element_valid_object_type(mock_input_manager: InputManage
 
 
 def test_validate_json_element_invalid_object_type(mock_input_manager: InputManager,
-                                                   mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
+                                                   mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
                                                    input_manager_original_method_states: Dict[str, Callable], ) -> None:
     """Unit test for nested invalid object type input_data for _validate_json_element in file input_manager.py"""
-    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
 
     input_data = {"element4": {"nested_element1": "value1", "nested_element2": 500}}
     result = mock_input_manager._validate_json_element(["element4"], "property_map_key1", input_data, True)
@@ -480,11 +515,11 @@ def test_validate_json_element_invalid_object_type(mock_input_manager: InputMana
 
 
 def test_validate_element_valid_nested_object_type(mock_input_manager: InputManager,
-                                                   mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
+                                                   mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
                                                    input_manager_original_method_states: Dict[str, Callable], ) -> None:
     """Unit test for valid object nested within another object type
     input_data for _validate_json_element in file input_manager.py"""
-    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
 
     input_data = {"element5": {"nested_element1": "value1", "nested_element2": 123,
                                "nested_element3": {"nested_sub_element1": "cows", "nested_sub_element2": [1, 2, 3]}}}
@@ -496,11 +531,12 @@ def test_validate_element_valid_nested_object_type(mock_input_manager: InputMana
 
 
 def test_validate_element_invalid_nested_object_type(mock_input_manager: InputManager,
-                                                     mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
-                                                     input_manager_original_method_states: Dict[str, Callable], ) -> None:
+                                                     mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
+                                                     input_manager_original_method_states: Dict[str, Callable],
+                                                     ) -> None:
     """Unit test for invalid object nested within another object type
     input_data for _validate_json_element in file input_manager.py"""
-    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
 
     input_data = {"element5": {"nested_element1": "value1", "nested_element2": 123,
                                "nested_element3": {"nested_sub_element1": "cows", "nested_sub_element2": []}}}

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -407,6 +407,7 @@ def test_validate_csv_element_valid_data(mock_input_manager: InputManager,
                                          valid_elements: int, invalid_elements: int, fixed_elements: int,
                                          input_manager_original_method_states: Dict[str, Callable],
                                          ) -> None:
+    """Unit test for _validate_csv_element function in file input_manager.py"""
     mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
     dummy_property = property
     properties_blob_key = "property_map_key1"
@@ -422,6 +423,36 @@ def test_validate_csv_element_valid_data(mock_input_manager: InputManager,
     assert result["fixed_elements"] == fixed_elements
 
     mock_input_manager._validate_csv_element = input_manager_original_method_states["_validate_csv_element"]
+
+
+@pytest.mark.parametrize(
+        "property, input_data, total_elements, valid_elements, invalid_elements, fixed_elements, eager_termination",
+        [
+            ("element1", {"element1": ["invalid1", "invalid2", "invalid3"]}, 3, 0, 3, 0, False),
+            ("element2", {"element2": [-6, 1149, 955, -22]}, 1, 0, 1, 0, True),
+        ]
+)
+def test_validate_csv_element_invalid_data(mock_input_manager: InputManager,
+                                           mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
+                                           property: str, input_data: list, total_elements: int,
+                                           valid_elements: int, invalid_elements: int, fixed_elements: int,
+                                           input_manager_original_method_states: Dict[str, Callable],
+                                           eager_termination: bool,
+                                           ) -> None:
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
+    mock_input_manager._fix_data = MagicMock(return_value=False)
+    properties_blob_key = "property_map_key1"
+
+    result = mock_input_manager._validate_csv_element(property, properties_blob_key,
+                                                      input_data, eager_termination)
+    assert result["is_valid"] is False
+    assert result["total_elements"] == total_elements
+    assert result["valid_elements"] == valid_elements
+    assert result["invalid_elements"] == invalid_elements
+    assert result["fixed_elements"] == fixed_elements
+
+    mock_input_manager._validate_csv_element = input_manager_original_method_states["_validate_csv_element"]
+    mock_input_manager._fix_data = input_manager_original_method_states["_fix_data"]
 
 
 def test_validate_json_element_string_type(mock_input_manager: InputManager,
@@ -568,7 +599,7 @@ def test_validate_element_invalid_nested_object_type(mock_input_manager: InputMa
     ],
 )
 def test_bool_type_validator(input_data_value: bool, expected_result: bool, mock_input_manager: InputManager) -> None:
-    """Unit test for function _bool_type_validator function in file input_manager.py"""
+    """Unit test for function _bool_type_validator in file input_manager.py"""
     variable_properties = {}
     var_name = "dummy_var_name"
     result = mock_input_manager._bool_type_validator(variable_properties, var_name, input_data_value)
@@ -625,7 +656,7 @@ def test_validate_json_element_invalid_var_type_raises_keyerror(mock_input_manag
 )
 def test_array_type_validator(dummy_value: list, dummy_variable_to_check: Dict[str, int], expected_result: bool,
                               expected_warning_call_count: int, mock_input_manager: InputManager) -> None:
-    """Unit test for function _array_type_validator function in file input_manager.py"""
+    """Unit test for function _array_type_validator in file input_manager.py"""
     dummy_var_name = "dummy_array"
 
     with patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning:
@@ -651,7 +682,7 @@ def test_num_type_validator(dummy_value: int,
                             expected_result: bool,
                             expected_warning_call_count: int,
                             mock_input_manager: InputManager) -> None:
-    """Unit test for function _num_type_validator function in file input_manager.py"""
+    """Unit test for function _num_type_validator in file input_manager.py"""
     dummy_var_name = "dummy_num"
 
     with patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning:
@@ -677,7 +708,7 @@ def test_string_type_validator(dummy_value: int,
                                expected_result: bool,
                                expected_warning_call_count: int,
                                mock_input_manager: InputManager) -> None:
-    """Unit test for function _string_type_validator function in file input_manager.py"""
+    """Unit test for _string_type_validator function in file input_manager.py"""
     dummy_var_name = "dummy_var"
 
     with patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning:

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -96,7 +96,7 @@ def test_load_data_from_json_missing_file_raises_error(mock_input_manager: Input
         with patch("RUFAS.output_manager.OutputManager.add_log") as add_log:
             with pytest.raises(FileNotFoundError):
                 mock_input_manager._load_data_from_json("non_existent_file.json")
-            assert add_log.call_count == 1
+                assert add_log.call_count == 1
 
 
 def test_load_data_from_json_invalid_data_raises_error(mock_input_manager: InputManager, ) -> None:
@@ -105,7 +105,7 @@ def test_load_data_from_json_invalid_data_raises_error(mock_input_manager: Input
         with patch("RUFAS.output_manager.OutputManager.add_log") as add_log:
             with pytest.raises(json.JSONDecodeError):
                 mock_input_manager._load_data_from_json("dummy_file.json")
-            assert add_log.call_count == 1
+                assert add_log.call_count == 1
 
 
 def test_load_data_from_csv(mock_input_manager: InputManager, ) -> None:
@@ -122,12 +122,12 @@ def test_load_data_from_csv(mock_input_manager: InputManager, ) -> None:
 
 
 def test_load_data_from_csv_missing_file_raises_error(mock_input_manager: InputManager, ) -> None:
-    """Unit test for function _load_data_from_csv with missing csv file in file input_manager.py"""
+    """Unit test for function _load_data_from_json with missing json file in file input_manager.py"""
     with patch("builtins.open", side_effect=FileNotFoundError):
         with patch("RUFAS.output_manager.OutputManager.add_log") as add_log:
             with pytest.raises(FileNotFoundError):
                 mock_input_manager._load_data_from_csv("non_existent_file.csv")
-            assert add_log.call_count == 1
+                assert add_log.call_count == 2
 
 
 def test_load_data_from_csv_invalid_data_raises_error(mock_input_manager: InputManager, ) -> None:
@@ -137,7 +137,7 @@ def test_load_data_from_csv_invalid_data_raises_error(mock_input_manager: InputM
             with patch("pandas.read_csv", side_effect=pd.errors.ParserError("Invalid CSV")):
                 with pytest.raises(pd.errors.ParserError):
                     mock_input_manager._load_data_from_csv("dummy_file.csv")
-                assert add_log.call_count == 1
+                    assert add_log.call_count == 1
 
 
 def test_start_data_processing(mock_input_manager: InputManager,
@@ -232,9 +232,9 @@ def test_populate_pool_invalid(mock_input_manager: InputManager, mock_metadata: 
     with patch("RUFAS.output_manager.OutputManager.add_log") as add_log:
         with patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning:
 
-            result = mock_input_manager._populate_pool(eager_termination=False)
+            result = mock_input_manager._populate_pool(eager_termination=True)
             assert result is False
-            assert add_log.call_count == 4
+            assert add_log.call_count == 0
             assert add_warning.call_count == 0
             assert "file1" not in mock_input_manager._InputManager__pool
             assert "file2" not in mock_input_manager._InputManager__pool
@@ -287,8 +287,8 @@ def test_populate_pool_raises_keyerror(mock_input_manager: InputManager,
             with pytest.raises(KeyError):
                 mock_input_manager._populate_pool(eager_termination=True)
 
-            assert add_log.call_count == 0
-            assert add_warning.call_count == 0
+                assert add_log.call_count == 0
+                assert add_warning.call_count == 0
 
     mock_input_manager._populate_pool = \
         input_manager_original_method_states["_populate_pool"]

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -1107,6 +1107,24 @@ def test_fix_string_type_fixable_data(dummy_variable_properties: dict[str, Any],
     assert add_warning.call_count == expected_warning_call_count
 
 
+def test_fix_string_type_csv_data(mock_input_manager: InputManager) -> None:
+    """Unit test for fixable number-type data from a csv array for _fix_data function in file input_manager.py"""
+
+    dummy_input_data = {"element1": [1, 2, 3, 4, 5]}
+    dummy_variable_properties = {"type": "number", "maximum": 4, "default": 3}
+    dummy_element_hierarchy = ["element1", 4]
+
+    with patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning:
+        result = mock_input_manager._fix_data(dummy_variable_properties, dummy_element_hierarchy, dummy_input_data)
+
+    fixed_variable = reduce(lambda d, key: d[key], dummy_element_hierarchy,
+                            dummy_input_data)
+
+    assert fixed_variable == 3
+    assert result is True
+    assert add_warning.call_count == 1
+
+
 @pytest.mark.parametrize(
     'dummy_variable_properties, dummy_element_hierarchy, expected_result, expected_warning_call_count',
     [

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -48,7 +48,7 @@ def input_manager_original_method_states(
         "_fix_data": mock_input_manager._fix_data,
         "get_data": mock_input_manager.get_data,
         "get_metadata": mock_input_manager.get_metadata,
-        "_get_validity": mock_input_manager._get_validity,
+        "_validate_input_type_dynamic": mock_input_manager._validate_input_type_dynamic,
         "_validate_csv_element": mock_input_manager._validate_csv_element,
     }
 
@@ -297,39 +297,60 @@ def test_populate_pool_raises_keyerror(mock_input_manager: InputManager,
 
 
 @pytest.mark.parametrize(
-        "variable_properties, input_data_value, var_type",
+        "variable_properties, input_data_value",
         [
-            ({"dummy_property": "dummy_value"}, "dummy_value", "string"),
-            ({"dummy_property": 10}, 10, "number"),
-            ({"dummy_property": True}, True, "bool"),
-            ({"dummy_property": []}, [], "array"),
+            ({"type": "string", "dummy_property": "dummy_value"}, "dummy_value"),
+            ({"type": "number", "dummy_property": 10}, 10),
+            ({"type": "bool", "dummy_property": True}, True),
+            ({"type": "array", "dummy_property": []}, []),
         ]
 )
-def test_get_validity_valid_data(mock_input_manager: InputManager,
-                                 input_manager_original_method_states: Dict[str, Callable],
-                                 variable_properties: Dict[str, Any], input_data_value: Any, var_type: str) -> None:
-    """Unit test for valid data type for function _get_validity in file input_manager.py"""
+def test_validate_input_type_dynamic_valid_data(mock_input_manager: InputManager,
+                                                input_manager_original_method_states: Dict[str, Callable],
+                                                variable_properties: Dict[str, Any],
+                                                input_data_value: Any) -> None:
+    """Unit test for valid data type for function _validate_input_type_dynamic in file input_manager.py"""
     var_name = "dummy_var"
 
-    result = mock_input_manager._get_validity(variable_properties, var_name, input_data_value, var_type)
+    result = mock_input_manager._validate_input_type_dynamic(variable_properties, var_name, input_data_value)
     assert result is True
 
-    mock_input_manager._get_validity = input_manager_original_method_states["_get_validity"]
+    mock_input_manager._validate_input_type_dynamic = \
+        input_manager_original_method_states["_validate_input_type_dynamic"]
 
 
-def test_get_validity_invalid_type_raises_keyerror(mock_input_manager: InputManager,
-                                                   input_manager_original_method_states: Dict[str, Callable],
-                                                   ) -> None:
-    """Unit test for invalid data type raising a KeyError for function _get_validity in file input_manager.py"""
+def test_validate_input_type_dynamic_invalid_type_raises_keyerror(mock_input_manager: InputManager,
+                                                                  input_manager_original_method_states:
+                                                                  Dict[str, Callable],
+                                                                  ) -> None:
+    """Unit test for invalid data type raising a KeyError for function
+    _validate_input_type_dynamic in file input_manager.py"""
+    variable_properties = {"type": "invalid_type", "dummy_property": "dummy_value"}
+    var_name = "dummy_var"
+    input_data_value = "dummy_value"
+
+    with pytest.raises(KeyError, match="Invalid type invalid_type"):
+        mock_input_manager._validate_input_type_dynamic(variable_properties, var_name, input_data_value)
+
+    mock_input_manager._validate_input_type_dynamic = \
+        input_manager_original_method_states["_validate_input_type_dynamic"]
+
+
+def test_validate_input_type_dynamic_missing_type_raises_keyerror(mock_input_manager: InputManager,
+                                                                  input_manager_original_method_states:
+                                                                  Dict[str, Callable],
+                                                                  ) -> None:
+    """Unit test for missing data type raising a KeyError for function
+    _validate_input_type_dynamic in file input_manager.py"""
     variable_properties = {"dummy_property": "dummy_value"}
     var_name = "dummy_var"
     input_data_value = "dummy_value"
-    var_type = "invalid_type"
 
-    with pytest.raises(KeyError, match="Invalid type invalid_type"):
-        mock_input_manager._get_validity(variable_properties, var_name, input_data_value, var_type)
+    with pytest.raises(KeyError, match="Missing 'type' key in variable_properties"):
+        mock_input_manager._validate_input_type_dynamic(variable_properties, var_name, input_data_value)
 
-    mock_input_manager._get_validity = input_manager_original_method_states["_get_validity"]
+    mock_input_manager._validate_input_type_dynamic = \
+        input_manager_original_method_states["_validate_input_type_dynamic"]
 
 
 @pytest.fixture
@@ -689,6 +710,26 @@ def test_validate_json_element_invalid_var_type_raises_keyerror(mock_input_manag
     eager_termination = False
 
     with pytest.raises(KeyError):
+        mock_input_manager._validate_json_element(element_hierarchy, properties_blob_key, input_data,
+                                                  eager_termination)
+
+    mock_input_manager._validate_json_element = input_manager_original_method_states["_validate_json_element"]
+
+
+def test_validate_json_element_missing_type_raises_keyerror(mock_input_manager: InputManager,
+                                                            input_manager_original_method_states:
+                                                            Dict[str, Callable],
+                                                            ) -> None:
+    """Unit test for missing data type raising a KeyError for function
+    _validate_json_element in file input_manager.py"""
+    element_hierarchy = ["valid_key"]
+    properties_blob_key = "dummy_valid_key"
+    input_data = {"valid_key": "some_value"}
+    mock_input_manager._InputManager__metadata = {"properties": {properties_blob_key:
+                                                                 {"valid_key": {}}}}
+    eager_termination = False
+
+    with pytest.raises(KeyError, match="Missing 'type' key in variable_properties"):
         mock_input_manager._validate_json_element(element_hierarchy, properties_blob_key, input_data,
                                                   eager_termination)
 

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -40,7 +40,7 @@ def input_manager_original_method_states(
         "_load_data_from_json": mock_input_manager._load_data_from_json,
         "_load_data_from_csv": mock_input_manager._load_data_from_csv,
         "_populate_pool": mock_input_manager._populate_pool,
-        "_validate_element": mock_input_manager._validate_element,
+        "_validate_json_element": mock_input_manager._validate_json_element,
         "_array_type_validator": mock_input_manager._array_type_validator,
         "_num_type_validator": mock_input_manager._num_type_validator,
         "_string_type_validator": mock_input_manager._string_type_validator,
@@ -178,12 +178,12 @@ def test_populate_pool_valid(mock_input_manager: InputManager, mock_metadata: Di
     mock_input_manager._InputManager__metadata = mock_metadata
     mock_input_manager._load_data_from_json = lambda _: {"element1": "value1", "element2": "value2"}
     mock_input_manager._load_data_from_csv = lambda _: {"element3": "value3", "element4": "value4"}
-    mock_input_manager._validate_element = lambda *args, **kwargs: {"fixed_elements": 1,
-                                                                    "valid_elements": 1,
-                                                                    "total_elements": 1,
-                                                                    "invalid_elements": 0,
-                                                                    "is_valid": True
-                                                                    }
+    mock_input_manager._validate_json_element = lambda *args, **kwargs: {"fixed_elements": 1,
+                                                                         "valid_elements": 1,
+                                                                         "total_elements": 1,
+                                                                         "invalid_elements": 0,
+                                                                         "is_valid": True
+                                                                         }
 
     with patch("RUFAS.output_manager.OutputManager.add_log") as add_log:
         with patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning:
@@ -197,7 +197,7 @@ def test_populate_pool_valid(mock_input_manager: InputManager, mock_metadata: Di
 
     mock_input_manager._populate_pool = \
         input_manager_original_method_states["_populate_pool"]
-    mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
+    mock_input_manager._validate_json_element = input_manager_original_method_states["_validate_json_element"]
 
 
 def test_populate_pool_invalid(mock_input_manager: InputManager, mock_metadata: Dict[str, Dict[str, Any]],
@@ -207,12 +207,12 @@ def test_populate_pool_invalid(mock_input_manager: InputManager, mock_metadata: 
 
     mock_input_manager._load_data_from_json = lambda _: {"element1": "value1", "element2": "value2"}
     mock_input_manager._load_data_from_csv = lambda _: {"element3": "value3", "element4": "value4"}
-    mock_input_manager._validate_element = lambda *args, **kwargs: {"fixed_elements": 1,
-                                                                    "valid_elements": 1,
-                                                                    "total_elements": 1,
-                                                                    "invalid_elements": 0,
-                                                                    "is_valid": False
-                                                                    }
+    mock_input_manager._validate_json_element = lambda *args, **kwargs: {"fixed_elements": 1,
+                                                                         "valid_elements": 1,
+                                                                         "total_elements": 1,
+                                                                         "invalid_elements": 0,
+                                                                         "is_valid": False
+                                                                         }
 
     with patch("RUFAS.output_manager.OutputManager.add_log") as add_log:
         with patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning:
@@ -226,7 +226,7 @@ def test_populate_pool_invalid(mock_input_manager: InputManager, mock_metadata: 
 
     mock_input_manager._populate_pool = \
         input_manager_original_method_states["_populate_pool"]
-    mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
+    mock_input_manager._validate_json_element = input_manager_original_method_states["_validate_json_element"]
 
 
 def test_populate_pool_eager_termination(mock_input_manager: InputManager, mock_metadata: Dict[str, Dict[str, Any]],
@@ -237,12 +237,12 @@ def test_populate_pool_eager_termination(mock_input_manager: InputManager, mock_
 
     mock_input_manager._load_data_from_json = lambda _: {"element1": "value1", "element2": "value2"}
     mock_input_manager._load_data_from_csv = lambda _: {"element3": "value3", "element4": "value4"}
-    mock_input_manager._validate_element = lambda *args, **kwargs: {"fixed_elements": 1,
-                                                                    "valid_elements": 1,
-                                                                    "total_elements": 1,
-                                                                    "invalid_elements": 0,
-                                                                    "is_valid": False
-                                                                    }
+    mock_input_manager._validate_json_element = lambda *args, **kwargs: {"fixed_elements": 1,
+                                                                         "valid_elements": 1,
+                                                                         "total_elements": 1,
+                                                                         "invalid_elements": 0,
+                                                                         "is_valid": False
+                                                                         }
 
     with patch("RUFAS.output_manager.OutputManager.add_log") as add_log:
         with patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning:
@@ -256,7 +256,7 @@ def test_populate_pool_eager_termination(mock_input_manager: InputManager, mock_
 
     mock_input_manager._populate_pool = \
         input_manager_original_method_states["_populate_pool"]
-    mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
+    mock_input_manager._validate_json_element = input_manager_original_method_states["_validate_json_element"]
 
 
 def test_populate_pool_raises_keyerror(mock_input_manager: InputManager,
@@ -276,11 +276,11 @@ def test_populate_pool_raises_keyerror(mock_input_manager: InputManager,
 
     mock_input_manager._populate_pool = \
         input_manager_original_method_states["_populate_pool"]
-    mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
+    mock_input_manager._validate_json_element = input_manager_original_method_states["_validate_json_element"]
 
 
 @pytest.fixture
-def mock_metadata_for_validate_element(mocker: MockerFixture) -> Dict[str, Dict[str, Any]]:
+def mock_metadata_for_validate_json_element(mocker: MockerFixture) -> Dict[str, Dict[str, Any]]:
     return {
         "files": {
             "file1": {
@@ -340,133 +340,133 @@ def mock_metadata_for_validate_element(mocker: MockerFixture) -> Dict[str, Dict[
     }
 
 
-def test_validate_element_string_type(mock_input_manager: InputManager,
-                                      mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
-                                      input_manager_original_method_states: Dict[str, Callable], ):
-    """Unit test for string type input_data for _validate_element in file input_manager.py"""
-    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
+def test_validate_json_element_string_type(mock_input_manager: InputManager,
+                                           mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
+                                           input_manager_original_method_states: Dict[str, Callable], ):
+    """Unit test for string type input_data for _validate_json_element in file input_manager.py"""
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element
 
     input_data = {"element1": "123-45-6789"}
-    result = mock_input_manager._validate_element(["element1"], "property_map_key1", input_data, True)
+    result = mock_input_manager._validate_json_element(["element1"], "property_map_key1", input_data, True)
 
     assert result["is_valid"] is True
 
     input_data = {"element1": "invalid_value"}
-    result = mock_input_manager._validate_element(["element1"], "property_map_key1", input_data, True)
+    result = mock_input_manager._validate_json_element(["element1"], "property_map_key1", input_data, True)
 
     assert result["is_valid"] is False
 
-    mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
+    mock_input_manager._validate_json_element = input_manager_original_method_states["_validate_json_element"]
 
 
-def test_validate_element_number_type(mock_input_manager: InputManager,
-                                      mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
-                                      input_manager_original_method_states: Dict[str, Callable], ):
-    """Unit test for number type input_data for _validate_element in file input_manager.py"""
-    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
+def test_validate_json_element_number_type(mock_input_manager: InputManager,
+                                           mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
+                                           input_manager_original_method_states: Dict[str, Callable], ):
+    """Unit test for number type input_data for _validate_json_element in file input_manager.py"""
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element
 
     input_data = {"element2": 123}
-    result = mock_input_manager._validate_element(["element2"], "property_map_key1", input_data, True)
+    result = mock_input_manager._validate_json_element(["element2"], "property_map_key1", input_data, True)
 
     assert result["is_valid"] is True
 
     input_data = {"element2": 500}
-    result = mock_input_manager._validate_element(["element2"], "property_map_key1", input_data, True)
+    result = mock_input_manager._validate_json_element(["element2"], "property_map_key1", input_data, True)
 
     assert result["is_valid"] is False
 
-    mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
+    mock_input_manager._validate_json_element = input_manager_original_method_states["_validate_json_element"]
 
 
-def test_validate_element_array_type(mock_input_manager: InputManager,
-                                     mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
-                                     input_manager_original_method_states: Dict[str, Callable], ):
-    """Unit test for array type input_data for _validate_element in file input_manager.py"""
-    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
+def test_validate_json_element_array_type(mock_input_manager: InputManager,
+                                          mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
+                                          input_manager_original_method_states: Dict[str, Callable], ):
+    """Unit test for array type input_data for _validate_json_element in file input_manager.py"""
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element
 
     input_data = {"element3": [1, 2, 3]}
-    result = mock_input_manager._validate_element(["element3"], "property_map_key1", input_data, True)
+    result = mock_input_manager._validate_json_element(["element3"], "property_map_key1", input_data, True)
 
     assert result["is_valid"] is True
 
     input_data = {"element3": [1, 2, 3, 6, 7, 8, 10]}
-    result = mock_input_manager._validate_element(["element3"], "property_map_key1", input_data, True)
+    result = mock_input_manager._validate_json_element(["element3"], "property_map_key1", input_data, True)
 
     assert result["is_valid"] is False
 
-    mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
+    mock_input_manager._validate_json_element = input_manager_original_method_states["_validate_json_element"]
 
 
-def test_validate_element_valid_object_type(mock_input_manager: InputManager,
-                                            mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
-                                            input_manager_original_method_states: Dict[str, Callable], ):
-    """Unit test for valid nested object type input_data for _validate_element in file input_manager.py"""
-    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
+def test_validate_json_element_valid_object_type(mock_input_manager: InputManager,
+                                                 mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
+                                                 input_manager_original_method_states: Dict[str, Callable], ):
+    """Unit test for valid nested object type input_data for _validate_json_element in file input_manager.py"""
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element
 
     input_data = {"element4": {"nested_element1": "value1", "nested_element2": 123}}
-    result = mock_input_manager._validate_element(["element4"], "property_map_key1", input_data, True)
+    result = mock_input_manager._validate_json_element(["element4"], "property_map_key1", input_data, True)
 
     assert result["is_valid"] is True
 
-    mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
+    mock_input_manager._validate_json_element = input_manager_original_method_states["_validate_json_element"]
 
 
-def test_validate_element_invalid_object_type(mock_input_manager: InputManager,
-                                              mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
-                                              input_manager_original_method_states: Dict[str, Callable], ):
-    """Unit test for nested invalid object type input_data for _validate_element in file input_manager.py"""
-    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
+def test_validate_json_element_invalid_object_type(mock_input_manager: InputManager,
+                                                   mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
+                                                   input_manager_original_method_states: Dict[str, Callable], ):
+    """Unit test for nested invalid object type input_data for _validate_json_element in file input_manager.py"""
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element
 
     input_data = {"element4": {"nested_element1": "value1", "nested_element2": 500}}
-    result = mock_input_manager._validate_element(["element4"], "property_map_key1", input_data, True)
+    result = mock_input_manager._validate_json_element(["element4"], "property_map_key1", input_data, True)
 
     assert result["is_valid"] is False
 
     input_data = {"element4": {"nested_element1": "value123456789value123456789", "nested_element2": 123}}
-    result = mock_input_manager._validate_element(["element4"], "property_map_key1", input_data, True)
+    result = mock_input_manager._validate_json_element(["element4"], "property_map_key1", input_data, True)
 
     assert result["is_valid"] is False
 
-    mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
+    mock_input_manager._validate_json_element = input_manager_original_method_states["_validate_json_element"]
 
 
 def test_validate_element_valid_nested_object_type(mock_input_manager: InputManager,
-                                                   mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
+                                                   mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
                                                    input_manager_original_method_states: Dict[str, Callable], ):
     """Unit test for valid object nested within another object type
-    input_data for _validate_element in file input_manager.py"""
-    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
+    input_data for _validate_json_element in file input_manager.py"""
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element
 
     input_data = {"element5": {"nested_element1": "value1", "nested_element2": 123,
                                "nested_element3": {"nested_sub_element1": "cows", "nested_sub_element2": [1, 2, 3]}}}
-    result = mock_input_manager._validate_element(["element5"], "property_map_key1", input_data, True)
+    result = mock_input_manager._validate_json_element(["element5"], "property_map_key1", input_data, True)
 
     assert result["is_valid"] is True
 
-    mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
+    mock_input_manager._validate_json_element = input_manager_original_method_states["_validate_json_element"]
 
 
 def test_validate_element_invalid_nested_object_type(mock_input_manager: InputManager,
-                                                     mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
+                                                     mock_metadata_for_validate_json_element: Dict[str, Dict[str, Any]],
                                                      input_manager_original_method_states: Dict[str, Callable], ):
     """Unit test for invalid object nested within another object type
-    input_data for _validate_element in file input_manager.py"""
-    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
+    input_data for _validate_json_element in file input_manager.py"""
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_json_element
 
     input_data = {"element5": {"nested_element1": "value1", "nested_element2": 123,
                                "nested_element3": {"nested_sub_element1": "cows", "nested_sub_element2": []}}}
-    result = mock_input_manager._validate_element(["element5"], "property_map_key1", input_data, True)
+    result = mock_input_manager._validate_json_element(["element5"], "property_map_key1", input_data, True)
 
     assert result["is_valid"] is False
 
     input_data = {"element5": {"nested_element1": "value1", "nested_element2": 123,
                                "nested_element3": {"nested_sub_element1": "invalid_cows",
                                                    "nested_sub_element2": [1, 2, 3]}}}
-    result = mock_input_manager._validate_element(["element5"], "property_map_key1", input_data, True)
+    result = mock_input_manager._validate_json_element(["element5"], "property_map_key1", input_data, True)
 
     assert result["is_valid"] is False
 
-    mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
+    mock_input_manager._validate_json_element = input_manager_original_method_states["_validate_json_element"]
 
 
 @pytest.mark.parametrize(
@@ -491,26 +491,28 @@ def test_bool_type_validator(input_data_value: bool, expected_result: bool, mock
     assert result == expected_result
 
 
-def test_validate_element_invalid_var_name_raises_keyerror(mock_input_manager: InputManager,
-                                                           input_manager_original_method_states: Dict[str, Callable],
-                                                           ) -> None:
-    """Unit test for keyerror raised for invalid var name for _validate_element in file input_manager.py"""
+def test_validate_json_element_invalid_var_name_raises_keyerror(mock_input_manager: InputManager,
+                                                                input_manager_original_method_states:
+                                                                Dict[str, Callable],
+                                                                ) -> None:
+    """Unit test for keyerror raised for invalid var name for _validate_json_element in file input_manager.py"""
     element_hierarchy = ["valid_key", "invalid_key"]
     properties_blob_key = "dummy_properties_blob_key"
     input_data = {"valid_key": {"another_valid_key": "value"}}
     eager_termination = False
 
     with pytest.raises(KeyError):
-        mock_input_manager._validate_element(element_hierarchy, properties_blob_key, input_data,
-                                             eager_termination)
+        mock_input_manager._validate_json_element(element_hierarchy, properties_blob_key, input_data,
+                                                  eager_termination)
 
-    mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
+    mock_input_manager._validate_json_element = input_manager_original_method_states["_validate_json_element"]
 
 
-def test_validate_element_invalid_var_type_raises_keyerror(mock_input_manager: InputManager, mocker: MockerFixture,
-                                                           input_manager_original_method_states: Dict[str, Callable],
-                                                           ) -> None:
-    """Unit test for keyerror raised for invalid var type for _validate_element in file input_manager.py"""
+def test_validate_json_element_invalid_var_type_raises_keyerror(mock_input_manager: InputManager, mocker: MockerFixture,
+                                                                input_manager_original_method_states:
+                                                                Dict[str, Callable],
+                                                                ) -> None:
+    """Unit test for keyerror raised for invalid var type for _validate_json_element in file input_manager.py"""
     element_hierarchy = ["valid_key"]
     properties_blob_key = "dummy_valid_key"
     input_data = {"valid_key": "some_value"}
@@ -519,10 +521,10 @@ def test_validate_element_invalid_var_type_raises_keyerror(mock_input_manager: I
     eager_termination = False
 
     with pytest.raises(KeyError):
-        mock_input_manager._validate_element(element_hierarchy, properties_blob_key, input_data,
-                                             eager_termination)
+        mock_input_manager._validate_json_element(element_hierarchy, properties_blob_key, input_data,
+                                                  eager_termination)
 
-    mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
+    mock_input_manager._validate_json_element = input_manager_original_method_states["_validate_json_element"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -184,6 +184,12 @@ def test_populate_pool_valid(mock_input_manager: InputManager, mock_metadata: Di
                                                                          "invalid_elements": 0,
                                                                          "is_valid": True
                                                                          }
+    mock_input_manager._validate_csv_element = lambda *args, **kwargs: {"fixed_elements": 1,
+                                                                        "valid_elements": 1,
+                                                                        "total_elements": 1,
+                                                                        "invalid_elements": 0,
+                                                                        "is_valid": True
+                                                                        }
 
     with patch("RUFAS.output_manager.OutputManager.add_log") as add_log:
         with patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning:
@@ -213,6 +219,12 @@ def test_populate_pool_invalid(mock_input_manager: InputManager, mock_metadata: 
                                                                          "invalid_elements": 0,
                                                                          "is_valid": False
                                                                          }
+    mock_input_manager._validate_csv_element = lambda *args, **kwargs: {"fixed_elements": 1,
+                                                                        "valid_elements": 1,
+                                                                        "total_elements": 1,
+                                                                        "invalid_elements": 0,
+                                                                        "is_valid": False
+                                                                        }
 
     with patch("RUFAS.output_manager.OutputManager.add_log") as add_log:
         with patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning:


### PR DESCRIPTION
This PR seeks to address issue #723 to ensure Input Manager can validate and fix input data loaded from CSV files.

To accomplish this, the PR:
1. Creates a new function `_validate_csv_element()` which validates each row of data under a particular column until all columns have been validated and/or fixed.
2. Renames `_validate_element()` to `_validate_json_element()` to follow the pattern of the new `_validate_csv_element()` and distinguish the type of file data it validates.
3. Creates a helper function `_get_validity()` which reduces duplicate code in both `_validate_csv_element()` and `_validate_json_element()`
4. Updates the _populate_pool() method to route elements by file type to the correct element validation functions.
5. Updates the _fix_data() function's argument types to allow for it to receive a csv array element index to fix.
6. Expands unit testing to show functionality of new features.