### PR TITLE
Fix Error if Extra Blank Line in Output Filter File

### DIFF
--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -639,7 +639,7 @@ class OutputManager(object):
                     else:
                         result = [json_content]
                 elif path.endswith(".txt"):
-                    list_of_elements = [i for i in filter_file.read().splitlines() if i]
+                    list_of_elements = [element for element in filter_file.read().splitlines() if element ]
                     result = [{"filters": list_of_elements}]
                 else:
                     raise Exception(

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -639,7 +639,7 @@ class OutputManager(object):
                     else:
                         result = [json_content]
                 elif path.endswith(".txt"):
-                    list_of_elements = filter_file.read().splitlines()
+                    list_of_elements = [i for i in filter_file.read().splitlines() if i]
                     result = [{"filters": list_of_elements}]
                 else:
                     raise Exception(

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -639,7 +639,7 @@ class OutputManager(object):
                     else:
                         result = [json_content]
                 elif path.endswith(".txt"):
-                    list_of_elements = [element for element in filter_file.read().splitlines() if element ]
+                    list_of_elements = [element for element in filter_file.read().splitlines() if element]
                     result = [{"filters": list_of_elements}]
                 else:
                     raise Exception(

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1231,7 +1231,7 @@ def test_exclude_info_maps(
 
 @pytest.mark.parametrize(
     "mock_file_text",
-    ["apples\nbananas\ncherries", 
+    ["apples\nbananas\ncherries",
      "apples\nbananas\ncherries\n\n\n",
      "apples\nbananas\n\n\n\ncherries",
      "apples\nbananas\n\n\ncherries\n\n\n"])

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1229,14 +1229,21 @@ def test_exclude_info_maps(
     ]
 
 
+@pytest.mark.parametrize(
+    "mock_file_text",
+    ["apples\nbananas\ncherries", 
+     "apples\nbananas\ncherries\n\n\n",
+     "apples\nbananas\n\n\n\ncherries",
+     "apples\nbananas\n\n\ncherries\n\n\n"])
 @patch("builtins.open", new_callable=mock_open)
 def test_load_filter_file_content_txt(
     mock_file: MagicMock,
     mock_output_manager: OutputManager,
     output_manager_original_method_states: Dict[str, Callable],
+    mock_file_text: str,
 ) -> None:
     """Test case for function _load_filter_file_content in output_manager.py"""
-    mock_file.return_value.read.return_value = "apples\nbananas\ncherries"
+    mock_file.return_value.read.return_value = mock_file_text
     result = mock_output_manager._load_filter_file_content("path/to/file.txt")
     assert result == [{"filters": ["apples", "bananas", "cherries"]}]
 


### PR DESCRIPTION
This PR addresses issue #761.

Fairly straight forward fix -

1. Filter out falsy (blank line) entries in txt output filter files with list comprehension.
2. Update testing to ensure it works.