### PR TITLE
100% test coverage for input and output managers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Testing](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml)
 [![Linting](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml)
-[![Coverage](https://img.shields.io/badge/coverage-84%25-yellowgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/coverage_pytest-cov.yml)
+[![Coverage](https://img.shields.io/badge/coverage-85%25-yellowgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/coverage_pytest-cov.yml)
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.
 

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -233,7 +233,7 @@ class InputManager:
             variable_properties = reduce(lambda d, key: d[key], element_hierarchy,
                                          self.__metadata["properties"][properties_blob_key])
         except KeyError as e:
-            raise e
+            raise KeyError(f"{str(e)} not found in input data")
 
         var_type = variable_properties["type"]
         is_nested = var_type == "object"

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -229,8 +229,12 @@ class InputManager:
                     }
         element_counter_and_validity = {"fixed_elements": 0, "total_elements": 0, "valid_elements": 0,
                                         "invalid_elements": 0, "is_valid": True}
-        variable_properties = reduce(lambda d, key: d[key], element_hierarchy,
-                                     self.__metadata["properties"][properties_blob_key])
+        try:
+            variable_properties = reduce(lambda d, key: d[key], element_hierarchy,
+                                         self.__metadata["properties"][properties_blob_key])
+        except KeyError as e:
+            raise e
+
         var_type = variable_properties["type"]
         is_nested = var_type == "object"
         if is_nested:
@@ -258,11 +262,7 @@ class InputManager:
             return element_counter_and_validity
         else:
             var_name = element_hierarchy[-1]
-            try:
-                input_data_value = reduce(lambda d, key: d[key], element_hierarchy, input_data)
-            except KeyError:
-                raise KeyError(f"Key {var_name} not found in input data")
-
+            input_data_value = reduce(lambda d, key: d[key], element_hierarchy, input_data)
             data_type_to_validator_map = {"string": self._string_type_validator,
                                           "number": self._num_type_validator,
                                           "array": self._array_type_validator,

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -665,10 +665,10 @@ class OutputManager(object):
         class_name.function_name.variable_name.info_maps: variable4_name
         """
 
-        var_list = [f"_{exclude_info_maps=}, expect info_maps accordingly.\n"]
+        var_list = [f"_{exclude_info_maps=}, expect info_maps accordingly.{os.linesep}"]
         for name, variable_data in self.variables_pool.items():
-            if not variable_data["values"]:
-                var_list.append(f"{name}: **NO VARIABLES**\n")
+            if "values" not in variable_data:
+                var_list.append(f"{name}: **NO VARIABLES**{os.linesep}")
                 continue
 
             parsable_dicts = []
@@ -680,10 +680,7 @@ class OutputManager(object):
             if is_variable_nested:
                 parsable_dicts.append("values")
             else:
-                var_list.append(f"{name}\n")
-
-            if format_option == "block":
-                var_list.append(f"{name}\n")
+                var_list.append(f"{name}{os.linesep}")
 
             prefix = name
             if format_option == "block":
@@ -692,10 +689,10 @@ class OutputManager(object):
             for parsable_dict in parsable_dicts:
                 keys = variable_data[parsable_dict][0].keys()
                 if format_option == "inline":
-                    var_list.append(f"{name}.{parsable_dict}: {list(keys)}\n")
+                    var_list.append(f"{name}.{parsable_dict}: {list(keys)}{os.linesep}")
                 else:
                     for key in keys:
-                        var_list.append(f"{prefix}.{parsable_dict}: {key}\n")
+                        var_list.append(f"{prefix}.{parsable_dict}: {key}{os.linesep}")
 
         file_path = os.path.join(
             path, self._generate_file_name("variable_names", "txt")

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -94,7 +94,7 @@ def test_load_data_from_json_missing_file_raises_error(mock_input_manager: Input
         with patch("RUFAS.output_manager.OutputManager.add_log") as add_log:
             with pytest.raises(FileNotFoundError):
                 mock_input_manager._load_data_from_json("non_existent_file.json")
-                assert add_log.call_count == 1
+            assert add_log.call_count == 1
 
 
 def test_load_data_from_json_invalid_data_raises_error(mock_input_manager: InputManager, ) -> None:
@@ -103,7 +103,7 @@ def test_load_data_from_json_invalid_data_raises_error(mock_input_manager: Input
         with patch("RUFAS.output_manager.OutputManager.add_log") as add_log:
             with pytest.raises(json.JSONDecodeError):
                 mock_input_manager._load_data_from_json("dummy_file.json")
-                assert add_log.call_count == 1
+            assert add_log.call_count == 1
 
 
 def test_load_data_from_csv(mock_input_manager: InputManager, ) -> None:
@@ -120,12 +120,12 @@ def test_load_data_from_csv(mock_input_manager: InputManager, ) -> None:
 
 
 def test_load_data_from_csv_missing_file_raises_error(mock_input_manager: InputManager, ) -> None:
-    """Unit test for function _load_data_from_json with missing json file in file input_manager.py"""
+    """Unit test for function _load_data_from_csv with missing csv file in file input_manager.py"""
     with patch("builtins.open", side_effect=FileNotFoundError):
         with patch("RUFAS.output_manager.OutputManager.add_log") as add_log:
             with pytest.raises(FileNotFoundError):
                 mock_input_manager._load_data_from_csv("non_existent_file.csv")
-                assert add_log.call_count == 2
+            assert add_log.call_count == 1
 
 
 def test_load_data_from_csv_invalid_data_raises_error(mock_input_manager: InputManager, ) -> None:
@@ -135,7 +135,7 @@ def test_load_data_from_csv_invalid_data_raises_error(mock_input_manager: InputM
             with patch("pandas.read_csv", side_effect=pd.errors.ParserError("Invalid CSV")):
                 with pytest.raises(pd.errors.ParserError):
                     mock_input_manager._load_data_from_csv("dummy_file.csv")
-                    assert add_log.call_count == 1
+                assert add_log.call_count == 1
 
 
 def test_start_data_processing(mock_input_manager: InputManager,
@@ -210,16 +210,16 @@ def test_populate_pool_invalid(mock_input_manager: InputManager, mock_metadata: 
     mock_input_manager._validate_element = lambda *args, **kwargs: {"fixed_elements": 1,
                                                                     "valid_elements": 1,
                                                                     "total_elements": 1,
-                                                                    "invalid_elements": 0,
+                                                                    "invalid_elements": 1,
                                                                     "is_valid": False
                                                                     }
 
     with patch("RUFAS.output_manager.OutputManager.add_log") as add_log:
         with patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning:
 
-            result = mock_input_manager._populate_pool(eager_termination=True)
+            result = mock_input_manager._populate_pool(eager_termination=False)
             assert result is False
-            assert add_log.call_count == 0
+            assert add_log.call_count == 4
             assert add_warning.call_count == 0
             assert "file1" not in mock_input_manager._InputManager__pool
             assert "file2" not in mock_input_manager._InputManager__pool
@@ -271,8 +271,8 @@ def test_populate_pool_raises_keyerror(mock_input_manager: InputManager,
             with pytest.raises(KeyError):
                 mock_input_manager._populate_pool(eager_termination=True)
 
-                assert add_log.call_count == 0
-                assert add_warning.call_count == 0
+            assert add_log.call_count == 0
+            assert add_warning.call_count == 0
 
     mock_input_manager._populate_pool = \
         input_manager_original_method_states["_populate_pool"]
@@ -334,7 +334,8 @@ def mock_metadata_for_validate_element(mocker: MockerFixture) -> Dict[str, Dict[
                                     "maximum_length": 5
                                  },
                                 }
-                             }
+                             },
+                "element6": {"type": "number", "minimum": 0, "maximum": 150, 'default': 10},
             }
         }
     }
@@ -357,6 +358,24 @@ def test_validate_element_string_type(mock_input_manager: InputManager,
     assert result["is_valid"] is False
 
     mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
+
+
+def test_validate_element_fixable_data(mock_input_manager: InputManager,
+                                       mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
+                                       input_manager_original_method_states: Dict[str, Callable], ) -> None:
+    """Unit test for a fixable number type input_data for _validate_element in file input_manager.py"""
+    mock_input_manager._InputManager__metadata = mock_metadata_for_validate_element
+    mock_input_manager._num_type_validator = MagicMock(return_value=False)
+    mock_input_manager._fix_data = MagicMock(return_value=True)
+
+    input_data = {"element2": 123}
+    result = mock_input_manager._validate_element(["element2"], "property_map_key1", input_data, True)
+
+    assert result["is_valid"] is True
+
+    mock_input_manager._validate_element = input_manager_original_method_states["_validate_element"]
+    mock_input_manager._num_type_validator = input_manager_original_method_states["_num_type_validator"]
+    mock_input_manager._fix_data = input_manager_original_method_states["_fix_data"]
 
 
 def test_validate_element_number_type(mock_input_manager: InputManager,
@@ -463,6 +482,10 @@ def test_validate_element_invalid_nested_object_type(mock_input_manager: InputMa
                                "nested_element3": {"nested_sub_element1": "invalid_cows",
                                                    "nested_sub_element2": [1, 2, 3]}}}
     result = mock_input_manager._validate_element(["element5"], "property_map_key1", input_data, True)
+
+    assert result["is_valid"] is False
+
+    result = mock_input_manager._validate_element(["element5"], "property_map_key1", input_data, False)
 
     assert result["is_valid"] is False
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -7,7 +7,8 @@ Author(s): Pooya Hekmati, sh2235@cornell.edu
 
 import os
 import re
-from typing import Any, Callable, Dict
+import json
+from typing import Any, Callable, Dict, List
 from mock import Mock, mock_open, patch
 
 import pytest
@@ -95,7 +96,8 @@ def test_init_simulation_engine(patch_simulation_engine: SimulationEngine) -> No
 
 def test_simulate(patch_simulation_engine: SimulationEngine, mocker: MockerFixture) -> None:
     """Unit test for function simulate in file RUFAS/simulation_engine.py"""
-    patch_for_run_simulation_main_loop = mocker.patch("RUFAS.simulation_engine.SimulationEngine._run_simulation_main_loop")
+    patch_for_run_simulation_main_loop = \
+        mocker.patch("RUFAS.simulation_engine.SimulationEngine._run_simulation_main_loop")
     patch_for_show_final_messages = mocker.patch("RUFAS.simulation_engine.SimulationEngine._show_final_messages")
     patch_for_manure_output_handler_produce_csv = mocker.patch(
         "RUFAS.simulation_engine.ManureManagerOutputHandler.produce_csv",
@@ -440,6 +442,35 @@ def test_dict_to_file_csv(
     assert written_data == expected_result
 
 
+def test_dict_to_file_json(mock_output_manager: OutputManager) -> None:
+    """Unit test for the function _dict_to_file_json in the file output_manager.py"""
+
+    data = {
+            "var1": {"values": [1], "info_maps": [{"map1": "value1"}, {"map1": "value2"}]},
+            "var2": {
+                    "values": [{'v1': 1, 'v2': 1}, {'v1': 2, 'v2': 2}],
+                    "info_maps": [{"map1": "value1"}, {"map1": "value2"}]},
+            }
+
+    open_mock = mock_open()
+    with patch("builtins.open", open_mock):
+        mock_output_manager._dict_to_file_json(data, "test")
+
+    written_data = ''.join(call[1][0] for call in open_mock().write.mock_calls)
+    assert written_data == json.dumps(data, indent=0)
+
+
+def test_dict_to_file_json_exception(mock_output_manager: OutputManager) -> None:
+    """Test file opening failure for _dict_to_file_json() in the file output_manager.py"""
+    open_mock = mock_open()
+    open_mock.side_effect = IOError
+    data = {"var1": {"values": [1, 2, 3], "info_maps": [1, 2, 3]}}
+
+    with patch("builtins.open", open_mock):
+        with raises(Exception):
+            mock_output_manager._dict_to_file_json(data, "test")
+
+
 def test_dict_to_file_csv_exception(mock_output_manager: OutputManager) -> None:
     """Unit test for the function _dict_to_file_csv in the file output_manager.py"""
     open_mock = mock_open()
@@ -466,6 +497,9 @@ def test_generate_key(mocker: MockerFixture) -> None:
     om = OutputManager()
     with raises(KeyError):
         om._generate_key("name", {})
+
+    with raises(KeyError):
+        om._generate_key("name", {"class": "test"})
 
     info_map = {"class": "dummy_class", "function": "dummy_func"}
     key = om._generate_key("key_name", info_map)
@@ -789,14 +823,29 @@ def test_dump_variables(
     output_manager_original_method_states: Dict[str, Callable],
 ) -> None:
     """Test case for function dump_variables in output_manager.py"""
+    filtered_info_maps_dict = {}
     mock_output_manager._generate_file_name = MagicMock(return_value="dummy_name")
     mock_output_manager._dict_to_file_json = MagicMock()
+    mock_output_manager._exclude_info_maps = MagicMock(return_value=filtered_info_maps_dict)
 
-    mock_output_manager.dump_variables("dummy_path")
+    mock_output_manager.dump_variables("dummy_path", False)
 
+    mock_output_manager._exclude_info_maps.assert_not_called()
     mock_output_manager._generate_file_name.assert_called_once_with("all_variables", "json")
     mock_output_manager._dict_to_file_json.assert_called_once_with(
         mock_output_manager.variables_pool, os.path.join("dummy_path", "dummy_name")
+    )
+
+    mock_output_manager._generate_file_name = MagicMock(return_value="dummy_name")
+    mock_output_manager._dict_to_file_json = MagicMock()
+    mock_output_manager._exclude_info_maps = MagicMock(return_value=filtered_info_maps_dict)
+
+    mock_output_manager.dump_variables("dummy_path", True)
+
+    mock_output_manager._exclude_info_maps.assert_called_once()
+    mock_output_manager._generate_file_name.assert_called_once_with("all_variables", "json")
+    mock_output_manager._dict_to_file_json.assert_called_once_with(
+        filtered_info_maps_dict, os.path.join("dummy_path", "dummy_name")
     )
 
     # Restore original methods
@@ -805,6 +854,9 @@ def test_dump_variables(
     ]
     mock_output_manager._dict_to_file_json = output_manager_original_method_states[
         "_dict_to_file_json"
+    ]
+    mock_output_manager._exclude_info_maps = output_manager_original_method_states[
+        "_exclude_info_maps"
     ]
 
 
@@ -908,20 +960,53 @@ def test_dump_errors(
     ]
 
 
+@pytest.mark.parametrize("expected_result, exclude_info_maps, format_option", [
+    (['_exclude_info_maps=False, expect info_maps accordingly.' + os.linesep, 'var1' + os.linesep,
+      'var1.info_maps: test' + os.linesep, 'var2.info_maps: map1' + os.linesep,
+      'var2.values: v1' + os.linesep, 'var2.values: v2' + os.linesep],
+     False, "verbose"),
+    (['_exclude_info_maps=True, expect info_maps accordingly.' + os.linesep, 'var1' + os.linesep,
+      'var2.values: v1' + os.linesep, 'var2.values: v2' + os.linesep],
+     True, "verbose"),
+    (['_exclude_info_maps=False, expect info_maps accordingly.' + os.linesep, 'var1' + os.linesep,
+      '    .info_maps: test' + os.linesep, '    .info_maps: map1' + os.linesep,
+      '    .values: v1' + os.linesep, '    .values: v2' + os.linesep],
+     False, "block"),
+    (['_exclude_info_maps=True, expect info_maps accordingly.' + os.linesep,
+      'var1' + os.linesep, '    .values: v1' + os.linesep, '    .values: v2' + os.linesep],
+     True, "block"),
+    (['_exclude_info_maps=False, expect info_maps accordingly.' + os.linesep, 'var1' + os.linesep,
+      "var1.info_maps: ['test']" + os.linesep, "var2.info_maps: ['map1']" + os.linesep,
+      "var2.values: ['v1', 'v2']" + os.linesep],
+     False, "inline"),
+    (['_exclude_info_maps=True, expect info_maps accordingly.' + os.linesep, 'var1' + os.linesep,
+      "var2.values: ['v1', 'v2']" + os.linesep],
+     True, "inline"),
+])
 def test_dump_variable_names_and_contexts(
     mock_output_manager: OutputManager,
     output_manager_original_method_states: Dict[str, Callable],
+    expected_result: List[str],
+    exclude_info_maps: bool,
+    format_option: str,
 ) -> None:
     """Test case for function dump_variable_names_and_contexts in output_manager.py"""
-    dummy_list = ['_exclude_info_maps=False, expect info_maps accordingly.\n']
+    mock_variable_pool: Dict[str, Dict[str, List[Any]]] = {
+        "var1": {"values": [1], "info_maps": [{"test": "value1"}, {"test": "value2"}]},
+        "var2": {
+                "values": [{'v1': 1, 'v2': 1}, {'v1': 2, 'v2': 2}],
+                "info_maps": [{"map1": "value1"}, {"map1": "value2"}]},
+     }
+    original_variables_pool = mock_output_manager.variables_pool
+    mock_output_manager.variables_pool = mock_variable_pool
     mock_output_manager._generate_file_name = MagicMock(return_value="dummy_name")
     mock_output_manager._list_to_file_txt = MagicMock()
 
-    mock_output_manager.dump_variable_names_and_contexts("dummy_path", False)
+    mock_output_manager.dump_variable_names_and_contexts("dummy_path", exclude_info_maps, format_option)
 
     mock_output_manager._generate_file_name.assert_called_once_with("variable_names", "txt")
     mock_output_manager._list_to_file_txt.assert_called_once_with(
-        dummy_list, os.path.join("dummy_path", "dummy_name")
+        expected_result, os.path.join("dummy_path", "dummy_name")
     )
 
     # Restore original methods
@@ -931,6 +1016,39 @@ def test_dump_variable_names_and_contexts(
     mock_output_manager._list_to_file_txt = output_manager_original_method_states[
         "_list_to_file_txt"
     ]
+    mock_output_manager.variables_pool = original_variables_pool
+
+
+def test_dump_variable_names_and_contexts_no_values(
+    mock_output_manager: OutputManager,
+    output_manager_original_method_states: Dict[str, Callable]
+) -> None:
+    """Test case for function dump_variable_names_and_contexts in output_manager.py"""
+    mock_variable_pool: Dict[str, Dict[str, List[Any]]] = {
+        "var1": {"no_values": [1], "info_maps": [{"test": "value1"}, {"test": "value2"}]},
+    }
+    expected_output = ['_exclude_info_maps=False, expect info_maps accordingly.' + os.linesep,
+                       'var1: **NO VARIABLES**' + os.linesep]
+    original_variables_pool = mock_output_manager.variables_pool
+    mock_output_manager.variables_pool = mock_variable_pool
+    mock_output_manager._generate_file_name = MagicMock(return_value="dummy_name")
+    mock_output_manager._list_to_file_txt = MagicMock()
+
+    mock_output_manager.dump_variable_names_and_contexts("dummy_path", False, format_option="verbose")
+
+    mock_output_manager._generate_file_name.assert_called_once_with("variable_names", "txt")
+    mock_output_manager._list_to_file_txt.assert_called_once_with(
+        expected_output, os.path.join("dummy_path", "dummy_name")
+    )
+
+    # Restore original methods
+    mock_output_manager._generate_file_name = output_manager_original_method_states[
+        "_generate_file_name"
+    ]
+    mock_output_manager._list_to_file_txt = output_manager_original_method_states[
+        "_list_to_file_txt"
+    ]
+    mock_output_manager.variables_pool = original_variables_pool
 
 
 def test_list_to_file_txt(
@@ -949,13 +1067,13 @@ def test_list_to_file_txt(
 
     with pytest.raises(TypeError) as e:
         mock_output_manager._list_to_file_txt(1234, dummy_file_path)
-        assert "object is not iterable" in str(e.value)
+    assert "object is not iterable" in str(e.value)
 
     dummy_broken_file_path = ""
 
     with pytest.raises(FileNotFoundError) as e:
         mock_output_manager._list_to_file_txt(dummy_list, dummy_broken_file_path)
-        assert "No such file or directory" in str(e.value)
+    assert "No such file or directory" in str(e.value)
 
     # Restore original method
     mock_output_manager._list_to_file_txt = output_manager_original_method_states[


### PR DESCRIPTION
This PR brings the test coverage for `input_manager.py` and `output_manager.py` as well as their respective unit test files to `100%`.

Very slight modifications were made to the source files themselves in order to remove unreachable code / conditions and to remove occurrences of a single `\n` byte. 