### PR TITLE
Update percentages of organic carbon content in soil profile input files

### DIFF
--- a/input/data/soil/ARL_soil.json
+++ b/input/data/soil/ARL_soil.json
@@ -18,7 +18,7 @@
             "saturated_hydraulic_conductivity": 9.17,
             "initial_temperature": 15.77575,
             "bulk_density": 1.34,
-            "percent_organic_carbon_content": 0.012,
+            "percent_organic_carbon_content": 2.32,
             "percent_clay_content": 21.95,
             "percent_silt_content": 63.42,
             "percent_sand_content": 14.63,
@@ -33,8 +33,7 @@
             "denitrification_threshold_water_content": 1.1,
             "residue_fresh_organic_mineralization_rate": 0.05,
             "denitrification_rate": 0.1,
-            "active_N_percent": 0.02,
-            "OM_percent": 0.04
+            "active_N_percent": 0.02
         },
         {
             "bottom_depth": 1041.4,
@@ -45,7 +44,7 @@
             "saturated_hydraulic_conductivity": 9.17,
             "initial_temperature": 14.50797297,
             "bulk_density": 1.42,
-            "percent_organic_carbon_content": 0.012,
+            "percent_organic_carbon_content": 0.348,
             "percent_clay_content": 27.27,
             "percent_silt_content": 59.09,
             "percent_sand_content": 13.64,
@@ -60,8 +59,7 @@
             "denitrification_threshold_water_content": 1.1,
             "residue_fresh_organic_mineralization_rate": 0.05,
             "denitrification_rate": 0.1,
-            "active_N_percent": 0.02,
-            "OM_percent": 0.006
+            "active_N_percent": 0.02
         },
         {
             "bottom_depth": 1168.4,
@@ -72,7 +70,7 @@
             "saturated_hydraulic_conductivity": 23.29,
             "initial_temperature": 13.38623,
             "bulk_density": 1.6,
-            "percent_organic_carbon_content": 0.012,
+            "percent_organic_carbon_content": 0.145,
             "percent_clay_content": 22.33,
             "percent_silt_content": 63.11,
             "percent_sand_content": 14.56,
@@ -87,8 +85,7 @@
             "denitrification_threshold_water_content": 1.1,
             "residue_fresh_organic_mineralization_rate": 0.05,
             "denitrification_rate": 0.1,
-            "active_N_percent": 0.02,
-            "OM_percent": 0.0025
+            "active_N_percent": 0.02
         },
         {
             "bottom_depth": 2006.6,
@@ -99,7 +96,7 @@
             "saturated_hydraulic_conductivity": 23.29,
             "initial_temperature": 13.38623,
             "bulk_density": 1.5,
-            "percent_organic_carbon_content": 0.012,
+            "percent_organic_carbon_content": 0.145,
             "percent_clay_content": 13.04,
             "percent_silt_content": 70.66,
             "percent_sand_content": 16.30,
@@ -114,8 +111,7 @@
             "denitrification_threshold_water_content": 1.1,
             "residue_fresh_organic_mineralization_rate": 0.05,
             "denitrification_rate": 0.1,
-            "active_N_percent": 0.02,
-            "OM_percent": 0.0025
+            "active_N_percent": 0.02
         }
     ]
 }

--- a/input/data/soil/default_soil.json
+++ b/input/data/soil/default_soil.json
@@ -18,7 +18,7 @@
             "saturated_hydraulic_conductivity": 20,
             "initial_temperature": 15.77575,
             "bulk_density": 1.3,
-            "percent_organic_carbon_content": 0.012,
+            "percent_organic_carbon_content": 1.2,
             "percent_clay_content": 20,
             "percent_silt_content": 65,
             "percent_sand_content": 15,
@@ -32,8 +32,7 @@
             "denitrification_threshold_water_content": 1.1,
             "residue_fresh_organic_mineralization_rate": 0.05,
             "active_N_percent": 0.02,
