### PR TITLE
Move dir path args from metadata to gnu args

### DIFF
--- a/RUFAS/config.py
+++ b/RUFAS/config.py
@@ -81,8 +81,6 @@ class Config:
         self.year_length = year_length
 
         self.sim_length = self.calc_sim_length()
-        self.csv_dir = data['csv_dir']
-        self.graphic_dir = data['graphic_dir']
 
     def calc_sim_length(self):
         """

--- a/input/data/animal/animal_user_defined_ration_md.json
+++ b/input/data/animal/animal_user_defined_ration_md.json
@@ -83,6 +83,8 @@
 				"preg_loss_rate_3": 0.017,
 				"avg_estrus_cycle_return": 23,
 				"std_estrus_cycle_return": 6,
+				"avg_estrus_cycle_heifer": 21,
+				"std_estrus_cycle_heifer": 2.5,
 				"avg_estrus_cycle_cow": 21,
 				"std_estrus_cycle_cow": 4,
 				"avg_estrus_cycle_after_pgf": 5,

--- a/input/data/animal/no_animal.json
+++ b/input/data/animal/no_animal.json
@@ -83,6 +83,8 @@
 				"preg_loss_rate_3": 0.017,
 				"avg_estrus_cycle_return": 23,
 				"std_estrus_cycle_return": 6,
+				"avg_estrus_cycle_heifer": 21,
+				"std_estrus_cycle_heifer": 2.5,
 				"avg_estrus_cycle_cow": 21,
 				"std_estrus_cycle_cow": 4,
 				"avg_estrus_cycle_after_pgf": 5,

--- a/input/data/config/ARL_config.json
+++ b/input/data/config/ARL_config.json
@@ -1,9 +1,6 @@
 {
     "start_date": "2013:1",
     "end_date": "2019:365",
-    "graphic_dir": "output/graphics/",
-    "output_dir": "output/",
-    "csv_dir": "output/CSVs/",
     "random_seed": 0,
     "set_seed": false,
     "simulate_animals": false,

--- a/input/data/config/barnyard_config.json
+++ b/input/data/config/barnyard_config.json
@@ -1,9 +1,6 @@
 {
     "start_date": "2009:244",
     "end_date": "2016:243",
-    "graphic_dir": "output/graphics/",
-    "output_dir": "output/",
-    "csv_dir": "output/CSVs",
     "random_seed": 0,
     "set_seed": false,
     "simulate_animals": false,

--- a/input/data/config/default_config.json
+++ b/input/data/config/default_config.json
@@ -1,9 +1,6 @@
 {
     "start_date": "2009:244",
     "end_date": "2010:264",
-    "graphic_dir": "output/graphics/",
-    "output_dir": "output/",
-    "csv_dir": "output/CSVs",
     "random_seed": 42,
     "set_seed": true,
     "simulate_animals": true,

--- a/input/data/config/multi_crop_config.json
+++ b/input/data/config/multi_crop_config.json
@@ -1,9 +1,6 @@
 {
     "start_date": "1989:1",
     "end_date": "2009:265",
-    "graphic_dir": "output/graphics/",
-    "output_dir": "output/",
-    "csv_dir": "output/CSVs/",
     "random_seed": 0,
     "set_seed": false,
     "simulate_animals": false,

--- a/input/data/config/swat_config.json
+++ b/input/data/config/swat_config.json
@@ -1,9 +1,6 @@
 {
   "start_date" : "2010:1",
   "end_date" : "2013:365",
-  "csv_dir": "output/CSVs/",
-  "output_dir": "output/",
-  "graphic_dir": "output/graphics/",
   "set_seed": false,
   "random_seed": 0,
   "simulate_animals": false,

--- a/input/data/config/testing_config.json
+++ b/input/data/config/testing_config.json
@@ -1,9 +1,6 @@
 {
   "start_date" : "1989:1",
   "end_date" : "1998:365",
-  "csv_dir": "output/CSVs/",
-  "output_dir": "output/",
-  "graphic_dir": "output/graphics/",
   "set_seed": false,
   "random_seed": 0,
   "simulate_animals": false,

--- a/input/metadata/ARL_metadata.json
+++ b/input/metadata/ARL_metadata.json
@@ -134,18 +134,6 @@
         "pattern": "[12][019][0-9]{2}:(?:[1-9]|[1-9][0-9]|[12][0-9]{2}|3[0-5][0-9]|36[0-6])$",
         "default": "2009:100"
       },
-      "graphic_dir": {
-        "type": "string",
-        "description": "The location of the output graphics directory",
-        "pattern": ".{1,50}",
-        "default": "output/graphics/"
-      },
-      "output_dir": {
-        "type": "string",
-        "description": "The location of the output directory",
-        "pattern": ".{1,50}",
-        "default": "output/"
-      },
       "random_seed": {
         "type": "number",
         "description": "The random seed",
@@ -156,11 +144,6 @@
         "type": "bool",
         "description": "Whether or not to set random seed",
         "default": true
-      },
-      "csv_dir": {
-        "type": "string",
-        "description": "The path to where the CSV output files will be saved",
-        "default": "output/CSVs"
       },
       "simulate_animals": {
         "type": "bool",

--- a/input/metadata/ARL_metadata.json
+++ b/input/metadata/ARL_metadata.json
@@ -601,6 +601,18 @@
               "minimum": 1,
               "default": 6
             },
+            "avg_estrus_cycle_heifer": {
+              "type": "number",
+              "description": "Average length of estrus cycle for heifers (default is 21).",
+              "minimum": 1,
+              "default": 21
+            },
+            "std_estrus_cycle_heifer": {
+              "type": "number",
+              "description": "Standard deviation of the length of estrus cycle for heifers (default is 2.5).",
+              "minimum": 1,
+              "default": 2.5
+            },
             "avg_estrus_cycle_cow": {
               "type": "number",
               "description": "Average length of estrus cycle for cows (default is 21).",

--- a/input/metadata/barnyard_metadata.json
+++ b/input/metadata/barnyard_metadata.json
@@ -184,7 +184,7 @@
       "nutrient_standard": {
         "type": "string",
         "default": "NASEM",
-        "pattern": "(NASEM|NRC)",
+        "pattern": "^(NASEM|NRC)$",
         "description": "The nutrient standard to use for feed."
       }
     },

--- a/input/metadata/barnyard_metadata.json
+++ b/input/metadata/barnyard_metadata.json
@@ -148,18 +148,6 @@
         "pattern": "[12][019][0-9]{2}:(?:[1-9]|[1-9][0-9]|[12][0-9]{2}|3[0-5][0-9]|36[0-6])$",
         "default": "2009:100"
       },
-      "graphic_dir": {
-        "type": "string",
-        "description": "The location of the output graphics directory",
-        "pattern": ".{1,50}",
-        "default": "output/graphics/"
-      },
-      "output_dir": {
-        "type": "string",
-        "description": "The location of the output directory",
-        "pattern": ".{1,50}",
-        "default": "output/"
-      },
       "random_seed": {
         "type": "number",
         "description": "The random seed",
@@ -170,11 +158,6 @@
         "type": "bool",
         "description": "Whether or not to set random seed",
         "default": true
-      },
-      "csv_dir": {
-        "type": "string",
-        "description": "The path to where the CSV output files will be saved",
-        "default": "output/CSVs"
       },
       "simulate_animals": {
         "type": "bool",

--- a/input/metadata/barnyard_metadata.json
+++ b/input/metadata/barnyard_metadata.json
@@ -615,6 +615,18 @@
               "minimum": 1,
               "default": 6
             },
+            "avg_estrus_cycle_heifer": {
+              "type": "number",
+              "description": "Average length of estrus cycle for heifers (default is 21).",
+              "minimum": 1,
+              "default": 21
+            },
+            "std_estrus_cycle_heifer": {
+              "type": "number",
+              "description": "Standard deviation of the length of estrus cycle for heifers (default is 2.5).",
+              "minimum": 1,
+              "default": 2.5
+            },
             "avg_estrus_cycle_cow": {
               "type": "number",
               "description": "Average length of estrus cycle for cows (default is 21).",

--- a/input/metadata/default_metadata.json
+++ b/input/metadata/default_metadata.json
@@ -177,7 +177,7 @@
       "nutrient_standard": {
         "type": "string",
         "default": "NASEM",
-        "pattern": "(NASEM|NRC)",
+        "pattern": "^(NASEM|NRC)$",
         "description": "The nutrient standard to use for feed."
       }
     },

--- a/input/metadata/default_metadata.json
+++ b/input/metadata/default_metadata.json
@@ -141,18 +141,6 @@
         "pattern": "[12][019][0-9]{2}:(?:[1-9]|[1-9][0-9]|[12][0-9]{2}|3[0-5][0-9]|36[0-6])$",
         "default": "2009:100"
       },
-      "graphic_dir": {
-        "type": "string",
-        "description": "The location of the output graphics directory",
-        "pattern": ".{1,50}",
-        "default": "output/graphics/"
-      },
-      "output_dir": {
-        "type": "string",
-        "description": "The location of the output directory",
-        "pattern": ".{1,50}",
-        "default": "output/"
-      },
       "random_seed": {
         "type": "number",
         "description": "The random seed",
@@ -163,11 +151,6 @@
         "type": "bool",
         "description": "Whether or not to set random seed",
         "default": true
-      },
-      "csv_dir": {
-        "type": "string",
-        "description": "The path to where the CSV output files will be saved",
-        "default": "output/CSVs"
       },
       "simulate_animals": {
         "type": "bool",

--- a/input/metadata/multi_crop_metadata.json
+++ b/input/metadata/multi_crop_metadata.json
@@ -134,18 +134,6 @@
         "pattern": "[12][019][0-9]{2}:(?:[1-9]|[1-9][0-9]|[12][0-9]{2}|3[0-5][0-9]|36[0-6])$",
         "default": "2009:100"
       },
-      "graphic_dir": {
-        "type": "string",
-        "description": "The location of the output graphics directory",
-        "pattern": ".{1,50}",
-        "default": "output/graphics/"
-      },
-      "output_dir": {
-        "type": "string",
-        "description": "The location of the output directory",
-        "pattern": ".{1,50}",
-        "default": "output/"
-      },
       "random_seed": {
         "type": "number",
         "description": "The random seed",
@@ -156,11 +144,6 @@
         "type": "bool",
         "description": "Whether or not to set random seed",
         "default": true
-      },
-      "csv_dir": {
-        "type": "string",
-        "description": "The path to where the CSV output files will be saved",
-        "default": "output/CSVs"
       },
       "simulate_animals": {
         "type": "bool",

--- a/input/metadata/multi_crop_metadata.json
+++ b/input/metadata/multi_crop_metadata.json
@@ -170,7 +170,7 @@
       "nutrient_standard": {
         "type": "string",
         "default": "NASEM",
-        "pattern": "(NASEM|NRC)",
+        "pattern": "^(NASEM|NRC)$",
         "description": "The nutrient standard to use for feed."
       }
     },

--- a/input/metadata/multi_crop_metadata.json
+++ b/input/metadata/multi_crop_metadata.json
@@ -601,6 +601,18 @@
               "minimum": 1,
               "default": 6
             },
+            "avg_estrus_cycle_heifer": {
+              "type": "number",
+              "description": "Average length of estrus cycle for heifers (default is 21).",
+              "minimum": 1,
+              "default": 21
+            },
+            "std_estrus_cycle_heifer": {
+              "type": "number",
+              "description": "Standard deviation of the length of estrus cycle for heifers (default is 2.5).",
+              "minimum": 1,
+              "default": 2.5
+            },
             "avg_estrus_cycle_cow": {
               "type": "number",
               "description": "Average length of estrus cycle for cows (default is 21).",

--- a/input/metadata/swat_metadata.json
+++ b/input/metadata/swat_metadata.json
@@ -134,18 +134,6 @@
         "pattern": "[12][019][0-9]{2}:(?:[1-9]|[1-9][0-9]|[12][0-9]{2}|3[0-5][0-9]|36[0-6])$",
         "default": "2009:100"
       },
-      "graphic_dir": {
-        "type": "string",
-        "description": "The location of the output graphics directory",
-        "pattern": ".{1,50}",
-        "default": "output/graphics/"
-      },
-      "output_dir": {
-        "type": "string",
-        "description": "The location of the output directory",
-        "pattern": ".{1,50}",
-        "default": "output/"
-      },
       "random_seed": {
         "type": "number",
         "description": "The random seed",
@@ -156,11 +144,6 @@
         "type": "bool",
         "description": "Whether or not to set random seed",
         "default": true
-      },
-      "csv_dir": {
-        "type": "string",
-        "description": "The path to where the CSV output files will be saved",
-        "default": "output/CSVs"
       },
       "simulate_animals": {
         "type": "bool",

--- a/input/metadata/swat_metadata.json
+++ b/input/metadata/swat_metadata.json
@@ -170,7 +170,7 @@
       "nutrient_standard": {
         "type": "string",
         "default": "NASEM",
-        "pattern": "(NASEM|NRC)",
+        "pattern": "^(NASEM|NRC)$",
         "description": "The nutrient standard to use for feed."
       }
     },

--- a/input/metadata/swat_metadata.json
+++ b/input/metadata/swat_metadata.json
@@ -601,6 +601,18 @@
               "minimum": 1,
               "default": 6
             },
+            "avg_estrus_cycle_heifer": {
+              "type": "number",
+              "description": "Average length of estrus cycle for heifers (default is 21).",
+              "minimum": 1,
+              "default": 21
+            },
+            "std_estrus_cycle_heifer": {
+              "type": "number",
+              "description": "Standard deviation of the length of estrus cycle for heifers (default is 2.5).",
+              "minimum": 1,
+              "default": 2.5
+            },
             "avg_estrus_cycle_cow": {
               "type": "number",
               "description": "Average length of estrus cycle for cows (default is 21).",

--- a/input/metadata/testing_metadata.json
+++ b/input/metadata/testing_metadata.json
@@ -134,18 +134,6 @@
         "pattern": "[12][019][0-9]{2}:(?:[1-9]|[1-9][0-9]|[12][0-9]{2}|3[0-5][0-9]|36[0-6])$",
         "default": "2009:100"
       },
-      "graphic_dir": {
-        "type": "string",
-        "description": "The location of the output graphics directory",
-        "pattern": ".{1,50}",
-        "default": "output/graphics/"
-      },
-      "output_dir": {
-        "type": "string",
-        "description": "The location of the output directory",
-        "pattern": ".{1,50}",
-        "default": "output/"
-      },
       "random_seed": {
         "type": "number",
         "description": "The random seed",
@@ -156,11 +144,6 @@
         "type": "bool",
         "description": "Whether or not to set random seed",
         "default": true
-      },
-      "csv_dir": {
-        "type": "string",
-        "description": "The path to where the CSV output files will be saved",
-        "default": "output/CSVs"
       },
       "simulate_animals": {
         "type": "bool",

--- a/input/metadata/testing_metadata.json
+++ b/input/metadata/testing_metadata.json
@@ -170,7 +170,7 @@
       "nutrient_standard": {
         "type": "string",
         "default": "NASEM",
-        "pattern": "(NASEM|NRC)",
+        "pattern": "^(NASEM|NRC)$",
         "description": "The nutrient standard to use for feed."
       }
     },

--- a/input/metadata/testing_metadata.json
+++ b/input/metadata/testing_metadata.json
@@ -601,6 +601,18 @@
               "minimum": 1,
               "default": 6
             },
+            "avg_estrus_cycle_heifer": {
+              "type": "number",
+              "description": "Average length of estrus cycle for heifers (default is 21).",
+              "minimum": 1,
+              "default": 21
+            },
+            "std_estrus_cycle_heifer": {
+              "type": "number",
+              "description": "Standard deviation of the length of estrus cycle for heifers (default is 2.5).",
+              "minimum": 1,
+              "default": 2.5
+            },
             "avg_estrus_cycle_cow": {
               "type": "number",
               "description": "Average length of estrus cycle for cows (default is 21).",

--- a/input/metadata/user_defined_ration.json
+++ b/input/metadata/user_defined_ration.json
@@ -177,7 +177,7 @@
       "nutrient_standard": {
         "type": "string",
         "default": "NASEM",
-        "pattern": "(NASEM|NRC)",
+        "pattern": "^(NASEM|NRC)$",
         "description": "The nutrient standard to use for feed."
       }
     },

--- a/input/metadata/user_defined_ration.json
+++ b/input/metadata/user_defined_ration.json
@@ -141,18 +141,6 @@
         "pattern": "[12][019][0-9]{2}:(?:[1-9]|[1-9][0-9]|[12][0-9]{2}|3[0-5][0-9]|36[0-6])$",
         "default": "2009:100"
       },
-      "graphic_dir": {
-        "type": "string",
-        "description": "The location of the output graphics directory",
-        "pattern": ".{1,50}",
-        "default": "output/graphics/"
-      },
-      "output_dir": {
-        "type": "string",
-        "description": "The location of the output directory",
-        "pattern": ".{1,50}",
-        "default": "output/"
-      },
       "random_seed": {
         "type": "number",
         "description": "The random seed",
@@ -163,11 +151,6 @@
         "type": "bool",
         "description": "Whether or not to set random seed",
         "default": true
-      },
-      "csv_dir": {
-        "type": "string",
-        "description": "The path to where the CSV output files will be saved",
-        "default": "output/CSVs"
       },
       "simulate_animals": {
         "type": "bool",

--- a/input/metadata/user_defined_ration.json
+++ b/input/metadata/user_defined_ration.json
@@ -608,6 +608,18 @@
               "minimum": 1,
               "default": 6
             },
+            "avg_estrus_cycle_heifer": {
+              "type": "number",
+              "description": "Average length of estrus cycle for heifers (default is 21).",
+              "minimum": 1,
+              "default": 21
+            },
+            "std_estrus_cycle_heifer": {
+              "type": "number",
+              "description": "Standard deviation of the length of estrus cycle for heifers (default is 2.5).",
+              "minimum": 1,
+              "default": 2.5
+            },
             "avg_estrus_cycle_cow": {
               "type": "number",
               "description": "Average length of estrus cycle for cows (default is 21).",

--- a/main.py
+++ b/main.py
@@ -22,7 +22,12 @@ from RUFAS.util import Utility
 
 def main():
     cmd_arguments = parse_gnu_args()
+    if cmd_arguments.load_pool:
+        load_pool = True
+    else:
+        load_pool = False
     run_rufas(
+        load_pool,
         produce_graphics=not cmd_arguments.no_graphics,
         format_option=cmd_arguments.format_option,
         verbose=LogVerbosity(cmd_arguments.verbose),
@@ -30,11 +35,12 @@ def main():
         exclude_info_maps=cmd_arguments.exclude_info_maps,
         only_run_validation=cmd_arguments.only_run_validation,
         graphics_dir=Path(cmd_arguments.graphics_dir),
-        load_pool=cmd_arguments.load_pool,
+        vars_file_path=cmd_arguments.load_pool,
     )
 
 
 def run_rufas(
+    load_pool: bool = False,
     produce_graphics: bool = True,
     format_option: str = "verbose",
     verbose: LogVerbosity = LogVerbosity.NONE,
@@ -42,12 +48,14 @@ def run_rufas(
     exclude_info_maps: bool = False,
     only_run_validation: bool = False,
     graphics_dir: Path = Path(""),
-    load_pool: bool = False,
+    vars_file_path: Path = Path(""),
 ) -> None:
     """Main function to run RuFaS, with options.
 
     Parameters
     ----------
