### PR TITLE
Add daily sell info

### DIFF
--- a/RUFAS/routines/animal/animal_module_reporter.py
+++ b/RUFAS/routines/animal/animal_module_reporter.py
@@ -1,4 +1,6 @@
+from typing import Dict, List
 import numpy as np
+import sys
 
 from RUFAS.output_manager import OutputManager
 from RUFAS.routines.animal.ration.ration_driver import RationReporter
@@ -67,7 +69,9 @@ class AnimalModuleReporter:
         for animal in pen.animals_in_pen:
             milk_data_update = {}
             milk_data_update["days_in_milk"] = animal.days_in_milk
-            milk_data_update["estimated_daily_milk_produced"] = animal.estimated_daily_milk_produced
+            milk_data_update[
+                "estimated_daily_milk_produced"
+            ] = animal.estimated_daily_milk_produced
             milk_data_update["milk_protein"] = animal.mPrt
             milk_data_update["milk_fat"] = animal.fat_percent
             milk_data_update["milk_lactose"] = animal.lactose_milk
@@ -109,7 +113,7 @@ class AnimalModuleReporter:
                 "class": "AnimalManager",
                 "function": "_calc_ration_at_interval",
                 "number_animals_in_pen": len(pen.animals_in_pen),
-                "simulation_day": simulation_day
+                "simulation_day": simulation_day,
             }
             om.add_variable(
                 f"ration_nutrient_amount_pen_{pen.id}_{pen.animal_combination.name}",
@@ -166,18 +170,25 @@ class AnimalModuleReporter:
             ration_total["dry_matter_intake_total"] = 0
             for key in ration_per_animal.keys():
                 if key != "status" and key != "objective":
-                    ration_total[key] = pen.ration_per_animal[key] * len(pen.animals_in_pen)
+                    ration_total[key] = pen.ration_per_animal[key] * len(
+                        pen.animals_in_pen
+                    )
                     ration_total["dry_matter_intake_total"] += ration_total[key]
-            AnimalModuleReporter.report_daily_feed_emissions(ration_total, pen.id, pen.animal_combination.name,
-                                                             animal_manager)
+            AnimalModuleReporter.report_daily_feed_emissions(
+                ration_total, pen.id, pen.animal_combination.name, animal_manager
+            )
             om.add_variable(
                 f"ration_daily_feed_totals_for_pen_{pen.id}_{pen.animal_combination.name}",
                 ration_total,
                 info_map,
             )
 
-    def report_daily_feed_emissions(ration_total: dict[str, float], pen_id: int, pen_animal_name: str,
-                                    animal_manager) -> None:
+    def report_daily_feed_emissions(
+        ration_total: dict[str, float],
+        pen_id: int,
+        pen_animal_name: str,
+        animal_manager,
+    ) -> None:
         """
         Adds emissions totals from purchased feeds on a pen / feed basis.
 
@@ -197,12 +208,13 @@ class AnimalModuleReporter:
             "class": AnimalModuleReporter.__name__,
             "function": AnimalModuleReporter.report_daily_feed_emissions.__name__,
         }
-        daily_feed_emissions = animal_manager.feeds_emissions_estimator.\
-            create_daily_purchased_feed_emissions_report(ration_total)
+        daily_feed_emissions = animal_manager.feeds_emissions_estimator.create_daily_purchased_feed_emissions_report(
+            ration_total
+        )
         om.add_variable(
             f"pen_{pen_id}_animal_{pen_animal_name}_feed_emissions",
             daily_feed_emissions,
-            info_map
+            info_map,
         )
 
     def report_animal_module_manure(
@@ -257,7 +269,11 @@ class AnimalModuleReporter:
         """
         info_map = {"class": "pen", "function": "calc_total_manure"}
         for manure_property, manure_value in pen.manure.items():
-            om.add_variable(f"pen_{pen.id}_daily_{str(manure_property)}", manure_value, info_map=info_map)
+            om.add_variable(
+                f"pen_{pen.id}_daily_{str(manure_property)}",
+                manure_value,
+                info_map=info_map,
+            )
 
     def report_life_cycle_manager_data(life_cycle_manager, sim_day: int) -> None:
         """
@@ -269,35 +285,85 @@ class AnimalModuleReporter:
             Day of simulation.
         """
         info_map = {"class": "LifeCycleManager", "function": "daily_update"}
-        om.add_variable("sold_heiferIII_oversupply_num", life_cycle_manager.sold_heiferIII_oversupply_num, info_map)
-        om.add_variable("bought_heifer_num", life_cycle_manager.bought_heifer_num, info_map)
-        om.add_variable("sold_heiferII_num", life_cycle_manager.sold_heiferII_num, info_map)
-        om.add_variable("cow_herd_exit_num", life_cycle_manager.cow_herd_exit_num, info_map)
-        om.add_variable("GnRH_injection_num_h", life_cycle_manager.GnRH_injection_num_h, info_map)
-        om.add_variable("GnRH_injection_num", life_cycle_manager.GnRH_injection_num, info_map)
-        om.add_variable("PGF_injection_num", life_cycle_manager.PGF_injection_num, info_map)
-        om.add_variable("PGF_injection_num_h", life_cycle_manager.PGF_injection_num_h, info_map)
+        om.add_variable(
+            "sold_heiferIII_oversupply_num",
+            life_cycle_manager.sold_heiferIII_oversupply_num,
+            info_map,
+        )
+        om.add_variable(
+            "bought_heifer_num", life_cycle_manager.bought_heifer_num, info_map
+        )
+        om.add_variable(
+            "sold_heiferII_num", life_cycle_manager.sold_heiferII_num, info_map
+        )
+        om.add_variable(
+            "cow_herd_exit_num", life_cycle_manager.cow_herd_exit_num, info_map
+        )
+        om.add_variable(
+            "GnRH_injection_num_h", life_cycle_manager.GnRH_injection_num_h, info_map
+        )
+        om.add_variable(
+            "GnRH_injection_num", life_cycle_manager.GnRH_injection_num, info_map
+        )
+        om.add_variable(
+            "PGF_injection_num", life_cycle_manager.PGF_injection_num, info_map
+        )
+        om.add_variable(
+            "PGF_injection_num_h", life_cycle_manager.PGF_injection_num_h, info_map
+        )
         om.add_variable("ai_num", life_cycle_manager.ai_num, info_map)
         om.add_variable("preg_check_num", life_cycle_manager.preg_check_num, info_map)
-        om.add_variable("preg_check_num_h", life_cycle_manager.preg_check_num_h, info_map)
+        om.add_variable(
+            "preg_check_num_h", life_cycle_manager.preg_check_num_h, info_map
+        )
         om.add_variable("sold_calf_num", life_cycle_manager.sold_calf_num, info_map)
-        om.add_variable("daily_milk_production", life_cycle_manager.daily_milk_production, info_map)
-        om.add_variable("herd_milk_fat_percent", life_cycle_manager.herd_milk_fat_percent, info_map)
-        om.add_variable("herd_milk_protein_percent", life_cycle_manager.herd_milk_protein_percent, info_map)
+        om.add_variable(
+            "daily_milk_production", life_cycle_manager.daily_milk_production, info_map
+        )
+        om.add_variable(
+            "herd_milk_fat_percent", life_cycle_manager.herd_milk_fat_percent, info_map
+        )
+        om.add_variable(
+            "herd_milk_protein_percent",
+            life_cycle_manager.herd_milk_protein_percent,
+            info_map,
+        )
         om.add_variable("open_cow_num", life_cycle_manager.open_cow_num, info_map)
         om.add_variable("vwp_cow_num", life_cycle_manager.vwp_cow_num, info_map)
         om.add_variable("preg_cow_num", life_cycle_manager.preg_cow_num, info_map)
         om.add_variable("milking_cow_num", life_cycle_manager.milking_cow_num, info_map)
         om.add_variable("dry_cow_num", life_cycle_manager.dry_cow_num, info_map)
-        om.add_variable("avg_days_in_milk", life_cycle_manager.avg_days_in_milk, info_map)
-        om.add_variable("avg_days_in_preg", life_cycle_manager.avg_days_in_preg, info_map)
-        om.add_variable("avg_cow_body_weight", life_cycle_manager.avg_cow_body_weight, info_map)
+        om.add_variable(
+            "avg_days_in_milk", life_cycle_manager.avg_days_in_milk, info_map
+        )
+        om.add_variable(
+            "avg_days_in_preg", life_cycle_manager.avg_days_in_preg, info_map
+        )
+        om.add_variable(
+            "avg_cow_body_weight", life_cycle_manager.avg_cow_body_weight, info_map
+        )
         om.add_variable("avg_parity_num", life_cycle_manager.avg_parity_num, info_map)
-        om.add_variable("avg_calving_interval", life_cycle_manager.avg_calving_interval, info_map)
-        om.add_variable("avg_breeding_to_preg_time", life_cycle_manager.avg_breeding_to_preg_time, info_map)
-        om.add_variable("avg_heifer_culling_age", life_cycle_manager.avg_heifer_culling_age, info_map)
-        om.add_variable("avg_cow_culling_age", life_cycle_manager.avg_cow_culling_age, info_map)
-        om.add_variable("avg_mature_body_weight", life_cycle_manager.avg_mature_body_weight, info_map)
+        om.add_variable(
+            "avg_calving_interval", life_cycle_manager.avg_calving_interval, info_map
+        )
+        om.add_variable(
+            "avg_breeding_to_preg_time",
+            life_cycle_manager.avg_breeding_to_preg_time,
+            info_map,
+        )
+        om.add_variable(
+            "avg_heifer_culling_age",
+            life_cycle_manager.avg_heifer_culling_age,
+            info_map,
+        )
+        om.add_variable(
+            "avg_cow_culling_age", life_cycle_manager.avg_cow_culling_age, info_map
+        )
+        om.add_variable(
+            "avg_mature_body_weight",
+            life_cycle_manager.avg_mature_body_weight,
+            info_map,
+        )
         om.add_variable("sim_day", sim_day, info_map)
         parity_1 = life_cycle_manager.num_cow_for_parity["1"]
         parity_2 = life_cycle_manager.num_cow_for_parity["2"]
@@ -306,24 +372,40 @@ class AnimalModuleReporter:
         om.add_variable("num_cow_for_parity_1", parity_1, info_map)
         om.add_variable("num_cow_for_parity_2", parity_2, info_map)
         om.add_variable("num_cow_for_parity_3", parity_3, info_map)
-        om.add_variable("num_cow_for_parity_greater_than_3", parity_greater_than_3, info_map)
+        om.add_variable(
+            "num_cow_for_parity_greater_than_3", parity_greater_than_3, info_map
+        )
         calving_to_preg_time_1 = life_cycle_manager.avg_calving_to_preg_time["1"]
         calving_to_preg_time_2 = life_cycle_manager.avg_calving_to_preg_time["2"]
         calving_to_preg_time_3 = life_cycle_manager.avg_calving_to_preg_time["3"]
-        calving_to_preg_time_greater_than_3 = life_cycle_manager.avg_calving_to_preg_time["greater_than_3"]
+        calving_to_preg_time_greater_than_3 = (
+            life_cycle_manager.avg_calving_to_preg_time["greater_than_3"]
+        )
         om.add_variable("calving_to_preg_time_1", calving_to_preg_time_1, info_map)
         om.add_variable("calving_to_preg_time_2", calving_to_preg_time_2, info_map)
         om.add_variable("calving_to_preg_time_3", calving_to_preg_time_3, info_map)
-        om.add_variable("calving_to_preg_time_greater_than_3", calving_to_preg_time_greater_than_3, info_map)
+        om.add_variable(
+            "calving_to_preg_time_greater_than_3",
+            calving_to_preg_time_greater_than_3,
+            info_map,
+        )
         avg_age_for_calving_1 = life_cycle_manager.avg_age_for_calving["1"]
         avg_age_for_calving_2 = life_cycle_manager.avg_age_for_calving["2"]
         avg_age_for_calving_3 = life_cycle_manager.avg_age_for_calving["3"]
-        avg_age_for_calving_greater_than_3 = life_cycle_manager.avg_age_for_calving["greater_than_3"]
+        avg_age_for_calving_greater_than_3 = life_cycle_manager.avg_age_for_calving[
+            "greater_than_3"
+        ]
         om.add_variable("avg_age_for_calving_1", avg_age_for_calving_1, info_map)
         om.add_variable("avg_age_for_calving_2", avg_age_for_calving_2, info_map)
         om.add_variable("avg_age_for_calving_3", avg_age_for_calving_3, info_map)
-        om.add_variable("avg_age_for_calving_greater_than_3", avg_age_for_calving_greater_than_3, info_map)
-        om.add_variable("cull_reason_stats", life_cycle_manager.cull_reason_stats, info_map)
+        om.add_variable(
+            "avg_age_for_calving_greater_than_3",
+            avg_age_for_calving_greater_than_3,
+            info_map,
+        )
+        om.add_variable(
+            "cull_reason_stats", life_cycle_manager.cull_reason_stats, info_map
+        )
 
     def report_sold_animal_information(animal_manager) -> None:
         """
@@ -365,6 +447,52 @@ class AnimalModuleReporter:
             else:
                 om.add_variable("parity", "NA", info_map)
 
+    def report_sold_animal_information_sort_by_sell_day(
+        sold_animals, report_name: str
+    ) -> None:
+        """
+        Adds a dictionary of sold animal information to the output manager on daily basis.
+
+        Parameters
+        ----------
+        animal_manager : AnimalManager
+            Instance of Class AnimalManager.
+        report_name : str
+            The string to be appended to the variable being reported to the OM.
+
+        """
+
+        info_map = {
+            "class": "AnimalModuleReporter",
+            "function": AnimalModuleReporter.report_sold_animal_information_sort_by_sell_day.__name__,
+        }
+
+        sold_at_day_min: int = sys.maxsize
+        sold_at_day_max: int = 0
+        daily_sell: Dict[int, List[object]] = {}
+
+        for animal in sold_animals:
+            if animal.sold_at_day < sold_at_day_min:
+                sold_at_day_min = animal.sold_at_day
+            if animal.sold_at_day > sold_at_day_max:
+                sold_at_day_max = animal.sold_at_day
+            if daily_sell.get(animal.sold_at_day):
+                daily_sell[animal.sold_at_day].append(animal)
+            else:
+                daily_sell[animal.sold_at_day] = [animal]
+
+        for day in range(sold_at_day_min, sold_at_day_max + 1):
+            if daily_sell.get(day):
+                sold_count = len(daily_sell[day])
+                sold_weight = sum(
+                    sold_animal.body_weight for sold_animal in daily_sell[day]
+                )
+                om.add_variable(f"{report_name}_sold_count", sold_count, info_map)
+                om.add_variable(f"{report_name}_sold_weight", sold_weight, info_map)
+            else:
+                om.add_variable(f"{report_name}_sold_count", 0, info_map)
+                om.add_variable(f"{report_name}_sold_weight", 0, info_map)
+
     def report_305d_milk(animal_manager):
         """
         Adds herd mean of latest_milk_production_305days to output manager,
@@ -380,12 +508,20 @@ class AnimalModuleReporter:
             "class": "cow",
             "function": "update_milk_production_history",
         }
