### PR TITLE
Correct CSV filtering/writing

### DIFF
--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -309,11 +309,13 @@ class OutputManager(object):
         except Exception as e:
             raise e
 
-    def _dict_to_csv_column_list(self, data_dict: Dict[str, List[Any]]) -> List[Tuple[str, pd.Series]]:
+    def _dict_to_csv_column_list(self, variable_name: str, data_dict: Dict[str, List[Any]]) -> List[pd.Series]:
         """Turns a dictionary to a list of csv columns.
 
         Parameters
         ----------
+        variable_name : str
+            The name of the variable having its values written into a CSV column.
         data_dict : Dict[str, List[Any]]
             The dictionary to read from
 
@@ -342,10 +344,11 @@ class OutputManager(object):
                         csv_column_lists[subkey].append(value)
 
                 for subkey in csv_column_lists.keys():
-                    column_title = f"{field}_{subkey}" if field == "info_maps" else subkey
-                    column_list.append((column_title, pd.Series(csv_column_lists[subkey], dtype=object)))
+                    column_title = f"{variable_name}.{field}_{subkey}" if field == "info_maps" else subkey
+                    column_list.append(pd.Series(csv_column_lists[subkey], dtype=object, name=column_title))
             else:
-                column_list.append((field, pd.Series(data_list, dtype=object)))
+                column_title = f"{variable_name}.{field}"
+                column_list.append(pd.Series(data_list, dtype=object, name=column_title))
 
         return column_list
 
@@ -375,9 +378,9 @@ class OutputManager(object):
             self.add_log("save_dict_file_try", f"Nothing to save to {path}. Data dictionary is empty.", info_map)
             return
 
-        (_, variable_data), = data_dict.items()
-        csv_column_data = self._dict_to_csv_column_list(variable_data)
-        df = pd.DataFrame(dict(csv_column_data))
+        (variable_name, variable_data), = data_dict.items()
+        csv_column_data = self._dict_to_csv_column_list(variable_name, variable_data)
+        df = pd.concat(csv_column_data, axis=1)
         try:
             df.to_csv(path, index=False)
         except Exception as e:

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -324,14 +324,6 @@ class OutputManager(object):
         List[Tuple[str, pd.Series]]
             A list of (column_name, column_data) tuples.
 
-        ED - plan for fixing this bug:
-            1. rewrite this method so that it only returns a list of pd.Series, with each Series getting its name set to
-                <name_of_the_variable>.value or <name_of_the_variable>.info_map.
-            2. rewrite _dict_to_file_csv() so that it takes a FULL dictionary of data, generates a Series of each
-                variable, combines all the Series into one DataFrame, and writes it to a CSV.
-            3. rewrite save_variables() to only call _dict_to_file_csv() for each CSV filter.
-            4. rewrite the tests.
-
         """
         column_list = []
         mandatory_fields = ["values", "info_maps"] if "info_maps" in data_dict else ["values"]

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -358,15 +358,14 @@ class OutputManager(object):
         Parameters
         ----------
         data_dict : Dict[str, Any]
-            The dictionary to be saved
-
+            The dictionary to be saved.
         path : str
-            The path to the file to be saved
+            The path to the file to be saved.
 
         Raises
         ------
         Exception
-            If an error occurs while writting to the file
+            If an error occurs while writing to the file.
 
         """
         info_map = {"class": self.__class__.__name__,
@@ -378,9 +377,13 @@ class OutputManager(object):
             self.add_log("save_dict_file_try", f"Nothing to save to {path}. Data dictionary is empty.", info_map)
             return
 
-        (variable_name, variable_data), = data_dict.items()
-        csv_column_data = self._dict_to_csv_column_list(variable_name, variable_data)
-        df = pd.concat(csv_column_data, axis=1)
+        csv_columns = []
+        for variable_name in data_dict.keys():
+            variable_data = data_dict[variable_name]
+            csv_column_data = self._dict_to_csv_column_list(variable_name, variable_data)
+            csv_columns.extend(csv_column_data)
+
+        df = pd.concat(csv_columns, axis=1)
         try:
             df.to_csv(path, index=False)
         except Exception as e:
@@ -570,12 +573,12 @@ class OutputManager(object):
                 file_path = os.path.join(save_path, self._generate_file_name(f"saved_variables_{filter_file}", "json"))
                 self._dict_to_file_json(filtered_pool, file_path)
             elif filter_file.startswith("csv_"):
-                csv_directory = os.path.join(save_path, "CSVs", "om", "variables")
-                self._save_variables_to_csv_files(filtered_pool, csv_directory)
+                csv_directory = os.path.join(save_path, "CSVs", "om")
+                self._save_variables_to_csv_files(filtered_pool, filter_file, csv_directory)
             else:
                 self.add_warning("invalid filter file", f"{filter_file} must be prefixed with csv_ or json_", info_map)
 
-    def _save_variables_to_csv_files(self, data_dict: Dict[str, Any], path: str) -> None:
+    def _save_variables_to_csv_files(self, data_dict: Dict[str, Any], filter_name: str, path: str) -> None:
         """
         Saves the variables_pool into one csv file per variable in the given path to a directory.
 