+    load_pool : bool, optional, default=False
+        Flag to load json file into Output Manager variables pool for processing.
     produce_graphics : bool, optional, default=True
         Produce graphics after simulation.
     format_option : str, optional, default="verbose"
@@ -62,13 +70,13 @@ def run_rufas(
         Validate input data and don't run a simulation.
     graphics_dir : Path, optional, default=Path("")
         The directory for saving graphics.
-    load_pool : bool, optional, default=False
-        Load json file into Output Manager variables pool for processing.
+    vars_file_path : Path, optional, default=Path("")
+        The path to the json file to load into Output Manager variables pool for processing.
     """
     sys.stdout.write("RuFaS: Ruminant Farm Systems Model 2023\n")
 
     if load_pool:
-        run_load_vars_pool(exclude_info_maps, format_option,
+        run_load_vars_pool(vars_file_path, exclude_info_maps, format_option,
                            produce_graphics, graphics_dir, clear_output)
         return
 
@@ -131,6 +139,7 @@ def is_file_in_dir(dir_path: Path = Path(config.global_variables.OUT_DIR), file_
 
 
 def run_load_vars_pool(
+    vars_file_path: Path = Path(""),
     exclude_info_maps: bool = False,
     format_option: str = "verbose",
     produce_graphics: bool = True,
@@ -142,6 +151,8 @@ def run_load_vars_pool(
 
     Parameters
     ----------
+    vars_file_path : Path, optional, default=Path("")
+        The path to the json file to load into Output Manager variables pool for processing.
     exclude_info_maps : bool, optional
         Flag for whether or not the user wants to inlcude info_maps data in their results files.
     produce_graphics : bool, optional
@@ -151,7 +162,6 @@ def run_load_vars_pool(
     clear_output : bool, optional
         Flag for whether or not the user wants to clear the output directory.
     """
-    vars_file_path = Path(input("Enter path to variables json file: ").strip())
     if clear_output:
         clear_output_dir(vars_file_path)
     output_manager = OutputManager()
@@ -358,7 +368,7 @@ def parse_gnu_args() -> argparse.Namespace:
         "-l",
         "--load-pool",
         help="Load the output manager's variables pool from provided path",
-        action="store_true"
+        type=Path,
     )
     return parser.parse_args()
 

