### PR TITLE
Updated Weather Metadata

### DIFF
--- a/input/metadata/ARL_metadata.json
+++ b/input/metadata/ARL_metadata.json
@@ -2395,15 +2395,13 @@
       "year": {
         "description": "Year.",
         "type": "number",
-        "minimum": 1900,
-        "default": 0
+        "minimum": 1900
       },
       "jday": {
         "description": "Julian day of the year.",
         "type": "number",
         "minimum": 0,
-        "maximum": 366,
-        "default": 0
+        "maximum": 366
       },
       "precip": {
         "description": "Amount of precipitation (mm H2O).",
@@ -2414,7 +2412,7 @@
       "high": {
         "description": "The maximum air temperature of the day (°C).",
         "type": "number",
-        "default": 0
+        "default": 21
       },
       "low": {
         "description": "The minimum air temperature of the day (°C).",
@@ -2432,7 +2430,7 @@
         "default": 0
       },
       "irrigation": {
-        "description": "Irrigation.",
+        "description": "Irrigation (mm H2O).",
         "type": "number",
         "default": 0
       }

--- a/input/metadata/ARL_metadata.json
+++ b/input/metadata/ARL_metadata.json
@@ -2392,10 +2392,48 @@
       }
     },
     "weather_properties": {
-      "precip": {
-        "description": "amount of precipitation",
+      "year": {
+        "description": "Year.",
+        "type": "number",
+        "minimum": 1900,
+        "default": 0
+      },
+      "jday": {
+        "description": "Julian day of the year.",
         "type": "number",
         "minimum": 0,
+        "maximum": 366,
+        "default": 0
+      },
+      "precip": {
+        "description": "Amount of precipitation (mm H2O).",
+        "type": "number",
+        "minimum": 0,
+        "default": 0
+      },
+      "high": {
+        "description": "The maximum air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "low": {
+        "description": "The minimum air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "avg": {
+        "description": "The average air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "Hday": {
+        "description": "The solar radiation of the day (MJ m^-2).",
+        "type": "number",
+        "default": 0
+      },
+      "irrigation": {
+        "description": "Irrigation.",
+        "type": "number",
         "default": 0
       }
     }

--- a/input/metadata/barnyard_metadata.json
+++ b/input/metadata/barnyard_metadata.json
@@ -2409,15 +2409,13 @@
       "year": {
         "description": "Year.",
         "type": "number",
-        "minimum": 1900,
-        "default": 0
+        "minimum": 1900
       },
       "jday": {
         "description": "Julian day of the year.",
         "type": "number",
         "minimum": 0,
-        "maximum": 366,
-        "default": 0
+        "maximum": 366
       },
       "precip": {
         "description": "Amount of precipitation (mm H2O).",
@@ -2428,7 +2426,7 @@
       "high": {
         "description": "The maximum air temperature of the day (°C).",
         "type": "number",
-        "default": 0
+        "default": 21
       },
       "low": {
         "description": "The minimum air temperature of the day (°C).",
@@ -2446,7 +2444,7 @@
         "default": 0
       },
       "irrigation": {
-        "description": "Irrigation.",
+        "description": "Irrigation (mm H2O).",
         "type": "number",
         "default": 0
       }

--- a/input/metadata/barnyard_metadata.json
+++ b/input/metadata/barnyard_metadata.json
@@ -2406,10 +2406,48 @@
       }
     },
     "weather_properties": {
-      "precip": {
-        "description": "amount of precipitation",
+      "year": {
+        "description": "Year.",
+        "type": "number",
+        "minimum": 1900,
+        "default": 0
+      },
+      "jday": {
+        "description": "Julian day of the year.",
         "type": "number",
         "minimum": 0,
+        "maximum": 366,
+        "default": 0
+      },
+      "precip": {
+        "description": "Amount of precipitation (mm H2O).",
+        "type": "number",
+        "minimum": 0,
+        "default": 0
+      },
+      "high": {
+        "description": "The maximum air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "low": {
+        "description": "The minimum air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "avg": {
+        "description": "The average air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "Hday": {
+        "description": "The solar radiation of the day (MJ m^-2).",
+        "type": "number",
+        "default": 0
+      },
+      "irrigation": {
+        "description": "Irrigation.",
+        "type": "number",
         "default": 0
       }
     }

--- a/input/metadata/default_metadata.json
+++ b/input/metadata/default_metadata.json
@@ -2402,15 +2402,13 @@
       "year": {
         "description": "Year.",
         "type": "number",
-        "minimum": 1900,
-        "default": 0
+        "minimum": 1900
       },
       "jday": {
         "description": "Julian day of the year.",
         "type": "number",
         "minimum": 0,
-        "maximum": 366,
-        "default": 0
+        "maximum": 366
       },
       "precip": {
         "description": "Amount of precipitation (mm H2O).",
@@ -2421,7 +2419,7 @@
       "high": {
         "description": "The maximum air temperature of the day (°C).",
         "type": "number",
-        "default": 0
+        "default": 21
       },
       "low": {
         "description": "The minimum air temperature of the day (°C).",
@@ -2439,7 +2437,7 @@
         "default": 0
       },
       "irrigation": {
-        "description": "Irrigation.",
+        "description": "Irrigation (mm H2O).",
         "type": "number",
         "default": 0
       }

--- a/input/metadata/default_metadata.json
+++ b/input/metadata/default_metadata.json
@@ -2399,10 +2399,48 @@
       }
     },
     "weather_properties": {
-      "precip": {
-        "description": "amount of precipitation",
+      "year": {
+        "description": "Year.",
+        "type": "number",
+        "minimum": 1900,
+        "default": 0
+      },
+      "jday": {
+        "description": "Julian day of the year.",
         "type": "number",
         "minimum": 0,
+        "maximum": 366,
+        "default": 0
+      },
+      "precip": {
+        "description": "Amount of precipitation (mm H2O).",
+        "type": "number",
+        "minimum": 0,
+        "default": 0
+      },
+      "high": {
+        "description": "The maximum air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "low": {
+        "description": "The minimum air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "avg": {
+        "description": "The average air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "Hday": {
+        "description": "The solar radiation of the day (MJ m^-2).",
+        "type": "number",
+        "default": 0
+      },
+      "irrigation": {
+        "description": "Irrigation.",
+        "type": "number",
         "default": 0
       }
     }

--- a/input/metadata/multi_crop_metadata.json
+++ b/input/metadata/multi_crop_metadata.json
@@ -2395,15 +2395,13 @@
       "year": {
         "description": "Year.",
         "type": "number",
-        "minimum": 1900,
-        "default": 0
+        "minimum": 1900
       },
       "jday": {
         "description": "Julian day of the year.",
         "type": "number",
         "minimum": 0,
-        "maximum": 366,
-        "default": 0
+        "maximum": 366
       },
       "precip": {
         "description": "Amount of precipitation (mm H2O).",
@@ -2414,7 +2412,7 @@
       "high": {
         "description": "The maximum air temperature of the day (°C).",
         "type": "number",
-        "default": 0
+        "default": 21
       },
       "low": {
         "description": "The minimum air temperature of the day (°C).",
@@ -2432,7 +2430,7 @@
         "default": 0
       },
       "irrigation": {
-        "description": "Irrigation.",
+        "description": "Irrigation (mm H2O).",
         "type": "number",
         "default": 0
       }

--- a/input/metadata/multi_crop_metadata.json
+++ b/input/metadata/multi_crop_metadata.json
@@ -2392,10 +2392,48 @@
       }
     },
     "weather_properties": {
-      "precip": {
-        "description": "amount of precipitation",
+      "year": {
+        "description": "Year.",
+        "type": "number",
+        "minimum": 1900,
+        "default": 0
+      },
+      "jday": {
+        "description": "Julian day of the year.",
         "type": "number",
         "minimum": 0,
+        "maximum": 366,
+        "default": 0
+      },
+      "precip": {
+        "description": "Amount of precipitation (mm H2O).",
+        "type": "number",
+        "minimum": 0,
+        "default": 0
+      },
+      "high": {
+        "description": "The maximum air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "low": {
+        "description": "The minimum air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "avg": {
+        "description": "The average air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "Hday": {
+        "description": "The solar radiation of the day (MJ m^-2).",
+        "type": "number",
+        "default": 0
+      },
+      "irrigation": {
+        "description": "Irrigation.",
+        "type": "number",
         "default": 0
       }
     }

--- a/input/metadata/swat_metadata.json
+++ b/input/metadata/swat_metadata.json
@@ -2395,15 +2395,13 @@
       "year": {
         "description": "Year.",
         "type": "number",
-        "minimum": 1900,
-        "default": 0
+        "minimum": 1900
       },
       "jday": {
         "description": "Julian day of the year.",
         "type": "number",
         "minimum": 0,
-        "maximum": 366,
-        "default": 0
+        "maximum": 366
       },
       "precip": {
         "description": "Amount of precipitation (mm H2O).",
@@ -2414,7 +2412,7 @@
       "high": {
         "description": "The maximum air temperature of the day (°C).",
         "type": "number",
-        "default": 0
+        "default": 21
       },
       "low": {
         "description": "The minimum air temperature of the day (°C).",
@@ -2432,7 +2430,7 @@
         "default": 0
       },
       "irrigation": {
-        "description": "Irrigation.",
+        "description": "Irrigation (mm H2O).",
         "type": "number",
         "default": 0
       }

--- a/input/metadata/swat_metadata.json
+++ b/input/metadata/swat_metadata.json
@@ -2392,10 +2392,48 @@
       }
     },
     "weather_properties": {
-      "precip": {
-        "description": "amount of precipitation",
+      "year": {
+        "description": "Year.",
+        "type": "number",
+        "minimum": 1900,
+        "default": 0
+      },
+      "jday": {
+        "description": "Julian day of the year.",
         "type": "number",
         "minimum": 0,
+        "maximum": 366,
+        "default": 0
+      },
+      "precip": {
+        "description": "Amount of precipitation (mm H2O).",
+        "type": "number",
+        "minimum": 0,
+        "default": 0
+      },
+      "high": {
+        "description": "The maximum air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "low": {
+        "description": "The minimum air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "avg": {
+        "description": "The average air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "Hday": {
+        "description": "The solar radiation of the day (MJ m^-2).",
+        "type": "number",
+        "default": 0
+      },
+      "irrigation": {
+        "description": "Irrigation.",
+        "type": "number",
         "default": 0
       }
     }

--- a/input/metadata/testing_metadata.json
+++ b/input/metadata/testing_metadata.json
@@ -2395,15 +2395,13 @@
       "year": {
         "description": "Year.",
         "type": "number",
-        "minimum": 1900,
-        "default": 0
+        "minimum": 1900
       },
       "jday": {
         "description": "Julian day of the year.",
         "type": "number",
         "minimum": 0,
-        "maximum": 366,
-        "default": 0
+        "maximum": 366
       },
       "precip": {
         "description": "Amount of precipitation (mm H2O).",
@@ -2414,7 +2412,7 @@
       "high": {
         "description": "The maximum air temperature of the day (°C).",
         "type": "number",
-        "default": 0
+        "default": 21
       },
       "low": {
         "description": "The minimum air temperature of the day (°C).",
@@ -2432,7 +2430,7 @@
         "default": 0
       },
       "irrigation": {
-        "description": "Irrigation.",
+        "description": "Irrigation (mm H2O).",
         "type": "number",
         "default": 0
       }

--- a/input/metadata/testing_metadata.json
+++ b/input/metadata/testing_metadata.json
@@ -2392,10 +2392,48 @@
       }
     },
     "weather_properties": {
-      "precip": {
-        "description": "amount of precipitation",
+      "year": {
+        "description": "Year.",
+        "type": "number",
+        "minimum": 1900,
+        "default": 0
+      },
+      "jday": {
+        "description": "Julian day of the year.",
         "type": "number",
         "minimum": 0,
+        "maximum": 366,
+        "default": 0
+      },
+      "precip": {
+        "description": "Amount of precipitation (mm H2O).",
+        "type": "number",
+        "minimum": 0,
+        "default": 0
+      },
+      "high": {
+        "description": "The maximum air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "low": {
+        "description": "The minimum air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "avg": {
+        "description": "The average air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "Hday": {
+        "description": "The solar radiation of the day (MJ m^-2).",
+        "type": "number",
+        "default": 0
+      },
+      "irrigation": {
+        "description": "Irrigation.",
+        "type": "number",
         "default": 0
       }
     }

--- a/input/metadata/user_defined_ration_md.json
+++ b/input/metadata/user_defined_ration_md.json
@@ -2402,15 +2402,13 @@
       "year": {
         "description": "Year.",
         "type": "number",
-        "minimum": 1900,
-        "default": 0
+        "minimum": 1900
       },
       "jday": {
         "description": "Julian day of the year.",
         "type": "number",
         "minimum": 0,
-        "maximum": 366,
-        "default": 0
+        "maximum": 366
       },
       "precip": {
         "description": "Amount of precipitation (mm H2O).",
@@ -2421,7 +2419,7 @@
       "high": {
         "description": "The maximum air temperature of the day (°C).",
         "type": "number",
-        "default": 0
+        "default": 21
       },
       "low": {
         "description": "The minimum air temperature of the day (°C).",
@@ -2439,7 +2437,7 @@
         "default": 0
       },
       "irrigation": {
-        "description": "Irrigation.",
+        "description": "Irrigation (mm H2O).",
         "type": "number",
         "default": 0
       }

--- a/input/metadata/user_defined_ration_md.json
+++ b/input/metadata/user_defined_ration_md.json
@@ -2399,10 +2399,48 @@
       }
     },
     "weather_properties": {
-      "precip": {
-        "description": "amount of precipitation",
+      "year": {
+        "description": "Year.",
+        "type": "number",
+        "minimum": 1900,
+        "default": 0
+      },
+      "jday": {
+        "description": "Julian day of the year.",
         "type": "number",
         "minimum": 0,
+        "maximum": 366,
+        "default": 0
+      },
+      "precip": {
+        "description": "Amount of precipitation (mm H2O).",
+        "type": "number",
+        "minimum": 0,
+        "default": 0
+      },
+      "high": {
+        "description": "The maximum air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "low": {
+        "description": "The minimum air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "avg": {
+        "description": "The average air temperature of the day (°C).",
+        "type": "number",
+        "default": 0
+      },
+      "Hday": {
+        "description": "The solar radiation of the day (MJ m^-2).",
+        "type": "number",
+        "default": 0
+      },
+      "irrigation": {
+        "description": "Irrigation.",
+        "type": "number",
         "default": 0
       }
     }


### PR DESCRIPTION
The weather section of the metadata only contains the `precip` variable and is missing the following variables:
- `year`
- `jday`
- `high`
- `low`
- `avg`
- `Hday`
- `irrigation`

This PR updates the weather section of all the metadata files to include the missing variables.