@@ -583,7 +586,8 @@ class OutputManager(object):
         ----------
         data_dict : Dict[str, Any]
             The dictionary to be saved
-
+        filter_name : str
+            Name of the filter that is being used for selecting data for the CSV.
         path : str
             Path to the output directory for the OutputManager.
 
@@ -593,9 +597,9 @@ class OutputManager(object):
         except Exception as e:
             raise e
 
-        for key in data_dict.keys():
-            variable_csv_file_path = os.path.join(path, self._generate_file_name(key, "csv"))
-            self._dict_to_file_csv({key: data_dict[key]}, variable_csv_file_path)
+        # for key in data_dict.keys():
+        variable_csv_file_path = os.path.join(path, self._generate_file_name(filter_name, "csv"))
+        self._dict_to_file_csv(data_dict, variable_csv_file_path)
 
     def dump_variables(self, path: str, exclude_info_maps: bool = False) -> None:
         """

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -322,6 +322,14 @@ class OutputManager(object):
         List[Tuple[str, pd.Series]]
             A list of (column_name, column_data) tuples.
 
+        ED - plan for fixing this bug:
+            1. rewrite this method so that it only returns a list of pd.Series, with each Series getting its name set to
+                <name_of_the_variable>.value or <name_of_the_variable>.info_map.
+            2. rewrite _dict_to_file_csv() so that it takes a FULL dictionary of data, generates a Series of each
+                variable, combines all the Series into one DataFrame, and writes it to a CSV.
+            3. rewrite save_variables() to only call _dict_to_file_csv() for each CSV filter.
+            4. rewrite the tests.
+
         """
         column_list = []
         mandatory_fields = ["values", "info_maps"] if "info_maps" in data_dict else ["values"]

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -598,7 +598,7 @@ class OutputManager(object):
             raise e
 
         # for key in data_dict.keys():
-        variable_csv_file_path = os.path.join(path, self._generate_file_name(filter_name, "csv"))
+        variable_csv_file_path = os.path.join(path, self._generate_file_name(f"saved_variables_{filter_name}", "csv"))
         self._dict_to_file_csv(data_dict, variable_csv_file_path)
 
     def dump_variables(self, path: str, exclude_info_maps: bool = False) -> None:

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -1,7 +1,7 @@
 # !/usr/bin/env python3
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Union
 import datetime
 import json
 import os

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -336,7 +336,8 @@ class OutputManager(object):
                         csv_column_lists[subkey].append(value)
 
                 for subkey in csv_column_lists.keys():
-                    column_title = f"{variable_name}.{field}_{subkey}" if field == "info_maps" else subkey
+                    column_title = f"{variable_name}.{field}_{subkey}" if field == "info_maps" else \
+                        f"{variable_name}.{subkey}"
                     column_list.append(pd.Series(csv_column_lists[subkey], dtype=object, name=column_title))
             else:
                 column_title = f"{variable_name}.{field}"

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -590,7 +590,6 @@ class OutputManager(object):
         except Exception as e:
             raise e
 
-        # for key in data_dict.keys():
         variable_csv_file_path = os.path.join(path, self._generate_file_name(f"saved_variables_{filter_name}", "csv"))
         self._dict_to_file_csv(data_dict, variable_csv_file_path)
 

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -321,7 +321,7 @@ class OutputManager(object):
 
         Returns
         -------
