### PR TITLE
small patch to address OM.py lines missing coverage

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -505,13 +505,13 @@ def test_dict_to_file_csv_exception(mock_output_manager: OutputManager) -> None:
 
 
 def test_save_variables_to_csv_files_exceptions(
-    mock_output_manager: OutputManager,
-    mocker: MockerFixture
+    mock_output_manager: OutputManager
 ) -> None:
     """Unit test for the function _save_variables_to_csv_files() in the file output_manager.py"""
-    mocker.patch("pathlib.Path.mkdir", side_effect=IOError)
-    with raises(Exception):
-        mock_output_manager._save_variables_to_csv_files({}, "test_dir")
+    invalid_path = '/invalid/directory'
+
+    with pytest.raises((PermissionError, OSError)):
+        mock_output_manager._save_variables_to_csv_files({}, 'filter', invalid_path)
 
 
 def test_generate_key(mocker: MockerFixture) -> None:


### PR DESCRIPTION
When looking through open issues I saw #533 and when double checking that we had 100% coverage for OM, saw that two lines were reading as uncovered (660-661 - an exception being raised by a bad path for saving variables to a CSV file).

This PR addresses that coverage discrepancy by more correcting the types of potential exceptions/errors that would be raised in a bad path exception - this should get OM test coverage to 100%.