### PR TITLE
Adding cows and calves sold counts to OM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ output/graphics/*
 !output/output_filters/
 output/output_filters/*
 !output/output_filters/report_example.json
+!output/output_filters/report_animals_sold.json
+!output/output_filters/report_animals_sold_by_sell_day.json
 
 # ignore project files
 *.sublime-project

--- a/RUFAS/routines/animal/animal_module_reporter.py
+++ b/RUFAS/routines/animal/animal_module_reporter.py
@@ -3,6 +3,7 @@ import numpy as np
 import sys
 
 from RUFAS.output_manager import OutputManager
+from RUFAS.routines.animal.life_cycle import animal_constants
 from RUFAS.routines.animal.ration.ration_driver import RationReporter
 from RUFAS.routines.animal.manure.general_manure import AnimalManureExcretions
 
@@ -184,10 +185,10 @@ class AnimalModuleReporter:
             )
 
     def report_daily_feed_emissions(
-        ration_total: dict[str, float],
-        pen_id: int,
-        pen_animal_name: str,
-        animal_manager,
+            ration_total: dict[str, float],
+            pen_id: int,
+            pen_animal_name: str,
+            animal_manager,
     ) -> None:
         """
         Adds emissions totals from purchased feeds on a pen / feed basis.
@@ -218,7 +219,7 @@ class AnimalModuleReporter:
         )
 
     def report_animal_module_manure(
-        manure_excretions_output_data: dict[str, dict[str | AnimalManureExcretions]],
+            manure_excretions_output_data: dict[str, dict[str | AnimalManureExcretions]],
     ) -> None:
         """
         Generate detailed report of manure properties in the Animal Module.
@@ -407,6 +408,7 @@ class AnimalModuleReporter:
             "cull_reason_stats", life_cycle_manager.cull_reason_stats, info_map
         )
 
+    @staticmethod
     def report_sold_animal_information(animal_manager) -> None:
         """
         Adds a dictionary of sold animal information to the output manager.
@@ -418,9 +420,11 @@ class AnimalModuleReporter:
 
         """
         sold_animals = (
-            animal_manager.life_cycle_manager.sold_heiferIIs
-            + animal_manager.life_cycle_manager.sold_heiferIIIs
-            + animal_manager.life_cycle_manager.sold_and_died_cows
+                animal_manager.life_cycle_manager.sold_calves
+                + animal_manager.life_cycle_manager.sold_heiferIIs
+                + animal_manager.life_cycle_manager.sold_heiferIIIs
+                + list(filter(lambda cow: cow.cull_reason != animal_constants.DEATH_CULL,
+                              animal_manager.life_cycle_manager.sold_and_died_cows))
         )
 
         info_map = {
@@ -431,6 +435,11 @@ class AnimalModuleReporter:
             om.add_variable("animal_id", animal.id, info_map)
             om.add_variable("animal_type", animal.__class__.__name__, info_map)
             om.add_variable("body_weight", animal.body_weight, info_map)
+
+            if hasattr(animal, "sold_at_day"):
+                om.add_variable("sold_day", animal.sold_at_day, info_map)
+            else:
+                om.add_variable("sold_day", "NA", info_map)
 
             if hasattr(animal, "cull_reason"):
                 om.add_variable("cull_reason", animal.cull_reason, info_map)
@@ -447,16 +456,17 @@ class AnimalModuleReporter:
             else:
                 om.add_variable("parity", "NA", info_map)
 
+    @staticmethod
     def report_sold_animal_information_sort_by_sell_day(
-        sold_animals, report_name: str, total_days: int
+            sold_animals, report_name: str, total_days: int
     ) -> None:
         """
         Adds a dictionary of sold animal information to the output manager on daily basis.
 
         Parameters
         ----------
-        animal_manager : AnimalManager
-            Instance of Class AnimalManager.
+        sold_animals : list[object]
+            List of sold animals.
         report_name : str
             The string to be appended to the variable being reported to the OM.
         total_days : int
@@ -546,6 +556,7 @@ class AnimalModuleReporter:
             if pen.animal_combination.name == "LAC_COW":
                 AnimalModuleReporter.report_milk(pen, animal_manager.simulation_day)
 
+    @staticmethod
     def report_end_of_simulation(animal_manager, total_days: int) -> None:
         """
         Calls all reporter methods that should happen at the end of the simulation.
@@ -558,6 +569,11 @@ class AnimalModuleReporter:
             The total number of days in the simulation
         """
         AnimalModuleReporter.report_sold_animal_information(animal_manager)
+
+        AnimalModuleReporter.report_sold_animal_information_sort_by_sell_day(
+            animal_manager.life_cycle_manager.sold_calves, "calves", total_days
+        )
+
         AnimalModuleReporter.report_sold_animal_information_sort_by_sell_day(
             animal_manager.life_cycle_manager.sold_heiferIIs, "heiferII", total_days
         )
@@ -565,7 +581,8 @@ class AnimalModuleReporter:
             animal_manager.life_cycle_manager.sold_heiferIIIs, "heiferIII", total_days
         )
         AnimalModuleReporter.report_sold_animal_information_sort_by_sell_day(
-            animal_manager.life_cycle_manager.sold_and_died_cows,
-            "sold_and_died_cows",
+            list(filter(lambda cow: cow.cull_reason != animal_constants.DEATH_CULL,
+                        animal_manager.life_cycle_manager.sold_and_died_cows)),
+            "sold_cows",
             total_days,
         )

--- a/RUFAS/routines/animal/life_cycle/calf.py
+++ b/RUFAS/routines/animal/life_cycle/calf.py
@@ -32,6 +32,7 @@ class Calf(AnimalBase):
 
         self.gender = ""
         self.sold = False
+        self.sold_at_day = 0
         self.wean_weight = 0
         self.birth_weight = 0
         self.animal_intake = 0

--- a/RUFAS/routines/animal/life_cycle/life_cycle.py
+++ b/RUFAS/routines/animal/life_cycle/life_cycle.py
@@ -77,6 +77,7 @@ class LifeCycleManager:
         self.sold_heiferIIIs: List[HeiferIII] = []
         self.sold_heiferIIs: List[HeiferII] = []
         self.sold_and_died_cows: List[Cow] = []
+        self.sold_calves: List[Calf] = []
 
         self.herd_num = 0
         self.calf_num = 0
@@ -1025,6 +1026,8 @@ class LifeCycleManager:
             calves_born.append(new_calf)
         if new_calf.sold:
             self.sold_calf_num += 1
+            self.sold_calves.append(new_calf)
+            new_calf.sold_at_day = sim_day
 
     def _calculate_herd_percentages(self, total_animal_num: int) -> None:
         """Calculates percentage of each animal class in the herd.

--- a/output/output_filters/report_animals_sold.json
+++ b/output/output_filters/report_animals_sold.json
@@ -1,0 +1,6 @@
+{
+  "name": "Animals sold in the whole simulation",
+  "filters": [
+    "AnimalModuleReporter.report_sold_animal_information.(animal_id|animal_type|body_weight|sold_day|cull_reason|parity|days_in_milk)"
+  ]
+}

--- a/output/output_filters/report_animals_sold_by_sell_day.json
+++ b/output/output_filters/report_animals_sold_by_sell_day.json
@@ -1,0 +1,6 @@
+{
+  "name": "Animals sold sort by sell day",
+  "filters": [
+    "AnimalModuleReporter.report_sold_animal_information_sort_by_sell_day.*"
+  ]
+}

--- a/tests/animal_module_tests/test_animal_life_cycle.py
+++ b/tests/animal_module_tests/test_animal_life_cycle.py
@@ -1031,6 +1031,7 @@ def test_handle_new_born(mocker: MockerFixture, life_cycle_manager: LifeCycleMan
     # Arrange
     sim_day = 1
     life_cycle_manager.sold_calf_num = sold_calf_num = 0
+    life_cycle_manager.sold_calves = []
     mock_animal_population = mocker.MagicMock(autospec=AnimalPopulation)
     mock_animal_population.next_id.return_value = calf_id = 100
     life_cycle_manager.animal_population = mock_animal_population
@@ -1046,6 +1047,7 @@ def test_handle_new_born(mocker: MockerFixture, life_cycle_manager: LifeCycleMan
     mock_calf.days_born = calf_days_born = 6
     mock_calf.culled = is_calf_culled
     mock_calf.sold = is_calf_sold
+    mock_calf.sold_at_day = 0
     patch_for_mock_calf = mocker.patch('RUFAS.routines.animal.life_cycle.life_cycle.Calf',
                                        return_value=mock_calf)
     calves_born = []
@@ -1075,6 +1077,9 @@ def test_handle_new_born(mocker: MockerFixture, life_cycle_manager: LifeCycleMan
         assert calves_born[0] == mock_calf
     if is_calf_sold:
         assert life_cycle_manager.sold_calf_num == sold_calf_num + 1
+        assert len(life_cycle_manager.sold_calves) == 1
+        assert life_cycle_manager.sold_calves[0] == mock_calf
+        assert mock_calf.sold_at_day == sim_day
 
 
 @pytest.mark.parametrize('cow_calves', [1, 2, 3, 4])

--- a/tests/animal_module_tests/test_animal_reporter.py
+++ b/tests/animal_module_tests/test_animal_reporter.py
@@ -5,6 +5,7 @@ from RUFAS.routines.animal.animal_module_reporter import AnimalModuleReporter
 from RUFAS.routines.animal.animal_manager import AnimalManager
 
 from RUFAS.output_manager import OutputManager
+from RUFAS.routines.animal.life_cycle import animal_constants
 
 om = OutputManager()
 
@@ -182,8 +183,8 @@ def test_report_ration_interval_data(animal_manager_fixture, mocker: MockerFixtu
 
     for i in range(1, 2):
         assert om.variables_pool[f"AnimalManager._calc_ration_at_interval.ration_nutrient_amount_pen_{i}_combo{i}"][
-            "values"
-        ] == [test_data["ration_nutrient_amount"]]
+                   "values"
+               ] == [test_data["ration_nutrient_amount"]]
 
         assert om.variables_pool[f"AnimalManager._calc_ration_at_interval.MEdiet_pen_{i}_combo{i}"]["values"] == [
             test_data["MEdiet"]
@@ -194,12 +195,12 @@ def test_report_ration_interval_data(animal_manager_fixture, mocker: MockerFixtu
         ]
 
         assert om.variables_pool[f"AnimalManager._calc_ration_at_interval.ration_per_animal_for_pen_{i}_combo{i}"][
-            "values"
-        ] == [test_data["formatted_ration"]]
+                   "values"
+               ] == [test_data["formatted_ration"]]
 
         assert om.variables_pool[f"AnimalManager._calc_ration_at_interval.ration_supply_report_for_pen_{i}_combo{i}"][
-            "values"
-        ] == ["ration_supply_report"]
+                   "values"
+               ] == ["ration_supply_report"]
 
 
 def test_report_daily_ration(animal_manager_fixture, mocker: MockerFixture):
@@ -226,9 +227,9 @@ def test_report_daily_ration(animal_manager_fixture, mocker: MockerFixture):
 
     for i in range(1, 2):
         assert om.variables_pool[
-            f"AnimalModuleReporter.report_daily_ration.ration_daily_feed_totals_for_pen_{i}_combo{i}"][
-            "values"
-        ] == [test_data[f"formatted_ration_{i}"]]
+                   f"AnimalModuleReporter.report_daily_ration.ration_daily_feed_totals_for_pen_{i}_combo{i}"][
+                   "values"
+               ] == [test_data[f"formatted_ration_{i}"]]
 
 
 def test_report_animal_module_manure():
@@ -308,49 +309,92 @@ def test_report_life_cycle_manager_data(mocker: MockerFixture):
     assert om.variables_pool["LifeCycleManager.daily_update.avg_age_for_calving_greater_than_3"]["values"] == [400]
 
 
-def test_report_sold_animal_information(mocker: MockerFixture):
-    sold_animals = [mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock()]
-    sold_report = {
-        "id": [1, 2, 3],
-        "cull_reason": ["low1", "low2"],
-        "body_weight": [100, 200, 300],
-        "days_in_milk": [100],
-        "calves": [42],
+# Test cases
+@pytest.mark.parametrize(
+    "animal_id, animal_type, body_weight, sold_at_day, "
+    "cull_reason, days_in_milk, calves",
+    [
+        (1, "Cow", 100, 10, "low production", 150, 2),
+        (1, "Cow", 100, 10, animal_constants.DEATH_CULL, 150, 2),
+        (1, "Cow", 150, None, None, None, None),
+        (2, "Calf", 50, 20, "male", 100, 1),
+        (2, "Calf", 50, None, None, None, None),
+        (3, "HeiferII", 200, 30, "disease", 200, 2),
+        (3, "HeiferII", 200, None, None, None, None),
+        (4, "HeiferIII", 300, 40, "disease", 250, 3),
+        (4, "HeiferIII", 300, None, None, None, None),
+    ]
+)
+def test_report_sold_animal_information(
+        animal_id: int,
+        animal_type: str,
+        body_weight: float,
+        sold_at_day: int,
+        cull_reason: str,
+        days_in_milk: int,
+        calves: int,
+        mocker: MockerFixture
+) -> None:
+    """Unit test for function report_sold_animal_information in file routines/animal/animal_module_reporter.py"""
+    # Arrange
+    mock_animal = mocker.MagicMock()
+    mock_animal.id = animal_id
+    mock_animal.__class__.__name__ = animal_type
+    mock_animal.body_weight = body_weight
+    optional_attrs_dict = {
+        "sold_at_day": sold_at_day,
+        "cull_reason": cull_reason,
+        "days_in_milk": days_in_milk,
+        "calves": calves,
     }
-    sold_report_expected = {
-        "animal_id": [1, 2, 3],
-        "animal_type": ["dummy", "dummy", "dummy"],
-        "cull_reason": ["low1", "low2", "NA"],
-        "body_weight": [100, 200, 300],
-        "days_in_milk": [100, "NA", "NA"],
-        "parity": [42, "NA", "NA"],
-    }
-    animalcount = 0
-    for animal in sold_animals:
-        for key in sold_report.keys():
-            if len(sold_report[key]) > animalcount:
-                setattr(animal, key, sold_report[key][animalcount])
-            else:
-                delattr(animal, key)
-        animalcount += 1
-
-    for animal in sold_animals:
-        animal.__class__.__name__ = "dummy"
+    none_str = "none"
+    for attr, value in optional_attrs_dict.items():
+        if value is not None:
+            setattr(mock_animal, attr, value)
+        else:
+            setattr(mock_animal, attr, none_str)
 
     animal_manager = mocker.MagicMock()
-    animal_manager.life_cycle_manager.sold_heiferIIs = [sold_animals[0]]
-    animal_manager.life_cycle_manager.sold_heiferIIIs = [sold_animals[1]]
-    animal_manager.life_cycle_manager.sold_and_died_cows = [sold_animals[2]]
+    animal_manager.life_cycle_manager.sold_calves = [mock_animal] if animal_type == "Calf" else []
+    animal_manager.life_cycle_manager.sold_heiferIIs = [mock_animal] if animal_type == "HeiferII" else []
+    animal_manager.life_cycle_manager.sold_heiferIIIs = [mock_animal] if animal_type == "HeiferIII" else []
+    animal_manager.life_cycle_manager.sold_and_died_cows = [mock_animal] if animal_type == "Cow" else []
 
-    # act
+    patch_for_add_variable = mocker.patch("RUFAS.routines.animal"
+                                          ".animal_module_reporter.om.add_variable")
+    assert patch_for_add_variable.call_count == 0
+
+    # Act
     AnimalModuleReporter.report_sold_animal_information(animal_manager)
 
-    # assert
-    for key in sold_report_expected.keys():
-        assert (
-            om.variables_pool[f"AnimalModuleReporter.report_sold_animal_information.{key}"]["values"]
-            == sold_report_expected[key]
-        )
+    # Assert
+    if cull_reason == animal_constants.DEATH_CULL:
+        assert patch_for_add_variable.call_count == 0
+        return
+
+    patch_for_add_variable.assert_any_call("animal_id", animal_id, mocker.ANY)
+    patch_for_add_variable.assert_any_call("animal_type", animal_type, mocker.ANY)
+    patch_for_add_variable.assert_any_call("body_weight", body_weight, mocker.ANY)
+
+    if sold_at_day is not None:
+        patch_for_add_variable.assert_any_call("sold_day", sold_at_day, mocker.ANY)
+    else:
+        patch_for_add_variable.assert_any_call("sold_day", none_str, mocker.ANY)
+
+    if cull_reason is not None:
+        patch_for_add_variable.assert_any_call("cull_reason", cull_reason, mocker.ANY)
+    else:
+        patch_for_add_variable.assert_any_call("cull_reason", none_str, mocker.ANY)
+
+    if days_in_milk is not None:
+        patch_for_add_variable.assert_any_call("days_in_milk", days_in_milk, mocker.ANY)
+    else:
+        patch_for_add_variable.assert_any_call("days_in_milk", none_str, mocker.ANY)
+
+    if calves is not None:
+        patch_for_add_variable.assert_any_call("parity", calves, mocker.ANY)
+    else:
+        patch_for_add_variable.assert_any_call("parity", none_str, mocker.ANY)
 
 
 def test_report_305d_milk(mocker: MockerFixture):


### PR DESCRIPTION
Issue #1076 

Adding to the OM only sold cows and excluding cows that died. To clarify, culled cows for any reason other than because of death are sold.

Also adding calf sold count to the OM.

I will remove example report json files for this PR before merging.