-        milk_history_list = [cow.latest_milk_production_305days for cow in animal_manager.cows if cow.is_lactating]
+        milk_history_list = [
+            cow.latest_milk_production_305days
+            for cow in animal_manager.cows
+            if cow.is_lactating
+        ]
         nonzero_milk_history_list = [x for x in milk_history_list if x != 0.0]
         milk_production_305days_herd_mean = ""
         if nonzero_milk_history_list:
             milk_production_305days_herd_mean = np.mean(nonzero_milk_history_list)
-        om.add_variable("milk_production_305days_herd_mean", milk_production_305days_herd_mean, info_map)
+        om.add_variable(
+            "milk_production_305days_herd_mean",
+            milk_production_305days_herd_mean,
+            info_map,
+        )
 
     def report_daily_reports(animal_manager):
         """
@@ -397,8 +533,9 @@ class AnimalModuleReporter:
             Instance of AnimalManager class.
         """
         AnimalModuleReporter.report_daily_animal_population(animal_manager)
-        AnimalModuleReporter.report_life_cycle_manager_data(animal_manager.life_cycle_manager,
-                                                            animal_manager.simulation_day)
+        AnimalModuleReporter.report_life_cycle_manager_data(
+            animal_manager.life_cycle_manager, animal_manager.simulation_day
+        )
         AnimalModuleReporter.report_daily_ration(animal_manager)
         AnimalModuleReporter.report_305d_milk(animal_manager)
         for pen in animal_manager.all_pens:
@@ -416,3 +553,12 @@ class AnimalModuleReporter:
             Instance of AnimalManager class.
         """
         AnimalModuleReporter.report_sold_animal_information(animal_manager)
+        AnimalModuleReporter.report_sold_animal_information_sort_by_sell_day(
+            animal_manager.life_cycle_manager.sold_heiferIIs, "heiferII"
+        )
+        AnimalModuleReporter.report_sold_animal_information_sort_by_sell_day(
+            animal_manager.life_cycle_manager.sold_heiferIIIs, "heiferIII"
+        )
+        AnimalModuleReporter.report_sold_animal_information_sort_by_sell_day(
+            animal_manager.life_cycle_manager.sold_and_died_cows, "sold_and_died_cows"
+        )

--- a/RUFAS/routines/animal/animal_module_reporter.py
+++ b/RUFAS/routines/animal/animal_module_reporter.py
@@ -448,7 +448,7 @@ class AnimalModuleReporter:
                 om.add_variable("parity", "NA", info_map)
 
     def report_sold_animal_information_sort_by_sell_day(
-        sold_animals, report_name: str
+        sold_animals, report_name: str, total_days: int
     ) -> None:
         """
         Adds a dictionary of sold animal information to the output manager on daily basis.
@@ -459,7 +459,8 @@ class AnimalModuleReporter:
             Instance of Class AnimalManager.
         report_name : str
             The string to be appended to the variable being reported to the OM.
-
+        total_days : int
+            The total number of days in the simulation
         """
 
         info_map = {
@@ -481,7 +482,9 @@ class AnimalModuleReporter:
             else:
                 daily_sell[animal.sold_at_day] = [animal]
 
-        for day in range(sold_at_day_min, sold_at_day_max + 1):
+        om.add_variable(f"{report_name}_first_sell_event", sold_at_day_min, info_map)
+        om.add_variable(f"{report_name}_last_sell_event", sold_at_day_max, info_map)
+        for day in range(total_days):
             if daily_sell.get(day):
                 sold_count = len(daily_sell[day])
                 sold_weight = sum(
@@ -543,7 +546,7 @@ class AnimalModuleReporter:
             if pen.animal_combination.name == "LAC_COW":
                 AnimalModuleReporter.report_milk(pen, animal_manager.simulation_day)
 
-    def report_end_of_simulation(animal_manager) -> None:
+    def report_end_of_simulation(animal_manager, total_days: int) -> None:
         """
         Calls all reporter methods that should happen at the end of the simulation.
 
@@ -551,14 +554,18 @@ class AnimalModuleReporter:
         ----------
         animal_manager : AnimalManager
             Instance of AnimalManager class.
+        total_days : int
+            The total number of days in the simulation
         """
         AnimalModuleReporter.report_sold_animal_information(animal_manager)
         AnimalModuleReporter.report_sold_animal_information_sort_by_sell_day(
-            animal_manager.life_cycle_manager.sold_heiferIIs, "heiferII"
+            animal_manager.life_cycle_manager.sold_heiferIIs, "heiferII", total_days
         )
         AnimalModuleReporter.report_sold_animal_information_sort_by_sell_day(
-            animal_manager.life_cycle_manager.sold_heiferIIIs, "heiferIII"
+            animal_manager.life_cycle_manager.sold_heiferIIIs, "heiferIII", total_days
         )
         AnimalModuleReporter.report_sold_animal_information_sort_by_sell_day(
-            animal_manager.life_cycle_manager.sold_and_died_cows, "sold_and_died_cows"
+            animal_manager.life_cycle_manager.sold_and_died_cows,
+            "sold_and_died_cows",
+            total_days,
         )

--- a/RUFAS/routines/animal/life_cycle/animal_base.py
+++ b/RUFAS/routines/animal/life_cycle/animal_base.py
@@ -18,7 +18,7 @@ class AnimalBase:
     @staticmethod
     def set_config(config):
         AnimalBase.config = config
-        AnimalBase.config['nutrient_standard'] = im.get_data("config.nutrient_standard")
+        AnimalBase.config["nutrient_standard"] = im.get_data("config.nutrient_standard")
 
     def __init__(self, args: AnimalBaseInitArgsTypedDict):
         """
@@ -35,11 +35,11 @@ class AnimalBase:
                         args.mature_body_weight: the mature body weight of the animal
                         args.events: events of the animal
         """
-        self.id = args['id']
-        self.breed = args['breed']
-        self.birth_date = args['birth_date']
-        self.days_born = args['days_born']
-        self.semen_used = self.config['semen_type']
+        self.id = args["id"]
+        self.breed = args["breed"]
+        self.birth_date = args["birth_date"]
+        self.days_born = args["days_born"]
+        self.semen_used = self.config["semen_type"]
         self.culled = False
         self.do_not_breed = False
         self.body_weight_history = []
@@ -50,7 +50,7 @@ class AnimalBase:
         self.set_default_nutrient_rqmts()
         self.dry_matter_intake = 0
         self.manure_excretion = {}
-        self.ration_formulation = {'objective': 0.00}
+        self.ration_formulation = {"objective": 0.00}
         self.DMIest = 0
         self.DBW = 0
         self.p_animal = 0
@@ -69,20 +69,21 @@ class AnimalBase:
         self.conceptus_weight = 0
         self.calf_birth_weight = 0
         self.tissue_changed = 0
-        if 'body_weight_history' in args:
-            self.body_weight_history = args['body_weight_history']
-            self.pen_history = args['pen_history']
-        if 'conceptus_weight' in args:
-            self.conceptus_weight = args['conceptus_weight']
-        if 'calf_birth_weight' in args:
-            self.calf_birth_weight = args['calf_birth_weight']
+        self.sold_at_day: int = None
+        if "body_weight_history" in args:
+            self.body_weight_history = args["body_weight_history"]
+            self.pen_history = args["pen_history"]
+        if "conceptus_weight" in args:
+            self.conceptus_weight = args["conceptus_weight"]
+        if "calf_birth_weight" in args:
+            self.calf_birth_weight = args["calf_birth_weight"]
 
     def set_default_nutrient_rqmts(self):
         """
         Sets the default nutrient requirement values to be 0.
         """
         for key in self.nutrients:
-            self.nutrient_rqmts[key] = {'op': '', 'val': 0}
+            self.nutrient_rqmts[key] = {"op": "", "val": 0}
 
     def set_ration(self, ration, DMI):
         """
