### PR TITLE
[Report Generator] No aggregation reports

### DIFF
--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -833,7 +833,7 @@ class OutputManager(object):
                                 if column_name not in reports.keys()
                                 else f"{column_name} {self._get_timestamp(True)}"
                             ] = {"values": value}
-                    except (ValueError, KeyError) as e:
+                    except KeyError as e:
                         self.add_error("report generation error", str(e), info_map)
                 else:
                     self._route_save_functions(

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -833,7 +833,7 @@ class OutputManager(object):
                                 if column_name not in reports.keys()
                                 else f"{column_name} {self._get_timestamp(True)}"
                             ] = {"values": value}
-                    except KeyError as e:
+                    except (KeyError, ValueError) as e:
                         self.add_error("report generation error", str(e), info_map)
                 else:
                     self._route_save_functions(

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -751,7 +751,7 @@ class OutputManager(object):
         exclude_info_maps: bool,
         produce_graphics: bool,
         graphics_dir: Path,
-        csv_dir: Path
+        csv_dir: Path,
     ) -> None:
         """
         Reads a text file containing a list of keys and filters the variables pool by those keys.
@@ -791,7 +791,7 @@ class OutputManager(object):
             info_map["filter file"] = filter_file
             input_path = os.path.join(filters_dir_path, filter_file)
             filter_contents = self._load_filter_file_content(input_path)
-            reports: Dict[str: Dict[str: List[Any]]] = {}
+            reports: Dict[str : Dict[str : List[Any]]] = {}
             for filter_content in filter_contents:
                 info_map["filter_content"] = filter_content
                 if (
@@ -822,16 +822,17 @@ class OutputManager(object):
                         report_name = filter_content.get(
                             "name", f"untitled_{self._get_timestamp(True)}"
                         )
-                        reports[
-                            report_name
-                            if report_name not in reports.keys()
-                            else f"{report_name} {self._get_timestamp(True)}"
-                        ] = {
-                            "values": report_generator.generate_report(
-                                filtered_pool,
-                                filter_content,
-                            )
-                        }
+                        report = report_generator.generate_report(
+                            filtered_pool,
+                            filter_content,
+                        )
+                        for key, value in report.items():
+                            column_name = f"{report_name}_{key}"
+                            reports[
+                                column_name
+                                if column_name not in reports.keys()
+                                else f"{column_name} {self._get_timestamp(True)}"
+                            ] = {"values": value}
                     except (ValueError, KeyError) as e:
                         self.add_error("report generation error", str(e), info_map)
                 else:
@@ -842,7 +843,7 @@ class OutputManager(object):
                         produce_graphics,
                         filter_content,
                         graphics_dir,
-                        csv_dir
+                        csv_dir,
                     )
             report_file_path = os.path.join(
                 save_path,
@@ -858,7 +859,7 @@ class OutputManager(object):
         produce_graphics: bool,
         filter_content: Dict[str, str | int],
         graphics_dir: Path,
-        csv_dir: Path
+        csv_dir: Path,
     ) -> None:
         """
         Checks the prefix of the filter_file to determine the format for saving. It then delegates the
@@ -877,7 +878,8 @@ class OutputManager(object):
         elif filter_file.startswith(self.__supported_filter_types_prefixes["csv"]):
             self.create_directory(csv_dir)
             variable_csv_file_path = os.path.join(
-                csv_dir, self._generate_file_name(f"saved_variables_{filter_file}", "csv")
+                csv_dir,
+                self._generate_file_name(f"saved_variables_{filter_file}", "csv"),
             )
             self._dict_to_file_csv(filtered_pool, variable_csv_file_path)
         elif filter_file.startswith(self.__supported_filter_types_prefixes["graph"]):
@@ -1115,12 +1117,19 @@ class OutputManager(object):
         }
         is_file_found_in_dir = self.is_file_in_dir(output_dir, vars_file_path)
         if is_file_found_in_dir:
-            self.add_error("Can't clear output directory", f"{vars_file_path} in output directory.", info_map)
+            self.add_error(
+                "Can't clear output directory",
+                f"{vars_file_path} in output directory.",
+                info_map,
+            )
         else:
             keep_list = [".keep", "output_filters"]
             Utility.empty_dir(output_dir, keep=keep_list)
