### PR TITLE
Adding ElementsCounter class to IM and refactoring helper methods for primitive types

### DIFF
--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -884,6 +884,99 @@ class InputManager:
             return False, "Value greater than maximum"
         return True, ""
 
+    @staticmethod
+    def _is_str_value(variable_value: Any, variable_properties: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Check if the variable value is a string.
+
+        Parameters
+        ----------
+        variable_value : Any
+            The value of the variable to check.
+        variable_properties : Dict[str, Any]
+            The properties for the variable of interest.
+
+        Returns
+        -------
+        Tuple[bool, str]
+            A tuple containing a boolean indicating if the check passed and a string containing the reason for failure.
+
+        """
+
+        if type(variable_value) is not str:
+            return False, "String variable is not a string."
+        return True, ""
+
+    @staticmethod
+    def _check_str_len_lower_bound(variable_value: str,
+                                   variable_properties: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Check if the variable value is greater than the minimum length.
+
+        Parameters
+        ----------
+        variable_value : str
+            The value of the variable to check.
+        variable_properties : Dict[str, Any]
+            The properties for the variable of interest.
+
+        Returns
+        -------
+        Tuple[bool, str]
+            A tuple containing a boolean indicating if the check passed and a string containing the reason for failure.
+        """
+
+        if "minimum_length" in variable_properties and len(variable_value) < variable_properties["minimum_length"]:
+            return False, "String length less than minimum."
+        return True, ""
+
+    @staticmethod
+    def _check_str_len_upper_bound(variable_value: str,
+                                   variable_properties: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Check if the variable value is less than the maximum length.
+
+        Parameters
+        ----------
+        variable_value : str
+            The value of the variable to check.
+        variable_properties : Dict[str, Any]
+            The properties for the variable of interest.
+
+        Returns
+        -------
+        Tuple[bool, str]
+            A tuple containing a boolean indicating if the check passed and a string containing the reason for failure.
+        """
+
+        if "maximum_length" in variable_properties and len(variable_value) > variable_properties["maximum_length"]:
+            return False, "String length greater than maximum."
+        return True, ""
+
+    @staticmethod
+    def _check_str_pattern_match(variable_value: str,
+                                 variable_properties: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Check if the variable value matches the specified pattern.
+
+        Parameters
+        ----------
+        variable_value : str
+              The value of the variable to check.
+        variable_properties : Dict[str, Any]
+              The properties for the variable of interest.
+
+        Returns
+        -------
+        Tuple[bool, str]
+              A tuple containing a boolean indicating if the check passed and a string containing the reason for
+              failure.
+        """
+
+        if "pattern" in variable_properties and not re.fullmatch(variable_properties["pattern"], variable_value):
+            return False, "String does not match pattern."
+        return True, ""
+
 
 class ElementsCounter:
     """

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -9,7 +9,6 @@ import pandas as pd
 from RUFAS.output_manager import OutputManager
 from typing import Any, Dict, List, Union
 
-
 om = OutputManager()
 
 
@@ -359,7 +358,7 @@ class InputManager:
 
         return element_counter_and_validity
 
-    def _validate_json_element(self, element_hierarchy: List[str], properties_blob_key: str,   # noqa
+    def _validate_json_element(self, element_hierarchy: List[str], properties_blob_key: str,  # noqa
                                input_data: Dict[str, Any], eager_termination: bool,
                                element_counter_and_validity: Dict[str, int | bool], ) -> dict:
         """
@@ -708,7 +707,7 @@ class InputManager:
             parent_address = str(data_address.split("." + invalid_key)[0])
 
             om.add_error("Validation: data not found:", f"Cannot find \"{data_address}\", "
-                         f"\"{parent_address}\" does not have attribute \"{invalid_key}\".",
+                                                        f"\"{parent_address}\" does not have attribute \"{invalid_key}\".",
                          info_map)
 
             raise KeyError(f"Data not found: Cannot find \"{data_address}\", "
@@ -774,7 +773,7 @@ class InputManager:
             parent_address = ".".join(element_hierarchy[:-1])
 
             om.add_error("Validation: data not found:", f"Cannot find \"{metadata_address}\", "
-                         f"\"{parent_address}\" does not have attribute \"{invalid_key}\".",
+                                                        f"\"{parent_address}\" does not have attribute \"{invalid_key}\".",
                          info_map)
 
             raise KeyError(f"Data not found: Cannot find \"{metadata_address}\", "
@@ -789,3 +788,121 @@ class InputManager:
                     }
         self.__pool = {}
         om.add_log("Clear variable pool", "The pool is emptied.", info_map)
+
+
+class ElementsCounter:
+    """
+    A class to keep track of element counts in various categories: total, valid, fixed, and invalid.
+
+    Attributes
+    ----------
+    total_elements : int
+        The count of all elements processed.
+    valid_elements : int
+        The count of all valid elements processed.
+    fixed_elements : int
+        The count of all elements that were fixed during processing.
+    invalid_elements : int
+        The count of all elements found to be invalid during processing.
+
+    Methods
+    -------
+    increment(name, value=1)
+        Increment the count of a specific attribute by the given value.
+    """
+
+    def __init__(self):
+        """
+        Initialize the ElementsCounter with all counts set to zero.
+        """
+
+        self.total_elements = 0
+        self.valid_elements = 0
+        self.fixed_elements = 0
+        self.invalid_elements = 0
+
+    def update(self, name: str, value: int):
+        """
+        Update the count of a specific attribute to the given value.
+
+        Parameters
+        ----------
+        name : str
+            The name of the attribute to update.
+        value : int
+            The new value of the attribute.
+        """
+
+        if hasattr(self, name):
+            setattr(self, name, value)
+        else:
+            raise Exception(f"Invalid sub-counter name: {name}")
+
+    def increment(self, name: str, value: int = 1):
+        """
+        Increment the count of a specific attribute by the given value.
+
+        Parameters
+        ----------
+        name : str
+            The name of the attribute to increment.
+        value : int, optional
+            The amount by which to increment the attribute (default is 1).
+
+        Raises
+        ------
+        Exception
+            If the given name is not an attribute of ElementsCounter.
+        """
+
+        self.update(name, getattr(self, name) + value)
+
+    def decrement(self, name: str, value: int = 1):
+        """
+        Decrement the count of a specific attribute by the given value.
+
+        Parameters
+        ----------
+        name : str
+            The name of the attribute to decrement.
+        value : int, optional
+            The amount by which to decrement the attribute (default is 1).
+
+        Raises
+        ------
+        Exception
+            If the given name is not an attribute of ElementsCounter.
+        """
+
+        self.update(name, getattr(self, name) - value)
+
+    def reset(self) -> None:
+        """
+        Reset all counts to zero.
+
+        Returns
+        -------
+        None
+        """
+
+        self.total_elements = 0
+        self.valid_elements = 0
+        self.fixed_elements = 0
+        self.invalid_elements = 0
+
+    def __str__(self) -> str:
+        """
+        String representation of the ElementsCounter instance.
+
+        Returns
+        -------
+        str
+            A string representation of the ElementsCounter, showing the counts of all categories.
+        """
+
+        return str({
+            "total_elements": self.total_elements,
+            "valid_elements": self.valid_elements,
+            "fixed_elements": self.fixed_elements,
+            "invalid_elements": self.invalid_elements,
+        })

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -710,7 +710,8 @@ class InputManager:
             parent_address = str(data_address.split("." + invalid_key)[0])
 
             om.add_error("Validation: data not found:", f"Cannot find \"{data_address}\", "
-                                                        f"\"{parent_address}\" does not have attribute \"{invalid_key}\".",
+                                                        f"\"{parent_address}\" does not have attribute "
+                                                        f"\"{invalid_key}\".",
                          info_map)
 
             raise KeyError(f"Data not found: Cannot find \"{data_address}\", "
@@ -776,7 +777,8 @@ class InputManager:
             parent_address = ".".join(element_hierarchy[:-1])
 
             om.add_error("Validation: data not found:", f"Cannot find \"{metadata_address}\", "
-                                                        f"\"{parent_address}\" does not have attribute \"{invalid_key}\".",
+                                                        f"\"{parent_address}\" does not have attribute"
+                                                        f" \"{invalid_key}\".",
                          info_map)
 
             raise KeyError(f"Data not found: Cannot find \"{metadata_address}\", "

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -1,13 +1,16 @@
 # !/usr/bin/env python3
+from __future__ import annotations
 
-from copy import deepcopy
-from functools import reduce
 import json
 import re
+from copy import deepcopy
+from functools import reduce
+from typing import Any, Dict, List, Union, Tuple
 
+import numpy as np
 import pandas as pd
+
 from RUFAS.output_manager import OutputManager
-from typing import Any, Dict, List, Union
 
 om = OutputManager()
 
@@ -788,6 +791,98 @@ class InputManager:
                     }
         self.__pool = {}
         om.add_log("Clear variable pool", "The pool is emptied.", info_map)
+
+    @staticmethod
+    def _is_bool_value(variable_value: Any, variable_properties: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Check if the variable value is a boolean.
+
+        Parameters
+        ----------
+        variable_value : Any
+            The value of the variable to check.
+        variable_properties : Dict[str, Any]
+            The properties for the variable of interest.
+
+        Returns
+        -------
+        Tuple[bool, str]
+            A tuple containing a boolean indicating if the check passed and a string containing the reason for failure.
+
+        """
+
+        if type(variable_value) is not bool:
+            return False, "Bool variable is not a boolean"
+        return True, ""
+
+    @staticmethod
+    def _is_numeric_value(variable_value: Any, variable_properties: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Check if the variable value is a number and not NaN.
+
+        Parameters
+        ----------
+        variable_value : Any
+            The value of the variable to check.
+        variable_properties : Dict[str, Any]
+            The properties for the variable of interest.
+
+        Returns
+        -------
+        Tuple[bool, str]
+            A tuple containing a boolean indicating if the check passed and a string containing the reason for failure.
+        """
+
+        if not type(variable_value) in (int, float) or np.isnan(variable_value):
+            return False, "Value is not a number"
+        return True, ""
+
+    @staticmethod
+    def _check_num_lower_bound(variable_value: int | float,
+                               variable_properties: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Check if the variable value is greater than the minimum value.
+
+        Parameters
+        ----------
+        variable_value : int | float
+            The value of the variable to check.
+        variable_properties : Dict[str, Any]
+            The properties for the variable of interest.
+
+        Returns
+        -------
+        Tuple[bool, str]
+            A tuple containing a boolean indicating if the check passed and a string containing the reason for failure.
+        """
+
+        if "minimum" in variable_properties and variable_value < variable_properties["minimum"]:
+            return False, "Value less than minimum"
+        return True, ""
+
+    @staticmethod
+    def _check_num_upper_bound(variable_value: int | float,
+                               variable_properties: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Check if the variable value is less than the maximum value.
+
+        Parameters
+        ----------
+        variable_value : int | float
+              The value of the variable to check.
+        variable_properties : Dict[str, Any]
+              The properties for the variable of interest.
+
+        Returns
+        -------
+        Tuple[bool, str]
+              A tuple containing a boolean indicating if the check passed and a string containing the reason for
+              failure.
+        """
+
+        if "maximum" in variable_properties and variable_value > variable_properties["maximum"]:
+            return False, "Value greater than maximum"
+        return True, ""
 
 
 class ElementsCounter:

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -795,6 +795,80 @@ class InputManager:
         om.add_log("Clear variable pool", "The pool is emptied.", info_map)
 
     @staticmethod
+    def _get_nested_dict_value(input_data: List | Dict[str, Any], keys: List[str | int]) -> Any:
+        """
+        Get a value from a nested dictionary by following the keys in the input_data dictionary.
+
+        Parameters
+        ----------
+        input_data : List | Dict[str, Any]
+            The list or dictionary to get the value from.
+        keys : List[str | int]
+            The keys to follow in the dictionary to get the value. When the key is an int, it is used to index a list.
+
+        Returns
+        -------
+        Any
+            The value from the nested dictionary.
+
+        Raises
+        ------
+        KeyError
+            If the key is not found in the input_data dictionary.
+        IndexError
+            If the index is not found in the input_data list.
+
+        Examples
+        --------
+        >>> InputManager._get_nested_dict_value({"a": {"b": 1}}, ["a", "b"])
+        1
+        >>> InputManager._get_nested_dict_value({"a": {"b": {"c": [1, 2, 3]}}}, ["a", "b", "c", 1])
+        2
+        >>> InputManager._get_nested_dict_value({"a": {"b": {"c": [1, 2, 3]}}}, ["a", "b", "c", 3])
+        KeyError: 3
+        """
+
+        for key in keys:
+            if isinstance(input_data, dict) or isinstance(input_data, list):
+                input_data = input_data[key]
+            else:
+                return input_data
+        return input_data
+
+    @staticmethod
+    def _convert_variable_path_to_str(variable_path: List[str | int]) -> str:
+        """
+        Convert a variable path list to a string.
+
+        Parameters
+        ----------
+        variable_path : List[str | int]
+            The variable path to convert.
+
+        Returns
+        -------
+        str
+            The variable path as a string.
+
+        Examples
+        --------
+        >>> InputManager._convert_variable_path_to_str(["a", "b", 1])
+        "a.b.[1]"
+        >>> InputManager._convert_variable_path_to_str(["a", "b", "c"])
+        "a.b.c"
+        >>> InputManager._convert_variable_path_to_str(["a", "b", "c", 0, 1])
+        "a.b.c.[0].[1]"
+        """
+
+        elems = []
+        for elem in variable_path:
+            if isinstance(elem, int):
+                elems.append(f"[{elem}]")
+            else:
+                elems.append(elem)
+        return ".".join(elems)
+
+    @staticmethod
     def _is_bool_value(variable_value: Any, variable_properties: Dict[str, Any]) -> Tuple[bool, str]:
         """
         Check if the variable value is a boolean.

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -12,7 +12,7 @@ import pandas as pd
 import pytest
 from pytest_mock import MockerFixture
 
-from RUFAS.input_manager import InputManager
+from RUFAS.input_manager import InputManager, ElementsCounter
 
 
 @pytest.fixture
@@ -162,17 +162,17 @@ def test_start_data_processing(mock_input_manager: InputManager,
 
 
 @pytest.mark.parametrize("input_data, metadata_properties, expected_result", [
-        (
+    (
             {'key1': 'value1', 'key2': 'value2'},
             {'key1': {'default': 'value3'}},
             {'key1': 'value1'}
-        ),
-        (
+    ),
+    (
             {'key1': {'nested_key1': 'value1', 'nested_key2': 'value2'}},
             {'key1': {'nested_key1': {'default': 'value2'}}},
             {'key1': {'nested_key1': 'value1'}}
-        )
-    ])
+    )
+])
 def test_filter_input_data_by_metadata(mock_input_manager: InputManager, input_data: Dict[str, Any],
                                        metadata_properties: Dict[str, Any], expected_result: Dict[str, Any],
                                        input_manager_original_method_states: Dict[str, Callable], ) -> None:
@@ -182,7 +182,7 @@ def test_filter_input_data_by_metadata(mock_input_manager: InputManager, input_d
 
     mock_input_manager._filter_input_data_by_metadata = input_manager_original_method_states[
         "_filter_input_data_by_metadata"
-        ]
+    ]
 
 
 @pytest.fixture
@@ -256,7 +256,6 @@ def test_populate_pool_invalid(mock_input_manager: InputManager, mock_metadata: 
 
     with patch("RUFAS.output_manager.OutputManager.add_log") as add_log:
         with patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning:
-
             result = mock_input_manager._populate_pool(eager_termination=False)
 
         assert result is False
@@ -288,7 +287,6 @@ def test_populate_pool_eager_termination(mock_input_manager: InputManager, mock_
 
     with patch("RUFAS.output_manager.OutputManager.add_log") as add_log:
         with patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning:
-
             result = mock_input_manager._populate_pool(eager_termination=True)
             assert result is False
             assert add_log.call_count == 0
@@ -322,13 +320,13 @@ def test_populate_pool_raises_keyerror(mock_input_manager: InputManager,
 
 
 @pytest.mark.parametrize(
-        "variable_properties, input_data_value",
-        [
-            ({"type": "string", "dummy_property": "dummy_value"}, "dummy_value"),
-            ({"type": "number", "dummy_property": 10}, 10),
-            ({"type": "bool", "dummy_property": True}, True),
-            ({"type": "array", "dummy_property": []}, []),
-        ]
+    "variable_properties, input_data_value",
+    [
+        ({"type": "string", "dummy_property": "dummy_value"}, "dummy_value"),
+        ({"type": "number", "dummy_property": 10}, 10),
+        ({"type": "bool", "dummy_property": True}, True),
+        ({"type": "array", "dummy_property": []}, []),
+    ]
 )
 def test_validate_input_type_dynamic_valid_data(mock_input_manager: InputManager,
                                                 input_manager_original_method_states: Dict[str, Callable],
@@ -406,12 +404,12 @@ def mock_metadata_for_validate_element(mocker: MockerFixture) -> Dict[str, Dict[
                                  "type": "string",
                                  "minimum_length": 1,
                                  "maximum_length": 20
-                                },
+                             },
                              "nested_element2": {
                                  "type": "number",
                                  "minimum": 0,
                                  "maximum": 250
-                                }
+                             }
                              },
                 "element5": {"type": "object",
                              "description": "dummy_description",
@@ -419,26 +417,26 @@ def mock_metadata_for_validate_element(mocker: MockerFixture) -> Dict[str, Dict[
                                  "type": "string",
                                  "minimum_length": 1,
                                  "maximum_length": 20
-                                },
+                             },
                              "nested_element2": {
                                  "type": "number",
                                  "minimum": 0,
                                  "maximum": 250
-                                },
+                             },
                              "nested_element3": {
                                  "type": "object",
                                  "description": "dummy_description",
                                  "nested_sub_element1": {
-                                    "type": "string",
-                                    "minimum_length": 1,
-                                    "maximum_length": 5
+                                     "type": "string",
+                                     "minimum_length": 1,
+                                     "maximum_length": 5
                                  },
                                  "nested_sub_element2": {
-                                    "type": "array",
-                                    "minimum_length": 1,
-                                    "maximum_length": 5
+                                     "type": "array",
+                                     "minimum_length": 1,
+                                     "maximum_length": 5
                                  },
-                                }
+                             }
                              },
                 "element6": {"type": "bool"},
                 "element7": {"type": "number", "maximum": 10, "default": 5},
@@ -474,12 +472,12 @@ def test_validate_element_fixable_data(mock_input_manager: InputManager,
 
 
 @pytest.mark.parametrize(
-        "property, input_data, total_elements, valid_elements, invalid_elements, fixed_elements",
-        [
-            ("element1", {"element1": ["123-45-6789", "000-11-6123", "555-55-5555"]}, 3, 3, 0, 0),
-            ("element2", {"element2": [6, 149, 55, 22]}, 4, 4, 0, 0),
-            ("element6", {"element6": [True, False, True]}, 3, 3, 0, 0),
-        ]
+    "property, input_data, total_elements, valid_elements, invalid_elements, fixed_elements",
+    [
+        ("element1", {"element1": ["123-45-6789", "000-11-6123", "555-55-5555"]}, 3, 3, 0, 0),
+        ("element2", {"element2": [6, 149, 55, 22]}, 4, 4, 0, 0),
+        ("element6", {"element6": [True, False, True]}, 3, 3, 0, 0),
+    ]
 )
 def test_validate_csv_element_valid_data(mock_input_manager: InputManager,
                                          mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
@@ -509,13 +507,13 @@ def test_validate_csv_element_valid_data(mock_input_manager: InputManager,
 
 
 @pytest.mark.parametrize(
-        "property, input_data, total_elements, valid_elements, invalid_elements, fixed_elements, is_valid,"
-        " eager_termination",
-        [
-            ("element1", {"element1": ["invalid1", "invalid2", "invalid3"]}, 3, 0, 3, 0, False, False),
-            ("element2", {"element2": [-6, 1149, 955, -22]}, 1, 0, 1, 0, False, True),
-            ("element7", {"element7": [50]}, 1, 0, 0, 1, True, False),
-        ]
+    "property, input_data, total_elements, valid_elements, invalid_elements, fixed_elements, is_valid,"
+    " eager_termination",
+    [
+        ("element1", {"element1": ["invalid1", "invalid2", "invalid3"]}, 3, 0, 3, 0, False, False),
+        ("element2", {"element2": [-6, 1149, 955, -22]}, 1, 0, 1, 0, False, True),
+        ("element7", {"element7": [50]}, 1, 0, 0, 1, True, False),
+    ]
 )
 def test_validate_csv_element_invalid_data(mock_input_manager: InputManager,
                                            mock_metadata_for_validate_element: Dict[str, Dict[str, Any]],
@@ -827,9 +825,9 @@ def test_validate_json_element_invalid_var_name_raises_input_data_keyerror(mock_
                                                                            ) -> None:
     """Unit test for keyerror raised for invalid var name for _validate_json_element in file input_manager.py"""
     mock_input_manager._InputManager__metadata = {"properties": {"dummy_properties_blob_key":
-                                                                 {"valid_key":
-                                                                  {"type": "object", "secondary_key":
-                                                                   {"type": "string"}}}}}
+                                                                     {"valid_key":
+                                                                          {"type": "object", "secondary_key":
+                                                                              {"type": "string"}}}}}
     element_hierarchy = ["valid_key", "secondary_key"]
     properties_blob_key = "dummy_properties_blob_key"
     input_data = {"valid_key": {"another_valid_key": "value"}}
@@ -857,7 +855,7 @@ def test_validate_json_element_invalid_var_type_raises_keyerror(mock_input_manag
     properties_blob_key = "dummy_valid_key"
     input_data = {"valid_key": "some_value"}
     mock_input_manager._InputManager__metadata = {"properties": {properties_blob_key:
-                                                                 {"valid_key": {"type": "invalid_type"}}}}
+                                                                     {"valid_key": {"type": "invalid_type"}}}}
     eager_termination = False
     mock_element_counter_and_validity = {"fixed_elements": 0, "total_elements": 0, "valid_elements": 0,
                                          "invalid_elements": 0, "is_valid": True}
@@ -879,7 +877,7 @@ def test_validate_json_element_missing_type_raises_keyerror(mock_input_manager: 
     properties_blob_key = "dummy_valid_key"
     input_data = {"valid_key": "some_value"}
     mock_input_manager._InputManager__metadata = {"properties": {properties_blob_key:
-                                                                 {"valid_key": {}}}}
+                                                                     {"valid_key": {}}}}
     eager_termination = False
     mock_element_counter_and_validity = {"fixed_elements": 0, "total_elements": 0, "valid_elements": 0,
                                          "invalid_elements": 0, "is_valid": True}
@@ -1663,32 +1661,32 @@ def mock_pool_for_get_metadata(mocker: MockerFixture) -> Dict[str, Dict[str, Any
                         "description": "Number of Calves (head)",
                         "default": 8,
                         "minimum": 0
-                        },
+                    },
                     "cow_repro_method": {
                         "type": "string",
                         "description": "Cow Reproductive Program (select one)",
                         "default": "ED",
                         "pattern": "^{TAI|ED|ED-TAI}$"
-                        },
+                    },
                     "simulate_animals": {
                         "type": "boolean",
                         "description": "Whether or not to simulate animals during the simulation",
                         "default": True
-                        },
+                    },
                     "dummy_cow_array": {
                         "type": "array",
                         "description": "dummy array for testing purposes",
                         "default": [1, 2, 3, 4],
                         "maximum_length": 7
-                        }
                     }
-                },
+                }
+            },
             "dummy_crop_properties": {
                 "crop_species": {
                     "type": "string",
                     "description": "Name of the crop being grown.",
                     "pattern": "^{generic|corn|spring_wheat|winter_wheat|cereal_rye|spring_barley}$"
-                    },
+                },
                 "harvest_years": {
                     "type": "array",
                     "description": "Calendar years in which the harvesting occurs",
@@ -1697,22 +1695,22 @@ def mock_pool_for_get_metadata(mocker: MockerFixture) -> Dict[str, Dict[str, Any
                     "properties": {
                         "type": "number",
                         "minimum": 1
-                        }
-                    },
+                    }
+                },
                 "pattern_skip": {
                     "type": "number",
                     "description": "Number of years to be skipped between schedule repetitions.",
                     "minimum": 0,
                     "default": 0
-                    },
+                },
                 "simulate_crops": {
                     "type": "boolean",
                     "description": "Dummy boolean variable for testing",
                     "default": False
-                    }
                 }
             }
         }
+    }
 
 
 @pytest.mark.parametrize(
@@ -1747,32 +1745,32 @@ def mock_pool_for_get_metadata(mocker: MockerFixture) -> Dict[str, Dict[str, Any
                         "description": "Number of Calves (head)",
                         "default": 8,
                         "minimum": 0
-                        },
+                    },
                     "cow_repro_method": {
                         "type": "string",
                         "description": "Cow Reproductive Program (select one)",
                         "default": "ED",
                         "pattern": "^{TAI|ED|ED-TAI}$"
-                        },
+                    },
                     "simulate_animals": {
                         "type": "boolean",
                         "description": "Whether or not to simulate animals during the simulation",
                         "default": True
-                        },
+                    },
                     "dummy_cow_array": {
                         "type": "array",
                         "description": "dummy array for testing purposes",
                         "default": [1, 2, 3, 4],
                         "maximum_length": 7
-                        }
                     }
-                },
+                }
+            },
             "dummy_crop_properties": {
                 "crop_species": {
                     "type": "string",
                     "description": "Name of the crop being grown.",
                     "pattern": "^{generic|corn|spring_wheat|winter_wheat|cereal_rye|spring_barley}$"
-                    },
+                },
                 "harvest_years": {
                     "type": "array",
                     "description": "Calendar years in which the harvesting occurs",
@@ -1781,21 +1779,21 @@ def mock_pool_for_get_metadata(mocker: MockerFixture) -> Dict[str, Dict[str, Any
                     "properties": {
                         "type": "number",
                         "minimum": 1
-                        }
-                    },
+                    }
+                },
                 "pattern_skip": {
                     "type": "number",
                     "description": "Number of years to be skipped between schedule repetitions.",
                     "minimum": 0,
                     "default": 0
-                    },
+                },
                 "simulate_crops": {
                     "type": "boolean",
                     "description": "Dummy boolean variable for testing",
                     "default": False
-                    }
                 }
-            }, 0)
+            }
+        }, 0)
     ]
 )
 def test_get_metadata_with_valid_key(dummy_metadata_path: str,
@@ -1855,3 +1853,199 @@ def test_flush_pool(mock_input_manager: InputManager) -> None:
 
         assert mock_input_manager._InputManager__pool == {}
         assert add_log.call_count == 1
+
+
+def test_elements_counter_init() -> None:
+    """
+    Unit test for the __init__() method of the ElementsCounter class in file input_manager.py.
+
+    This test checks if all counters are initialized to zero.
+    """
+
+    # Arrange & Act
+    counter = ElementsCounter()
+
+    # Assert
+    assert counter.total_elements == 0
+    assert counter.valid_elements == 0
+    assert counter.fixed_elements == 0
+    assert counter.invalid_elements == 0
+
+
+@pytest.mark.parametrize(
+    "attribute_name, new_value, expected_values, should_raise_exception",
+    [
+        # Valid cases for each counter
+        ("total_elements", 5,
+         {"total_elements": 5, "valid_elements": 0, "fixed_elements": 0, "invalid_elements": 0},
+         False),
+
+        ("valid_elements", 3,
+         {"total_elements": 0, "valid_elements": 3, "fixed_elements": 0, "invalid_elements": 0},
+         False),
+
+        ("fixed_elements", 2,
+         {"total_elements": 0, "valid_elements": 0, "fixed_elements": 2, "invalid_elements": 0},
+         False),
+
+        ("invalid_elements", 4,
+         {"total_elements": 0, "valid_elements": 0, "fixed_elements": 0, "invalid_elements": 4},
+         False),
+
+        # Invalid case
+        ("nonexistent_counter", 1, None, True),
+    ]
+)
+def test_elements_counter_update(attribute_name: str,
+                                 new_value: int,
+                                 expected_values: dict[str, int],
+                                 should_raise_exception: bool) -> None:
+    """
+    Unit test for the update() method of the ElementsCounter class in file input_manager.py.
+
+    This test checks if the counters are correctly updated for valid attributes,
+    and if an exception is raised for invalid attributes.
+    """
+
+    # Arrange
+    counter = ElementsCounter()
+
+    # Act & Assert
+    if should_raise_exception:
+        with pytest.raises(Exception) as excinfo:
+            counter.update(attribute_name, new_value)
+        assert f"Invalid sub-counter name: {attribute_name}" in str(excinfo.value)
+    else:
+        counter.update(attribute_name, new_value)
+        for attr, expected in expected_values.items():
+            assert getattr(counter, attr) == expected
+
+
+@pytest.mark.parametrize(
+    "attribute_name, increment_value, initial_values, expected_values, should_raise_exception",
+    [
+        # Valid increment cases for each counter
+        ("total_elements", 2, {"total_elements": 3},
+         {"total_elements": 5, "valid_elements": 0, "fixed_elements": 0, "invalid_elements": 0}, False),
+
+        ("valid_elements", 1, {"valid_elements": 2},
+         {"total_elements": 0, "valid_elements": 3, "fixed_elements": 0, "invalid_elements": 0}, False),
+
+        ("fixed_elements", 3, {"fixed_elements": 1},
+         {"total_elements": 0, "valid_elements": 0, "fixed_elements": 4, "invalid_elements": 0}, False),
+
+        ("invalid_elements", 4, {"invalid_elements": 5},
+         {"total_elements": 0, "valid_elements": 0, "fixed_elements": 0, "invalid_elements": 9}, False),
+
+        # Increment with default value of 1
+        ("total_elements", 1, {},
+         {"total_elements": 1, "valid_elements": 0, "fixed_elements": 0, "invalid_elements": 0},
+         False),
+
+        # Invalid case
+        ("nonexistent_counter", 1, {}, None, True),
+    ]
+)
+def test_elements_counter_increment(attribute_name: str,
+                                    increment_value: int,
+                                    initial_values: dict[str, int],
+                                    expected_values: dict[str, int],
+                                    should_raise_exception: bool) -> None:
+    """
+    Unit test for the increment() method of the ElementsCounter class in file input_manager.py.
+
+    This test checks if the counters are correctly incremented for valid attributes,
+    and if an exception is raised for invalid attributes.
+    """
+
+    # Arrange
+    counter = ElementsCounter()
+    for attr, value in initial_values.items():
+        setattr(counter, attr, value)
+
+    # Act & Assert
+    if should_raise_exception:
+        with pytest.raises(Exception) as excinfo:
+            counter.increment(attribute_name, increment_value)
+            assert f"Invalid sub-counter name: {attribute_name}" in str(excinfo.value)
+    else:
+        counter.increment(attribute_name, increment_value)
+        for attr, expected in expected_values.items():
+            assert getattr(counter, attr) == expected
+
+
+@pytest.mark.parametrize(
+    "attribute_name, decrement_value, initial_values, expected_values, should_raise_exception",
+    [
+        # Valid decrement cases for each counter
+        ("total_elements", 2, {"total_elements": 5},
+         {"total_elements": 3, "valid_elements": 0, "fixed_elements": 0, "invalid_elements": 0}, False),
+
+        ("valid_elements", 1, {"valid_elements": 4},
+         {"total_elements": 0, "valid_elements": 3, "fixed_elements": 0, "invalid_elements": 0}, False),
+
+        ("fixed_elements", 3, {"fixed_elements": 7},
+         {"total_elements": 0, "valid_elements": 0, "fixed_elements": 4, "invalid_elements": 0}, False),
+
+        ("invalid_elements", 4, {"invalid_elements": 8},
+         {"total_elements": 0, "valid_elements": 0, "fixed_elements": 0, "invalid_elements": 4}, False),
+
+        # Decrement with default value of 1
+        ("total_elements", 1, {"total_elements": 2},
+         {"total_elements": 1, "valid_elements": 0, "fixed_elements": 0, "invalid_elements": 0}, False),
+
+        # Invalid case
+        ("nonexistent_counter", 1, {}, None, True),
+    ]
+)
+def test_elements_counter_decrement(attribute_name: str,
+                                    decrement_value: int,
+                                    initial_values: dict[str, int],
+                                    expected_values: dict[str, int],
+                                    should_raise_exception: bool) -> None:
+    """
+    Unit test for the decrement() method of the ElementsCounter class in file input_manager.py.
+
+    This test checks if the counters are correctly decremented for valid attributes,
+    and if an exception is raised for invalid attributes.
+    """
+
+    # Arrange
+    counter = ElementsCounter()
+    for attr, value in initial_values.items():
+        setattr(counter, attr, value)
+
+    # Act & Assert
+    if should_raise_exception:
+        with pytest.raises(Exception) as excinfo:
+            counter.decrement(attribute_name, decrement_value)
+        assert f"Invalid sub-counter name: {attribute_name}" in str(excinfo.value)
+    else:
+        counter.decrement(attribute_name, decrement_value)
+        for attr, expected in expected_values.items():
+            assert getattr(counter, attr) == expected
+
+
+def test_elements_counter_reset() -> None:
+    """
+    Unit test for the reset() method of the ElementsCounter class in file input_manager.py.
+
+    This test checks if all counters are reset to zero.
+    """
+
+    # Arrange
+    counter = ElementsCounter()
+    # Initially set the counters to some non-zero values
+    counter.total_elements = 5
+    counter.valid_elements = 3
+    counter.fixed_elements = 2
+    counter.invalid_elements = 1
+
+    # Act
+    counter.reset()
+
+    # Assert
+    assert counter.total_elements == 0
+    assert counter.valid_elements == 0
+    assert counter.fixed_elements == 0
+    assert counter.invalid_elements == 0

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -827,10 +827,10 @@ def test_validate_json_element_invalid_var_name_raises_input_data_keyerror(mock_
                                                                            Dict[str, Callable],
                                                                            ) -> None:
     """Unit test for keyerror raised for invalid var name for _validate_json_element in file input_manager.py"""
-    mock_input_manager._InputManager__metadata = {"properties": {"dummy_properties_blob_key":
-                                                                     {"valid_key":
-                                                                          {"type": "object", "secondary_key":
-                                                                              {"type": "string"}}}}}
+    mock_input_manager._InputManager__metadata = {"properties": {"dummy_properties_blob_key": {
+                                                                "valid_key": {
+                                                                    "type": "object", "secondary_key": {
+                                                                        "type": "string"}}}}}
     element_hierarchy = ["valid_key", "secondary_key"]
     properties_blob_key = "dummy_properties_blob_key"
     input_data = {"valid_key": {"another_valid_key": "value"}}
@@ -857,8 +857,9 @@ def test_validate_json_element_invalid_var_type_raises_keyerror(mock_input_manag
     element_hierarchy = ["valid_key"]
     properties_blob_key = "dummy_valid_key"
     input_data = {"valid_key": "some_value"}
-    mock_input_manager._InputManager__metadata = {"properties": {properties_blob_key:
-                                                                     {"valid_key": {"type": "invalid_type"}}}}
+    mock_input_manager._InputManager__metadata = {"properties": {properties_blob_key: {
+        "valid_key": {
+            "type": "invalid_type"}}}}
     eager_termination = False
     mock_element_counter_and_validity = {"fixed_elements": 0, "total_elements": 0, "valid_elements": 0,
                                          "invalid_elements": 0, "is_valid": True}
@@ -879,8 +880,8 @@ def test_validate_json_element_missing_type_raises_keyerror(mock_input_manager: 
     element_hierarchy = ["valid_key"]
     properties_blob_key = "dummy_valid_key"
     input_data = {"valid_key": "some_value"}
-    mock_input_manager._InputManager__metadata = {"properties": {properties_blob_key:
-                                                                     {"valid_key": {}}}}
+    mock_input_manager._InputManager__metadata = {"properties": {properties_blob_key: {
+        "valid_key": {}}}}
     eager_termination = False
     mock_element_counter_and_validity = {"fixed_elements": 0, "total_elements": 0, "valid_elements": 0,
                                          "invalid_elements": 0, "is_valid": True}

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -9,6 +9,7 @@ import json
 from typing import Any, Callable, Dict
 from mock import MagicMock, Mock, mock_open, patch
 import pandas as pd
+import numpy as np
 import pytest
 from pytest_mock import MockerFixture
 
@@ -2344,7 +2345,7 @@ def test_elements_counter_decrement(attribute_name: str,
     if should_raise_exception:
         with pytest.raises(Exception) as excinfo:
             counter.decrement(attribute_name, decrement_value)
-        assert f"Invalid sub-counter name: {attribute_name}" in str(excinfo.value)
+            assert f"Invalid sub-counter name: {attribute_name}" in str(excinfo.value)
     else:
         counter.decrement(attribute_name, decrement_value)
         for attr, expected in expected_values.items():

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -4,9 +4,11 @@ File name: test_input_manager.py
 Description: Implements test cases for Input Manager
 Author(s): Niko Tomlinson, ndt2@cornell.edu; Allister Liu, al25632@cornell.edu; Michael Richards, mr2372@cornell.edu
 """
+from __future__ import annotations
+
 from functools import reduce
 import json
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Type
 from mock import MagicMock, Mock, mock_open, patch
 import pandas as pd
 import numpy as np
@@ -1854,6 +1856,72 @@ def test_flush_pool(mock_input_manager: InputManager) -> None:
 
         assert mock_input_manager._InputManager__pool == {}
         assert add_log.call_count == 1
+
+
+@pytest.mark.parametrize("input_data, keys, expected_result, expected_exception", [
+    # Test for getting a nested value in a dictionary
+    ({"a": {"b": 1}}, ["a", "b"], 1, None),
+
+    # Test for getting a value in a list inside a nested dictionary
+    ({"a": {"b": {"c": [1, 2, 3]}}}, ["a", "b", "c", 1], 2, None),
+
+    # Test for KeyError when the key is not present in the dictionary
+    ({"a": {"b": {"c": {"d": 1}}}}, ["a", "b", "c", "e"], None, KeyError),
+
+    # Test for IndexError when the index is not present in the list
+    ({"a": {"b": {"c": [1, 2, 3]}}}, ["a", "b", "c", 3], None, IndexError),
+
+    # Test for accessing a value in a nested list
+    ([{"a": [1, 2]}, {"b": [3, 4]}], [1, "b", 0], 3, None),
+])
+def test_get_nested_dict_value(
+        input_data: list[Any] | dict[str, Any] | Any,
+        keys: list[str | int],
+        expected_result: Any,
+        expected_exception: Type[BaseException] | None,
+) -> None:
+    """
+    Unit test for method _get_nested_dict_value() in file input_manager.py.
+
+    """
+
+    # Act and Assert
+    if expected_exception:
+        with pytest.raises(expected_exception):
+            InputManager._get_nested_dict_value(input_data, keys)
+    else:
+        assert InputManager._get_nested_dict_value(input_data, keys) == expected_result
+
+
+@pytest.mark.parametrize("variable_path, expected_result", [
+    # Test with mix of strings and integer
+    (["a", "b", 1], "a.b.[1]"),
+
+    # Test with only strings
+    (["a", "b", "c"], "a.b.c"),
+
+    # Test with multiple integers
+    (["a", "b", "c", 0, 1], "a.b.c.[0].[1]"),
+
+    # Test with single string
+    (["a"], "a"),
+
+    # Test with single integer
+    ([0], "[0]"),
+
+    # Test with empty list
+    ([], ""),
+])
+def test_convert_variable_path_to_str(variable_path: list[str | int], expected_result: str) -> None:
+    """
+    Unit test for method _convert_variable_path_to_str() in file input_manager.py.
+    """
+
+    # Act
+    result = InputManager._convert_variable_path_to_str(variable_path)
+
+    # Assert
+    assert result == expected_result
 
 
 @pytest.mark.parametrize("variable_value, variable_properties, expected_result", [

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -1855,6 +1855,55 @@ def test_flush_pool(mock_input_manager: InputManager) -> None:
         assert add_log.call_count == 1
 
 
+@pytest.mark.parametrize("variable_value, variable_properties, expected_result", [
+    # Test with a boolean True
+    (True, {}, (True, "")),
+
+    # Test with a boolean False
+    (False, {}, (True, "")),
+
+    # Test with a string "True"
+    ("True", {}, (False, "Bool variable is not a boolean")),
+
+    # Test with a string "False"
+    ("False", {}, (False, "Bool variable is not a boolean")),
+
+    # Test with an integer 1
+    (1, {}, (False, "Bool variable is not a boolean")),
+
+    # Test with an integer 0
+    (0, {}, (False, "Bool variable is not a boolean")),
+
+    # Test with a None value
+    (None, {}, (False, "Bool variable is not a boolean")),
+
+    # Test with an empty list
+    ([], {}, (False, "Bool variable is not a boolean")),
+
+    # Test with a list
+    ([1, 2, 3], {}, (False, "Bool variable is not a boolean")),
+
+    # Test with an empty dictionary
+    ({}, {}, (False, "Bool variable is not a boolean")),
+
+    # Test with a dictionary
+    ({"key": "value"}, {}, (False, "Bool variable is not a boolean")),
+
+    # Test with a float 1.0
+    (1.0, {}, (False, "Bool variable is not a boolean")),
+
+    # Test with a float 0.0
+    (0.0, {}, (False, "Bool variable is not a boolean")),
+])
+def test_is_bool_value(variable_value: Any, variable_properties: dict[str, Any],
+                       expected_result: tuple[bool, str]) -> None:
+    """
+    Unit test for method _is_bool_value() in file input_manager.py.
+    """
+
+    assert InputManager._is_bool_value(variable_value, variable_properties) == expected_result
+
+
 def test_elements_counter_init() -> None:
     """
     Unit test for the __init__() method of the ElementsCounter class in file input_manager.py.

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -1904,6 +1904,108 @@ def test_is_bool_value(variable_value: Any, variable_properties: dict[str, Any],
     assert InputManager._is_bool_value(variable_value, variable_properties) == expected_result
 
 
+@pytest.mark.parametrize("variable_value, variable_properties, expected_result", [
+    # Test with an integer
+    (10, {}, (True, "")),
+
+    # Test with zero
+    (0, {}, (True, "")),
+
+    # Test with a negative integer
+    (-1, {}, (True, "")),
+
+    # Test with a float
+    (1.5, {}, (True, "")),
+
+    # Test with a NaN float
+    (float("nan"), {}, (False, "Value is not a number")),
+
+    # Test with numpy NaN float
+    (np.nan, {}, (False, "Value is not a number")),
+
+    # Test with a negative float
+    (-2.3, {}, (True, "")),
+
+    # Test with a string
+    ("string", {}, (False, "Value is not a number")),
+
+    # Test with a boolean True
+    (True, {}, (False, "Value is not a number")),
+
+    # Test with a None value
+    (None, {}, (False, "Value is not a number")),
+
+    # Test with a list
+    ([1, 2, 3], {}, (False, "Value is not a number")),
+
+    # Test with a dictionary
+    ({"key": "value"}, {}, (False, "Value is not a number")),
+])
+def test_is_numeric_value(variable_value: Any, variable_properties: dict[str, Any],
+                          expected_result: tuple[bool, str]) -> None:
+    """
+    Unit test for method _is_numeric_value() in file input_manager.py.
+    """
+
+    assert InputManager._is_numeric_value(variable_value, variable_properties) == expected_result
+
+
+@pytest.mark.parametrize("variable_value, variable_properties, expected_result", [
+    # Value greater than minimum
+    (5, {"minimum": 3}, (True, "")),
+
+    # Value equal to minimum
+    (3, {"minimum": 3}, (True, "")),
+
+    # Value less than minimum
+    (2, {"minimum": 3}, (False, "Value less than minimum")),
+
+    # No minimum set
+    (5, {}, (True, "")),
+
+    # Negative value less than minimum
+    (-1, {"minimum": 0}, (False, "Value less than minimum")),
+
+    # Zero value greater than negative minimum
+    (0, {"minimum": -1}, (True, "")),
+])
+def test_check_num_lower_bound(variable_value: int | float, variable_properties: dict[str, Any],
+                               expected_result: tuple[bool, str]) -> None:
+    """
+    Unit test for method _check_num_lower_bound() in file input_manager.py.
+    """
+
+    assert InputManager._check_num_lower_bound(variable_value, variable_properties) == expected_result
+
+
+@pytest.mark.parametrize("variable_value, variable_properties, expected_result", [
+    # Value less than maximum
+    (5, {"maximum": 7}, (True, "")),
+
+    # Value equal to maximum
+    (7, {"maximum": 7}, (True, "")),
+
+    # Value greater than maximum
+    (8, {"maximum": 7}, (False, "Value greater than maximum")),
+
+    # No maximum set
+    (5, {}, (True, "")),
+
+    # Zero value greater than negative maximum
+    (0, {"maximum": -1}, (False, "Value greater than maximum")),
+
+    # Negative value less than maximum
+    (-2, {"maximum": -1}, (True, "")),
+])
+def test_check_num_upper_bound(variable_value: int | float, variable_properties: dict[str, Any],
+                               expected_result: tuple[bool, str]) -> None:
+    """
+    Unit test for method _check_num_upper_bound() in file input_manager.py.
+    """
+
+    assert InputManager._check_num_upper_bound(variable_value, variable_properties) == expected_result
+
+
 def test_elements_counter_init() -> None:
     """
     Unit test for the __init__() method of the ElementsCounter class in file input_manager.py.

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -2006,6 +2006,180 @@ def test_check_num_upper_bound(variable_value: int | float, variable_properties:
     assert InputManager._check_num_upper_bound(variable_value, variable_properties) == expected_result
 
 
+@pytest.mark.parametrize("variable_value, variable_properties, expected_result", [
+    # Test with a regular string
+    ("hello", {}, (True, "")),
+
+    # Test with an empty string
+    ("", {}, (True, "")),
+
+    # Test with an integer
+    (123, {}, (False, "String variable is not a string.")),
+
+    # Test with a float
+    (1.0, {}, (False, "String variable is not a string.")),
+
+    # Test with a boolean
+    (True, {}, (False, "String variable is not a string.")),
+
+    # Test with a list
+    ([1, 2, 3], {}, (False, "String variable is not a string.")),
+
+    # Test with a dictionary
+    ({"key": "value"}, {}, (False, "String variable is not a string.")),
+
+    # Test with a None value
+    (None, {}, (False, "String variable is not a string."))
+])
+def test_is_str_value(variable_value, variable_properties, expected_result):
+    """
+    Unit test for method _is_str_value() in file input_manager.py.
+    """
+
+    assert InputManager._is_str_value(variable_value, variable_properties) == expected_result
+
+
+@pytest.mark.parametrize("variable_value, variable_properties, expected_result", [
+    # Test with string longer than minimum
+    ("hello", {"minimum_length": 3}, (True, "")),
+
+    # Test with string shorter than minimum
+    ("hi", {"minimum_length": 3}, (False, "String length less than minimum.")),
+
+    # Test with string equal to minimum
+    ("hello", {}, (True, "")),
+
+    # Test with empty string and some minimum length
+    ("", {"minimum_length": 1}, (False, "String length less than minimum.")),
+
+    # Test with empty string and zero minimum length
+    ("", {"minimum_length": 0}, (True, "")),
+])
+def test_check_str_len_lower_bound(variable_value: str, variable_properties: dict[str, Any],
+                                   expected_result: tuple[bool, str]) -> None:
+    """
+    Unit test for method _check_str_len_lower_bound() in file input_manager.py.
+    """
+
+    assert InputManager._check_str_len_lower_bound(variable_value, variable_properties) == expected_result
+
+
+@pytest.mark.parametrize("variable_value, variable_properties, expected_result", [
+    # Test with string equal to maximum length
+    ("hello", {"maximum_length": 5}, (True, "")),
+
+    # Test with string shorter than maximum length
+    ("hello", {"maximum_length": 10}, (True, "")),
+
+    # Test with string longer than maximum length
+    ("hello", {"maximum_length": 4}, (False, "String length greater than maximum.")),
+
+    # Test with string but no maximum length specified
+    ("hello", {}, (True, "")),
+
+    # Test with empty string and no maximum length specified
+    ("", {"maximum_length": 0}, (True, "")),
+
+    # Test with empty string and some maximum length
+    ("", {"maximum_length": 1}, (True, "")),
+])
+def test_check_str_len_upper_bound(variable_value: str, variable_properties: dict[str, Any],
+                                   expected_result: tuple[bool, str]) -> None:
+    """
+    Unit test for method _check_str_len_upper_bound() in file input_manager.py.
+    """
+
+    assert InputManager._check_str_len_upper_bound(variable_value, variable_properties) == expected_result
+
+
+@pytest.mark.parametrize("variable_value, variable_properties, expected_result", [
+    # Test with an alphanumeric string matching the pattern
+    ("hello123", {"pattern": r"\w+"}, (True, "")),
+
+    # Test with an alphanumeric string not matching the pattern
+    ("hello123", {"pattern": r"\d+"}, (False, "String does not match pattern.")),
+
+    # Test with a numeric string matching the pattern
+    ("12345", {"pattern": r"\d+"}, (True, "")),
+
+    # Test with an exact match
+    ("hello", {"pattern": r"hello"}, (True, "")),
+
+    # Test with a case-sensitive failed match
+    ("HELLO", {"pattern": r"hello"}, (False, "String does not match pattern.")),
+
+    # Test with a string containing a space
+    ("hello world", {"pattern": r"hello world"}, (True, "")),
+
+    # Test with a string matching a character class pattern
+    ("hello", {"pattern": r"[a-z]+"}, (True, "")),
+
+    # Test with an empty string and a pattern that matches anything
+    ("", {"pattern": r".*"}, (True, "")),
+
+    # Test with a string but no pattern specified
+    ("hello", {}, (True, "")),
+
+    # Test with case-insensitive flag
+    ("HELLO", {"pattern": r"(?i)hello"}, (True, "")),  # Case-insensitive flag, should match
+
+    # Test with pipe character to match one of two options
+    ("cat", {"pattern": r"cat|dog"}, (True, "")),
+
+    # Test with pipe character to match one of two options
+    ("dog", {"pattern": r"cat|dog"}, (True, "")),
+
+    # Test with pipe character and no match
+    ("bird", {"pattern": r"cat|dog"}, (False, "String does not match pattern.")),
+
+    # Test with pipe character and match all options
+    ("catdog", {"pattern": r"cat|dog"}, (False, "String does not match pattern.")),
+
+    # Test with pipe character and match some options but not all
+    ("dogfish", {"pattern": r"cat|dog"}, (False, "String does not match pattern.")),
+
+    # Test with pipe character, start, and end of string
+    ("dog", {"pattern": r"^dog|cat$"}, (True, "")),
+
+    # Test with pipe character, start, and end of string
+    ("cat", {"pattern": r"^dog|cat$"}, (True, "")),
+
+    # Test with pipe character, start, and end of string and only part of the string matches
+    ("a cat", {"pattern": r"^dog|cat$"}, (False, "String does not match pattern.")),
+
+    # Test with dot character
+    ("hello.world", {"pattern": r"hello.world"}, (True, "")),
+
+    # Test with dot character but no match
+    ("helloworld", {"pattern": r"hello.world"}, (False, "String does not match pattern.")),
+
+    # Test with literal dot character
+    ("hello.world", {"pattern": r"hello\.world"}, (True, "")),
+
+    # Test with literal dot character but no match
+    ("helloworld", {"pattern": r"hello\.world"}, (False, "String does not match pattern.")),
+
+    # Test with minimum number of characters
+    ("helloooo", {"pattern": r"hello{2,}"}, (True, "")),
+
+    # Test with minimum number of characters but no match
+    ("hello", {"pattern": r"hello{2,}"}, (False, "String does not match pattern.")),
+
+    # Test with maximum number of characters
+    ("hello", {"pattern": r"hello{,2}"}, (True, "")),
+
+    # Test with maximum number of characters but no match
+    ("helloooo", {"pattern": r"hello{,2}"}, (False, "String does not match pattern.")),
+])
+def test_check_str_pattern_match(variable_value: str, variable_properties: dict[str, Any],
+                                 expected_result: tuple[bool, str]) -> None:
+    """
+    Unit test for method _check_str_pattern_match() in file input_manager.py.
+    """
+
+    assert InputManager._check_str_pattern_match(variable_value, variable_properties) == expected_result
+
+
 def test_elements_counter_init() -> None:
     """
     Unit test for the __init__() method of the ElementsCounter class in file input_manager.py.


### PR DESCRIPTION
Context:
I have a fairly big, mostly complete PR (#886) that needs to be broken down into smaller PRs. The current state of the input manager is that it can validate primitive data types including boolean, numeric, and string but it can't validate more complex, recursive types like objects and arrays. Also, when we replace faulty data with default data, we should try to revalidate the default data that is being used. 

Content:
In this first PR which is more about refactoring, I added helper methods to validate the three primitive data types: boolean, numeric, and string. Another new addition is a separate `ElementsCounter` class to help keep track of the number of elements the input manager processes. 

Two other standalone helper methods: 
- `_get_nested_dict_value()`: to replace the use of the `reduce()` later on and to generalize to extract nested pieces of data from both lists and dictionaries.
- `_convert_variable_path_to_str`: to convert the paths of input data trails that lead to errors into a string format for the output manager.

If interested, you can refer to the previously mentioned PR #886 to see how things are connected together in the end.