### PR TITLE
Fix formatting of arrays of objects in the example metadata.

### DIFF
--- a/input/example_metadata.json
+++ b/input/example_metadata.json
@@ -884,87 +884,96 @@
       }
     },
     "crop_schedule_properties": {
-      "crop_species": {
-        "type": "string",
-        "description": "Name of the crop being grown.",
-        "pattern": "^{generic|corn|silage_corn|spring_wheat|winter_wheat|cereal_rye|spring_barley|fall_oats|tall_fescue|alfalfa|soybean|sugar_beet|potato|triticale}$"
-      },
-      "harvest_days": {
+      "crop_schedules": {
         "type": "array",
-        "description": "Julian day(s) of year to harvest",
-        "minimum_length": 0,
-        "default": [],
-        "properties": {
-          "type": "number",
-          "minimum": 1,
-          "maximum": 366
-        }
+        "description": "Array of all crop schedules to be executed over the run of the simulation.",
+        "minimum_length": 0
       },
-      "harvest_years": {
-        "type": "array",
-        "description": "Calendar years in which the harvesting occurs",
-        "minimum_length": 0,
-        "default": [],
-        "properties": {
-          "type": "number",
-          "minimum": 1
-        }
-      },
-      "harvest_operations": {
-        "type": "array",
-        "description": "Operation(s) with which this crop will be harvested.",
-        "minimum_length": 1,
-        "default": [
-          "default"
-        ],
-        "properties": {
+      "crop_schedule": {
+        "type": "object",
+        "description": "Contains all the properties necessary to create a CropSchedule object.",
+        "crop_species": {
           "type": "string",
-          "pattern": "^{default|no_kill}$",
-          "default": "default"
-        }
-      },
-      "harvest_type": {
-        "type": "array",
-        "description": "Whether the crop uses scheduled harvests or optimal harvests",
-        "default": [
-          "scheduled"
-        ],
-        "properties": {
-          "type": "string",
-          "pattern": "^{scheduled|optimal}$",
-          "default": "scheduled"
-        }
-      },
-      "planting_days": {
-        "type": "array",
-        "description": "Julian day(s) of year to plant",
-        "default": [],
-        "properties": {
+          "description": "Name of the crop being grown.",
+          "pattern": "^{generic|corn|silage_corn|spring_wheat|winter_wheat|cereal_rye|spring_barley|fall_oats|tall_fescue|alfalfa|soybean|sugar_beet|potato|triticale}$"
+        },
+        "harvest_days": {
+          "type": "array",
+          "description": "Julian day(s) of year to harvest",
+          "minimum_length": 0,
+          "default": [],
+          "properties": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 366
+          }
+        },
+        "harvest_years": {
+          "type": "array",
+          "description": "Calendar years in which the harvesting occurs",
+          "minimum_length": 0,
+          "default": [],
+          "properties": {
+            "type": "number",
+            "minimum": 1
+          }
+        },
+        "harvest_operations": {
+          "type": "array",
+          "description": "Operation(s) with which this crop will be harvested.",
+          "minimum_length": 1,
+          "default": [
+            "default"
+          ],
+          "properties": {
+            "type": "string",
+            "pattern": "^{default|no_kill}$",
+            "default": "default"
+          }
+        },
+        "harvest_type": {
+          "type": "array",
+          "description": "Whether the crop uses scheduled harvests or optimal harvests",
+          "default": [
+            "scheduled"
+          ],
+          "properties": {
+            "type": "string",
+            "pattern": "^{scheduled|optimal}$",
+            "default": "scheduled"
+          }
+        },
+        "planting_days": {
+          "type": "array",
+          "description": "Julian day(s) of year to plant",
+          "default": [],
+          "properties": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 366
+          }
+        },
+        "planting_years": {
+          "type": "array",
+          "description": "Calendar years in which the planting occurs",
+          "default": [],
+          "properties": {
+            "type": "number",
+            "minimum": 1
+          }
+        },
+        "pattern_repeat": {
           "type": "number",
-          "minimum": 1,
-          "maximum": 366
-        }
-      },
-      "planting_years": {
-        "type": "array",
-        "description": "Calendar years in which the planting occurs",
-        "default": [],
-        "properties": {
+          "description": "Number of times that this crop schedule should be repeated.",
+          "minimum": 0,
+          "default": 0
+        },
+        "pattern_skip": {
           "type": "number",
-          "minimum": 1
+          "description": "Number of years to be skipped between schedule repetitions.",
+          "minimum": 0,
+          "default": 0
         }
-      },
-      "pattern_repeat": {
-        "type": "number",
-        "description": "Number of times that this crop schedule should be repeated.",
-        "minimum": 0,
-        "default": 0
-      },
-      "pattern_skip": {
-        "type": "number",
-        "description": "Number of years to be skipped between schedule repetitions.",
-        "minimum": 0,
-        "default": 0
       }
     },
     "fertilizer_schedule_properties": {

--- a/input/example_metadata.json
+++ b/input/example_metadata.json
@@ -887,92 +887,92 @@
       "crop_schedules": {
         "type": "array",
         "description": "Array of all crop schedules to be executed over the run of the simulation.",
-        "minimum_length": 0
-      },
-      "crop_schedule": {
-        "type": "object",
-        "description": "Contains all the properties necessary to create a CropSchedule object.",
-        "crop_species": {
-          "type": "string",
-          "description": "Name of the crop being grown.",
-          "pattern": "^{generic|corn|silage_corn|spring_wheat|winter_wheat|cereal_rye|spring_barley|fall_oats|tall_fescue|alfalfa|soybean|sugar_beet|potato|triticale}$"
-        },
-        "harvest_days": {
-          "type": "array",
-          "description": "Julian day(s) of year to harvest",
-          "minimum_length": 0,
-          "default": [],
-          "properties": {
-            "type": "number",
-            "minimum": 1,
-            "maximum": 366
-          }
-        },
-        "harvest_years": {
-          "type": "array",
-          "description": "Calendar years in which the harvesting occurs",
-          "minimum_length": 0,
-          "default": [],
-          "properties": {
-            "type": "number",
-            "minimum": 1
-          }
-        },
-        "harvest_operations": {
-          "type": "array",
-          "description": "Operation(s) with which this crop will be harvested.",
-          "minimum_length": 1,
-          "default": [
-            "default"
-          ],
-          "properties": {
+        "minimum_length": 0,
+        "properties": {
+          "type": "object",
+          "description": "Contains all the properties necessary to create a CropSchedule object.",
+          "crop_species": {
             "type": "string",
-            "pattern": "^{default|no_kill}$",
-            "default": "default"
-          }
-        },
-        "harvest_type": {
-          "type": "array",
-          "description": "Whether the crop uses scheduled harvests or optimal harvests",
-          "default": [
-            "scheduled"
-          ],
-          "properties": {
-            "type": "string",
-            "pattern": "^{scheduled|optimal}$",
-            "default": "scheduled"
-          }
-        },
-        "planting_days": {
-          "type": "array",
-          "description": "Julian day(s) of year to plant",
-          "default": [],
-          "properties": {
+            "description": "Name of the crop being grown.",
+            "pattern": "^{generic|corn|silage_corn|spring_wheat|winter_wheat|cereal_rye|spring_barley|fall_oats|tall_fescue|alfalfa|soybean|sugar_beet|potato|triticale}$"
+          },
+          "harvest_days": {
+            "type": "array",
+            "description": "Julian day(s) of year to harvest",
+            "minimum_length": 0,
+            "default": [],
+            "properties": {
+              "type": "number",
+              "minimum": 1,
+              "maximum": 366
+            }
+          },
+          "harvest_years": {
+            "type": "array",
+            "description": "Calendar years in which the harvesting occurs",
+            "minimum_length": 0,
+            "default": [],
+            "properties": {
+              "type": "number",
+              "minimum": 1
+            }
+          },
+          "harvest_operations": {
+            "type": "array",
+            "description": "Operation(s) with which this crop will be harvested.",
+            "minimum_length": 1,
+            "default": [
+              "default"
+            ],
+            "properties": {
+              "type": "string",
+              "pattern": "^{default|no_kill}$",
+              "default": "default"
+            }
+          },
+          "harvest_type": {
+            "type": "array",
+            "description": "Whether the crop uses scheduled harvests or optimal harvests",
+            "default": [
+              "scheduled"
+            ],
+            "properties": {
+              "type": "string",
+              "pattern": "^{scheduled|optimal}$",
+              "default": "scheduled"
+            }
+          },
+          "planting_days": {
+            "type": "array",
+            "description": "Julian day(s) of year to plant",
+            "default": [],
+            "properties": {
+              "type": "number",
+              "minimum": 1,
+              "maximum": 366
+            }
+          },
+          "planting_years": {
+            "type": "array",
+            "description": "Calendar years in which the planting occurs",
+            "default": [],
+            "properties": {
+              "type": "number",
+              "minimum": 1
+            }
+          },
+          "pattern_repeat": {
             "type": "number",
-            "minimum": 1,
-            "maximum": 366
-          }
-        },
-        "planting_years": {
-          "type": "array",
-          "description": "Calendar years in which the planting occurs",
-          "default": [],
-          "properties": {
+            "description": "Number of times that this crop schedule should be repeated.",
+            "minimum": 0,
+            "default": 0
+          },
+          "pattern_skip": {
             "type": "number",
-            "minimum": 1
+            "description": "Number of years to be skipped between schedule repetitions.",
+            "minimum": 0,
+            "default": 0
           }
-        },
-        "pattern_repeat": {
-          "type": "number",
-          "description": "Number of times that this crop schedule should be repeated.",
-          "minimum": 0,
-          "default": 0
-        },
-        "pattern_skip": {
-          "type": "number",
-          "description": "Number of years to be skipped between schedule repetitions.",
-          "minimum": 0,
-          "default": 0
         }
       }
     },
@@ -2362,145 +2362,145 @@
       "soil_layers": {
         "type": "array",
         "description": "The soil layers that this profile contains. Each element of the array should be a `soil_layer` object.",
-        "minimum_length": 1
-      },
-      "soil_layer_properties": {
-        "type": "object",
-        "description": "This represents a single soil layer.",
-        "bottom_depth": {
-          "type": "number",
-          "description": "Bottom depth of this soil layer.\nUnits: mm.",
-          "minimum": 20
-        },
-        "soil_water_concentration": {
-          "type": "number",
-          "description": "Concentration of water in this layer at the beginning of the simulation.\nUnits: mm water / mm soil.",
-          "minimum": 0.0,
-          "maximum": 0.95,
-          "default": 0.25
-        },
-        "field_capacity_water_concentration": {
-          "type": "number",
-          "description": "Concentration of water in this layer when at field capacity.\nUnits: mm water / mm soil.",
-          "minimum": 0.0,
-          "maximum": 0.95,
-          "default": 0.3
-        },
-        "wilting_point_water_concentration": {
-          "type": "number",
-          "description": "Concentration of water in this layer when at field capacity.\nUnits: mm water / mm soil.",
-          "minimum": 0.0,
-          "maximum": 0.95,
-          "default": 0.2
-        },
-        "saturation_point_water_concentration": {
-          "type": "number",
-          "description": "Concentration of water in a layer when it has become saturated.\nUnits: mm water / mm soil.",
-          "minimum": 0.0,
-          "maximum": 0.95,
-          "default": 0.5
-        },
-        "temperature": {
-          "type": "number",
-          "description": "Temperature of the layer at the beginning of the simulation.\nUnits: degrees Celsius.",
-          "default": 15.05
-        },
-        "saturated_hydraulic_conductivity": {
-          "type": "number",
-          "description": "Measure of ease of water movement through the soil.\nUnits: mm / hour.\nReference: SWAT Input .SOL - SOL_K.",
-          "minimum": 0.01,
-          "default": 9.5
-        },
-        "bulk_density": {
-          "type": "number",
-          "description": "Ratio of mass of solid particles to total volume of soil.\nUnits: Megagrams / cubic meter or grams / cubic centimeter.",
-          "minimum": 1.1,
-          "maximum": 1.9,
-          "default": 1.4
-        },
-        "percent_organic_carbon_content": {
-          "type": "number",
-          "description": "Percent of soil weight that is organic carbon.\nUnitless.\nReference: SWAT Input .SOL - SOL_CBN.",
-          "minimum": 0.0,
-          "maximum": 100.0,
-          "default": 1.2
-        },
-        "percent_clay_content": {
-          "type": "number",
-          "description": "Percent of soil weight that is clay.\nUnitless.\nReference: SWAT Input .SOL - SOL_CLAY.",
-          "minimum": 0.0,
-          "maximum": 100.0,
-          "default": 22.5
-        },
-        "percent_silt_content": {
-          "type": "number",
-          "description": "Percent of soil weight that is silt.\nUnitless.\nReference: SWAT Input .SOL - SOL_SILT.",
-          "minimum": 0.0,
-          "maximum": 100.0,
-          "default": 62.5
-        },
-        "percent_sand_content": {
-          "type": "number",
-          "description": "Percent of soil weight that is sand.\nUnitless.\nReference: SWAT Input .SOL - SOL_SAND.",
-          "minimum": 0.0,
-          "maximum": 100.0,
-          "default": 12.5
-        },
-        "percent_rock_content": {
-          "type": "number",
-          "description": "Percent of soil weight that is rock.\nUnitless.\nReference: SWAT Input .SOL - SOL_ROCK.",
-          "minimum": 0.0,
-          "maximum": 100.0,
-          "default": 1.3
-        },
-        "initial_labile_inorganic_phosphorus_concentration": {
-          "type": "number",
-          "description": "Concentration of labile inorganic phosphorus at the beginning of the simulation.\nUnits: milligrams / kilogram soil.",
-          "minimum": 0.0,
-          "default": null
-        },
-        "initial_fresh_organic_phosphorus_concentration": {
-          "type": "number",
-          "description": "Concentration of fresh organic phosphorus at the beginning of the simulation.\nUnits: milligrams / kilogram soil.",
-          "minimum": 0.0,
-          "default": 0.0
-        },
-        "initial_soil_nitrate_concentration": {
-          "type": "number",
-          "description": "Concentration of nitrate in the layer at the beginning of the simulation.\nUnits: milligrams / kilogram soil.",
-          "minimum": 0.0,
-          "default": null
-        },
-        "initial_soil_ammonium_concentration": {
-          "type": "number",
-          "description": "Concentration of ammonium in the layer at the beginning of the simulation.\nUnits: milligrams / kilogram soil.",
-          "minimum": 0.0,
-          "default": null
-        },
-        "humus_mineralization_rate_factor": {
-          "type": "number",
-          "description": "Rate factor for humus mineralization of active organic nutrients (N and P).\nUnitless.\nReference: SWAT Input .BSN - CMN.",
-          "minimum": 0.0,
-          "default": 0.0003
-        },
-        "denitrification_rate_coefficient": {
-          "type": "number",
-          "description": "Controls the rate of denitrification.\nUnitless.\nReference: SWAT Input .BSN - CDN.",
-          "minimum": 0.0,
-          "maximum": 3.0,
-          "default": 1.4
-        },
-        "denitrification_threshold_water_content": {
-          "type": "number",
-          "description": "Fraction of field capacity water content above which denitrification takes place.\nUnitless.\nReference: SWAT Input .BSN - SDNCO",
-          "minimum": 0.0,
-          "default": 1.1
-        },
-        "residue_fresh_organic_mineralization_rate": {
-          "type": "number",
-          "description": "Fraction of residue that will decompose in a day given optimal conditions.\nUnitless.\nReference SWAT Input: .BSN - RSDCO.",
-          "minimum": 0.0,
-          "default": 0.05
+        "minimum_length": 1,
+        "properties": {
+          "type": "object",
+          "description": "This represents a single soil layer.",
+          "bottom_depth": {
+            "type": "number",
+            "description": "Bottom depth of this soil layer.\nUnits: mm.",
+            "minimum": 20
+          },
+          "soil_water_concentration": {
+            "type": "number",
+            "description": "Concentration of water in this layer at the beginning of the simulation.\nUnits: mm water / mm soil.",
+            "minimum": 0.0,
+            "maximum": 0.95,
+            "default": 0.25
+          },
+          "field_capacity_water_concentration": {
+            "type": "number",
+            "description": "Concentration of water in this layer when at field capacity.\nUnits: mm water / mm soil.",
+            "minimum": 0.0,
+            "maximum": 0.95,
+            "default": 0.3
+          },
+          "wilting_point_water_concentration": {
+            "type": "number",
+            "description": "Concentration of water in this layer when at field capacity.\nUnits: mm water / mm soil.",
+            "minimum": 0.0,
+            "maximum": 0.95,
+            "default": 0.2
+          },
+          "saturation_point_water_concentration": {
+            "type": "number",
+            "description": "Concentration of water in a layer when it has become saturated.\nUnits: mm water / mm soil.",
+            "minimum": 0.0,
+            "maximum": 0.95,
+            "default": 0.5
+          },
+          "temperature": {
+            "type": "number",
+            "description": "Temperature of the layer at the beginning of the simulation.\nUnits: degrees Celsius.",
+            "default": 15.05
+          },
+          "saturated_hydraulic_conductivity": {
+            "type": "number",
+            "description": "Measure of ease of water movement through the soil.\nUnits: mm / hour.\nReference: SWAT Input .SOL - SOL_K.",
+            "minimum": 0.01,
+            "default": 9.5
+          },
+          "bulk_density": {
+            "type": "number",
+            "description": "Ratio of mass of solid particles to total volume of soil.\nUnits: Megagrams / cubic meter or grams / cubic centimeter.",
+            "minimum": 1.1,
+            "maximum": 1.9,
+            "default": 1.4
+          },
+          "percent_organic_carbon_content": {
+            "type": "number",
+            "description": "Percent of soil weight that is organic carbon.\nUnitless.\nReference: SWAT Input .SOL - SOL_CBN.",
+            "minimum": 0.0,
+            "maximum": 100.0,
+            "default": 1.2
+          },
+          "percent_clay_content": {
+            "type": "number",
+            "description": "Percent of soil weight that is clay.\nUnitless.\nReference: SWAT Input .SOL - SOL_CLAY.",
+            "minimum": 0.0,
+            "maximum": 100.0,
+            "default": 22.5
+          },
+          "percent_silt_content": {
+            "type": "number",
+            "description": "Percent of soil weight that is silt.\nUnitless.\nReference: SWAT Input .SOL - SOL_SILT.",
+            "minimum": 0.0,
+            "maximum": 100.0,
+            "default": 62.5
+          },
+          "percent_sand_content": {
+            "type": "number",
+            "description": "Percent of soil weight that is sand.\nUnitless.\nReference: SWAT Input .SOL - SOL_SAND.",
+            "minimum": 0.0,
+            "maximum": 100.0,
+            "default": 12.5
+          },
+          "percent_rock_content": {
+            "type": "number",
+            "description": "Percent of soil weight that is rock.\nUnitless.\nReference: SWAT Input .SOL - SOL_ROCK.",
+            "minimum": 0.0,
+            "maximum": 100.0,
+            "default": 1.3
+          },
+          "initial_labile_inorganic_phosphorus_concentration": {
+            "type": "number",
+            "description": "Concentration of labile inorganic phosphorus at the beginning of the simulation.\nUnits: milligrams / kilogram soil.",
+            "minimum": 0.0,
+            "default": null
+          },
+          "initial_fresh_organic_phosphorus_concentration": {
+            "type": "number",
+            "description": "Concentration of fresh organic phosphorus at the beginning of the simulation.\nUnits: milligrams / kilogram soil.",
+            "minimum": 0.0,
+            "default": 0.0
+          },
+          "initial_soil_nitrate_concentration": {
+            "type": "number",
+            "description": "Concentration of nitrate in the layer at the beginning of the simulation.\nUnits: milligrams / kilogram soil.",
+            "minimum": 0.0,
+            "default": null
+          },
+          "initial_soil_ammonium_concentration": {
+            "type": "number",
+            "description": "Concentration of ammonium in the layer at the beginning of the simulation.\nUnits: milligrams / kilogram soil.",
+            "minimum": 0.0,
+            "default": null
+          },
+          "humus_mineralization_rate_factor": {
+            "type": "number",
+            "description": "Rate factor for humus mineralization of active organic nutrients (N and P).\nUnitless.\nReference: SWAT Input .BSN - CMN.",
+            "minimum": 0.0,
+            "default": 0.0003
+          },
+          "denitrification_rate_coefficient": {
+            "type": "number",
+            "description": "Controls the rate of denitrification.\nUnitless.\nReference: SWAT Input .BSN - CDN.",
+            "minimum": 0.0,
+            "maximum": 3.0,
+            "default": 1.4
+          },
+          "denitrification_threshold_water_content": {
+            "type": "number",
+            "description": "Fraction of field capacity water content above which denitrification takes place.\nUnitless.\nReference: SWAT Input .BSN - SDNCO",
+            "minimum": 0.0,
+            "default": 1.1
+          },
+          "residue_fresh_organic_mineralization_rate": {
+            "type": "number",
+            "description": "Fraction of residue that will decompose in a day given optimal conditions.\nUnitless.\nReference SWAT Input: .BSN - RSDCO.",
+            "minimum": 0.0,
+            "default": 0.05
+          }
         }
       }
     },


### PR DESCRIPTION
This is a small PR that corrects some formatting mistakes of arrays of objects in the properties section of `example_metadata.json`.

I had written the crop schedule to be a single collection of values, when it should be multiple collections of the same set of values. In other words, I specified it to be a single object when it should have been an array of objects. Also, the way that the array of soil layer objects was being specified was inconsistent with the current standard (see Niko's comment below), so that has been corrected as well.