### PR TITLE
Change hard-coded values in `life_cycle` and `herd_factory`

### DIFF
--- a/RUFAS/routines/animal/life_cycle/herd_factory.py
+++ b/RUFAS/routines/animal/life_cycle/herd_factory.py
@@ -143,10 +143,10 @@ class HerdFactory:
                 args = heiferIII.get_heiferIII_values()
 
                 args.update(id=self.pre_animal_population.next_id())
-                args.update(repro_program='TAI')
-                args.update(presynch_method='PreSynch')
-                args.update(tai_method_c='OvSynch 56')
-                args.update(resynch_method='TAIafterPD')
+                args.update(repro_program=AnimalBase.config["cow_repro_method"])
+                args.update(presynch_method=AnimalBase.config["cows"]["presynch_protocol"])
+                args.update(tai_method_c=AnimalBase.config["cows"]["repro_sub_protocol"])
+                args.update(resynch_method=AnimalBase.config["cows"]["resynch_protocol"])
 
                 cow = Cow(args)
 

--- a/RUFAS/routines/animal/life_cycle/life_cycle.py
+++ b/RUFAS/routines/animal/life_cycle/life_cycle.py
@@ -1002,7 +1002,7 @@ class LifeCycleManager:
     def _handle_new_born(self, sim_day: int, cow: Cow, calves_born: List[Calf]) -> None:
         args = {
             "id": self.animal_population.next_id(),
-            "breed": "HO",
+            "breed": im.get_data("animal.herd_information.breed"),
             "birth_date": sim_day,
             "days_born": 0,
             "p_init": cow.p_gest_for_calf,

--- a/RUFAS/routines/animal/life_cycle/life_cycle.py
+++ b/RUFAS/routines/animal/life_cycle/life_cycle.py
@@ -1022,7 +1022,6 @@ class LifeCycleManager:
             new_calf.events.add_event(
                 new_calf.days_born, sim_day, animal_constants.ENTER_HERD
             )
-            # calves.append(new_calf)
             calves_born.append(new_calf)
         if new_calf.sold:
             self.sold_calf_num += 1

--- a/input/data/animal/barnyard_animal.json
+++ b/input/data/animal/barnyard_animal.json
@@ -7,7 +7,6 @@
 		"cow_num": 0,
 		"replace_num": 0,
 		"herd_num": 0,
-		"herd_init": false,
 		"breed": "HO"
 	},
 	"herd_initialization": {

--- a/input/data/animal/default_animal.json
+++ b/input/data/animal/default_animal.json
@@ -7,7 +7,6 @@
     "cow_num": 100,
     "replace_num": 500,
     "herd_num": 100,
-    "herd_init": false,
     "breed": "HO"
   },
   "herd_initialization": {

--- a/tests/animal_module_tests/life_cycle/test_herd_factory.py
+++ b/tests/animal_module_tests/life_cycle/test_herd_factory.py
@@ -369,6 +369,16 @@ def test_heiferIII_update_cow_stage_true_day_less_than_3000(heiferIII_num: int,
     mock_cow_init = mocker.patch("RUFAS.routines.animal.life_cycle.herd_factory.Cow.__init__",
                                  return_value=None)
 
+    mocker.patch("RUFAS.routines.animal.life_cycle.herd_factory.AnimalBase.config",
+                 return_value={
+                     'cow_repro_method': None,
+                     'cows': {
+                         'presynch_protocol': None,
+                         'repro_sub_protocol': None,
+                         'resynch_protocol': None
+                     }
+                 })
+
     mock_pre_animal_population = mock.MagicMock(auto_spec=AnimalPopulation)
     mock_pre_animal_population.heiferIIIs = mock_heiferIIIs
     mock_pre_animal_population.cows = []
@@ -407,6 +417,16 @@ def test_heiferIII_update_cow_stage_true_day_greater_than_3000(heiferIII_num: in
         return_value={})
     mock_cow_init = mocker.patch("RUFAS.routines.animal.life_cycle.herd_factory.Cow.__init__",
                                  return_value=None)
+
+    mocker.patch("RUFAS.routines.animal.life_cycle.herd_factory.AnimalBase.config",
+                 return_value={
+                     'cow_repro_method': None,
+                     'cows': {
+                         'presynch_protocol': None,
+                         'repro_sub_protocol': None,
+                         'resynch_protocol': None
+                     }
+                 })
 
     mock_pre_animal_population = mock.MagicMock(auto_spec=AnimalPopulation)
     mock_pre_animal_population.heiferIIIs = mock_heiferIIIs

--- a/tests/animal_module_tests/test_animal_life_cycle.py
+++ b/tests/animal_module_tests/test_animal_life_cycle.py
@@ -1050,6 +1050,9 @@ def test_handle_new_born(mocker: MockerFixture, life_cycle_manager: LifeCycleMan
                                        return_value=mock_calf)
     calves_born = []
 
+    mock_input_manager = InputManager()
+    patch_im_getdata = mocker.patch.object(mock_input_manager, 'get_data', return_value='HO')
+
     # Act
     life_cycle_manager._handle_new_born(sim_day, mock_cow, calves_born)
 
@@ -1057,6 +1060,7 @@ def test_handle_new_born(mocker: MockerFixture, life_cycle_manager: LifeCycleMan
     assert mock_cow.p_animal == expected_cow_p_animal
     assert mock_cow.p_gest_for_calf == approx(0.0)
     assert mock_cow.calf_birth_weight == approx(0.0)
+    patch_im_getdata.assert_called_once_with("animal.herd_information.breed")
     patch_for_mock_calf.assert_called_once_with({
         'id': calf_id,
         'breed': 'HO',


### PR DESCRIPTION
Addresses issue #1047 
This PR changes the following hard-coded values:
1. `RUFAS.routines.animal.life_cycle.life_cycle.LifeCycleManager._handle_new_born()` line 854:
The `breed` for new-born calf is hard-coded.
```python
    def _handle_new_born(self, sim_day: int, cow: Cow, calves_born: List[Calf]) -> None:
        args = {
            'id': self.animal_population.next_id(),
            'breed': 'HO',
            'birth_date': sim_day,
            'days_born': 0,
            'p_init': cow.p_gest_for_calf,
            'birth_weight': cow.calf_birth_weight
        }
```
2. `RUFAS.routines.animal.life_cycle.herd_factory.HerdFactory._heiferIIIs_update()` line 148-151:
The `repro_program`, `presynch_method`, `tai_method_c`, and `resynch_method` are hard-coded.
```python
    def _heiferIIIs_update(self, day: int) -> None:
        """HeiferIIIs update for generating herd simulation"""
        remaining_heiferIIIs: List[HeiferIII] = []
        for heiferIII in self.pre_animal_population.heiferIIIs:
            cow_stage = heiferIII.update(0)
            if cow_stage:
                args = heiferIII.get_heiferIII_values()

                args.update(id=self.pre_animal_population.next_id())
                args.update(repro_program='TAI')
                args.update(presynch_method='PreSynch')
                args.update(tai_method_c='OvSynch 56')
                args.update(resynch_method='TAIafterPD')

                cow = Cow(args)
```