### PR TITLE
GitHub Linting Action Quick Fix

### DIFF
--- a/.github/workflows/lint_flake8.yml
+++ b/.github/workflows/lint_flake8.yml
@@ -30,7 +30,10 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Get all added or modified files
       run: |
-        echo "FILES=$( echo ${{ steps.files.outputs.added_modified }} | tr " " "\n" | grep -E "\.py$" )" >> "$GITHUB_ENV"
+        echo "FILES=$( echo ${{ steps.files.outputs.added_modified }} |
+                        tr " " "\n" |
+                        grep -E "\.py$" |
+                        tr "\n" " ")" >> "$GITHUB_ENV"
     - name: Lint with flake8
       if: ${{ env.FILES != '' }}
       run: |


### PR DESCRIPTION
After merging #806 this morning, the newly written GitHub Action failed for linting failed on #796 and #807, like this: 
![linting_github_action_failure](https://github.com/RuminantFarmSystems/MASM/assets/43901812/828724c5-7e94-435d-a5ab-a50a60dc466e)
I don't totally understand this issue, but I'm pretty sure it has something to do with writing a multi-line string into the GITHUB_ENV variable (there is actually a dedicated way to do [this](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings), but I didn't use this in the fix).

My solution is to reformat the output of the grep command to be on a single line, using a second call to `tr`.
I have tested it on 796 and 807 and it has worked as expected:

796:
![796_linting_fix_demo](https://github.com/RuminantFarmSystems/MASM/assets/43901812/9e499b49-bf8b-4ed7-ae54-3ed8ddc0be9b)

807:
![807_linting_fix_demo](https://github.com/RuminantFarmSystems/MASM/assets/43901812/051ec3f6-e953-49d5-b253-6d6be8184416)
