### PR TITLE
Adding ration per animal to om

### DIFF
--- a/RUFAS/routines/animal/animal_manager.py
+++ b/RUFAS/routines/animal/animal_manager.py
@@ -1353,13 +1353,13 @@ class AnimalManager:
 
                 info_map = {"class": self.__class__.__name__,
                     "function": self._calc_ration_at_interval.__name__,
-                    "available_feeds": available_feeds.feed_id, }
+                    "available_feeds": available_feeds.feed_id, 
+                    f'number_animals_in_pen_{pen.id}': len(pen.animals_in_pen)}
                 om.add_variable(f'ration_nutrient_amount_pen_{pen.id}', nutrient_amount, info_map)
-                om.add_variable(f'ration_nutrient_conc_pen_{pen.id}', nutrient_conc, info_map)
                 om.add_variable(f'MEdiet_pen_{pen.id}', pen.MEdiet, info_map)
-                om.add_variable(f'dry_matter_intake_pen_{pen.id}', pen.dry_matter_intake, info_map)
                 om.add_variable(f'avg_rqmts_pen_{pen.id}', pen.avg_nutrient_rqmts, info_map)
-
+                om.add_variable(f'ration_per_animal_for_pen_{pen.id}', pen.ration_per_animal, info_map)
+                
     @classmethod
     def _get_animal_types_in_pen(cls, pen: Pen) -> Set[AnimalType]:
         """


### PR DESCRIPTION
Following deprecation of output handler, feed information is no longer being stored

This quick PR simply adds the number of animals in each pen to the info_map (necessary to calculate total feed ingredients fed per pen), and adds the ration per animal itself to om.

This also removes extraneous info from om (concentrations, when those are a product of DMI, and DMI, which is a sum of ration_per_animal)