### PR TITLE
Add metadata prefix to graph file names

### DIFF
--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -102,6 +102,9 @@ class GraphGenerator:
     NOTE: This class is not multi-thread safe!!!
     """
 
+    def __init__(self, metadata_prefix: str = "") -> None:
+        self.metadata_prefix = metadata_prefix
+
     def generate_graph(
         self,
         filtered_pool: Dict[str, Dict[str, List[Any]]],
@@ -330,9 +333,9 @@ class GraphGenerator:
 
         if "title" in graph_details.keys():
             title = "-".join(graph_details["title"].split()).lower()
-            filename = f"{title}-{timestamp}.png"
+            filename = f"{self.metadata_prefix}_{title}-{timestamp}.png"
         else:
-            filename = f"saved_graph_{filter_file_name}-{timestamp}.png"
+            filename = f"{self.metadata_prefix}_{filter_file_name}-{timestamp}.png"
 
         graph_path = os.path.join(graph_directory, filename)
         return Path(graph_path)

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -652,7 +652,11 @@ class OutputManager(object):
                     else:
                         result = [json_content]
                 elif path.endswith(".txt"):
-                    list_of_elements = [element for element in filter_file.read().splitlines() if element]
+                    list_of_elements = [
+                        element
+                        for element in filter_file.read().splitlines()
+                        if element
+                    ]
                     result = [{"filters": list_of_elements}]
                 else:
                     raise Exception(
@@ -837,7 +841,7 @@ class OutputManager(object):
         elif filter_file.startswith(self.__supported_filter_types_prefixes["graph"]):
             if produce_graphics:
                 try:
-                    graph_generator = GraphGenerator()
+                    graph_generator = GraphGenerator(self.__metadata_prefix)
                     graph_generator.generate_graph(
                         filtered_pool,
                         filter_content,
@@ -1053,17 +1057,27 @@ class OutputManager(object):
         Exception
             If an error occurs while opening or reading the user-provided file path.
         """
-        info_map = {"class": self.__class__.__name__,
-                    "function": self.load_variables_pool_from_file.__name__,
-                    }
-        self.add_log("open_json_file", f"Attempting to open {str(file_path)}.", info_map)
+        info_map = {
+            "class": self.__class__.__name__,
+            "function": self.load_variables_pool_from_file.__name__,
+        }
+        self.add_log(
+            "open_json_file", f"Attempting to open {str(file_path)}.", info_map
+        )
         try:
             with open(file_path) as file:
                 self.variables_pool = json.load(file)
-                self.add_log("load_data_successful", f"Successfully loaded data from {str(file_path)}.",
-                             info_map)
+                self.add_log(
+                    "load_data_successful",
+                    f"Successfully loaded data from {str(file_path)}.",
+                    info_map,
+                )
         except FileNotFoundError:
-            self.add_error("File not found", f"The file '{str(file_path)}' does not exist.", info_map)
+            self.add_error(
+                "File not found",
+                f"The file '{str(file_path)}' does not exist.",
+                info_map,
+            )
             raise
         except json.JSONDecodeError as e:
             self.add_error("JSON parsing error", str(e), info_map)

--- a/tests/test_graph_generator.py
+++ b/tests/test_graph_generator.py
@@ -10,7 +10,7 @@ from RUFAS.graph_generator import GraphGenerator, TUPLE_BASED_FUNCTIONS
 
 @pytest.fixture
 def graph_generator() -> GraphGenerator:
-    return GraphGenerator()
+    return GraphGenerator("metadata_name")
 
 
 def test_save_graph_successful(graph_generator: GraphGenerator) -> None:
@@ -95,7 +95,7 @@ def test_generate_graph_path_with_title(graph_generator: GraphGenerator) -> None
             )
             mock_mkdir.assert_called_once()
             assert result == Path(
-                r"/path/to/save/graphics/_test-graph-13-Oct-2023_Fri_11-41-23.png"
+                r"/path/to/save/graphics/metadata_name_test-graph-13-Oct-2023_Fri_11-41-23.png"
             )
 
 
@@ -115,7 +115,7 @@ def test_generate_graph_path_no_title(graph_generator: GraphGenerator) -> None:
             )
             mock_mkdir.assert_called_once()
             assert result == Path(
-                r"/path/to/save/graphics/_test_filter.png-13-Oct-2023_Fri_11-41-23.png"
+                r"/path/to/save/graphics/metadata_name_test_filter.png-13-Oct-2023_Fri_11-41-23.png"
             )
 
 

--- a/tests/test_graph_generator.py
+++ b/tests/test_graph_generator.py
@@ -95,7 +95,7 @@ def test_generate_graph_path_with_title(graph_generator: GraphGenerator) -> None
             )
             mock_mkdir.assert_called_once()
             assert result == Path(
-                r"/path/to/save/graphics/test-graph-13-Oct-2023_Fri_11-41-23.png"
+                r"/path/to/save/graphics/_test-graph-13-Oct-2023_Fri_11-41-23.png"
             )
 
 

--- a/tests/test_graph_generator.py
+++ b/tests/test_graph_generator.py
@@ -115,7 +115,7 @@ def test_generate_graph_path_no_title(graph_generator: GraphGenerator) -> None:
             )
             mock_mkdir.assert_called_once()
             assert result == Path(
-                r"/path/to/save/graphics/saved_graph_test_filter.png-13-Oct-2023_Fri_11-41-23.png"
+                r"/path/to/save/graphics/_test_filter.png-13-Oct-2023_Fri_11-41-23.png"
             )
 
 


### PR DESCRIPTION
This PR adds metadata prefix to the generated graphs' file names, similar to what we get from the output manager.