-            self.add_log("Output directory successfully cleared",
-                         "Provided variables-file path was not in output directory.", info_map)
+            self.add_log(
+                "Output directory successfully cleared",
+                "Provided variables-file path was not in output directory.",
+                info_map,
+            )
 
     def is_file_in_dir(self, dir_path: Path, file_path: Path) -> bool:
         """Checks if a file path is in the provided directory.
@@ -1148,17 +1157,25 @@ class OutputManager(object):
         path : Path
             The path where the directory will be created if it does not already exist.
         """
-        info_map = {"class": self.__class__.__name__,
-                    "function": self.create_directory.__name__}
-        self.add_log("Attempting to create a new directory.",
-                     f"Attempting to create a new directory at {path}.",
-                     info_map)
+        info_map = {
+            "class": self.__class__.__name__,
+            "function": self.create_directory.__name__,
+        }
+        self.add_log(
+            "Attempting to create a new directory.",
+            f"Attempting to create a new directory at {path}.",
+            info_map,
+        )
         try:
             path.mkdir(parents=True, exist_ok=True)
-            self.add_log("Directory successfully created.",
-                         f"Created a new directory at {path}.",
-                         info_map)
+            self.add_log(
+                "Directory successfully created.",
+                f"Created a new directory at {path}.",
+                info_map,
+            )
         except PermissionError as e:
-            self.add_error("Permission Error", f"{path=}; Exception: {str(e)}", info_map)
+            self.add_error(
+                "Permission Error", f"{path=}; Exception: {str(e)}", info_map
+            )
         except Exception as e:
             self.add_error("mkdir failure", f"{path=}; Exception: {str(e)}", info_map)

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -791,7 +791,7 @@ class OutputManager(object):
             info_map["filter file"] = filter_file
             input_path = os.path.join(filters_dir_path, filter_file)
             filter_contents = self._load_filter_file_content(input_path)
-            reports: Dict[str : Dict[str : List[Any]]] = {}
+            reports: Dict[str: Dict[str: List[Any]]] = {}
             for filter_content in filter_contents:
                 info_map["filter_content"] = filter_content
                 if (

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -1,5 +1,3 @@
-# !/usr/bin/env python3
-
 from copy import deepcopy
 from enum import Enum
 from pathlib import Path

--- a/RUFAS/report_generator.py
+++ b/RUFAS/report_generator.py
@@ -160,6 +160,8 @@ class ReportGenerator:
 
         Raises
         ------
+        ValueError
+            If the report data is empty or if the necessary aggregation keys are not found in filter_content.
         KeyError
             If a key specified in the `horizontal_order` of `filter_content` is not found in the `report_data`.
             This usually indicates a mismatch between the expected structure of `filtered_pool` and its actual content.

--- a/RUFAS/report_generator.py
+++ b/RUFAS/report_generator.py
@@ -204,7 +204,7 @@ class ReportGenerator:
                 for _, data_series in report_data.items()
             ]
             if not horizontal_aggregator:
-                return vertical_aggregator
+                return vertically_aggregated
 
             if filter_content.get("horizontal_first", False):
                 return [vertical_aggregator(horizontally_aggregated)]

--- a/RUFAS/report_generator.py
+++ b/RUFAS/report_generator.py
@@ -196,6 +196,8 @@ class ReportGenerator:
                 raise KeyError(
                     f"{e.args[0]} not found in filtered pool. Check the `horizontal_order` entry in the filter file."
                 )