@@ -124,7 +125,12 @@ class AnimalBase:
             self.dP_reserves = 0
 
         # amount of P in the animal (A.1G.A.3)
-        self.p_animal = self.p_animal + self.p_gest + self.p_growth + (self.dP_reserves - dP_reserves_prev)
+        self.p_animal = (
+            self.p_animal
+            + self.p_gest
+            + self.p_growth
+            + (self.dP_reserves - dP_reserves_prev)
+        )
 
     def calc_base_manure(self):
         """
@@ -144,10 +150,14 @@ class AnimalBase:
         # amount of P excreted by an animal (g) (A.1G.B.2)
         if self.dP_reserves == 0 and self.p_intake >= self.p_req:
             p_feces_excrt = self.p_intake - self.p_req + self.p_maint_feces
-        elif self.dP_reserves < 0 and self.p_intake >= self.p_req and \
-                self.p_excess >= (-1) * self.dP_reserves / 0.7:
-            p_feces_excrt = self.p_intake - self.p_req + self.p_maint_feces + \
-                            self.dP_reserves / 0.7
+        elif (
+            self.dP_reserves < 0
+            and self.p_intake >= self.p_req
+            and self.p_excess >= (-1) * self.dP_reserves / 0.7
+        ):
+            p_feces_excrt = (
+                self.p_intake - self.p_req + self.p_maint_feces + self.dP_reserves / 0.7
+            )
         else:
             p_feces_excrt = self.p_maint_feces
 
@@ -172,11 +182,11 @@ class AnimalBase:
             curr_day: the current simulation day
             classes_in_pen: the classes in the animal's current pen
         """
-        last_pen = self.pen_history[-1].pen if len(
-            self.pen_history) > 0 else None
+        last_pen = self.pen_history[-1].pen if len(self.pen_history) > 0 else None
         if last_pen is None or last_pen != curr_pen:
-            self.pen_history.append(PenHistory(curr_day, curr_day, curr_pen,
-                                               list(classes_in_pen)))
+            self.pen_history.append(
+                PenHistory(curr_day, curr_day, curr_pen, list(classes_in_pen))
+            )
         else:  # last_pen == curr_pen
             self.pen_history[-1].end_date = curr_day
             self.pen_history[-1].classes_in_pen = list(classes_in_pen)
@@ -189,6 +199,6 @@ class AnimalBase:
         Args:
             sim_day: simulation day
         """
-        self.body_weight_history.append(BodyWeightHistory(sim_day,
-                                                          self.days_born,
-                                                          self.body_weight))
+        self.body_weight_history.append(
+            BodyWeightHistory(sim_day, self.days_born, self.body_weight)
+        )

--- a/RUFAS/routines/animal/life_cycle/life_cycle.py
+++ b/RUFAS/routines/animal/life_cycle/life_cycle.py
@@ -10,8 +10,11 @@ from typing import Union
 
 from RUFAS.input_manager import InputManager
 from RUFAS.output_manager import OutputManager
-from RUFAS.routines.animal.animal_typed_dicts import AnimalConfigTypedDict, HerdInfoTypedDict, \
-    InitialHerdSummaryTypedDict
+from RUFAS.routines.animal.animal_typed_dicts import (
+    AnimalConfigTypedDict,
+    HerdInfoTypedDict,
+    InitialHerdSummaryTypedDict,
+)
 from RUFAS.routines.animal.life_cycle import animal_constants
 from RUFAS.routines.animal.life_cycle.animal_base import AnimalBase
 from RUFAS.routines.animal.life_cycle.animal_population import AnimalPopulation
@@ -21,12 +24,16 @@ from RUFAS.routines.animal.life_cycle.cow import Cow
 from RUFAS.routines.animal.life_cycle.heiferI import HeiferI
 from RUFAS.routines.animal.life_cycle.heiferII import HeiferII
 from RUFAS.routines.animal.life_cycle.heiferIII import HeiferIII
-from RUFAS.routines.animal.life_cycle.repro_protocol_enums import HeiferReproProtocolEnum
+from RUFAS.routines.animal.life_cycle.repro_protocol_enums import (
+    HeiferReproProtocolEnum,
+)
 from RUFAS.util import Utility
 
 # GenericAnimal is a placeholder/generic type that represents any of the five classes listed in the union.
 # 'bound' is used to restrict the type to only the classes listed in the union.
-GenericAnimal = TypeVar("GenericAnimal", bound=Union[Calf, HeiferI, HeiferII, HeiferIII, Cow])
+GenericAnimal = TypeVar(
+    "GenericAnimal", bound=Union[Calf, HeiferI, HeiferII, HeiferIII, Cow]
+)
 
 im = InputManager()
 om = OutputManager()
@@ -45,25 +52,23 @@ class LifeCycleManager:
             data: life cycle data from the input JSON file
 
         """
-        self.avg_calving_to_preg_time = {'1': 0.0,
-                                         '2': 0.0,
-                                         '3': 0.0,
-                                         'greater_than_3': 0.0
-                                         }
-        self.cull_reason_stats: Dict[str, int] = {animal_constants.DEATH_CULL: 0,
-                                                  animal_constants.LOW_PROD_CULL: 0,
-                                                  animal_constants.LAMENESS_CULL: 0,
-                                                  animal_constants.INJURY_CULL: 0,
-                                                  animal_constants.MASTITIS_CULL: 0,
-                                                  animal_constants.DISEASE_CULL: 0,
-                                                  animal_constants.UDDER_CULL: 0,
-                                                  animal_constants.UNKNOWN_CULL: 0
-                                                  }
-        self.num_cow_for_parity = {'1': 0,
-                                   '2': 0,
-                                   '3': 0,
-                                   'greater_than_3': 0
-                                   }
+        self.avg_calving_to_preg_time = {
+            "1": 0.0,
+            "2": 0.0,
+            "3": 0.0,
+            "greater_than_3": 0.0,
+        }
+        self.cull_reason_stats: Dict[str, int] = {
+            animal_constants.DEATH_CULL: 0,
+            animal_constants.LOW_PROD_CULL: 0,
+            animal_constants.LAMENESS_CULL: 0,
+            animal_constants.INJURY_CULL: 0,
+            animal_constants.MASTITIS_CULL: 0,
+            animal_constants.DISEASE_CULL: 0,
+            animal_constants.UDDER_CULL: 0,
+            animal_constants.UNKNOWN_CULL: 0,
+        }
+        self.num_cow_for_parity = {"1": 0, "2": 0, "3": 0, "greater_than_3": 0}
         self.animal_config = data  # animal_config in animal_management
         self.avg_daily_cow_milking = 0.0
         self.initial_herd_summary: Optional[InitialHerdSummaryTypedDict] = None
@@ -136,18 +141,8 @@ class LifeCycleManager:
         self.cull_reason_stats_range: Dict[str, int] = defaultdict(int)
         self.parity_culling_stats_range: Dict[Union[int, str], int] = defaultdict(int)
 
-        self.avg_age_for_calving = {
-            '1': 0.0,
-            '2': 0.0,
-            '3': 0.0,
-            'greater_than_3': 0.0
-        }
-        self.avg_age_for_parity = {
-            '1': 0.0,
-            '2': 0.0,
-            '3': 0.0,
-            'greater_than_3': 0.0
-        }
+        self.avg_age_for_calving = {"1": 0.0, "2": 0.0, "3": 0.0, "greater_than_3": 0.0}
+        self.avg_age_for_parity = {"1": 0.0, "2": 0.0, "3": 0.0, "greater_than_3": 0.0}
         self.cull_reason_stats_percent: Dict[str, float] = {
             animal_constants.DEATH_CULL: 0.0,
             animal_constants.LOW_PROD_CULL: 0.0,
@@ -156,22 +151,22 @@ class LifeCycleManager:
             animal_constants.MASTITIS_CULL: 0.0,
             animal_constants.DISEASE_CULL: 0.0,
             animal_constants.UDDER_CULL: 0.0,
-            animal_constants.UNKNOWN_CULL: 0.0
+            animal_constants.UNKNOWN_CULL: 0.0,
         }
         self.percent_cow_for_parity = {
-            '1': 0.0,
-            '2': 0.0,
-            '3': 0.0,
-            'greater_than_3': 0.0
+            "1": 0.0,
+            "2": 0.0,
+            "3": 0.0,
+            "greater_than_3": 0.0,
         }
 
         self.replacement_market: List[Cow] = []
         self.animal_population: Optional[AnimalPopulation] = None
 
     # TODO: Annotate config after removing all the imports in all the __init__.py files
-    def initialize_herd(self, herd_data: HerdInfoTypedDict) -> Tuple[List[Calf], List[HeiferI],
-                                                                     List[HeiferII], List[HeiferIII],
-                                                                     List[Cow]]:
+    def initialize_herd(
+        self, herd_data: HerdInfoTypedDict
+    ) -> Tuple[List[Calf], List[HeiferI], List[HeiferII], List[HeiferIII], List[Cow]]:
         """Generates a replacement herd to simulate the market, for the herd to get replacements.
 
         Parameters
@@ -192,9 +187,9 @@ class LifeCycleManager:
             heiferIIs=list(map(HeiferII, animal_population["heiferIIs"])),
             heiferIIIs=list(map(HeiferIII, animal_population["heiferIIIs"])),
             cows=list(map(Cow, animal_population["cows"])),
-            replacement=list(map(Cow, animal_population["replacement"]))
+            replacement=list(map(Cow, animal_population["replacement"])),
         )
-        self.herd_num = herd_data['herd_num']
+        self.herd_num = herd_data["herd_num"]
         self._set_avg_CI()
 
         calves = self._get_animals(Calf)
@@ -206,11 +201,14 @@ class LifeCycleManager:
         return calves, heiferIs, heiferIIs, heiferIIIs, cows
 
     def _set_avg_CI(self) -> None:
-        if 'use_input_calving_interval' in self.animal_config and self.animal_config['use_input_calving_interval']:
-            self.avg_CI = self.animal_config['calving_interval']
+        if (
+            "use_input_calving_interval" in self.animal_config
+            and self.animal_config["use_input_calving_interval"]
+        ):
+            self.avg_CI = self.animal_config["calving_interval"]
         else:
             self.initial_herd_summary = self.animal_population.get_herd_summary()
-            self.avg_CI = self.initial_herd_summary['cow_avg_CI']
+            self.avg_CI = self.initial_herd_summary["cow_avg_CI"]
 
     def _get_animals(self, animal_type: Type[GenericAnimal]) -> List[GenericAnimal]:
         """Gets a list of animals of a given type.
