### PR TITLE
Rename All occurrences of `OM.save_variables()` to `save_results()`

### DIFF
--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -886,7 +886,7 @@ class OutputManager(object):
 
     @deprecated(
         reason="""This function is still in the code base but it is not used. We want to keep it for debugging purposes
-        when save_variables() is not working.""",
+        when save_results() is not working.""",
         version="MVP",
     )
     def dump_variables(self, path: str, exclude_info_maps: bool = False) -> None:

--- a/main.py
+++ b/main.py
@@ -158,7 +158,7 @@ def run_load_vars_pool(
     output_manager.flush_pools()
     output_manager.load_variables_pool_from_file(vars_file_path)
     output_manager.set_metadata_prefix("reload")
-    output_manager.save_variables(
+    output_manager.save_results(
             Path(r"output"),
             Path(r"output/output_filters/"),
             exclude_info_maps,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -296,7 +296,7 @@ def test_run_load_vars_pool(mocker: MockerFixture, exclude_info_maps: bool,
     mock_output_manager.load_variables_pool_from_file.return_value = None
     mock_output_manager.set_metadata_prefix.return_value = None
     mock_output_manager.dump_all_nondata_pools.return_value = None
-    mock_output_manager.save_variables.return_value = None
+    mock_output_manager.save_results.return_value = None
     mocker.patch("main.OutputManager", return_value=mock_output_manager)
 
     run_load_vars_pool(exclude_info_maps, format_option, produce_graphics, graphics_dir, clear_output)
@@ -308,7 +308,7 @@ def test_run_load_vars_pool(mocker: MockerFixture, exclude_info_maps: bool,
     assert mock_output_manager.flush_pools.call_count == 1
     assert mock_output_manager.load_variables_pool_from_file.call_count == 1
     assert mock_output_manager.set_metadata_prefix.call_count == 1
-    assert mock_output_manager.save_variables.call_count == 1
+    assert mock_output_manager.save_results.call_count == 1
     assert mock_output_manager.dump_all_nondata_pools.call_count == 1
 
 


### PR DESCRIPTION
The `save_variables()` function in `OutputManager` was renamed to `save_results()` in @PooyaHekmati's PR #929. 
However, I have found that `output_manager.save_variables()` is still referenced in `main.py` in the `main` branch. 

In this PR, I went through the codebase to rename all of the still-existing references to the old `OutputManager.save_variables()` function to `save_results()`