+            if not vertical_aggregator:
+                return horizontally_aggregated
 
         if vertical_aggregator:
             vertically_aggregated = [
@@ -209,9 +211,6 @@ class ReportGenerator:
                 return [horizontal_aggregator(vertically_aggregated)]
             else:
                 return vertically_aggregated
-
-        if horizontal_aggregator:
-            return horizontally_aggregated
 
         raise ValueError(
             f"Didn't find `horizontal_aggregation` or `vertical_aggregation` in {filter_content.get('name')}."

--- a/RUFAS/report_generator.py
+++ b/RUFAS/report_generator.py
@@ -137,7 +137,7 @@ class ReportGenerator:
         self,
         filtered_pool: Dict[str, Dict[str, List[Any]]],
         filter_content: Dict[str, str | int | List[str]],
-    ) -> List[float]:
+    ) -> Dict[str, List[float]]:
         """
         Generates a report based on filtered data and aggregation criteria.
 
@@ -155,16 +155,13 @@ class ReportGenerator:
 
         Returns
         -------
-        List[float]
-            The aggregated report data as a list.
+        Dict[str, List[float]]
+            The sliced and aggregated data.
 
         Raises
         ------
         ValueError
             If the report data is empty or if the necessary aggregation keys are not found in filter_content.
-        KeyError
-            If a key specified in the `horizontal_order` of `filter_content` is not found in the `report_data`.
-            This usually indicates a mismatch between the expected structure of `filtered_pool` and its actual content.
         """
         report_data = self._prepare_report_data(
             filtered_pool,
@@ -196,7 +193,7 @@ class ReportGenerator:
                     f"{e.args[0]} not found in filtered pool. Check the `horizontal_order` entry in the filter file."
                 )
             if not vertical_aggregator:
-                return horizontally_aggregated
+                return {"hor_agg": horizontally_aggregated}
 
         if vertical_aggregator:
             vertically_aggregated = [
@@ -204,15 +201,13 @@ class ReportGenerator:
                 for _, data_series in report_data.items()
             ]
             if not horizontal_aggregator:
-                return vertically_aggregated
+                return {"ver_agg": vertically_aggregated}
 
             if filter_content.get("horizontal_first", False):
-                return [vertical_aggregator(horizontally_aggregated)]
-            return [horizontal_aggregator(vertically_aggregated)]
+                return {"hor_ver_agg": [vertical_aggregator(horizontally_aggregated)]}
+            return {"ver_hor_agg": [horizontal_aggregator(vertically_aggregated)]}
 