@@ -225,26 +223,38 @@ class LifeCycleManager:
             A list of animals of the given type.
 
         """
-        animal_getter_by_animal_type: Dict[Type[GenericAnimal], Callable[..., List[GenericAnimal]]] = {
+        animal_getter_by_animal_type: Dict[
+            Type[GenericAnimal], Callable[..., List[GenericAnimal]]
+        ] = {
             Calf: self.animal_population.get_calves,
             HeiferI: self.animal_population.get_heiferIs,
             HeiferII: self.animal_population.get_heiferIIs,
             HeiferIII: self.animal_population.get_heiferIIIs,
-            Cow: self.animal_population.get_cows
+            Cow: self.animal_population.get_cows,
         }
         animals = animal_getter_by_animal_type[animal_type]()
         for animal in animals:
             animal.events.add_event(animal.days_born, 0, animal_constants.INIT_HERD)
         return animals
 
-    def daily_update(self, sim_day: int,
-                     calves: List[Calf],
-                     heiferIs: List[HeiferI],
-                     heiferIIs: List[HeiferII],
-                     heiferIIIs: List[HeiferIII],
-                     cows: List[Cow]) \
-            -> Tuple[List[Cow], List[Cow], List[Calf], List[Calf],
-                     List[HeiferI], List[HeiferII], List[HeiferIII], List[Cow]]:
+    def daily_update(
+        self,
+        sim_day: int,
+        calves: List[Calf],
+        heiferIs: List[HeiferI],
+        heiferIIs: List[HeiferII],
+        heiferIIIs: List[HeiferIII],
+        cows: List[Cow],
+    ) -> Tuple[
+        List[Cow],
+        List[Cow],
+        List[Calf],
+        List[Calf],
+        List[HeiferI],
+        List[HeiferII],
+        List[HeiferIII],
+        List[Cow],
+    ]:
         """
         Updates the status of the animals.
 
@@ -277,34 +287,57 @@ class LifeCycleManager:
         self._reset_parity()
         self._reset_cull_reason_stats()
 
-        total_animal_num = self._evaluate_calves_for_weaning(sim_day, calves, heiferIs, total_animal_num)
-        total_animal_num = self._evaluate_heiferIs_for_transitioning_to_heiferIIs(sim_day, heiferIs, heiferIIs,
-                                                                                  total_animal_num)
-        total_animal_num, preg_heifer_num = self._evaluate_heiferIIs_for_transitioning_to_heiferIIIs(sim_day, heiferIIs,
-                                                                                                     heiferIIIs,
-                                                                                                     preg_heifer_num,
-                                                                                                     total_animal_num)
-        total_animal_num = self._evaluate_heiferIIIs_for_transitioning_to_cows(sim_day, heiferIIIs, cows,
-                                                                               total_animal_num)
+        total_animal_num = self._evaluate_calves_for_weaning(
+            sim_day, calves, heiferIs, total_animal_num
+        )
+        total_animal_num = self._evaluate_heiferIs_for_transitioning_to_heiferIIs(
+            sim_day, heiferIs, heiferIIs, total_animal_num
+        )
+        (
+            total_animal_num,
+            preg_heifer_num,
+        ) = self._evaluate_heiferIIs_for_transitioning_to_heiferIIIs(
+            sim_day, heiferIIs, heiferIIIs, preg_heifer_num, total_animal_num
+        )
+        total_animal_num = self._evaluate_heiferIIIs_for_transitioning_to_cows(
+            sim_day, heiferIIIs, cows, total_animal_num
+        )
 
-        total_animal_num = self._cull_cows_and_record_stats(sim_day, cows, calves_born,
-                                                            animals_removed, total_animal_num)
-        self._check_if_heifers_need_to_be_sold(heiferIIIs, cows, animals_removed)
-        self._check_if_replacement_heifers_needed(sim_day, heiferIIIs, cows, animals_added)
+        total_animal_num = self._cull_cows_and_record_stats(
+            sim_day, cows, calves_born, animals_removed, total_animal_num
+        )
+        self._check_if_heifers_need_to_be_sold(
+            heiferIIIs, cows, animals_removed, sim_day
+        )
+        self._check_if_replacement_heifers_needed(
+            sim_day, heiferIIIs, cows, animals_added
+        )
 
         self._calculate_herd_percentages(total_animal_num)
         self._calculate_cow_percentages()
         self._calculate_cull_reason_stats_percent()
         self._calculate_percent_cow_per_parity()
 
-        self.daily_milk_production = sum(cow.estimated_daily_milk_produced for cow in cows)
+        self.daily_milk_production = sum(
+            cow.estimated_daily_milk_produced for cow in cows
+        )
         self.herd_milk_fat_kg = sum(cow.milk_fat_kg for cow in cows)
         self.herd_milk_fat_percent = self.herd_milk_fat_kg / self.daily_milk_production
         self.herd_milk_protein_kg = sum(cow.milk_protein_kg for cow in cows)
-        self.herd_milk_protein_percent = self.herd_milk_protein_kg / self.daily_milk_production
+        self.herd_milk_protein_percent = (
+            self.herd_milk_protein_kg / self.daily_milk_production
+        )
 
-        return (animals_added, animals_removed, calves_born, calves, heiferIs,
-                heiferIIs, heiferIIIs, cows)
+        return (
+            animals_added,
+            animals_removed,
+            calves_born,
+            calves,
+            heiferIs,
+            heiferIIs,
+            heiferIIIs,
+            cows,
+        )
 
     def _reset_daily_stats(self) -> None:
         """Resets daily-based attributes."""
@@ -383,8 +416,13 @@ class LifeCycleManager:
             self.cull_reason_stats[cull_reason] = 0
             self.cull_reason_stats_percent[cull_reason] = 0.0
 
-    def _evaluate_calves_for_weaning(self, sim_day: int, calves: List[Calf],
-                                     heiferIs: List[HeiferI], total_animal_num: int) -> int:
+    def _evaluate_calves_for_weaning(
+        self,
+        sim_day: int,
+        calves: List[Calf],
+        heiferIs: List[HeiferI],
+        total_animal_num: int,
+    ) -> int:
         """Evaluates calves for weaning.
 
         If a calf is to be weaned, it will be removed from the calves list and
@@ -409,8 +447,11 @@ class LifeCycleManager:
                 removed_calves_idx.append(idx)
             else:
                 self.calf_num += 1
-                total_animal_num, self.avg_mature_body_weight = \
-                    Utility.calc_average(total_animal_num, self.avg_mature_body_weight, calf.mature_body_weight)
+                total_animal_num, self.avg_mature_body_weight = Utility.calc_average(
+                    total_animal_num,
+                    self.avg_mature_body_weight,
+                    calf.mature_body_weight,
+                )
 
         Utility.remove_items_from_list_by_indices(calves, removed_calves_idx)
         return total_animal_num
@@ -425,16 +466,22 @@ class LifeCycleManager:
 
         """
         calf_vals = calf.get_calf_values()
-        calf_vals.update({
-            'body_weight_history': calf.body_weight_history,
-            'pen_history': calf.pen_history
-        })
+        calf_vals.update(
+            {
+                "body_weight_history": calf.body_weight_history,
+                "pen_history": calf.pen_history,
+            }
+        )
         new_heiferI = HeiferI(calf_vals)
         heiferIs.append(new_heiferI)
 
-    def _evaluate_heiferIs_for_transitioning_to_heiferIIs(self, sim_day: int, heiferIs: List[HeiferI],
-                                                          heiferIIs: List[HeiferII],
-                                                          total_animal_num: int) -> int:
+    def _evaluate_heiferIs_for_transitioning_to_heiferIIs(
+        self,
+        sim_day: int,
+        heiferIs: List[HeiferI],
+        heiferIIs: List[HeiferII],
+        total_animal_num: int,
+    ) -> int:
         """Evaluates heiferIs for transitioning to heiferIIs.
 
         If a heiferI transitions to a heiferII, it will be removed
@@ -459,14 +506,19 @@ class LifeCycleManager:
                 removed_heiferIs_idx.append(idx)
             else:
                 self.heiferI_num += 1
-                total_animal_num, self.avg_mature_body_weight = \
-                    Utility.calc_average(total_animal_num, self.avg_mature_body_weight, heiferI.mature_body_weight)
+                total_animal_num, self.avg_mature_body_weight = Utility.calc_average(
+                    total_animal_num,
+                    self.avg_mature_body_weight,
+                    heiferI.mature_body_weight,
+                )
 
         Utility.remove_items_from_list_by_indices(heiferIs, removed_heiferIs_idx)
         return total_animal_num
 
     @staticmethod
-    def _convert_heiferI_to_heiferII(heiferI: HeiferI, heiferIIs: List[HeiferII]) -> None:
+    def _convert_heiferI_to_heiferII(
+        heiferI: HeiferI, heiferIIs: List[HeiferII]
+    ) -> None:
         """Converts a heiferI to a heiferII and appends it to the heiferIIs list.
 
         Args:
@@ -475,26 +527,43 @@ class LifeCycleManager:
 
         """
         heiferI_vals = heiferI.get_heiferI_values()
-        heiferI_vals.update({
-            'body_weight_history': heiferI.body_weight_history,
-            'pen_history': heiferI.pen_history
-        })
+        heiferI_vals.update(
+            {
+                "body_weight_history": heiferI.body_weight_history,
+                "pen_history": heiferI.pen_history,
+            }
+        )
         heiferI_vals.update(repro_program=HeiferII.get_user_defined_repro_protocol())
-        if HeiferII.get_user_defined_repro_protocol() == HeiferReproProtocolEnum.TAI.value:
-            heiferI_vals.update(tai_method_h=HeiferII.get_user_defined_repro_sub_protocol())
-            heiferI_vals.update(synch_ed_method_h='')
-        elif HeiferII.get_user_defined_repro_protocol() == HeiferReproProtocolEnum.SynchED.value:
-            heiferI_vals.update(tai_method_h='')
-            heiferI_vals.update(synch_ed_method_h=HeiferII.get_user_defined_repro_sub_protocol())
+        if (
+            HeiferII.get_user_defined_repro_protocol()
+            == HeiferReproProtocolEnum.TAI.value
+        ):
+            heiferI_vals.update(
+                tai_method_h=HeiferII.get_user_defined_repro_sub_protocol()
+            )
+            heiferI_vals.update(synch_ed_method_h="")
+        elif (
+            HeiferII.get_user_defined_repro_protocol()
+            == HeiferReproProtocolEnum.SynchED.value
+        ):
+            heiferI_vals.update(tai_method_h="")
+            heiferI_vals.update(
+                synch_ed_method_h=HeiferII.get_user_defined_repro_sub_protocol()
+            )
         else:
-            heiferI_vals.update(tai_method_h='')
-            heiferI_vals.update(synch_ed_method_h='')
+            heiferI_vals.update(tai_method_h="")
+            heiferI_vals.update(synch_ed_method_h="")
         new_heiferII = HeiferII(heiferI_vals)
         heiferIIs.append(new_heiferII)
 
-    def _evaluate_heiferIIs_for_transitioning_to_heiferIIIs(self, sim_day: int, heiferIIs: List[HeiferII],
-                                                            heiferIIIs: List[HeiferIII], preg_heifer_num: int,
-                                                            total_animal_num: int) -> Tuple[int, int]:
+    def _evaluate_heiferIIs_for_transitioning_to_heiferIIIs(
+        self,
+        sim_day: int,
+        heiferIIs: List[HeiferII],
+        heiferIIIs: List[HeiferIII],
+        preg_heifer_num: int,
+        total_animal_num: int,
+    ) -> Tuple[int, int]:
         """Evaluates heiferIIs for transitioning to heiferIIIs.
 
         If a heiferII is to be culled or transitions to a heiferIII, it will be removed
