### PR TITLE
Quick debug in main

### DIFF
--- a/RUFAS/routines/animal/life_cycle/cow.py
+++ b/RUFAS/routines/animal/life_cycle/cow.py
@@ -358,7 +358,7 @@ class Cow(HeiferIII):
         om.add_variable("milk_protein", self.mPrt, info_map)
         om.add_variable("milk_lactose", self.lactose_milk, info_map)
         om.add_variable("lactating", self.milking, info_map)
-        om.add_variable("cow_id", self.cow_id, info_map)
+        om.add_variable("cow_id", self.id, info_map)
         om.add_variable("parity", self.calves, info_map)
 
         # if not self.milking:


### PR DESCRIPTION
A bug was introduced following @ew3361zh's #861.

In `RUFAS/routines/animal/life_cycle/cow.py`, line 361, when referring to the id of a cow, it should be `self.id` but not `self.cow_id`
<img width="694" alt="image" src="https://github.com/RuminantFarmSystems/MASM/assets/39185942/bb088f61-db2c-4f93-bbf7-c613d4ebff2e">
