### PR TITLE
Add deep copy to IM

### DIFF
--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -1,5 +1,6 @@
 # !/usr/bin/env python3
 
+from copy import deepcopy
 from functools import reduce
 import json
 import re
@@ -562,7 +563,7 @@ class InputManager:
         try:
             data_value = reduce(lambda d, key: d[key], element_hierarchy,
                                 self.__pool)
-            return data_value
+            return deepcopy(data_value)
 
         except KeyError as key_error:
             invalid_key = str(key_error).strip("\'")
@@ -628,7 +629,7 @@ class InputManager:
         try:
             metadata_value = reduce(lambda d, key: d[key], element_hierarchy,
                                     self.__metadata)
-            return metadata_value
+            return deepcopy(metadata_value)
 
         except KeyError:
             invalid_key = element_hierarchy[-1]


### PR DESCRIPTION
The entire codebase uses data stored in the IM pool. Since Python passes data by reference only, this means that the whole code base has write access to the IM pool. Consequently, if somewhere in the code we retrieve data from IM and change it, other parts of the code will be affected, which is not desirable.
To mitigate this issue, this PR adds deep copy to the get_data() and get_metadata() functions. Deep copy copies all elements and values within a nested data structure. It adds some computation overhead, but it is needed to prevent side effects. 
For ref, deep copy is implemented here: https://github.com/python/cpython/blob/3.11/Lib/copy.py#L128 