@@ -516,23 +585,33 @@ class LifeCycleManager:
         for idx, heiferII in enumerate(heiferIIs):
             is_cull_stage, is_heiferIII_stage = heiferII.update(sim_day)
             if is_cull_stage:
-                self.sold_heiferII_num, self.avg_heifer_culling_age = \
-                    Utility.calc_average(self.sold_heiferII_num, self.avg_heifer_culling_age, heiferII.days_born)
+                (
+                    self.sold_heiferII_num,
+                    self.avg_heifer_culling_age,
+                ) = Utility.calc_average(
+                    self.sold_heiferII_num,
+                    self.avg_heifer_culling_age,
+                    heiferII.days_born,
+                )
+                heiferII.sold_at_day = sim_day
                 self.sold_heiferIIs.append(heiferII)
                 removed_heiferIIs_idx.append(idx)
             elif is_heiferIII_stage:
                 self._convert_heiferII_to_heiferIII(heiferII, heiferIIIs)
                 removed_heiferIIs_idx.append(idx)
             else:
-                total_animal_num, preg_heifer_num = \
-                    self._remain_heiferII(heiferII, total_animal_num, preg_heifer_num)
+                total_animal_num, preg_heifer_num = self._remain_heiferII(
+                    heiferII, total_animal_num, preg_heifer_num
+                )
                 self._extract_repro_stats_from_heiferII(heiferII)
 
         Utility.remove_items_from_list_by_indices(heiferIIs, removed_heiferIIs_idx)
         return total_animal_num, preg_heifer_num
 
     @staticmethod
-    def _convert_heiferII_to_heiferIII(heiferII: HeiferII, heiferIIIs: List[HeiferIII]) -> None:
+    def _convert_heiferII_to_heiferIII(
+        heiferII: HeiferII, heiferIIIs: List[HeiferIII]
+    ) -> None:
         """Converts a heiferII to a heiferIII and appends it to the heiferIIIs list.
 
         Args:
@@ -541,16 +620,20 @@ class LifeCycleManager:
 
         """
         heiferII_vals = heiferII.get_heiferII_values()
-        heiferII_vals.update({
-            'body_weight_history': heiferII.body_weight_history,
-            'pen_history': heiferII.pen_history,
-            'conceptus_weight': heiferII.conceptus_weight,
-            'calf_birth_weight': heiferII.calf_birth_weight
-        })
+        heiferII_vals.update(
+            {
+                "body_weight_history": heiferII.body_weight_history,
+                "pen_history": heiferII.pen_history,
+                "conceptus_weight": heiferII.conceptus_weight,
+                "calf_birth_weight": heiferII.calf_birth_weight,
+            }
+        )
         new_heiferIII = HeiferIII(heiferII_vals)
         heiferIIIs.append(new_heiferIII)
 
-    def _remain_heiferII(self, heiferII: HeiferII, total_animal_num: int, preg_heifer_num: int):
+    def _remain_heiferII(
+        self, heiferII: HeiferII, total_animal_num: int, preg_heifer_num: int
+    ):
         """Updates relevant stats by keeping a heiferII as is.
 
         The following attributes are updated: heiferII_num, avg_mature_body_weight,
@@ -565,13 +648,15 @@ class LifeCycleManager:
 
         """
         self.heiferII_num += 1
-        total_animal_num, self.avg_mature_body_weight = \
-            Utility.calc_average(total_animal_num, self.avg_mature_body_weight,
-                                 heiferII.mature_body_weight)
+        total_animal_num, self.avg_mature_body_weight = Utility.calc_average(
+            total_animal_num, self.avg_mature_body_weight, heiferII.mature_body_weight
+        )
         if heiferII.breeding_to_preg_time != 0:
-            preg_heifer_num, self.avg_breeding_to_preg_time = \
-                Utility.calc_average(preg_heifer_num, self.avg_breeding_to_preg_time,
-                                     heiferII.breeding_to_preg_time)
+            preg_heifer_num, self.avg_breeding_to_preg_time = Utility.calc_average(
+                preg_heifer_num,
+                self.avg_breeding_to_preg_time,
+                heiferII.breeding_to_preg_time,
+            )
         return total_animal_num, preg_heifer_num
 
     def _extract_repro_stats_from_heiferII(self, heiferII: HeiferII) -> None:
@@ -589,8 +674,13 @@ class LifeCycleManager:
         self.ai_num_h += heiferII.AI_times
         self.ed_period_h += heiferII.ED_days
 
-    def _evaluate_heiferIIIs_for_transitioning_to_cows(self, sim_day: int, heiferIIIs: List[HeiferIII], cows: List[Cow],
-                                                       total_animal_num: int) -> int:
+    def _evaluate_heiferIIIs_for_transitioning_to_cows(
+        self,
+        sim_day: int,
+        heiferIIIs: List[HeiferIII],
+        cows: List[Cow],
+        total_animal_num: int,
+    ) -> int:
         """Evaluates heiferIIIs for transitioning to cows.
 
         Args:
@@ -612,8 +702,11 @@ class LifeCycleManager:
                 removed_heiferIIIs_idx.append(idx)
             else:
                 self.heiferIII_num += 1
-                temp = Utility.calc_average(total_animal_num, self.avg_mature_body_weight,
-                                            heiferIII.mature_body_weight)
+                temp = Utility.calc_average(
+                    total_animal_num,
+                    self.avg_mature_body_weight,
+                    heiferIII.mature_body_weight,
+                )
                 total_animal_num, self.avg_mature_body_weight = temp
 
         Utility.remove_items_from_list_by_indices(heiferIIIs, removed_heiferIIIs_idx)
@@ -629,23 +722,30 @@ class LifeCycleManager:
 
         """
         args = heiferIII.get_heiferIII_values()
-        args.update({
-            'body_weight_history': heiferIII.body_weight_history,
-            'pen_history': heiferIII.pen_history,
-            'conceptus_weight': heiferIII.conceptus_weight,
-            'calf_birth_weight': heiferIII.calf_birth_weight
-        })
-        args.update(repro_program=AnimalBase.config['cow_repro_method'])
-        args.update(presynch_method=AnimalBase.config['cows']['presynch_protocol'])
-        args.update(tai_method_c=AnimalBase.config['cows']['repro_sub_protocol'])
-        args.update(resynch_method=AnimalBase.config['cows']['resynch_protocol'])
+        args.update(
+            {
+                "body_weight_history": heiferIII.body_weight_history,
+                "pen_history": heiferIII.pen_history,
+                "conceptus_weight": heiferIII.conceptus_weight,
+                "calf_birth_weight": heiferIII.calf_birth_weight,
+            }
+        )
+        args.update(repro_program=AnimalBase.config["cow_repro_method"])
+        args.update(presynch_method=AnimalBase.config["cows"]["presynch_protocol"])
+        args.update(tai_method_c=AnimalBase.config["cows"]["repro_sub_protocol"])
+        args.update(resynch_method=AnimalBase.config["cows"]["resynch_protocol"])
         new_cow = Cow(args)
         if len(cows) > 0:
             new_cow.milk_production_reduction = cows[0].milk_production_reduction
         cows.append(new_cow)
 
-    def _check_if_heifers_need_to_be_sold(self, heiferIIIs: List[HeiferIII], cows: List[Cow],
-                                          animals_removed: List[Cow]) -> None:
+    def _check_if_heifers_need_to_be_sold(
+        self,
+        heiferIIIs: List[HeiferIII],
+        cows: List[Cow],
+        animals_removed: List[Cow],
+        sim_day: int | None = None,
+    ) -> None:
         """Checks if any heifers need to be sold.
 
         If the number of heifers exceeds what is needed for the herd,
@@ -658,15 +758,24 @@ class LifeCycleManager:
 
         """
         sell_threshold = 1.03
-        while len(heiferIIIs) + len(cows) > self.herd_num * sell_threshold and len(heiferIIIs) > 0:
+        while (
+            len(heiferIIIs) + len(cows) > self.herd_num * sell_threshold
+            and len(heiferIIIs) > 0
+        ):
             removed_heiferIII = heiferIIIs.pop()
             animals_removed.append(removed_heiferIII)
+            removed_heiferIII.sold_at_day = sim_day
             self.sold_heiferIIIs.append(removed_heiferIII)
             self.sold_heiferIII_oversupply_num += 1
             self.heiferIII_num -= 1
 
-    def _check_if_replacement_heifers_needed(self, sim_day: int, heiferIIIs: List[HeiferIII], cows: List[Cow],
-                                             animals_added: List[Cow]) -> None:
+    def _check_if_replacement_heifers_needed(
+        self,
+        sim_day: int,
+        heiferIIIs: List[HeiferIII],
+        cows: List[Cow],
+        animals_added: List[Cow],
+    ) -> None:
         """Checks if replacement heifers are needed.
 
         If the number of heifers is less than what is needed for the herd,
@@ -680,18 +789,29 @@ class LifeCycleManager:
 
         """
         buy_threshold = 1.01
-        while len(cows) + len(heiferIIIs) + self.bought_heifer_num < self.herd_num * buy_threshold \
-                and sim_day > 1:
+        while (
+            len(cows) + len(heiferIIIs) + self.bought_heifer_num
+            < self.herd_num * buy_threshold
+            and sim_day > 1
+        ):
             if len(self.replacement_market) == 0:
                 break
             replacement = self.replacement_market.pop(0)
-            replacement.events.add_event(replacement.days_born, sim_day, animal_constants.ENTER_HERD)
+            replacement.events.add_event(
+                replacement.days_born, sim_day, animal_constants.ENTER_HERD
+            )
             replacement.set_p_purchased()
             animals_added.append(replacement)
             self.bought_heifer_num += 1
 
-    def _cull_cows_and_record_stats(self, sim_day: int, cows: List[Cow], calves_born: List[Calf],
-                                    animals_removed: List[Cow], total_animal_num: int) -> int:
+    def _cull_cows_and_record_stats(
+        self,
+        sim_day: int,
+        cows: List[Cow],
+        calves_born: List[Calf],
+        animals_removed: List[Cow],
+        total_animal_num: int,
+    ) -> int:
         """Culls cows and records stats.
 
         Args:
@@ -706,18 +826,8 @@ class LifeCycleManager:
 
         """
         calving_interval_avail_num = 0