-            "denitrification_rate": 0.1,
-            "OM_percent": 0.019
+            "denitrification_rate": 0.1
         },
         {
             "bottom_depth": 300,
@@ -44,7 +43,7 @@
             "saturated_hydraulic_conductivity": 20,
             "initial_temperature": 14.50797297,
             "bulk_density": 1.3,
-            "percent_organic_carbon_content": 0.012,
+            "percent_organic_carbon_content": 1.2,
             "percent_clay_content": 20,
             "percent_silt_content": 65,
             "percent_sand_content": 15,
@@ -58,8 +57,7 @@
             "denitrification_threshold_water_content": 1.1,
             "residue_fresh_organic_mineralization_rate": 0.05,
             "active_N_percent": 0.02,
-            "denitrification_rate": 0.1,
-            "OM_percent": 0.019
+            "denitrification_rate": 0.1
         },
         {
             "bottom_depth": 450,
@@ -70,7 +68,7 @@
             "saturated_hydraulic_conductivity": 20,
             "initial_temperature": 13.38623,
             "bulk_density": 1.3,
-            "percent_organic_carbon_content": 0.012,
+            "percent_organic_carbon_content": 1.2,
             "percent_clay_content": 20,
             "percent_silt_content": 65,
             "percent_sand_content": 15,
@@ -84,8 +82,7 @@
             "denitrification_threshold_water_content": 1.1,
             "residue_fresh_organic_mineralization_rate": 0.05,
             "active_N_percent": 0.02,
-            "denitrification_rate": 0.1,
-            "OM_percent": 0.019
+            "denitrification_rate": 0.1
         }
     ]
 }

--- a/input/data/soil/default_soil_2.json
+++ b/input/data/soil/default_soil_2.json
@@ -18,7 +18,7 @@
             "saturated_hydraulic_conductivity": 9.17,
             "initial_temperature": 15.77575,
             "bulk_density": 1.34,
-            "percent_organic_carbon_content": 0.012,
+            "percent_organic_carbon_content": 2.32,
             "percent_clay_content": 21.95,
             "percent_silt_content": 63.42,
             "percent_sand_content": 14.63,
@@ -33,8 +33,7 @@
             "denitrification_threshold_water_content": 1.1,
             "residue_fresh_organic_mineralization_rate": 0.05,
             "denitrification_rate": 0.1,
-            "active_N_percent": 0.02,
-            "OM_percent": 0.04
+            "active_N_percent": 0.02
         },
         {
             "bottom_depth": 1041.4,
@@ -45,7 +44,7 @@
             "saturated_hydraulic_conductivity": 9.17,
             "initial_temperature": 14.50797297,
             "bulk_density": 1.42,
-            "percent_organic_carbon_content": 0.012,
+            "percent_organic_carbon_content": 0.348,
             "percent_clay_content": 27.27,
             "percent_silt_content": 59.09,
             "percent_sand_content": 13.64,
@@ -60,8 +59,7 @@
             "denitrification_threshold_water_content": 1.1,
             "residue_fresh_organic_mineralization_rate": 0.05,
             "denitrification_rate": 0.1,
-            "active_N_percent": 0.02,
-            "OM_percent": 0.006
+            "active_N_percent": 0.02
         },
         {
             "bottom_depth": 1168.4,
@@ -72,7 +70,7 @@
             "saturated_hydraulic_conductivity": 23.29,
             "initial_temperature": 13.38623,
             "bulk_density": 1.6,
-            "percent_organic_carbon_content": 0.012,
+            "percent_organic_carbon_content": 0.145,
             "percent_clay_content": 22.33,
             "percent_silt_content": 63.11,
             "percent_sand_content": 14.56,
@@ -87,8 +85,7 @@
             "denitrification_threshold_water_content": 1.1,
             "residue_fresh_organic_mineralization_rate": 0.05,
             "denitrification_rate": 0.1,
-            "active_N_percent": 0.02,
-            "OM_percent": 0.0025
+            "active_N_percent": 0.02
         },
         {
             "bottom_depth": 2006.6,
@@ -99,7 +96,7 @@
             "saturated_hydraulic_conductivity": 23.29,
             "initial_temperature": 13.38623,
             "bulk_density": 1.5,
-            "percent_organic_carbon_content": 0.012,
+            "percent_organic_carbon_content": 0.145,
             "percent_clay_content": 13.04,
             "percent_silt_content": 70.66,
             "percent_sand_content": 16.30,
@@ -114,8 +111,7 @@
             "denitrification_threshold_water_content": 1.1,
             "residue_fresh_organic_mineralization_rate": 0.05,
             "denitrification_rate": 0.1,
-            "active_N_percent": 0.02,
-            "OM_percent": 0.0025
+            "active_N_percent": 0.02
         }
     ]
 }

--- a/input/data/soil/regular_barnyard_soil.json
+++ b/input/data/soil/regular_barnyard_soil.json
@@ -32,8 +32,7 @@
             "denitrification_threshold_water_content": 1.1,
             "residue_fresh_organic_mineralization_rate": 0.05,
             "active_N_percent": 0.02,
