### PR TITLE
Adding a class to handle ration config variables

### DIFF
--- a/RUFAS/routines/animal/ration/ration_config.py
+++ b/RUFAS/routines/animal/ration/ration_config.py
@@ -48,7 +48,7 @@ class RationConfig:
                  type_: list[str] | None = None, is_wetforage_: list[bool] | None = None,
                  Kd_: list[float] | None = None, N_A_: list[float] | None = None, N_B_: list[float] | None = None,
                  CP_: list[float] | None = None, dRUP_: list[float] | None = None,
-                 limit_: list[float] | None = None, cow_type_: bool = False, DMIest_: float | None = None):
+                 limit_: list[float] | None = None, cow_type_: bool = False, DMIest_: float | None = None) -> None:
         """
         Initialize the RationConfig class with the provided feed information. If the input
         is a list, it should have a length corresponding to the decision vector.
@@ -125,7 +125,6 @@ class RationConfig:
         self.MP_req = MP_req_
         self.C_req = C_req_
         self.P_req = P_req_
-        self.DMIest = DMIest_
         self.TDN = TDN_ if TDN_ is not None else []
         self.DE = DE_ if DE_ is not None else []
         self.EE = EE_ if EE_ is not None else []
@@ -143,3 +142,5 @@ class RationConfig:
         self.dRUP = dRUP_ if dRUP_ is not None else []
         self.limit = limit_ if limit_ is not None else []
         self.cow_type = cow_type_
+        self.DMIest = DMIest_
+

--- a/RUFAS/routines/animal/ration/ration_config.py
+++ b/RUFAS/routines/animal/ration/ration_config.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+
+class RationConfig:
+    """
+    RationConfig provides a structured way to represent the configuration for rations.
+
+    Attributes:
+
+    - price: The price of each feed.
+    - n: The length of the price list.
+    - NEmaint: Net energy for maintenance requirement (Mcal).
+    - NEa: Net energy for activity requirement (Mcal).
+    - NEpreg: Net energy requirement for pregnancy (Mcal).
+    - NEl: Net energy requirement for lactation (Mcal).
+    - NEg: Net energy for growth requirement (Mcal).
+    - MP_req: Metabolizable protein requirement for growth (g).
+    - C_req: Calcium requirement (g).
+    - P_req: Phosphorus requirement (g).
+    - TDN: Total digestible nutrient in each feed (% of DM).
+    - DE: Digestible energy in each feed (Mcal/kg).
+    - EE: Ether extract, crude fat in each feed (% of DM).
+    - is_fat: Indicates if the feed is a fat supplement.
+    - BW: The average body weight of the pen.
+    - calcium: Calcium content of each feed (% of DM).
+    - phosphorus: Phosphorus content of each feed (% of DM).
+    - NDF: Neutral detergent fiber in each feed (% of DM).
+    - type: Feed types (Forage, Concentrate, or Mineral).
+    - is_wetforage: Indicates if the feed is wet forage.
+    - Kd: Rumen protein degradation rate in each feed (%/h).
+    - N_A: Fraction A of protein, degraded immediately in rumen for each feed (% of CP).
+    - N_B: Fraction B of protein, potentially degradable protein in rumen for each feed (% of CP).
+    - CP: Crude protein in each feed (% of DM).
+    - dRUP: RUP degradability in each feed (% of RUP).
+    - limit: Limiting upper bounds for each feed (kg).
+    - cow_type: Indicates if the cow is lactating.
+    - DMIest: Dry matter intake estimation (kg).
+
+    Methods:
+
+    """
+
+    def __init__(self, price_: list[float] | None = None, NEmaint_: float = 0, NEa_: float = 0, NEpreg_: float = 0,
+                 NEl_: float = 0, NEg_: float = 0, MP_req_: float = 0, C_req_: float = 0, P_req_: float = 0,
+                 TDN_: list[float] | None = None, DE_: list[float] | None = None, EE_: list[float] | None = None,
+                 is_fat_: list[bool] | None = None, BW_: float = 0, calcium_: list[float] | None = None,
+                 phosphorus_: list[float] | None = None, NDF_: list[float] | None = None,
+                 type_: list[str] | None = None, is_wetforage_: list[bool] | None = None,
+                 Kd_: list[float] | None = None, N_A_: list[float] | None = None, N_B_: list[float] | None = None,
+                 CP_: list[float] | None = None, dRUP_: list[float] | None = None,
+                 limit_: list[float] | None = None, cow_type_: bool = False, DMIest_: float | None = None):
+        """
+        Initialize the RationConfig class with the provided feed information. If the input
+        is a list, it should have a length corresponding to the decision vector.
+
+        Parameters
+        ----------
+        price_ : list, optional
+            The price of each feed.
+        NEmaint_ : float, optional
+            Net energy for maintenance requirement (Mcal).
+        NEa_ : float, optional
+            Net energy for activity requirement (Mcal).
+        NEpreg_ : float, optional
+            Net energy requirement for pregnancy (Mcal).
+        NEl_ : float, optional
+            Net energy requirement for lactation (Mcal).
+        NEg_ : float, optional
+            Net energy for growth requirement (Mcal).
+        MP_req_ : float, optional
+            Metabolizable protein requirement for growth (g).
+        C_req_ : float, optional
+            Calcium requirement (g).
+        P_req_ : float, optional
+            Phosphorus requirement (g).
+        TDN_ : list, optional
+            Total digestible nutrient in each feed (% of DM).
+        DE_ : list, optional
+            Digestible energy in each feed (Mcal/kg).
+        EE_ : list, optional
+            Ether extract, crude fat in each feed (% of DM).
+        is_fat_ : list of bool, optional
+            Indicates if the feed is a fat supplement (yes = True; no = False).
+        BW_ : float, optional
+            The average body weight of the pen.
+        calcium_ : list, optional
+            Calcium content of each feed (% of DM).
+        phosphorus_ : list, optional
+            Phosphorus content of each feed (% of DM).
+        NDF_ : list, optional
+            Neutral detergent fiber in each feed (% of DM).
+        type_ : list, optional
+            Feed types (Forage, Concentrate, or Mineral).
+        is_wetforage_ : list of bool, optional
+            Indicates if the feed is wet forage (yes = True; no = False).
+        Kd_ : list, optional
+            Rumen protein degradation rate in each feed (%/h).
+        N_A_ : list, optional
+            Fraction A of protein, degraded immediately in rumen for each feed (% of CP).
+        N_B_ : list, optional
+            Fraction B of protein, potentially degradable protein, requires time to degrade in rumen for each feed (% of CP).
+        CP_ : list, optional
+            Crude protein in each feed (% of DM).
+        dRUP_ : list, optional
+            RUP degradability in each feed (% of RUP).
+        limit_ : list, optional
+            Limiting upper bounds for each feed (kg).
+        cow_type_ : bool, optional
+            True if the cow is lactating, False otherwise.
+        DMIest_ : float, optional
+            Dry matter intake estimation (kg).
+
+        Returns
+        -------
+        None
+        """
+
+        self.price = price_ if price_ is not None else []
+        self.n = len(self.price)
+        self.NEmaint = NEmaint_
+        self.NEa = NEa_
+        self.NEpreg = NEpreg_
+        self.NEl = NEl_
+        self.NEg = NEg_
+        self.MP_req = MP_req_
+        self.C_req = C_req_
+        self.P_req = P_req_
+        self.DMIest = DMIest_
+        self.TDN = TDN_ if TDN_ is not None else []
+        self.DE = DE_ if DE_ is not None else []
+        self.EE = EE_ if EE_ is not None else []
+        self.is_fat = is_fat_ if is_fat_ is not None else []
+        self.BW = BW_
+        self.calcium = calcium_ if calcium_ is not None else []
+        self.phosphorus = phosphorus_ if phosphorus_ is not None else []
+        self.NDF = NDF_ if NDF_ is not None else []
+        self.type = type_ if type_ is not None else []
+        self.is_wetforage = is_wetforage_ if is_wetforage_ is not None else []
+        self.Kd = Kd_ if Kd_ is not None else []
+        self.N_A = N_A_ if N_A_ is not None else []
+        self.N_B = N_B_ if N_B_ is not None else []
+        self.CP = CP_ if CP_ is not None else []
+        self.dRUP = dRUP_ if dRUP_ is not None else []
+        self.limit = limit_ if limit_ is not None else []
+        self.cow_type = cow_type_

--- a/tests/test_animal_module/ration/test_ration_config.py
+++ b/tests/test_animal_module/ration/test_ration_config.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import pytest
+from pytest import approx
+
+from RUFAS.routines.animal.ration.ration_config import RationConfig
+
+
+def test_default_initialization():
+    """
+    Test the default initialization of the RationConfig class.
+
+    This test checks that when a RationConfig object is instantiated without
+    any parameters, all its attributes are correctly set to their default values.
+    """
+    # Act
+    ration_config = RationConfig()
+
+    # Assert
+    assert ration_config.price == []
+    assert ration_config.n == 0
+    assert ration_config.NEmaint == 0
+    assert ration_config.NEa == 0
+    assert ration_config.NEpreg == 0
+    assert ration_config.NEl == 0
+    assert ration_config.NEg == 0
+    assert ration_config.MP_req == 0
+    assert ration_config.C_req == 0
+    assert ration_config.P_req == 0
+    assert ration_config.TDN == []
+    assert ration_config.DE == []
+    assert ration_config.EE == []
+    assert ration_config.is_fat == []
+    assert ration_config.BW == approx(0)
+    assert ration_config.calcium == []
+    assert ration_config.phosphorus == []
+    assert ration_config.NDF == []
+    assert ration_config.type == []
+    assert ration_config.is_wetforage == []
+    assert ration_config.Kd == []
+    assert ration_config.N_A == []
+    assert ration_config.N_B == []
+    assert ration_config.CP == []
+    assert ration_config.dRUP == []
+    assert ration_config.limit == []
+    assert not ration_config.cow_type
+    assert ration_config.DMIest is None
+
+
+@pytest.mark.parametrize(
+    'price, NEmaint, NEa, NEpreg, NEl, NEg,'
+    'MP_req, C_req, P_req, TDN, DE, EE,'
+    'is_fat, BW, calcium, phosphorus, NDF, type_input,'
+    'is_wetforage, Kd, N_A, N_B, CP, dRUP,'
+    'limit, cow_type, DMIest',
+    [
+        # Default values
+        ([], 0, 0, 0, 0, 0,
+         0, 0, 0, [], [], [],
+         [], 0, [], [], [], [],
+         [], [], [], [], [], [],
+         [], False, None),
+
+        # Custom values
+        ([1, 2], 3, 4, 5, 6, 7,
+         8, 9, 10, [11, 12], [13, 14], [15, 16],
+         [True, False], 17, [18, 19], [20, 21], [22, 23], [24, 25],
+         [True, False], [26, 27], [28, 29], [30, 31], [32, 33], [34, 35],
+         [36, 37], True, 38),
+    ],
+)
+def test_custom_initialization(price: list[float], NEmaint: float, NEa: float, NEpreg: float, NEl: float, NEg: float,
+                               MP_req: float, C_req: float, P_req: float, TDN: list[float], DE: list[float],
+                               EE: list[float], is_fat: list[bool], BW: float, calcium: list[float],
+                               phosphorus: list[float], NDF: list[float], type_input: list[str],
+                               is_wetforage: list[bool], Kd: list[float], N_A: list[float], N_B: list[float],
+                               CP: list[float], dRUP: list[float], limit: list[float], cow_type: bool, DMIest: float) \
+        -> None:
+    """
+    Test the initialization of the RationConfig class with custom values.
+
+    This test verifies that all attributes are correctly initialized based on the provided values.
+    """
+
+    # Act
+    ration_config = RationConfig(
+        price_=price,
+        NEmaint_=NEmaint,
+        NEa_=NEa,
+        NEpreg_=NEpreg,
+        NEl_=NEl,
+        NEg_=NEg,
+        MP_req_=MP_req,
+        C_req_=C_req,
+        P_req_=P_req,
+        TDN_=TDN,
+        DE_=DE,
+        EE_=EE,
+        is_fat_=is_fat,
+        BW_=BW,
+        calcium_=calcium,
+        phosphorus_=phosphorus,
+        NDF_=NDF,
+        type_=type_input,
+        is_wetforage_=is_wetforage,
+        Kd_=Kd,
+        N_A_=N_A,
+        N_B_=N_B,
+        CP_=CP,
+        dRUP_=dRUP,
+        limit_=limit,
+        cow_type_=cow_type,
+        DMIest_=DMIest,
+    )
+
+    # Assert
+    assert ration_config.price == price
+    assert ration_config.n == len(price)
+    assert ration_config.NEmaint == NEmaint
+    assert ration_config.NEa == NEa
+    assert ration_config.NEpreg == NEpreg
+    assert ration_config.NEl == NEl
+    assert ration_config.NEg == NEg
+    assert ration_config.MP_req == MP_req
+    assert ration_config.C_req == C_req
+    assert ration_config.P_req == P_req
+    assert ration_config.TDN == TDN
+    assert ration_config.DE == DE
+    assert ration_config.EE == EE
+    assert ration_config.is_fat == is_fat
+    assert ration_config.BW == approx(BW)
+    assert ration_config.calcium == calcium
+    assert ration_config.phosphorus == phosphorus
+    assert ration_config.NDF == NDF
+    assert ration_config.type == type_input
+    assert ration_config.is_wetforage == is_wetforage
+    assert ration_config.Kd == Kd
+    assert ration_config.N_A == N_A
+    assert ration_config.N_B == N_B
+    assert ration_config.CP == CP
+    assert ration_config.dRUP == dRUP
+    assert ration_config.limit == limit
+    assert ration_config.cow_type == cow_type
+    assert ration_config.DMIest == DMIest


### PR DESCRIPTION
This PR's goal is to pull out the global variables used in the ration optimizer and put them in a separate class called `RationConfig`. Although this helps with the overall refactoring of the ration module, the next step would be to divide this list of almost 30 variables into logical groups to make things easier to manage. 