-        calving_age_avail_num = {
-            '1': 0,
-            '2': 0,
-            '3': 0,
-            'greater_than_3': 0
-        }
-        calf_to_preg_time_avail_num = {
-            '1': 0,
-            '2': 0,
-            '3': 0,
-            'greater_than_3': 0
-        }
+        calving_age_avail_num = {"1": 0, "2": 0, "3": 0, "greater_than_3": 0}
+        calf_to_preg_time_avail_num = {"1": 0, "2": 0, "3": 0, "greater_than_3": 0}
         removed_cows_idx: List[int] = []
 
         # cow culling action and stats
@@ -726,15 +836,21 @@ class LifeCycleManager:
 
             # culled cows, calculate slaughter value and record culling reasons
             if culled:
-                self._cull_cow(cow)
+                self._cull_cow(cow, sim_day)
                 animals_removed.append(cow)
                 removed_cows_idx.append(index)
             else:
-                total_animal_num = self._handle_cow_body_weight_and_parity(cow, total_animal_num)
+                total_animal_num = self._handle_cow_body_weight_and_parity(
+                    cow, total_animal_num
+                )
                 self._handle_cow_milking(cow)
                 self._handle_cow_days_in_preg(cow)
-                self._handle_cow_calves(cow, calving_age_avail_num, calf_to_preg_time_avail_num)
-                calving_interval_avail_num = self._handle_cow_CI(cow, calving_interval_avail_num)
+                self._handle_cow_calves(
+                    cow, calving_age_avail_num, calf_to_preg_time_avail_num
+                )
+                calving_interval_avail_num = self._handle_cow_CI(
+                    cow, calving_interval_avail_num
+                )
                 self._extract_repro_stats_from_cow(cow)
 
             if new_born:
@@ -743,23 +859,27 @@ class LifeCycleManager:
         Utility.remove_items_from_list_by_indices(cows, removed_cows_idx)
         return total_animal_num
 
-    def _cull_cow(self, cow: Cow) -> None:
+    def _cull_cow(self, cow: Cow, sim_day: int | None = None) -> None:
         """Culls a cow and records the culling reason.
 
         Args:
             cow: The cow to be culled.
 
         """
+        cow.sold_at_day = sim_day
         self.sold_and_died_cows.append(cow)
         self.cull_reason_stats_range[cow.cull_reason] += 1
         self.cull_reason_stats[cow.cull_reason] += 1
 
-        parity = cow.calves if cow.calves <= 3 else '4+'
+        parity = cow.calves if cow.calves <= 3 else "4+"
         self.parity_culling_stats_range[parity] += 1
-        self.cow_herd_exit_num, self.avg_cow_culling_age = \
-            Utility.calc_average(self.cow_herd_exit_num, self.avg_cow_culling_age, cow.days_born)
+        self.cow_herd_exit_num, self.avg_cow_culling_age = Utility.calc_average(
+            self.cow_herd_exit_num, self.avg_cow_culling_age, cow.days_born
+        )
 
-    def _handle_cow_body_weight_and_parity(self, cow: Cow, total_animal_num: int) -> int:
+    def _handle_cow_body_weight_and_parity(
+        self, cow: Cow, total_animal_num: int
+    ) -> int:
         """Adjusts the average cow body weight, average parity number, and average mature body weight
 
         Args:
@@ -771,12 +891,15 @@ class LifeCycleManager:
 
         """
         _, self.avg_cow_body_weight = Utility.calc_average(
-            self.cow_num, self.avg_cow_body_weight, cow.body_weight)
+            self.cow_num, self.avg_cow_body_weight, cow.body_weight
+        )
         self.cow_num, self.avg_parity_num = Utility.calc_average(
-            self.cow_num, self.avg_parity_num, cow.calves)
+            self.cow_num, self.avg_parity_num, cow.calves
+        )
 
-        total_animal_num, self.avg_mature_body_weight = \
-            Utility.calc_average(total_animal_num, self.avg_mature_body_weight, cow.mature_body_weight)
+        total_animal_num, self.avg_mature_body_weight = Utility.calc_average(
+            total_animal_num, self.avg_mature_body_weight, cow.mature_body_weight
+        )
         return total_animal_num
 
     def _handle_cow_milking(self, cow: Cow) -> None:
@@ -787,10 +910,11 @@ class LifeCycleManager:
 
         """
         if cow.milking:
-            self.milking_cow_num, self.avg_days_in_milk = \
-                Utility.calc_average(self.milking_cow_num, self.avg_days_in_milk, cow.days_in_milk)
+            self.milking_cow_num, self.avg_days_in_milk = Utility.calc_average(
+                self.milking_cow_num, self.avg_days_in_milk, cow.days_in_milk
+            )
 
-            if cow.days_in_milk < self.animal_config['voluntary_waiting_period']:
+            if cow.days_in_milk < self.animal_config["voluntary_waiting_period"]:
                 self.vwp_cow_num += 1
         else:
             self.dry_cow_num += 1
@@ -805,28 +929,42 @@ class LifeCycleManager:
         if cow.days_in_preg == 0:
             self.open_cow_num += 1
         elif cow.days_in_preg > 0:
-            self.preg_cow_num, self.avg_days_in_preg = \
-                Utility.calc_average(self.preg_cow_num, self.avg_days_in_preg, cow.days_in_preg)
+            self.preg_cow_num, self.avg_days_in_preg = Utility.calc_average(
+                self.preg_cow_num, self.avg_days_in_preg, cow.days_in_preg
+            )
 
-    def _handle_cow_calves(self, cow: Cow, calving_age_avail_num, calf_to_preg_time_avail_num) -> None:
+    def _handle_cow_calves(
+        self, cow: Cow, calving_age_avail_num, calf_to_preg_time_avail_num
+    ) -> None:
         """Adjusts the average cow age per parity, average calving age, and average time from calf to pregnant."""
         if 0 < cow.calves <= 3:
             key = str(cow.calves)
         else:
-            key = 'greater_than_3'
+            key = "greater_than_3"
 
-        self.num_cow_for_parity[key], self.avg_age_for_parity[key] = \
-            Utility.calc_average(self.num_cow_for_parity[key], self.avg_age_for_parity[key], cow.days_born)
+        (
+            self.num_cow_for_parity[key],
+            self.avg_age_for_parity[key],
+        ) = Utility.calc_average(
+            self.num_cow_for_parity[key], self.avg_age_for_parity[key], cow.days_born
+        )
 
         calving_age = cow.events.get_most_recent_date(animal_constants.NEW_BIRTH)
         if calving_age != -1:
-            calving_age_avail_num[key], self.avg_age_for_calving[key] = \
-                Utility.calc_average(calving_age_avail_num[key], self.avg_age_for_calving[key], calving_age)
+            (
+                calving_age_avail_num[key],
+                self.avg_age_for_calving[key],
+            ) = Utility.calc_average(
+                calving_age_avail_num[key], self.avg_age_for_calving[key], calving_age
+            )
 
         if cow.calving_to_preg_time != 0:
             avg_times = self.avg_calving_to_preg_time
-            calf_to_preg_time_avail_num[key], avg_times[key] = \
-                Utility.calc_average(calf_to_preg_time_avail_num[key], avg_times[key], cow.calving_to_preg_time)
+            calf_to_preg_time_avail_num[key], avg_times[key] = Utility.calc_average(
+                calf_to_preg_time_avail_num[key],
+                avg_times[key],
+                cow.calving_to_preg_time,
+            )
 
     def _handle_cow_CI(self, cow: Cow, calving_interval_avail_num: int) -> int:
         """Adjusts the average calving interval.
@@ -840,8 +978,12 @@ class LifeCycleManager:
 
         """
         if cow.CI != 0:
-            calving_interval_avail_num, self.avg_calving_interval = \
-                Utility.calc_average(calving_interval_avail_num, self.avg_calving_interval, cow.CI)
+            (
+                calving_interval_avail_num,
+                self.avg_calving_interval,
+            ) = Utility.calc_average(
+                calving_interval_avail_num, self.avg_calving_interval, cow.CI
+            )
         return calving_interval_avail_num
 
     def _extract_repro_stats_from_cow(self, cow: Cow) -> None:
@@ -859,23 +1001,27 @@ class LifeCycleManager:
 
     def _handle_new_born(self, sim_day: int, cow: Cow, calves_born: List[Calf]) -> None:
         args = {
-            'id': self.animal_population.next_id(),
-            'breed': 'HO',
-            'birth_date': sim_day,
-            'days_born': 0,
-            'p_init': cow.p_gest_for_calf,
-            'birth_weight': cow.calf_birth_weight
+            "id": self.animal_population.next_id(),
+            "breed": "HO",
+            "birth_date": sim_day,
+            "days_born": 0,
+            "p_init": cow.p_gest_for_calf,
+            "birth_weight": cow.calf_birth_weight,
         }
         # at parturition, the sum of P absorbed for gestation rqmts is
         # subtracted from the animal value. the sum of P absorbed for
         # gestation is equal to the initial animal P value for the calf
         # (A.1G.A.4)
-        cow.p_animal = cow.p_animal - cow.p_gest_for_calf + cow.p_growth + cow.dP_reserves
+        cow.p_animal = (
+            cow.p_animal - cow.p_gest_for_calf + cow.p_growth + cow.dP_reserves
+        )
         new_calf = Calf(args)
         cow.p_gest_for_calf = 0
         cow.calf_birth_weight = 0
         if not (new_calf.culled or new_calf.sold):
-            new_calf.events.add_event(new_calf.days_born, sim_day, animal_constants.ENTER_HERD)
+            new_calf.events.add_event(
+                new_calf.days_born, sim_day, animal_constants.ENTER_HERD
+            )
             # calves.append(new_calf)
             calves_born.append(new_calf)
         if new_calf.sold:
@@ -913,7 +1059,9 @@ class LifeCycleManager:
         denominator = self.cow_herd_exit_num if self.cow_herd_exit_num > 0 else 1
         pc = Utility.percent_calculator(denominator)
         for cull_reason in self.cull_reason_stats:
-            self.cull_reason_stats_percent[cull_reason] = pc(self.cull_reason_stats[cull_reason])
+            self.cull_reason_stats_percent[cull_reason] = pc(
+                self.cull_reason_stats[cull_reason]
+            )
 
     def _calculate_percent_cow_per_parity(self) -> None:
         """Calculates the percentage of cows for each parity number."""

--- a/RUFAS/simulation_engine.py
+++ b/RUFAS/simulation_engine.py
@@ -47,6 +47,7 @@ class SimulationEngine:
         """
         Initializes the simulation engine.
         """
+        self.day_counter: int = 0
         self._initialize_simulation()
 
     def simulate(self) -> None:
@@ -60,13 +61,23 @@ class SimulationEngine:
         }
         t_start_sim = timer.time()
         self._run_simulation_main_loop()
-        routines.animal.animal_module_reporter.AnimalModuleReporter.report_end_of_simulation(self.state.animal_manager)
+        routines.animal.animal_module_reporter.AnimalModuleReporter.report_end_of_simulation(
+            self.state.animal_manager, self.day_counter
+        )
         t_end_sim = timer.time()
 
         sys.stdout.write("\nSimulation Successful\n\n")
         total_simulation_time = t_end_sim - t_start_sim
         total_simulation_time_log = f"Total simulation time is: {total_simulation_time}"
         om.add_log("total_simulation_time", total_simulation_time_log, info_map)
+        om.add_variable(
+            "day_counter_final_value",
+            self.day_counter,
+            {
+                "class": self.__class__.__name__,
+                "function": self.simulate.__name__,
+            },
+        )
 
     def _run_simulation_main_loop(self) -> None:
         """