-            "denitrification_rate": 0.1,
-            "OM_percent": 0.019
+            "denitrification_rate": 0.1
         },
         {
             "bottom_depth": 300,
@@ -44,7 +43,7 @@
             "saturated_hydraulic_conductivity": 20,
             "initial_temperature": 14.50797297,
             "bulk_density": 1.4,
-            "percent_organic_carbon_content": 0.012,
+            "percent_organic_carbon_content": 1.2,
             "percent_clay_content": 20,
             "percent_silt_content": 65,
             "percent_sand_content": 15,
@@ -58,8 +57,7 @@
             "denitrification_threshold_water_content": 1.1,
             "residue_fresh_organic_mineralization_rate": 0.05,
             "active_N_percent": 0.02,
-            "denitrification_rate": 0.1,
-            "OM_percent": 0.019
+            "denitrification_rate": 0.1
         },
         {
             "bottom_depth": 450,
@@ -70,7 +68,7 @@
             "saturated_hydraulic_conductivity": 20,
             "initial_temperature": 13.38623,
             "bulk_density": 1.4,
-            "percent_organic_carbon_content": 0.012,
+            "percent_organic_carbon_content": 1.2,
             "percent_clay_content": 20,
             "percent_silt_content": 65,
             "percent_sand_content": 15,
@@ -84,8 +82,7 @@
             "denitrification_threshold_water_content": 1.1,
             "residue_fresh_organic_mineralization_rate": 0.05,
             "active_N_percent": 0.02,
-            "denitrification_rate": 0.1,
-            "OM_percent": 0.019
+            "denitrification_rate": 0.1
         }
     ]
 }

--- a/input/data/soil/testing_soil.json
+++ b/input/data/soil/testing_soil.json
@@ -18,7 +18,7 @@
             "saturated_hydraulic_conductivity": 20,
             "initial_temperature": 14.50797297,
             "bulk_density": 1.4,
-            "percent_organic_carbon_content": 0.012,
+            "percent_organic_carbon_content": 1.2,
             "percent_clay_content": 20,
             "percent_silt_content": 65,
             "percent_sand_content": 15,
@@ -32,8 +32,7 @@
             "denitrification_threshold_water_content": 1.1,
             "residue_fresh_organic_mineralization_rate": 0.05,
             "active_N_percent": 0.0,
-            "denitrification_rate": 0.05,
-            "OM_percent": 0.0
+            "denitrification_rate": 0.05
         },
         {
             "bottom_depth": 300,
@@ -44,7 +43,7 @@
             "saturated_hydraulic_conductivity": 20,
             "initial_temperature": 14.50797297,
             "bulk_density": 1.4,
-            "percent_organic_carbon_content": 0.012,
+            "percent_organic_carbon_content": 1.2,
             "percent_clay_content": 20,
             "percent_silt_content": 65,
             "percent_sand_content": 15,
@@ -58,8 +57,7 @@
             "denitrification_threshold_water_content": 1.1,
             "residue_fresh_organic_mineralization_rate": 0.05,
             "active_N_percent": 0.0,
-            "denitrification_rate": 0.05,
-            "OM_percent": 0.0
+            "denitrification_rate": 0.05
         },
         {
             "bottom_depth": 450,
@@ -70,7 +68,7 @@
             "saturated_hydraulic_conductivity": 20,
             "initial_temperature": 13.38632147,
             "bulk_density": 1.4,
-            "percent_organic_carbon_content": 0.012,
+            "percent_organic_carbon_content": 1.2,
             "percent_clay_content": 20,
             "percent_silt_content": 65,
             "percent_sand_content": 15,
@@ -84,8 +82,7 @@
             "denitrification_threshold_water_content": 1.1,
             "residue_fresh_organic_mineralization_rate": 0.05,
             "active_N_percent": 0.0,
-            "denitrification_rate": 0.5,
-            "OM_percent": 0.0
+            "denitrification_rate": 0.5
         }
     ]
 }


### PR DESCRIPTION
Doubles checks all soil profile input files to make sure that the percent organic carbon content matches its input source.

Profile to source mappings:
- `ARL_soil.json` comes from [this excel sheet](https://3.basecamp.com/3486446/buckets/5296287/uploads/2928055772).
- `regular_barnyard_soil.json` comes from [this excel sheet](https://3.basecamp.com/3486446/buckets/5296287/uploads/2788739772).
- `testing_soil.json` is just a slight variation on `regular_barnyard_soil.json`.
- `default_soil.json` is a copy of `regular_barnyard_soil.json`.
- `default_soil_2.json` is a copy of `ARL_soil.json`.

Also, the `OM_percent` field has been removed. This parameter may or may not be brought back to replace `percent_organic_carbon_content` for RuFaS V1, and if it is resurrected it can easily be calculated using SWAT Theoretical documentation eqn. 4:1.1.4

SWAT eqn. 4:1.1.4 is used to determine the fraction of a soil layer that is organic carbon based on the amount of organic matter in the soil layer - and can be used in the reverse direction to estimate organic matter based on organic carbon content.

Closes #982