-        raise ValueError(
-            f"Didn't find `horizontal_aggregation` or `vertical_aggregation` in {filter_content.get('name')}."
-        )
+        return report_data
 
     def _prepare_report_data(
         self,

--- a/RUFAS/report_generator.py
+++ b/RUFAS/report_generator.py
@@ -160,8 +160,9 @@ class ReportGenerator:
 
         Raises
         ------
-        ValueError
-            If the report data is empty or if the necessary aggregation keys are not found in filter_content.
+        KeyError
+            If a key specified in the `horizontal_order` of `filter_content` is not found in the `report_data`.
+            This usually indicates a mismatch between the expected structure of `filtered_pool` and its actual content.
         """
         report_data = self._prepare_report_data(
             filtered_pool,

--- a/RUFAS/report_generator.py
+++ b/RUFAS/report_generator.py
@@ -205,7 +205,7 @@ class ReportGenerator:
             ]
 
             if horizontal_aggregator:
-                if filter_content.get("horizontal_first", True):
+                if filter_content.get("horizontal_first", False):
                     return [vertical_aggregator(horizontally_aggregated)]
                 return [horizontal_aggregator(vertically_aggregated)]
             else:

--- a/RUFAS/report_generator.py
+++ b/RUFAS/report_generator.py
@@ -177,8 +177,6 @@ class ReportGenerator:
                 f"filter {filter_content.get('filters')} in {filter_content.get('name')} led to empty report data."
             )
 
-        number_of_elements = len(report_data[next(iter(report_data))])
-
         horizontal_agg_key = filter_content.get("horizontal_aggregation")
         horizontal_aggregator = AGGREGATION_FUNCTIONS.get(horizontal_agg_key)
 
@@ -187,6 +185,7 @@ class ReportGenerator:
 
         if horizontal_aggregator:
             loop_list = filter_content.get("horizontal_order", report_data.keys())
+            number_of_elements = len(report_data[next(iter(report_data))])
             try:
                 horizontally_aggregated = [
                     horizontal_aggregator([report_data[key][i] for key in loop_list])

--- a/RUFAS/report_generator.py
+++ b/RUFAS/report_generator.py
@@ -203,16 +203,15 @@ class ReportGenerator:
                 for _, data_series in report_data.items()
             ]
 
-        if horizontal_aggregator and vertical_aggregator:
-            if filter_content.get("horizontal_first", True):
-                return [vertical_aggregator(horizontally_aggregated)]
-            return [horizontal_aggregator(vertically_aggregated)]
+            if horizontal_aggregator:
+                if filter_content.get("horizontal_first", True):
+                    return [vertical_aggregator(horizontally_aggregated)]
+                return [horizontal_aggregator(vertically_aggregated)]
+            else:
+                return vertically_aggregated
 
         if horizontal_aggregator:
             return horizontally_aggregated
-
-        if vertical_aggregator:
-            return vertically_aggregated
 
         raise ValueError(
             f"Didn't find `horizontal_aggregation` or `vertical_aggregation` in {filter_content.get('name')}."

--- a/RUFAS/report_generator.py
+++ b/RUFAS/report_generator.py
@@ -203,13 +203,12 @@ class ReportGenerator:
                 vertical_aggregator(data_series)
                 for _, data_series in report_data.items()
             ]
+            if not horizontal_aggregator:
+                return vertical_aggregator
 
-            if horizontal_aggregator:
-                if filter_content.get("horizontal_first", False):
-                    return [vertical_aggregator(horizontally_aggregated)]
-                return [horizontal_aggregator(vertically_aggregated)]
-            else:
-                return vertically_aggregated
+            if filter_content.get("horizontal_first", False):
+                return [vertical_aggregator(horizontally_aggregated)]
+            return [horizontal_aggregator(vertically_aggregated)]
 
         raise ValueError(
             f"Didn't find `horizontal_aggregation` or `vertical_aggregation` in {filter_content.get('name')}."

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -1702,7 +1702,7 @@ def test_save_results_report_generation(
             )
 
         # test for exception handling
-        mock_report_generator.generate_report.side_effect = ValueError()
+        mock_report_generator.generate_report.side_effect = KeyError()
         mock_output_manager.save_results(
             "save_path",
             "filters_path",

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -84,7 +84,9 @@ def test_generate_report_vertical_then_horizontal(
         "vertical_aggregation": "sum",
         "horizontal_first": False,
     }
-    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {'ver_hor_agg': [18.0]}
+    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {
+        "ver_hor_agg": [18.0]
+    }
 
 
 def test_generate_report_horizontal_then_vertical(
@@ -97,7 +99,9 @@ def test_generate_report_horizontal_then_vertical(
         "vertical_aggregation": "average",
         "horizontal_first": True,
     }
-    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {'hor_ver_agg': [9.0]}
+    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {
+        "hor_ver_agg": [9.0]
+    }
 
 
 def test_generate_report_only_horizontal(
@@ -108,7 +112,9 @@ def test_generate_report_only_horizontal(
         "variables": ["a", "b"],
         "horizontal_aggregation": "sum",
     }
-    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {'hor_agg': [3, 7, 11, 15]}
+    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {
+        "hor_agg": [3, 7, 11, 15]
+    }
 
 
 def test_generate_report_only_vertical(
@@ -119,7 +125,9 @@ def test_generate_report_only_vertical(
         "variables": ["a", "b"],
         "vertical_aggregation": "average",
     }
-    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {'ver_agg': [4.0, 5.0]}
+    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {
+        "ver_agg": [4.0, 5.0]
+    }
 
 
 def test_generate_report_no_aggregation(
@@ -129,7 +137,10 @@ def test_generate_report_no_aggregation(
     filter_content = {
         "variables": ["a", "b"],
     }
-    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {"a":[1,3,5,7],"b":[2,4,6,8]}
+    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {
+        "a": [1, 3, 5, 7],
+        "b": [2, 4, 6, 8],
+    }
 
 
 def test_generate_report_invalid_empty_data(report_generator: ReportGenerator) -> None:
@@ -213,6 +224,10 @@ def test_generate_report_with_valid_horizontal_order(
         "horizontal_first": True,
     }
     filter_content["horizontal_order"] = ["a", "b"]
-    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {"hor_ver_agg":[        2.9583333333333335 ]}
+    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {
+        "hor_ver_agg": [2.9583333333333335]
+    }
     filter_content["horizontal_order"] = ["b", "a"]
-    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {"hor_ver_agg":[ 5.676190476190476    ]}
+    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {
+        "hor_ver_agg": [5.676190476190476]
+    }

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -119,10 +119,7 @@ def test_generate_report_only_vertical(
         "variables": ["a", "b"],
         "vertical_aggregation": "average",
     }
-    assert report_generator.generate_report(sample_filtered_pool, filter_content) == [
-        4,
-        5,
-    ]
+    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {'ver_agg': [4.0, 5.0]}
 
 
 def test_generate_report_no_aggregation(

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -84,10 +84,7 @@ def test_generate_report_vertical_then_horizontal(
         "vertical_aggregation": "sum",
         "horizontal_first": False,
     }
-    assert report_generator.generate_report(sample_filtered_pool, filter_content) == [
-        18
-    ]
-
+    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {'ver_hor_agg': [18.0]}
 
 def test_generate_report_horizontal_then_vertical(
     report_generator: ReportGenerator,

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -86,6 +86,7 @@ def test_generate_report_vertical_then_horizontal(
     }
     assert report_generator.generate_report(sample_filtered_pool, filter_content) == {'ver_hor_agg': [18.0]}
 
+
 def test_generate_report_horizontal_then_vertical(
     report_generator: ReportGenerator,
     sample_filtered_pool: Dict[str, Dict[str, List[Dict[str, int]]]],
@@ -96,7 +97,7 @@ def test_generate_report_horizontal_then_vertical(
         "vertical_aggregation": "average",
         "horizontal_first": True,
     }
-    assert report_generator.generate_report(sample_filtered_pool, filter_content) == [9]
+    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {'hor_ver_agg': [9.0]}
 
 
 def test_generate_report_only_horizontal(

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -213,10 +213,6 @@ def test_generate_report_with_valid_horizontal_order(
         "horizontal_first": True,
     }
     filter_content["horizontal_order"] = ["a", "b"]
-    assert report_generator.generate_report(sample_filtered_pool, filter_content) == [
-        2.9583333333333335
-    ]
+    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {"hor_ver_agg":[        2.9583333333333335 ]}
     filter_content["horizontal_order"] = ["b", "a"]
-    assert report_generator.generate_report(sample_filtered_pool, filter_content) == [
-        5.676190476190476
-    ]
+    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {"hor_ver_agg":[ 5.676190476190476    ]}

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -108,12 +108,7 @@ def test_generate_report_only_horizontal(
         "variables": ["a", "b"],
         "horizontal_aggregation": "sum",
     }
-    assert report_generator.generate_report(sample_filtered_pool, filter_content) == [
-        3,
-        7,
-        11,
-        15,
-    ]
+    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {'hor_agg': [3, 7, 11, 15]}
 
 
 def test_generate_report_only_vertical(

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -129,8 +129,7 @@ def test_generate_report_no_aggregation(
     filter_content = {
         "variables": ["a", "b"],
     }
-    with pytest.raises(ValueError):
-        report_generator.generate_report(sample_filtered_pool, filter_content)
+    assert report_generator.generate_report(sample_filtered_pool, filter_content) == {"a":[1,3,5,7],"b":[2,4,6,8]}
 
 
 def test_generate_report_invalid_empty_data(report_generator: ReportGenerator) -> None:


### PR DESCRIPTION
This PR mainly focuses on allowing users to provide a report filter with no aggregation. Previously, we handled this case by raising an error. The user might be interested in this feature as it allows them to slice data, assign labels to it, and save it along with aggregated data in the same CSV file.
If data is being aggregated, we now append `hor_agg`, `ver_agg`, `ver_hor_agg`, or `hor_ver_agg` to the column name to denote the aggregation.
The PR also makes some minor improvements in terms of code organization in `RG.generate_report()`.