--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ def main():
         exclude_info_maps=cmd_arguments.exclude_info_maps,
         only_run_validation=cmd_arguments.only_run_validation,
         graphics_dir=Path(cmd_arguments.graphics_dir),
-        vars_file_path=cmd_arguments.load_pool,
+        vars_file_path=Path(cmd_arguments.load_pool),
     )
 
 
@@ -368,7 +368,6 @@ def parse_gnu_args() -> argparse.Namespace:
         "-l",
         "--load-pool",
         help="Load the output manager's variables pool from provided path",
-        type=Path,
     )
     return parser.parse_args()
 

--- a/main.py
+++ b/main.py
@@ -36,6 +36,8 @@ def main():
         only_run_validation=cmd_arguments.only_run_validation,
         graphics_dir=Path(cmd_arguments.graphics_dir),
         vars_file_path=Path(cmd_arguments.load_pool),
+        output_dir=Path(cmd_arguments.output_dir),
+        filters_dir=Path(cmd_arguments.filters_dir)
     )
 
 
@@ -49,6 +51,8 @@ def run_rufas(
     only_run_validation: bool = False,
     graphics_dir: Path = Path(""),
     vars_file_path: Path = Path(""),
+    output_dir: Path = Path("output/"),
+    filters_dir: Path = Path("output/output_filters/")
 ) -> None:
     """Main function to run RuFaS, with options.
 
@@ -72,12 +76,17 @@ def run_rufas(
         The directory for saving graphics.
     vars_file_path : Path, optional, default=Path("")
         The path to the json file to load into Output Manager variables pool for processing.
+    output_dir : Path, optional, default=Path("output/")
+        The directory for saving output.
+    filters_dir : Path, optional, default=Path("output/output_filters")
+        The directory for the files containing the keys for filtering.
     """
     sys.stdout.write("RuFaS: Ruminant Farm Systems Model 2023\n")
 
     if load_pool:
         run_load_vars_pool(vars_file_path, exclude_info_maps, format_option,
-                           produce_graphics, graphics_dir, clear_output)
+                           produce_graphics, graphics_dir, clear_output, output_dir,
+                           filters_dir)
         return
 
     if clear_output:
@@ -85,7 +94,7 @@ def run_rufas(
 
     metadata_files: List[MetadataPaths] = METADATA_PATHS
     if only_run_validation:
-        run_validation(metadata_files, exclude_info_maps, format_option, verbose)
+        run_validation(metadata_files, exclude_info_maps, format_option, verbose, output_dir)
     else:
         execute_simulations(
             metadata_files,
@@ -145,6 +154,8 @@ def run_load_vars_pool(
     produce_graphics: bool = True,
     graphics_dir: Path = Path(""),
     clear_output: bool = False,
+    output_dir: Path = Path("output/"),
+    filters_dir: Path = Path("output/output_filters/")
 ) -> None:
     """Instantiates Output Manager and triggers loading of the variables pool from the provided file path
     for post-processing.
@@ -161,6 +172,10 @@ def run_load_vars_pool(
         The directory for saving graphics.
     clear_output : bool, optional
         Flag for whether or not the user wants to clear the output directory.
+    output_dir : Path, optional, default=Path("output/")
+        The directory for saving output.
+    filters_dir : Path, optional, default=Path("output/output_filters")
+        The directory for the files containing the keys for filtering.
     """
     if clear_output:
         clear_output_dir(vars_file_path)
@@ -169,14 +184,14 @@ def run_load_vars_pool(
     output_manager.load_variables_pool_from_file(vars_file_path)
     output_manager.set_metadata_prefix("reload")
     output_manager.save_results(
-            Path(r"output"),
-            Path(r"output/output_filters/"),
+            output_dir,
+            filters_dir,
             exclude_info_maps,
             produce_graphics,
             graphics_dir,
         )
     output_manager.dump_all_nondata_pools(
-            r"output", exclude_info_maps, format_option
+            output_dir, exclude_info_maps, format_option
         )
 
 
@@ -185,6 +200,7 @@ def run_validation(
     exclude_info_maps: bool = False,
     format_option: str = "verbose",
     verbose: LogVerbosity = LogVerbosity.NONE,
+    output_dir: Path = Path("output/"),
 ) -> None:
     """Instantiates I/O Managers and triggers validation of input data.
 
@@ -198,6 +214,8 @@ def run_validation(
         The formatting option for select output files.
     verbose : LogVerbosity
         The verbose option set by the user.
+    output_dir : Path, optional, default=Path("output/")
+        The directory for saving output.
     """
     info_map = {
         "class": "No caller class",
@@ -231,7 +249,7 @@ def run_validation(
                 info_map,
             )
         output_manager.dump_all_nondata_pools(
-            r"output", exclude_info_maps, format_option
+            output_dir, exclude_info_maps, format_option
         )
 
 
@@ -242,6 +260,8 @@ def execute_simulations(
     graphics_dir: Path = Path(""),
     format_option: str = "verbose",
     verbose: LogVerbosity = LogVerbosity.NONE,
+    output_dir: Path = Path("output/"),
+    filters_dir: Path = Path("output/output_filters/")
 ) -> None:
     """Instantiates I/O Managers and processes the metadata files provided by the user to run the simulation.
 
@@ -261,6 +281,10 @@ def execute_simulations(
         The formatting option for select output files.
     verbose : LogVerbosity
         The verbose option set by the user.
+    output_dir : Path, optional, default=Path("output/")
+        The directory for saving output.
+    filters_dir : Path, optional, default=Path("output/output_filters")
+        The directory for the files containing the keys for filtering.
     """
     info_map = {
         "class": "No caller class",
@@ -300,14 +324,14 @@ def execute_simulations(
                 info_map,
             )
         output_manager.save_results(
-            Path(r"output"),
-            Path(r"output/output_filters/"),
+            output_dir,
+            filters_dir,
             exclude_info_maps,
             produce_graphics,
             graphics_dir,
         )
         output_manager.dump_all_nondata_pools(
-            r"output", exclude_info_maps, format_option
+            output_dir, exclude_info_maps, format_option
         )
 
 
@@ -368,6 +392,19 @@ def parse_gnu_args() -> argparse.Namespace:
         "-l",
         "--load-pool",
         help="Load the output manager's variables pool from provided path",
+        default=""
+    )
+    parser.add_argument(
+        "-O",
+        "--output-dir",
+        help="The saving directory for output",
+        default="output/",
+    )
+    parser.add_argument(
+        "-F",
+        "--filters-dir",
+        help="The directory for the files containing the keys for filtering",
+        default="output/",
     )
     return parser.parse_args()
 

--- a/main.py
+++ b/main.py
@@ -103,6 +103,8 @@ def run_rufas(
             graphics_dir,
             format_option,
             verbose,
+            output_dir,
+            filters_dir,
         )
 
 
@@ -392,7 +394,7 @@ def parse_gnu_args() -> argparse.Namespace:
         "-l",
         "--load-pool",
         help="Load the output manager's variables pool from provided path",
-        default=""
+        default="",
     )
     parser.add_argument(
         "-O",
@@ -404,7 +406,7 @@ def parse_gnu_args() -> argparse.Namespace:
         "-F",
         "--filters-dir",
         help="The directory for the files containing the keys for filtering",
-        default="output/",
+        default="output/output_filters/",
     )
     return parser.parse_args()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,13 +30,18 @@ file_path = os.path.join(dir_path, "input/ARL.json")
 
 @pytest.mark.parametrize(
     "load_pool, no_graphics, format_option, verbose, clear_output, exclude_info_maps, only_run_validation,"
-    "graphics_dir, vars_file_path",
+    "graphics_dir, vars_file_path, output_dir, filters_dir",
     [
-        (False, False, "verbose", LogVerbosity.ERRORS, True, True, True, "graphics", ""),
-        (False, True, "basic", LogVerbosity.LOGS, False, False, False, "custom_graphics", ""),
-        (False, True, "block", LogVerbosity.NONE, True, False, False, "graphics", ""),
-        (True, False, "inline", LogVerbosity.WARNINGS, False, False, False, "custom_graphics", "path.json"),
-        (True, True, "verbose", LogVerbosity.LOGS, False, True, False, "graphics", "path.json"),
+        (False, False, "verbose", LogVerbosity.ERRORS, True, True, True, "graphics", "", "output/",
+         "output/output_filters"),
+        (False, True, "basic", LogVerbosity.LOGS, False, False, False, "custom_graphics", "", "output/",
+         "output/output_filters"),
+        (False, True, "block", LogVerbosity.NONE, True, False, False, "graphics", "", "output/",
+         "output/output_filters"),
+        (True, False, "inline", LogVerbosity.WARNINGS, False, False, False, "custom_graphics", "path.json", "output/",
+         "output/output_filters"),
+        (True, True, "verbose", LogVerbosity.LOGS, False, True, False, "graphics", "path.json", "output/",
+         "output/output_filters"),
     ],
 )
 def test_main(
@@ -49,6 +54,8 @@ def test_main(
     only_run_validation: bool,
     graphics_dir: str,
     vars_file_path: str,
+    output_dir: str,
+    filters_dir: str,
 ) -> None:
     with patch("main.parse_gnu_args") as mock_parse_gnu_args:
         mock_parse_gnu_args.return_value = argparse.Namespace(
@@ -60,6 +67,8 @@ def test_main(
             only_run_validation=only_run_validation,
             graphics_dir=graphics_dir,
             load_pool=vars_file_path,
+            output_dir=output_dir,
+            filters_dir=filters_dir,
         )
 
         with patch("main.run_rufas") as mock_run_rufas:
@@ -74,32 +83,36 @@ def test_main(
                 exclude_info_maps=exclude_info_maps,
                 only_run_validation=only_run_validation,
                 graphics_dir=Path(graphics_dir),
-                vars_file_path=Path(vars_file_path)
+                vars_file_path=Path(vars_file_path),
+                output_dir=Path(output_dir),
+                filters_dir=Path(filters_dir)
             )
 
 
 @pytest.mark.parametrize(
     "format_option, produce_graphics, verbose, clear_output, exclude_info_maps, only_run_validation,"
-    "graphics_dir, load_pool, vars_file_path",
+    "graphics_dir, load_pool, vars_file_path, output_dir, filters_dir",
     [
-        ("verbose", True, LogVerbosity.NONE, True, True, True, "", False, ""),
-        ("block", False, LogVerbosity.LOGS, True, True, True, "", False, ""),
-        ("inline", True, LogVerbosity.ERRORS, True, True, True, "", False, ""),
-        ("basic", True, LogVerbosity.WARNINGS, False, True, True, "", False, ""),
-        ("verbose", True, LogVerbosity.NONE, True, False, True, "", False, ""),
-        ("block", True, LogVerbosity.LOGS, True, True, False, "", False, ""),
-        ("inline", False, LogVerbosity.ERRORS, True, True, True, "", False, ""),
-        ("basic", False, LogVerbosity.WARNINGS, False, True, True, "", False, ""),
-        ("verbose", False, LogVerbosity.NONE, True, False, True, "", False, ""),
-        ("block", False, LogVerbosity.LOGS, True, True, False, "", False, ""),
-        ("inline", False, LogVerbosity.ERRORS, False, True, True, "", False, ""),
-        ("basic", False, LogVerbosity.WARNINGS, True, False, True, "", False, ""),
-        ("verbose", False, LogVerbosity.NONE, True, True, False, "", False, ""),
-        ("block", False, LogVerbosity.WARNINGS, False, False, True, "", False, ""),
-        ("inline", False, LogVerbosity.LOGS, False, True, False, "", False, ""),
-        ("basic", False, LogVerbosity.ERRORS, False, False, False, "", False, ""),
-        ("basic", False, LogVerbosity.LOGS, False, False, False, "graphics", False, ""),
-        ("basic", False, LogVerbosity.LOGS, False, False, False, "graphics", True, "path.json"),
+        ("verbose", True, LogVerbosity.NONE, True, True, True, "", False, "", "output/", "output/output_filters"),
+        ("block", False, LogVerbosity.LOGS, True, True, True, "", False, "", "output/", "output/output_filters"),
+        ("inline", True, LogVerbosity.ERRORS, True, True, True, "", False, "", "output/", "output/output_filters"),
+        ("basic", True, LogVerbosity.WARNINGS, False, True, True, "", False, "", "output/", "output/output_filters"),
+        ("verbose", True, LogVerbosity.NONE, True, False, True, "", False, "", "output/", "output/output_filters"),
+        ("block", True, LogVerbosity.LOGS, True, True, False, "", False, "", "output/", "output/output_filters"),
+        ("inline", False, LogVerbosity.ERRORS, True, True, True, "", False, "", "output/", "output/output_filters"),
+        ("basic", False, LogVerbosity.WARNINGS, False, True, True, "", False, "", "output/", "output/output_filters"),
+        ("verbose", False, LogVerbosity.NONE, True, False, True, "", False, "", "output/", "output/output_filters"),
+        ("block", False, LogVerbosity.LOGS, True, True, False, "", False, "", "output/", "output/output_filters"),
+        ("inline", False, LogVerbosity.ERRORS, False, True, True, "", False, "", "output/", "output/output_filters"),
+        ("basic", False, LogVerbosity.WARNINGS, True, False, True, "", False, "", "output/", "output/output_filters"),
+        ("verbose", False, LogVerbosity.NONE, True, True, False, "", False, "", "output/", "output/output_filters"),
+        ("block", False, LogVerbosity.WARNINGS, False, False, True, "", False, "", "output/", "output/output_filters"),
+        ("inline", False, LogVerbosity.LOGS, False, True, False, "", False, "", "output/", "output/output_filters"),
+        ("basic", False, LogVerbosity.ERRORS, False, False, False, "", False, "", "output/", "output/output_filters"),
+        ("basic", False, LogVerbosity.LOGS, False, False, False, "graphics", False, "", "output/",
+         "output/output_filters"),
+        ("basic", False, LogVerbosity.LOGS, False, False, False, "graphics", True, "path.json", "output/",
+         "output/output_filters"),
     ],
 )
 def test_run_rufas(
@@ -112,6 +125,8 @@ def test_run_rufas(
     graphics_dir: str,
     load_pool: bool,
     vars_file_path: str,
+    output_dir: str,
+    filters_dir: str,
     mocker: MockerFixture,
     capsys,
 ) -> None:
@@ -134,17 +149,30 @@ def test_run_rufas(
         only_run_validation,
         graphics_dir,
         vars_file_path,
+        output_dir,
+        filters_dir
     )
 
     # Assert
     if load_pool:
         patch_run_load_vars_pool.assert_called_once_with(
-            vars_file_path, exclude_info_maps, format_option, produce_graphics, graphics_dir, clear_output
+            vars_file_path,
+            exclude_info_maps,
+            format_option,
+            produce_graphics,
+            graphics_dir,
+            clear_output,
+            output_dir,
+            filters_dir,
         )
         return
     elif only_run_validation:
         patch_run_validation.assert_called_once_with(
-            metadata_file_list, exclude_info_maps, format_option, verbose
+            metadata_file_list,
+            exclude_info_maps,
+            format_option,
+            verbose,
+            output_dir,
         )
     else:
         patch_execute_simulations.assert_called_once_with(
@@ -154,6 +182,8 @@ def test_run_rufas(
             graphics_dir,
             format_option,
             verbose,
+            output_dir,
+            filters_dir,
         )
 
     if clear_output:
@@ -186,8 +216,12 @@ def test_run_validation(mocker: MockerFixture, is_data_valid: bool) -> None:
         {"prefix": metadata_prefix2, "path": metadata_file_path2},
     ]
     mock_input_manager.start_data_processing.return_value = is_data_valid
+    exclude_info_maps = False
+    format_option = "verbose"
+    verbose = LogVerbosity.NONE
+    output_dir = Path("output/")
 
-    run_validation(metadata_file_list, True, "verbose", "none")
+    run_validation(metadata_file_list, exclude_info_maps, format_option, verbose, output_dir)
 
     assert mock_output_manager.flush_pools.call_count == len(metadata_file_list)
     assert mock_input_manager.flush_pool.call_count == len(metadata_file_list)
@@ -195,7 +229,7 @@ def test_run_validation(mocker: MockerFixture, is_data_valid: bool) -> None:
         metadata_file_list
     )
     assert mock_output_manager.dump_all_nondata_pools.call_args_list == [
-        mocker.call("output", True, "verbose")
+        mocker.call(output_dir, exclude_info_maps, format_option)
     ] * len(metadata_file_list)
 
 
@@ -243,6 +277,8 @@ def test_execute_simulations(
     mock_simulator = mocker.MagicMock(auto_spec=SimulationEngine)
     mock_simulator.simulate.return_value = None
     mocker.patch("main.SimulationEngine", return_value=mock_simulator)
+    output_dir = Path("output/")
+    filters_dir = Path("output/output_filters/")
 
     # Act
     execute_simulations(
@@ -251,6 +287,8 @@ def test_execute_simulations(
         produce_graphics=produce_graphics,
         graphics_dir=Path(""),
         format_option=format_option,
+        output_dir=output_dir,
+        filters_dir=filters_dir,
     )
 
     # Assert
@@ -262,13 +300,13 @@ def test_execute_simulations(
         metadata_file_list
     )
     assert mock_output_manager.dump_all_nondata_pools.call_args_list == [
-        mocker.call("output", exlclude_info_maps, format_option)
+        mocker.call(output_dir, exlclude_info_maps, format_option)
     ] * len(metadata_file_list)
     assert mock_output_manager.save_results.call_count == len(metadata_file_list)
     assert mock_output_manager.save_results.call_args_list == [
         mocker.call(
-            Path("output"),
-            Path("output/output_filters/"),
+            output_dir,
+            filters_dir,
             exlclude_info_maps,
             produce_graphics,
             Path(""),
@@ -292,6 +330,8 @@ def test_run_load_vars_pool(mocker: MockerFixture, vars_file_path: str, exclude_
                             format_option: str, produce_graphics: bool,
                             graphics_dir: Path, clear_output: bool, ) -> None:
     """Checks the run_load_vars_pool function in main.py"""
+    output_dir = Path("output/")
+    filters_dir = Path("output/output_filters/")
     mock_output_manager = mocker.MagicMock(auto_spec=OutputManager)
     patch_clear_output_dir = mocker.patch("main.clear_output_dir")
     mock_output_manager.flush_pools.return_value = None
@@ -301,7 +341,8 @@ def test_run_load_vars_pool(mocker: MockerFixture, vars_file_path: str, exclude_
     mock_output_manager.save_results.return_value = None
     mocker.patch("main.OutputManager", return_value=mock_output_manager)
 
-    run_load_vars_pool(vars_file_path, exclude_info_maps, format_option, produce_graphics, graphics_dir, clear_output)
+    run_load_vars_pool(vars_file_path, exclude_info_maps, format_option, produce_graphics, graphics_dir, clear_output,
+                       output_dir, filters_dir)
 
     if clear_output:
         patch_clear_output_dir.assert_called_once()
@@ -368,7 +409,7 @@ def test_parse_gnu_args(mocker: MockerFixture) -> None:
     actual_args = parse_gnu_args()
 
     # Assert
-    assert mock_add_argument.call_count == 8
+    assert mock_add_argument.call_count == 10
     assert mock_add_argument.call_args_list == [
         mocker.call(
             "-f",
@@ -417,6 +458,19 @@ def test_parse_gnu_args(mocker: MockerFixture) -> None:
             "-l",
             "--load-pool",
             help="Load the output manager's variables pool from provided path",
+            default="",
+        ),
+        mocker.call(
+            "-O",
+            "--output-dir",
+            help="The saving directory for output",
+            default="output/",
+        ),
+        mocker.call(
+            "-F",
+            "--filters-dir",
+            help="The directory for the files containing the keys for filtering",
+            default="output/output_filters/",
         ),
     ]
     mock_parse_args.assert_called_once()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -29,17 +29,18 @@ file_path = os.path.join(dir_path, "input/ARL.json")
 
 
 @pytest.mark.parametrize(
-    "no_graphics, format_option, verbose, clear_output, exclude_info_maps, only_run_validation, graphics_dir,"
-    "load_pool",
+    "load_pool, no_graphics, format_option, verbose, clear_output, exclude_info_maps, only_run_validation,"
+    "graphics_dir, vars_file_path",
     [
-        (False, "verbose", LogVerbosity.ERRORS, True, True, True, "graphics", False),
-        (True, "basic", LogVerbosity.LOGS, False, False, False, "custom_graphics", False),
-        (True, "block", LogVerbosity.NONE, True, False, False, "graphics", False),
-        (False, "inline", LogVerbosity.WARNINGS, False, False, False, "custom_graphics", True),
-        (True, "verbose", LogVerbosity.LOGS, False, True, False, "graphics", True),
+        (False, False, "verbose", LogVerbosity.ERRORS, True, True, True, "graphics", ""),
+        (False, True, "basic", LogVerbosity.LOGS, False, False, False, "custom_graphics", ""),
+        (False, True, "block", LogVerbosity.NONE, True, False, False, "graphics", ""),
+        (True, False, "inline", LogVerbosity.WARNINGS, False, False, False, "custom_graphics", "path.json"),
+        (True, True, "verbose", LogVerbosity.LOGS, False, True, False, "graphics", "path.json"),
     ],
 )
 def test_main(
+    load_pool: bool,
     no_graphics: bool,
     format_option: str,
     verbose: LogVerbosity,
@@ -47,7 +48,7 @@ def test_main(
     exclude_info_maps: bool,
     only_run_validation: bool,
     graphics_dir: str,
-    load_pool: bool,
+    vars_file_path: str,
 ) -> None:
     with patch("main.parse_gnu_args") as mock_parse_gnu_args:
         mock_parse_gnu_args.return_value = argparse.Namespace(
@@ -58,13 +59,14 @@ def test_main(
             exclude_info_maps=exclude_info_maps,
             only_run_validation=only_run_validation,
             graphics_dir=graphics_dir,
-            load_pool=load_pool,
+            load_pool=vars_file_path,
         )
 
         with patch("main.run_rufas") as mock_run_rufas:
             main()
             mock_parse_gnu_args.assert_called_once()
             mock_run_rufas.assert_called_once_with(
+                load_pool,
                 produce_graphics=not no_graphics,
                 format_option=format_option,
                 verbose=verbose,
@@ -72,32 +74,32 @@ def test_main(
                 exclude_info_maps=exclude_info_maps,
                 only_run_validation=only_run_validation,
                 graphics_dir=Path(graphics_dir),
-                load_pool=load_pool
+                vars_file_path=Path(vars_file_path)
             )
 
 
 @pytest.mark.parametrize(
     "format_option, produce_graphics, verbose, clear_output, exclude_info_maps, only_run_validation,"
-    "graphics_dir, load_pool",
+    "graphics_dir, load_pool, vars_file_path",
     [
-        ("verbose", True, LogVerbosity.NONE, True, True, True, "", False),
-        ("block", False, LogVerbosity.LOGS, True, True, True, "", False),
-        ("inline", True, LogVerbosity.ERRORS, True, True, True, "", False),
-        ("basic", True, LogVerbosity.WARNINGS, False, True, True, "", False),
-        ("verbose", True, LogVerbosity.NONE, True, False, True, "", False),
-        ("block", True, LogVerbosity.LOGS, True, True, False, "", False),
-        ("inline", False, LogVerbosity.ERRORS, True, True, True, "", False),
-        ("basic", False, LogVerbosity.WARNINGS, False, True, True, "", False),
-        ("verbose", False, LogVerbosity.NONE, True, False, True, "", False),
-        ("block", False, LogVerbosity.LOGS, True, True, False, "", False),
-        ("inline", False, LogVerbosity.ERRORS, False, True, True, "", False),
-        ("basic", False, LogVerbosity.WARNINGS, True, False, True, "", False),
-        ("verbose", False, LogVerbosity.NONE, True, True, False, "", False),
-        ("block", False, LogVerbosity.WARNINGS, False, False, True, "", False),
-        ("inline", False, LogVerbosity.LOGS, False, True, False, "", False),
-        ("basic", False, LogVerbosity.ERRORS, False, False, False, "", False),
-        ("basic", False, LogVerbosity.LOGS, False, False, False, "graphics", False),
-        ("basic", False, LogVerbosity.LOGS, False, False, False, "graphics", True),
+        ("verbose", True, LogVerbosity.NONE, True, True, True, "", False, ""),
+        ("block", False, LogVerbosity.LOGS, True, True, True, "", False, ""),
+        ("inline", True, LogVerbosity.ERRORS, True, True, True, "", False, ""),
+        ("basic", True, LogVerbosity.WARNINGS, False, True, True, "", False, ""),
+        ("verbose", True, LogVerbosity.NONE, True, False, True, "", False, ""),
+        ("block", True, LogVerbosity.LOGS, True, True, False, "", False, ""),
+        ("inline", False, LogVerbosity.ERRORS, True, True, True, "", False, ""),
+        ("basic", False, LogVerbosity.WARNINGS, False, True, True, "", False, ""),
+        ("verbose", False, LogVerbosity.NONE, True, False, True, "", False, ""),
+        ("block", False, LogVerbosity.LOGS, True, True, False, "", False, ""),
+        ("inline", False, LogVerbosity.ERRORS, False, True, True, "", False, ""),
+        ("basic", False, LogVerbosity.WARNINGS, True, False, True, "", False, ""),
+        ("verbose", False, LogVerbosity.NONE, True, True, False, "", False, ""),
+        ("block", False, LogVerbosity.WARNINGS, False, False, True, "", False, ""),
+        ("inline", False, LogVerbosity.LOGS, False, True, False, "", False, ""),
+        ("basic", False, LogVerbosity.ERRORS, False, False, False, "", False, ""),
+        ("basic", False, LogVerbosity.LOGS, False, False, False, "graphics", False, ""),
+        ("basic", False, LogVerbosity.LOGS, False, False, False, "graphics", True, "path.json"),
     ],
 )
 def test_run_rufas(
@@ -109,6 +111,7 @@ def test_run_rufas(
     only_run_validation: bool,
     graphics_dir: str,
     load_pool: bool,
+    vars_file_path: str,
     mocker: MockerFixture,
     capsys,
 ) -> None:
@@ -122,6 +125,7 @@ def test_run_rufas(
 
     # Act
     run_rufas(
+        load_pool,
         produce_graphics,
         format_option,
         verbose,
@@ -129,13 +133,13 @@ def test_run_rufas(
         exclude_info_maps,
         only_run_validation,
         graphics_dir,
-        load_pool,
+        vars_file_path,
     )
 
     # Assert
     if load_pool:
         patch_run_load_vars_pool.assert_called_once_with(
-            exclude_info_maps, format_option, produce_graphics, graphics_dir, clear_output
+            vars_file_path, exclude_info_maps, format_option, produce_graphics, graphics_dir, clear_output
         )
         return
     elif only_run_validation:
@@ -273,23 +277,21 @@ def test_execute_simulations(
 
 
 @pytest.mark.parametrize(
-    "exclude_info_maps, format_option, produce_graphics, graphics_dir, clear_output",
+    "vars_file_path, exclude_info_maps, format_option, produce_graphics, graphics_dir, clear_output",
     [
-        (True, "verbose", True, Path(""), True),
-        (True, "verbose", True, Path(""), False),
-        (True, "verbose", False, Path(""), False),
-        (True, "verbose", False, Path(""), True),
-        (False, "verbose", True, Path(""), False),
-        (False, "verbose", False, Path(""), False),
-        (False, "verbose", False, Path(""), True),
+        ("", True, "verbose", True, Path(""), True),
+        ("", True, "verbose", True, Path(""), False),
+        ("path.json", True, "verbose", False, Path(""), False),
+        ("path.json", True, "verbose", False, Path(""), True),
+        ("", False, "verbose", True, Path(""), False),
+        ("", False, "verbose", False, Path(""), False),
+        ("path.json", False, "verbose", False, Path(""), True),
     ],
 )
-def test_run_load_vars_pool(mocker: MockerFixture, exclude_info_maps: bool,
+def test_run_load_vars_pool(mocker: MockerFixture, vars_file_path: str, exclude_info_maps: bool,
                             format_option: str, produce_graphics: bool,
-                            graphics_dir: Path, clear_output: bool, monkeypatch) -> None:
+                            graphics_dir: Path, clear_output: bool, ) -> None:
     """Checks the run_load_vars_pool function in main.py"""
-    user_input = "test.json"
-    monkeypatch.setattr('builtins.input', lambda _: user_input)
     mock_output_manager = mocker.MagicMock(auto_spec=OutputManager)
     patch_clear_output_dir = mocker.patch("main.clear_output_dir")
     mock_output_manager.flush_pools.return_value = None
@@ -299,7 +301,7 @@ def test_run_load_vars_pool(mocker: MockerFixture, exclude_info_maps: bool,
     mock_output_manager.save_results.return_value = None
     mocker.patch("main.OutputManager", return_value=mock_output_manager)
 
-    run_load_vars_pool(exclude_info_maps, format_option, produce_graphics, graphics_dir, clear_output)
+    run_load_vars_pool(vars_file_path, exclude_info_maps, format_option, produce_graphics, graphics_dir, clear_output)
 
     if clear_output:
         patch_clear_output_dir.assert_called_once()
@@ -415,7 +417,6 @@ def test_parse_gnu_args(mocker: MockerFixture) -> None:
             "-l",
             "--load-pool",
             help="Load the output manager's variables pool from provided path",
-            action="store_true"
         ),
     ]
     mock_parse_args.assert_called_once()


### PR DESCRIPTION
This PR moves all dir paths set in config input files and from user prompts to gnu args. This addresses issue #951 and #939.

Additional related cleanup present:
1. Ensure all metadata files share the same properties and the same validation guidelines. 
2. Ensure all input files shares the same fields (not necessarily the same values for those fields) required by the metadata.
3. Updates unit testing.