@@ -78,12 +89,17 @@ class SimulationEngine:
 
     def _daily_simulation(self) -> None:
         """Executes the daily simulation routines."""
+        self.day_counter += 1
         self.state.animal_manager.daily_updates(
-            self.state.feed, self.weather, self.time)
+            self.state.feed, self.weather, self.time
+        )
         simulate_daily_manure_manager(
-            self.state.manure_manager, self.state.animal_manager)
+            self.state.manure_manager, self.state.animal_manager
+        )
         self.state.field_manager.daily_update_routine(self.weather, self.time)
-        routines.daily_feed_routine(self.state.feed, self.state.field_manager, self.state.animal_manager)
+        routines.daily_feed_routine(
+            self.state.feed, self.state.field_manager, self.state.animal_manager
+        )
 
         self.time.record_time()
         self.weather.record_weather(self.time)
@@ -102,9 +118,7 @@ class SimulationEngine:
         }
         if print_day:
             simulating_day_log = f"simulating day: {self.time.to_str()}"
-            om.add_log("simulation_day",
-                       simulating_day_log,
-                       info_map)
+            om.add_log("simulation_day", simulating_day_log, info_map)
         self.time.advance()
         self.state.animal_manager.simulation_day += 1
 
@@ -136,7 +150,7 @@ class SimulationEngine:
             the interval at which the char symbol is updated. Default is 50 days.
         """
 
-        chars = ['-', '\\', '|', '/']
+        chars = ["-", "\\", "|", "/"]
         if day % update_interval == 0:
             sys.stdout.write("\b")
             sys.stdout.write(chars[(day // update_interval) % len(chars)])
@@ -158,8 +172,8 @@ class SimulationEngine:
         Instantiates the simulation object by requesting data from the Input Manager.
         """
 
-        data_config = im.get_data('config')
-        data_weather = im.get_data('weather')
+        data_config = im.get_data("config")
+        data_weather = im.get_data("weather")
         self.config = Config(data_config)
 
         if self.config.set_seed:

--- a/tests/animal_module_tests/test_animal_reporter.py
+++ b/tests/animal_module_tests/test_animal_reporter.py
@@ -419,7 +419,7 @@ def test_report_end_of_simulation(mocker: MockerFixture):
     )
 
     # act
-    AnimalModuleReporter.report_end_of_simulation(animal_manager)
+    AnimalModuleReporter.report_end_of_simulation(animal_manager, 100)
 
     # assert
     assert patch_for_plan_animal_allocation.call_count == 1

--- a/tests/test_simulation_engine.py
+++ b/tests/test_simulation_engine.py
@@ -10,7 +10,9 @@ def test_simulation_engine_init(mocker: MockerFixture) -> None:
     """
 
     # Arrange
-    mock_initialize_simulation = mocker.patch.object(SimulationEngine, '_initialize_simulation')
+    mock_initialize_simulation = mocker.patch.object(
+        SimulationEngine, "_initialize_simulation"
+    )
 
     # Act
     _ = SimulationEngine()
@@ -19,28 +21,32 @@ def test_simulation_engine_init(mocker: MockerFixture) -> None:
     mock_initialize_simulation.assert_called_once()
 
 
-@pytest.mark.parametrize(
-    "start_time, end_time", [
-        (100, 200),
-        (300, 400)
-    ])
+@pytest.mark.parametrize("start_time, end_time", [(100, 200), (300, 400)])
 def test_simulate(mocker: MockerFixture, start_time: int, end_time: int) -> None:
     """
     Unit test for function simulate in file RUFAS/simulation_engine.py
     """
 
     # Arrange
-    patch_for_output_manager = mocker.patch('RUFAS.simulation_engine.om')
-    mocker.patch('RUFAS.simulation_engine.timer.time', side_effect=[start_time, end_time])
-    patch_for_sys_stdout_write = mocker.patch('RUFAS.simulation_engine.sys.stdout.write')
-    mocker.patch.object(SimulationEngine, '__init__', return_value=None)
+    patch_for_output_manager = mocker.patch("RUFAS.simulation_engine.om")
+    mocker.patch(
+        "RUFAS.simulation_engine.timer.time", side_effect=[start_time, end_time]
+    )
+    patch_for_sys_stdout_write = mocker.patch(
+        "RUFAS.simulation_engine.sys.stdout.write"
+    )
+    mocker.patch.object(SimulationEngine, "__init__", return_value=None)
     simulation_engine = SimulationEngine()
+    simulation_engine.day_counter = 100
     simulation_engine.state = mocker.MagicMock()
-    patch_for_run_simulation_main_loop = mocker.patch.object(simulation_engine, '_run_simulation_main_loop',
-                                                             return_value=None)
-    patch_for_animal_module_reporter = mocker.patch('RUFAS.simulation_engine.routines.animal'
-                                                    '.animal_module_reporter.AnimalModuleReporter'
-                                                    '.report_end_of_simulation')
+    patch_for_run_simulation_main_loop = mocker.patch.object(
+        simulation_engine, "_run_simulation_main_loop", return_value=None
+    )
+    patch_for_animal_module_reporter = mocker.patch(
+        "RUFAS.simulation_engine.routines.animal"
+        ".animal_module_reporter.AnimalModuleReporter"
+        ".report_end_of_simulation"
+    )
 
     info_map = {
         "class": simulation_engine.__class__.__name__,
@@ -55,10 +61,12 @@ def test_simulate(mocker: MockerFixture, start_time: int, end_time: int) -> None
     patch_for_sys_stdout_write.assert_called_once_with("\nSimulation Successful\n\n")
     expected_simulation_time = end_time - start_time
     expected_log_message = f"Total simulation time is: {expected_simulation_time}"
-    patch_for_output_manager.add_log.assert_called_with("total_simulation_time",
-                                                        expected_log_message,
-                                                        info_map)
-    patch_for_animal_module_reporter.assert_called_once_with(simulation_engine.state.animal_manager)
+    patch_for_output_manager.add_log.assert_called_with(
+        "total_simulation_time", expected_log_message, info_map
+    )
+    patch_for_animal_module_reporter.assert_called_once_with(
+        simulation_engine.state.animal_manager, 100
+    )
 
 
 def test_daily_simulation(mocker: MockerFixture) -> None:
@@ -67,31 +75,43 @@ def test_daily_simulation(mocker: MockerFixture) -> None:
     """
 
     # Arrange
-    mocker.patch.object(SimulationEngine, '__init__', return_value=None)
+    mocker.patch.object(SimulationEngine, "__init__", return_value=None)
     simulation_engine = SimulationEngine()
+    simulation_engine.day_counter = 100
     simulation_engine.state = mocker.MagicMock()
     simulation_engine.weather = mocker.MagicMock()
     simulation_engine.time = mocker.MagicMock()
 
-    patch_for_simulate_daily_manure_manager = mocker.patch('RUFAS.simulation_engine.simulate_daily_manure_manager')
-    patch_for_daily_feed_routine = mocker.patch('RUFAS.simulation_engine.routines.daily_feed_routine')
-    patch_for_advance_time = mocker.patch.object(simulation_engine, '_advance_time')
+    patch_for_simulate_daily_manure_manager = mocker.patch(
+        "RUFAS.simulation_engine.simulate_daily_manure_manager"
+    )
+    patch_for_daily_feed_routine = mocker.patch(
+        "RUFAS.simulation_engine.routines.daily_feed_routine"
+    )
+    patch_for_advance_time = mocker.patch.object(simulation_engine, "_advance_time")
 
     # Act
     simulation_engine._daily_simulation()
 
     # Assert
     simulation_engine.state.animal_manager.daily_updates.assert_called_once_with(
-        simulation_engine.state.feed, simulation_engine.weather, simulation_engine.time)
+        simulation_engine.state.feed, simulation_engine.weather, simulation_engine.time
+    )
     patch_for_simulate_daily_manure_manager.assert_called_once_with(
-        simulation_engine.state.manure_manager, simulation_engine.state.animal_manager)
+        simulation_engine.state.manure_manager, simulation_engine.state.animal_manager
+    )
     simulation_engine.state.field_manager.daily_update_routine.assert_called_once_with(
-        simulation_engine.weather, simulation_engine.time)
+        simulation_engine.weather, simulation_engine.time
+    )
     patch_for_daily_feed_routine.assert_called_once_with(
-        simulation_engine.state.feed, simulation_engine.state.field_manager,
-        simulation_engine.state.animal_manager)
+        simulation_engine.state.feed,
+        simulation_engine.state.field_manager,
+        simulation_engine.state.animal_manager,
+    )
     simulation_engine.time.record_time.assert_called_once()
-    simulation_engine.weather.record_weather.assert_called_once_with(simulation_engine.time)
+    simulation_engine.weather.record_weather.assert_called_once_with(
+        simulation_engine.time
+    )
     patch_for_advance_time.assert_called_once()
 
 