-        List[Tuple[str, pd.Series]]
+        List[pd.Series]
             A list of (column_name, column_data) tuples.
 
         """
@@ -355,11 +355,6 @@ class OutputManager(object):
         path : str
             The path to the file to be saved.
 
-        Raises
-        ------
-        Exception
-            If an error occurs while writing to the file.
-
         """
         info_map = {"class": self.__class__.__name__,
                     "function": self._dict_to_file_csv.__name__,
@@ -377,10 +372,8 @@ class OutputManager(object):
             csv_columns.extend(csv_column_data)
 
         df = pd.concat(csv_columns, axis=1)
-        try:
-            df.to_csv(path, index=False)
-        except Exception as e:
-            raise e
+
+        df.to_csv(path, index=False)
 
         self.add_log("save_dict_file_try", f"Successfully saved to {path}.", info_map)
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -334,36 +334,36 @@ def test_dict_to_csv_column_list(mock_output_manager: OutputManager) -> None:
     data = {
         "values": [1.0, True, "test", {"key": 1}],
     }
-    result = mock_output_manager._dict_to_csv_column_list(data)
-    (_, v) = result[0]
+    result = mock_output_manager._dict_to_csv_column_list("dummy_variable_name", data)
+    v = result[0]
     assert v.to_list() == data['values']
 
     data["info_maps"] = [{"map1": "value1", "map2": 1}, {"map1": "value2", "map2": 2}]
-    result = mock_output_manager._dict_to_csv_column_list(data)
+    result = mock_output_manager._dict_to_csv_column_list("dummy_variable_name", data)
     assert len(result) == 3
-    (title1, data_series) = result[0]
-    (title2, map1_series) = result[1]
-    (title3, map2_series) = result[2]
-    assert title1 == 'values'
+    data_series = result[0]
+    map1_series = result[1]
+    map2_series = result[2]
+    assert data_series.name == "dummy_variable_name.values"
     assert data_series.to_list() == data['values']
-    assert title2 == "info_maps_map1"
+    assert map1_series.name == "dummy_variable_name.info_maps_map1"
     assert map1_series.to_list() == ['value1', 'value2']
-    assert title3 == "info_maps_map2"
+    assert map2_series.name == "dummy_variable_name.info_maps_map2"
     assert map2_series.to_list() == [1, 2]
 
 
 def test_dict_to_csv_column_list_empty_list(mock_output_manager: OutputManager) -> None:
     """Unit test for the function _dict_to_csv_column_list in the file output_manager.py"""
     data = {"values": [], "info_maps": []}
-    result = mock_output_manager._dict_to_csv_column_list(data)
+    result = mock_output_manager._dict_to_csv_column_list("dummy_variable_name", data)
 
     assert len(result) == 2
-    (title, data_series) = result[0]
-    assert title == "values"
-    assert data_series.to_list() == []
-    (title, data_series) = result[1]
-    assert title == "info_maps"
-    assert data_series.to_list() == []
+    series = result[0]
+    assert series.name == "dummy_variable_name.values"
+    assert series.to_list() == []
+    series = result[1]
+    assert series.name == "dummy_variable_name.info_maps"
+    assert series.to_list() == []
 
 
 @pytest.mark.parametrize("data, expected_result, should_write", [

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -870,10 +870,12 @@ def test_save_variables_to_csv_files(
 
     with patch('pathlib.Path.mkdir') as mock_mkdir:
         mock_mkdir.return_value = None
-        mock_output_manager._save_variables_to_csv_files(mock_variable_pool, "dummy_path")
+        mock_output_manager._save_variables_to_csv_files(mock_variable_pool, "csv_dummy_filter_filepath.txt",
+                                                         "dummy_path")
 
     mock_mkdir.assert_called_with(parents=True, exist_ok=True)
-    mock_output_manager._generate_file_name.assert_called_once_with("var1", "csv")
+    mock_output_manager._generate_file_name.assert_called_once_with("saved_variables_csv_dummy_filter_filepath.txt",
+                                                                    "csv")
     mock_output_manager._dict_to_file_csv.assert_called_once_with(
         mock_variable_pool, os.path.join("dummy_path", "dummy_name")
     )
@@ -1540,7 +1542,7 @@ def test_save_variables(
         mock_output_manager.variables_pool, os.path.join("dummy_path", "dummy_name")
     )
     mock_output_manager._save_variables_to_csv_files.assert_called_with(
-        mock_output_manager.variables_pool, os.path.join("dummy_path", "CSVs", "om", "variables")
+        mock_output_manager.variables_pool, 'csv_dummy_input_filepath.txt', os.path.join("dummy_path", "CSVs", "om")
     )
 
     # test case for when exclude_info_maps flag set to True
@@ -1554,7 +1556,7 @@ def test_save_variables(
         mock_output_manager.variables_pool, os.path.join("dummy_path", "dummy_name")
     )
     mock_output_manager._save_variables_to_csv_files.assert_called_with(
-        mock_output_manager.variables_pool, os.path.join("dummy_path", "CSVs", "om", "variables")
+        mock_output_manager.variables_pool, 'csv_dummy_input_filepath.txt', os.path.join("dummy_path", "CSVs", "om")
     )
 
     # test case for when the filter files to don start with csv_ or json_

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -368,19 +368,19 @@ def test_dict_to_csv_column_list_empty_list(mock_output_manager: OutputManager) 
 
 @pytest.mark.parametrize("data, expected_result, should_write", [
     ({"var1": {"values": [1.0, True, "test"], "info_maps": []}},
-     f"values,info_maps{os.linesep}1.0,{os.linesep}True,{os.linesep}test,{os.linesep}",
+     f"var1.values,var1.info_maps{os.linesep}1.0,{os.linesep}True,{os.linesep}test,{os.linesep}",
      True),
     ({"var1": {"values": [1.0, True, "test"]}},
-     f"values{os.linesep}1.0{os.linesep}True{os.linesep}test{os.linesep}",
+     f"var1.values{os.linesep}1.0{os.linesep}True{os.linesep}test{os.linesep}",
      True),
     ({"var1": {"values": [1, 2, 3], "info_maps": [{"v": 1}, {"v": 2}, {"v": 3}]}},
-     f"values,info_maps_v{os.linesep}1,1{os.linesep}2,2{os.linesep}3,3{os.linesep}",
+     f"var1.values,var1.info_maps_v{os.linesep}1,1{os.linesep}2,2{os.linesep}3,3{os.linesep}",
      True),
     ({"var1": {"values": [1, 2, 3]}},
-     f"values{os.linesep}1{os.linesep}2{os.linesep}3{os.linesep}",
+     f"var1.values{os.linesep}1{os.linesep}2{os.linesep}3{os.linesep}",
      True),
     ({"var1": {"values": [1], "info_maps": [{"map1": "value1"}, {"map1": "value2"}]}},
-     f"values,info_maps_map1{os.linesep}1,value1{os.linesep},value2{os.linesep}",
+     f"var1.values,var1.info_maps_map1{os.linesep}1,value1{os.linesep},value2{os.linesep}",
      True),
     ({"var1":
       {
@@ -388,7 +388,7 @@ def test_dict_to_csv_column_list_empty_list(mock_output_manager: OutputManager) 
         "info_maps": [{"map1": "value1"}, {"map1": "value2"}]
       }
       },
-     f"v1,v2,info_maps_map1{os.linesep}1,1,value1{os.linesep}2,2,value2{os.linesep}",
+     f"v1,v2,var1.info_maps_map1{os.linesep}1,1,value1{os.linesep}2,2,value2{os.linesep}",
      True),
     ({
         "simple_key": {
@@ -415,7 +415,8 @@ def test_dict_to_csv_column_list_empty_list(mock_output_manager: OutputManager) 
             ]
         }
     },
-     f"key1,key2,info_maps_subkey1,info_maps_subkey2,info_maps_subkey3,info_maps_subkey4{os.linesep}"
+     f"key1,key2,simple_key.info_maps_subkey1,simple_key.info_maps_subkey2,simple_key.info_maps_subkey3,"
+     f"simple_key.info_maps_subkey4{os.linesep}"
      f"1,\"[1, 1]\",1,Hello,\"[1, 2, 3]\",\"{{'nestedkey1': 'World', 'nestedkey2': [4, 5, 6]}}\"{os.linesep}"
      f"2,\"[2, 2]\",2,Hi,\"[4, 5, 6]\",\"{{'nestedkey1': 'There', 'nestedkey2': [7, 8, 9]}}\"{os.linesep}"
      f"3,\"[3, 3]\",,,,{os.linesep}",

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -388,7 +388,7 @@ def test_dict_to_csv_column_list_empty_list(mock_output_manager: OutputManager) 
         "info_maps": [{"map1": "value1"}, {"map1": "value2"}]
       }
       },
-     f"v1,v2,var1.info_maps_map1{os.linesep}1,1,value1{os.linesep}2,2,value2{os.linesep}",
+     f"var1.v1,var1.v2,var1.info_maps_map1{os.linesep}1,1,value1{os.linesep}2,2,value2{os.linesep}",
      True),
     ({
         "simple_key": {
@@ -415,8 +415,8 @@ def test_dict_to_csv_column_list_empty_list(mock_output_manager: OutputManager) 
             ]
         }
     },
-     f"key1,key2,simple_key.info_maps_subkey1,simple_key.info_maps_subkey2,simple_key.info_maps_subkey3,"
-     f"simple_key.info_maps_subkey4{os.linesep}"
+     f"simple_key.key1,simple_key.key2,simple_key.info_maps_subkey1,simple_key.info_maps_subkey2,"
+     f"simple_key.info_maps_subkey3,simple_key.info_maps_subkey4{os.linesep}"
      f"1,\"[1, 1]\",1,Hello,\"[1, 2, 3]\",\"{{'nestedkey1': 'World', 'nestedkey2': [4, 5, 6]}}\"{os.linesep}"
      f"2,\"[2, 2]\",2,Hi,\"[4, 5, 6]\",\"{{'nestedkey1': 'There', 'nestedkey2': [7, 8, 9]}}\"{os.linesep}"
      f"3,\"[3, 3]\",,,,{os.linesep}",

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -421,6 +421,44 @@ def test_dict_to_csv_column_list_empty_list(mock_output_manager: OutputManager) 
      f"2,\"[2, 2]\",2,Hi,\"[4, 5, 6]\",\"{{'nestedkey1': 'There', 'nestedkey2': [7, 8, 9]}}\"{os.linesep}"
      f"3,\"[3, 3]\",,,,{os.linesep}",
      True),
+    ({
+        "simple_key1": {
+            "values": [1, 2, 3]
+        },
+        "simple_key2": {
+            "values": [4, 5, 6]
+        }
+    },
+     f"simple_key1.values,simple_key2.values{os.linesep}"
+     f"1,4{os.linesep}2,5{os.linesep}3,6{os.linesep}",
+     True),
+    ({
+        "simple_key1": {
+            "values": [1, 2, 3],
+            "info_maps": [
+                {
+                    "subkey1": "Farm",
+                    "subkey2": "Field"
+                }
+            ]
+        },
+        "simple_key2": {
+            "values": [4, 5, 6, 8, 9],
+            "info_maps": [
+                {
+                    "subkey1": "Tractor",
+                }
+            ]
+        }
+    },
+     f"simple_key1.values,simple_key1.info_maps_subkey1,simple_key1.info_maps_subkey2,simple_key2.values,"
+     f"simple_key2.info_maps_subkey1{os.linesep}"
+     f"1,Farm,Field,4,Tractor{os.linesep}"
+     f"2,,,5,{os.linesep}"
+     f"3,,,6,{os.linesep}"
+     f",,,8,{os.linesep}"
+     f",,,9,{os.linesep}",
+     True),
     ({}, "",
      False),
 ])


### PR DESCRIPTION
This PR modifies how CSV files are produced when passed output filters that request results written to CSVs.

Before:
- Every variable listed in the filter would get written to its own individual CSV file.
- Each file name would take the be formatted `<variable_name>_<time stamp>.csv`.
- Each file would be written to the directory `output/CSVs/om/variables`
- If multiple filters were present, only the variables from the last filter would be present after all the post-processing was finished.

Now:
- All variables listed in the same filter file are written to the same CSV file.
- Files are named `saved_variables_<filter file name>_<timestamp>.csv`.
- Files are written to the directory `output/CSVs/om`.
- Each filter has its results written to the above directory.

`coverage` and `flake8` have been run, code coverage is maintained and no new formatting errors have been introduced.

I highly encourage pulling this branch and reviewing some output written to CSVs, it will help catch any styling mistakes or poor formatting choices for writing the column headers.