@@ -101,33 +121,42 @@ def test_initialize_simulation(mocker: MockerFixture) -> None:
     """
 
     # Arrange
-    mocker.patch.object(SimulationEngine, '__init__', return_value=None)
+    mocker.patch.object(SimulationEngine, "__init__", return_value=None)
     simulation_engine = SimulationEngine()
 
-    config_data = {'set_seed': True, 'seed': 42}
-    patch_for_get_data = mocker.patch('RUFAS.simulation_engine.im.get_data',
-                                      side_effect=[config_data, {}])
+    config_data = {"set_seed": True, "seed": 42}
+    patch_for_get_data = mocker.patch(
+        "RUFAS.simulation_engine.im.get_data", side_effect=[config_data, {}]
+    )
 
     mock_config = mocker.MagicMock(**config_data)
-    patch_for_config = mocker.patch('RUFAS.simulation_engine.Config', return_value=mock_config)
+    patch_for_config = mocker.patch(
+        "RUFAS.simulation_engine.Config", return_value=mock_config
+    )
 
     mock_weather = mocker.MagicMock()
-    patch_for_weather = mocker.patch('RUFAS.simulation_engine.Weather', return_value=mock_weather)
+    patch_for_weather = mocker.patch(
+        "RUFAS.simulation_engine.Weather", return_value=mock_weather
+    )
 
     mock_time = mocker.MagicMock()
-    patch_for_time = mocker.patch('RUFAS.simulation_engine.Time', return_value=mock_time)
+    patch_for_time = mocker.patch(
+        "RUFAS.simulation_engine.Time", return_value=mock_time
+    )
 
     mock_state = mocker.MagicMock()
-    patch_for_state = mocker.patch('RUFAS.simulation_engine.State', return_value=mock_state)
+    patch_for_state = mocker.patch(
+        "RUFAS.simulation_engine.State", return_value=mock_state
+    )
 
-    patch_for_random_seed = mocker.patch('RUFAS.simulation_engine.random.seed')
-    patch_for_numpy_seed = mocker.patch('RUFAS.simulation_engine.numpy.random.seed')
+    patch_for_random_seed = mocker.patch("RUFAS.simulation_engine.random.seed")
+    patch_for_numpy_seed = mocker.patch("RUFAS.simulation_engine.numpy.random.seed")
 
     # Act
     simulation_engine._initialize_simulation()
 
     # Assert
-    patch_for_get_data.assert_has_calls([mocker.call('config'), mocker.call('weather')])
+    patch_for_get_data.assert_has_calls([mocker.call("config"), mocker.call("weather")])
     patch_for_random_seed.assert_called_once_with(42)
     patch_for_numpy_seed.assert_called_once_with(42)
 
@@ -138,30 +167,33 @@ def test_initialize_simulation(mocker: MockerFixture) -> None:
 
 
 @pytest.mark.parametrize(
-    "day, update_interval, expected_output, should_write", [
+    "day, update_interval, expected_output, should_write",
+    [
         # Day is a multiple of update_interval, should write first char
         (0, 50, "-", True),
-
         # Day is a multiple of update_interval, should write second char
         (50, 50, "\\", True),
-
         # Day is a multiple of update_interval, should write third char
         (100, 50, "|", True),
-
         # Day is a multiple of update_interval, should write fourth char
         (150, 50, "/", True),
-
         # Day is not a multiple of update_interval, should not write
         (51, 50, "", False),
-    ])
-def test_visualize_sim_progress(mocker: MockerFixture, day: int, update_interval: int,
-                                expected_output: str, should_write: bool) -> None:
+    ],
+)
+def test_visualize_sim_progress(
+    mocker: MockerFixture,
+    day: int,
+    update_interval: int,
+    expected_output: str,
+    should_write: bool,
+) -> None:
     """
     Unit test for function _visualize_sim_progress in file RUFAS/simulation_engine.py
     """
 
     # Arrange
-    mock_stdout = mocker.patch('RUFAS.simulation_engine.sys.stdout')
+    mock_stdout = mocker.patch("RUFAS.simulation_engine.sys.stdout")
 
     # Act
     SimulationEngine._visualize_sim_progress(day, update_interval)
@@ -174,29 +206,39 @@ def test_visualize_sim_progress(mocker: MockerFixture, day: int, update_interval
 
 
 @pytest.mark.parametrize(
-    "end_year_side_effect, expected_day_count", [
+    "end_year_side_effect, expected_day_count",
+    [
         # Simulate 1 year end
         ([False, True], 1),
-
         # Simulate 2 years end
         ([False, False, True], 2),
-
         # Simulate 4 years end
         ([False] * 4 + [True], 4),
-    ])
-def test_annual_simulation(mocker: MockerFixture, end_year_side_effect: list, expected_day_count: int) -> None:
+    ],
+)
+def test_annual_simulation(
+    mocker: MockerFixture, end_year_side_effect: list, expected_day_count: int
+) -> None:
     """
     Unit test for function _annual_simulation in file RUFAS/simulation_engine.py
     """
 
     # Arrange
-    mocker.patch.object(SimulationEngine, '__init__', return_value=None)
+    mocker.patch.object(SimulationEngine, "__init__", return_value=None)
     simulation_engine = SimulationEngine()
 
-    patch_for_run_pre_annual_routines = mocker.patch.object(simulation_engine, '_run_pre_annual_routines')
-    patch_for_run_post_annual_routines = mocker.patch.object(simulation_engine, '_run_post_annual_routines')
-    patch_for_daily_simulation = mocker.patch.object(simulation_engine, '_daily_simulation')
-    patch_for_visualize_sim_progress = mocker.patch.object(simulation_engine, '_visualize_sim_progress')
+    patch_for_run_pre_annual_routines = mocker.patch.object(
+        simulation_engine, "_run_pre_annual_routines"
+    )
+    patch_for_run_post_annual_routines = mocker.patch.object(
+        simulation_engine, "_run_post_annual_routines"
+    )
+    patch_for_daily_simulation = mocker.patch.object(
+        simulation_engine, "_daily_simulation"
+    )
+    patch_for_visualize_sim_progress = mocker.patch.object(
+        simulation_engine, "_visualize_sim_progress"
+    )
 
     simulation_engine.time = mocker.MagicMock()
     simulation_engine.time.end_year.side_effect = end_year_side_effect
@@ -217,7 +259,7 @@ def test_run_post_annual_routines(mocker: MockerFixture) -> None:
     """
 
     # Arrange
-    mocker.patch.object(SimulationEngine, '__init__', return_value=None)
+    mocker.patch.object(SimulationEngine, "__init__", return_value=None)
     simulation_engine = SimulationEngine()
 
     simulation_engine.state = mocker.MagicMock()
@@ -227,7 +269,9 @@ def test_run_post_annual_routines(mocker: MockerFixture) -> None:
     simulation_engine._run_post_annual_routines()
 
     # Assert
-    simulation_engine.state.annual_mass_balance.assert_called_once_with(simulation_engine.time)
+    simulation_engine.state.annual_mass_balance.assert_called_once_with(
+        simulation_engine.time
+    )
     simulation_engine.state.annual_reset.assert_called_once()
     simulation_engine.time.advance.assert_called_once()
 
@@ -238,12 +282,14 @@ def test_run_pre_annual_routines(mocker: MockerFixture) -> None:
     """
 
     # Arrange
-    mocker.patch.object(SimulationEngine, '__init__', return_value=None)
+    mocker.patch.object(SimulationEngine, "__init__", return_value=None)
     simulation_engine = SimulationEngine()
 
     simulation_engine.state = mocker.MagicMock()
 
-    patch_for_annual_feed_routine = mocker.patch('RUFAS.simulation_engine.routines.annual_feed_routine')
+    patch_for_annual_feed_routine = mocker.patch(
+        "RUFAS.simulation_engine.routines.annual_feed_routine"
+    )
 
     # Act
     simulation_engine._run_pre_annual_routines()
@@ -253,38 +299,45 @@ def test_run_pre_annual_routines(mocker: MockerFixture) -> None:
 
 
 @pytest.mark.parametrize(
-    "print_day, initial_simulation_day, to_str_return_value, expected_simulation_day", [
+    "print_day, initial_simulation_day, to_str_return_value, expected_simulation_day",
+    [
         (True, 0, "Day 1", 1),
         (False, 0, "Day 1", 1),
         (True, 10, "Day 11", 11),
         (False, 10, "Day 11", 11),
         (True, 365, "Day 366", 366),
         (False, 365, "Day 366", 366),
-    ]
+    ],
 )
-def test_advance_time(mocker: MockerFixture, print_day: bool,
-                      initial_simulation_day: int, to_str_return_value: str,
-                      expected_simulation_day: int) -> None:
+def test_advance_time(
+    mocker: MockerFixture,
+    print_day: bool,
+    initial_simulation_day: int,
+    to_str_return_value: str,
+    expected_simulation_day: int,
+) -> None:
     """
     Unit test for function _advance_time in file RUFAS/simulation_engine.py
     """
 
     # Arrange
-    mocker.patch.object(SimulationEngine, '__init__', return_value=None)
+    mocker.patch.object(SimulationEngine, "__init__", return_value=None)
     simulation_engine = SimulationEngine()
 
     simulation_engine.time = mocker.MagicMock()
     simulation_engine.time.to_str.return_value = to_str_return_value
     simulation_engine.state = mocker.MagicMock()
     simulation_engine.state.animal_manager.simulation_day = initial_simulation_day
-    patch_for_add_log = mocker.patch('RUFAS.simulation_engine.om.add_log')
+    patch_for_add_log = mocker.patch("RUFAS.simulation_engine.om.add_log")
 
     # Act
     simulation_engine._advance_time(print_day)
 
     # Assert
     simulation_engine.time.advance.assert_called_once()
-    assert simulation_engine.state.animal_manager.simulation_day == expected_simulation_day
+    assert (
+        simulation_engine.state.animal_manager.simulation_day == expected_simulation_day
+    )
 
     if print_day:
         expected_log_message = f"simulating day: {to_str_return_value}"
@@ -294,39 +347,40 @@ def test_advance_time(mocker: MockerFixture, print_day: bool,
             "print_day": print_day,
         }
         patch_for_add_log.assert_called_once_with(
-            "simulation_day",
-            expected_log_message,
-            expected_info_map
+            "simulation_day", expected_log_message, expected_info_map
         )
     else:
         patch_for_add_log.assert_not_called()
 
 
 @pytest.mark.parametrize(
-    "end_simulation_side_effect, expected_iterations", [
+    "end_simulation_side_effect, expected_iterations",
+    [
         # Simulate a loop that runs once
         ([False, True], 1),
-
         # Simulate a loop that runs twice
         ([False, False, True], 2),
-
         # Simulate a loop that runs three times
         ([False, False, False, True], 3),
-    ])
-def test_run_simulation_main_loop(mocker: MockerFixture, end_simulation_side_effect: list,
-                                  expected_iterations: int) -> None:
+    ],
+)
+def test_run_simulation_main_loop(
+    mocker: MockerFixture, end_simulation_side_effect: list, expected_iterations: int
+) -> None:
     """
     Unit test for function _run_simulation_main_loop in file RUFAS/simulation_engine.py
     """
 
     # Arrange
-    mocker.patch.object(SimulationEngine, '__init__', return_value=None)
+    mocker.patch.object(SimulationEngine, "__init__", return_value=None)
     simulation_engine = SimulationEngine()
 
     simulation_engine.time = mocker.MagicMock()
     simulation_engine.time.end_simulation.side_effect = end_simulation_side_effect
 
-    patch_for_annual_simulation = mocker.patch.object(simulation_engine, '_annual_simulation')
+    patch_for_annual_simulation = mocker.patch.object(
+        simulation_engine, "_annual_simulation"
+    )
 
     # Act
     simulation_engine._run_simulation_main_loop()


### PR DESCRIPTION
This PR addresses issue #1067 by adding the `sold_at_day` variable to the base animal and populating it when a HeiferII, HeiferIII, or Cow is sold. Then, in animal module reporter, uses this value to compile a list of daily sales and reports how many animals were sold and how much they weighed to OM. Adds the following keys to OM:
```
AnimalModuleReporter.report_sold_animal_information_sort_by_sell_day.heiferII_sold_count
AnimalModuleReporter.report_sold_animal_information_sort_by_sell_day.heiferII_sold_weight
AnimalModuleReporter.report_sold_animal_information_sort_by_sell_day.heiferIII_sold_count
AnimalModuleReporter.report_sold_animal_information_sort_by_sell_day.heiferIII_sold_weight
AnimalModuleReporter.report_sold_animal_information_sort_by_sell_day.sold_and_died_cows_sold_count
AnimalModuleReporter.report_sold_animal_information_sort_by_sell_day.sold_and_died_cows_sold_weight
```

This is needed urgently, will do the tests later.