### PR TITLE
Update manure metadata patterns

### DIFF
--- a/input/data/animal/default_animal.json
+++ b/input/data/animal/default_animal.json
@@ -177,7 +177,7 @@
       "housing_type": "open air barn",
       "pen_type": "tiestall",
       "max_stocking_density": 1.2,
-      "manure_management_scenario_id": 2
+      "manure_management_scenario_id": 6
     },
     {
       "id": 3,
@@ -189,7 +189,7 @@
       "housing_type": "open air barn",
       "pen_type": "tiestall",
       "max_stocking_density": 1.2,
-      "manure_management_scenario_id": 4
+      "manure_management_scenario_id": 7
     }
   ]
 }

--- a/input/data/animal/default_animal.json
+++ b/input/data/animal/default_animal.json
@@ -177,7 +177,7 @@
       "housing_type": "open air barn",
       "pen_type": "tiestall",
       "max_stocking_density": 1.2,
-      "manure_management_scenario_id": 6
+      "manure_management_scenario_id": 2
     },
     {
       "id": 3,
@@ -189,7 +189,7 @@
       "housing_type": "open air barn",
       "pen_type": "tiestall",
       "max_stocking_density": 1.2,
-      "manure_management_scenario_id": 7
+      "manure_management_scenario_id": 4
     }
   ]
 }

--- a/input/data/manure/manure_management.json
+++ b/input/data/manure/manure_management.json
@@ -58,7 +58,7 @@
     },
     {
       "scenario_id": 8,
-      "bedding_type": "CBPB_sawdust",
+      "bedding_type": "CBPB sawdust",
       "manure_handler": "tillage",
       "manure_separator": "none",
       "manure_treatment": "compost bedded pack barn"
@@ -83,7 +83,7 @@
       "sand_removal_efficiency": 0.0
     },
     {
-      "bedding_type": "CBPB_sawdust",
+      "bedding_type": "CBPB sawdust",
       "bedding_mass_per_day": 12,
       "bedding_density": 350.0,
       "bedding_dry_matter_content": 0.9,

--- a/input/data/manure/manure_management.json
+++ b/input/data/manure/manure_management.json
@@ -32,7 +32,7 @@
       "scenario_id": 4,
       "bedding_type": "sand",
       "manure_handler": "flush system",
-      "manure_separator": "sand lane",
+      "manure_separator": "none",
       "manure_treatment": "anaerobic lagoon"
     },
     {

--- a/input/data/manure/manure_management.json
+++ b/input/data/manure/manure_management.json
@@ -32,7 +32,7 @@
       "scenario_id": 4,
       "bedding_type": "sand",
       "manure_handler": "flush system",
-      "manure_separator": "sand lane manure separation",
+      "manure_separator": "sand lane",
       "manure_treatment": "anaerobic lagoon"
     },
     {
@@ -54,11 +54,11 @@
       "bedding_type": "sawdust",
       "manure_handler": "flush system",
       "manure_separator": "rotary screen",
-      "manure_treatment": "anaerobic digestion and lagoon with split"
+      "manure_treatment": "anaerobic digestion and lagoon with separator"
     },
     {
       "scenario_id": 8,
-      "bedding_type": "CBPB sawdust",
+      "bedding_type": "CBPB_sawdust",
       "manure_handler": "tillage",
       "manure_separator": "none",
       "manure_treatment": "compost bedded pack barn"
@@ -83,7 +83,7 @@
       "sand_removal_efficiency": 0.0
     },
     {
-      "bedding_type": "CBPB sawdust",
+      "bedding_type": "CBPB_sawdust",
       "bedding_mass_per_day": 12,
       "bedding_density": 350.0,
       "bedding_dry_matter_content": 0.9,

--- a/input/metadata/ARL_metadata.json
+++ b/input/metadata/ARL_metadata.json
@@ -3115,7 +3115,7 @@
           "manure_treatment_methods": {
             "type": "string",
             "description": "Manure Treatment Methods -- Select the Manure Treatment Methods.",
-            "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion|other)$"
+            "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion and lagoon|anaerobic digestion and lagoon with separator)$"
           }
         }
       },
@@ -3223,7 +3223,7 @@
             "manure_treatment_type": {
               "type": "string",
               "description": "Manure Treatment Methods -- Select the Manure Treatment Methods.",
-              "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion|other)$"
+              "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion and lagoon|anaerobic digestion and lagoon with separator)$"
             },
             "total_solids_removal_efficiency_for_treatment": {
               "type": "number"

--- a/input/metadata/ARL_metadata.json
+++ b/input/metadata/ARL_metadata.json
@@ -3110,7 +3110,7 @@
           "manure_separator": {
             "type": "string",
             "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-            "pattern": "^(screw press|sand lane|rotary screen|none)$"
+            "pattern": "^(screw press|rotary screen|none)$"
           },
           "manure_treatment_methods": {
             "type": "string",
@@ -3189,7 +3189,7 @@
             "manure_separator_type": {
               "type": "string",
               "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-              "pattern": "^(screw press|sand lane|rotary screen|none)$"
+              "pattern": "^(screw press|rotary screen|none)$"
             },
             "percent_dry_solids": {
               "type": "number"

--- a/input/metadata/ARL_metadata.json
+++ b/input/metadata/ARL_metadata.json
@@ -3100,7 +3100,7 @@
           "bedding_type": {
             "type": "string",
             "description": "Bedding Type -- The material used for bedding pack.",
-            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
+            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB sawdust)$"
           },
           "manure_handler": {
             "type": "string",
@@ -3127,7 +3127,7 @@
             "bedding_type": {
               "type": "string",
               "description": "Bedding Type -- The material used for bedding pack.",
-              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
+              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB sawdust)$"
             },
             "bedding_mass_per_day": {
               "type": "number"

--- a/input/metadata/ARL_metadata.json
+++ b/input/metadata/ARL_metadata.json
@@ -3100,17 +3100,17 @@
           "bedding_type": {
             "type": "string",
             "description": "Bedding Type -- The material used for bedding pack.",
-            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|Other)$"
+            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
           },
           "manure_handler": {
             "type": "string",
             "description": "Manure Handling Method -- Method for cleaning barn alleyways.",
-            "pattern": "^(flush system|alley scraper|manual scraping|tillage|manual skid steer scraping|harrowing)$"
+            "pattern": "^(flush system|alley scraper|manual scraping|tillage|harrowing)$"
           },
           "manure_separator": {
             "type": "string",
             "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-            "pattern": "^(screw press|sand lane|rotary screen|none|other)$"
+            "pattern": "^(screw press|sand lane|rotary screen|none)$"
           },
           "manure_treatment_methods": {
             "type": "string",
@@ -3127,7 +3127,7 @@
             "bedding_type": {
               "type": "string",
               "description": "Bedding Type -- The material used for bedding pack.",
-              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|Other)$"
+              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
             },
             "bedding_mass_per_day": {
               "type": "number"
@@ -3161,7 +3161,7 @@
             "manure_handler_type": {
               "type": "string",
               "description": "Manure Handling Method -- Method for cleaning barn alleyways.",
-              "pattern": "^(flush system|alley scraper|manual scraping|tillage|manual skid steer scraping)$"
+              "pattern": "^(flush system|alley scraper|manual scraping|tillage)$"
             },
             "cleaning_water_use_rate": {
               "type": "number"
@@ -3189,7 +3189,7 @@
             "manure_separator_type": {
               "type": "string",
               "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-              "pattern": "^(screw press|sand lane|rotary screen|none|other)$"
+              "pattern": "^(screw press|sand lane|rotary screen|none)$"
             },
             "percent_dry_solids": {
               "type": "number"

--- a/input/metadata/barnyard_metadata.json
+++ b/input/metadata/barnyard_metadata.json
@@ -3114,7 +3114,7 @@
           "bedding_type": {
             "type": "string",
             "description": "Bedding Type -- The material used for bedding pack.",
-            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
+            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB sawdust)$"
           },
           "manure_handler": {
             "type": "string",
@@ -3141,7 +3141,7 @@
             "bedding_type": {
               "type": "string",
               "description": "Bedding Type -- The material used for bedding pack.",
-              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
+              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB sawdust)$"
             },
             "bedding_mass_per_day": {
               "type": "number"

--- a/input/metadata/barnyard_metadata.json
+++ b/input/metadata/barnyard_metadata.json
@@ -3129,7 +3129,7 @@
           "manure_treatment_methods": {
             "type": "string",
             "description": "Manure Treatment Methods -- Select the Manure Treatment Methods.",
-            "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion|other)$"
+            "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion and lagoon|anaerobic digestion and lagoon with separator)$"
           }
         }
       },
@@ -3237,7 +3237,7 @@
             "manure_treatment_type": {
               "type": "string",
               "description": "Manure Treatment Methods -- Select the Manure Treatment Methods.",
-              "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion|other)$"
+              "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion and lagoon|anaerobic digestion and lagoon with separator)$"
             },
             "total_solids_removal_efficiency_for_treatment": {
               "type": "number"

--- a/input/metadata/barnyard_metadata.json
+++ b/input/metadata/barnyard_metadata.json
@@ -3124,7 +3124,7 @@
           "manure_separator": {
             "type": "string",
             "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-            "pattern": "^(screw press|sand lane|rotary screen|none)$"
+            "pattern": "^(screw press|rotary screen|none)$"
           },
           "manure_treatment_methods": {
             "type": "string",
@@ -3203,7 +3203,7 @@
             "manure_separator_type": {
               "type": "string",
               "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-              "pattern": "^(screw press|sand lane|rotary screen|none)$"
+              "pattern": "^(screw press|rotary screen|none)$"
             },
             "percent_dry_solids": {
               "type": "number"

--- a/input/metadata/barnyard_metadata.json
+++ b/input/metadata/barnyard_metadata.json
@@ -3114,17 +3114,17 @@
           "bedding_type": {
             "type": "string",
             "description": "Bedding Type -- The material used for bedding pack.",
-            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|Other)$"
+            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
           },
           "manure_handler": {
             "type": "string",
             "description": "Manure Handling Method -- Method for cleaning barn alleyways.",
-            "pattern": "^(flush system|alley scraper|manual scraping|tillage|manual skid steer scraping|harrowing)$"
+            "pattern": "^(flush system|alley scraper|manual scraping|tillage|harrowing)$"
           },
           "manure_separator": {
             "type": "string",
             "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-            "pattern": "^(screw press|sand lane|rotary screen|none|other)$"
+            "pattern": "^(screw press|sand lane|rotary screen|none)$"
           },
           "manure_treatment_methods": {
             "type": "string",
@@ -3141,7 +3141,7 @@
             "bedding_type": {
               "type": "string",
               "description": "Bedding Type -- The material used for bedding pack.",
-              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|Other)$"
+              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
             },
             "bedding_mass_per_day": {
               "type": "number"
@@ -3175,7 +3175,7 @@
             "manure_handler_type": {
               "type": "string",
               "description": "Manure Handling Method -- Method for cleaning barn alleyways.",
-              "pattern": "^(flush system|alley scraper|manual scraping|tillage|manual skid steer scraping)$"
+              "pattern": "^(flush system|alley scraper|manual scraping|tillage)$"
             },
             "cleaning_water_use_rate": {
               "type": "number"
@@ -3203,7 +3203,7 @@
             "manure_separator_type": {
               "type": "string",
               "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-              "pattern": "^(screw press|sand lane|rotary screen|none|other)$"
+              "pattern": "^(screw press|sand lane|rotary screen|none)$"
             },
             "percent_dry_solids": {
               "type": "number"

--- a/input/metadata/default_metadata.json
+++ b/input/metadata/default_metadata.json
@@ -3107,7 +3107,7 @@
           "bedding_type": {
             "type": "string",
             "description": "Bedding Type -- The material used for bedding pack.",
-            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
+            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB sawdust)$"
           },
           "manure_handler": {
             "type": "string",
@@ -3134,7 +3134,7 @@
             "bedding_type": {
               "type": "string",
               "description": "Bedding Type -- The material used for bedding pack.",
-              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
+              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB sawdust)$"
             },
             "bedding_mass_per_day": {
               "type": "number"

--- a/input/metadata/default_metadata.json
+++ b/input/metadata/default_metadata.json
@@ -3122,7 +3122,7 @@
           "manure_treatment_methods": {
             "type": "string",
             "description": "Manure Treatment Methods -- Select the Manure Treatment Methods.",
-            "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion|other)$"
+            "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion and lagoon|anaerobic digestion and lagoon with separator)$"
           }
         }
       },
@@ -3230,7 +3230,7 @@
             "manure_treatment_type": {
               "type": "string",
               "description": "Manure Treatment Methods -- Select the Manure Treatment Methods.",
-              "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion|other)$"
+              "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion and lagoon|anaerobic digestion and lagoon with separator)$"
             },
             "total_solids_removal_efficiency_for_treatment": {
               "type": "number"

--- a/input/metadata/default_metadata.json
+++ b/input/metadata/default_metadata.json
@@ -3107,17 +3107,17 @@
           "bedding_type": {
             "type": "string",
             "description": "Bedding Type -- The material used for bedding pack.",
-            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|Other)$"
+            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
           },
           "manure_handler": {
             "type": "string",
             "description": "Manure Handling Method -- Method for cleaning barn alleyways.",
-            "pattern": "^(flush system|alley scraper|manual scraping|tillage|manual skid steer scraping|harrowing)$"
+            "pattern": "^(flush system|alley scraper|manual scraping|tillage|harrowing)$"
           },
           "manure_separator": {
             "type": "string",
             "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-            "pattern": "^(screw press|sand lane|rotary screen|none|other)$"
+            "pattern": "^(screw press|sand lane|rotary screen|none)$"
           },
           "manure_treatment_methods": {
             "type": "string",
@@ -3134,7 +3134,7 @@
             "bedding_type": {
               "type": "string",
               "description": "Bedding Type -- The material used for bedding pack.",
-              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|Other)$"
+              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
             },
             "bedding_mass_per_day": {
               "type": "number"
@@ -3168,7 +3168,7 @@
             "manure_handler_type": {
               "type": "string",
               "description": "Manure Handling Method -- Method for cleaning barn alleyways.",
-              "pattern": "^(flush system|alley scraper|manual scraping|tillage|manual skid steer scraping)$"
+              "pattern": "^(flush system|alley scraper|manual scraping|tillage)$"
             },
             "cleaning_water_use_rate": {
               "type": "number"
@@ -3196,7 +3196,7 @@
             "manure_separator_type": {
               "type": "string",
               "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-              "pattern": "^(screw press|sand lane|rotary screen|none|other)$"
+              "pattern": "^(screw press|sand lane|rotary screen|none)$"
             },
             "percent_dry_solids": {
               "type": "number"

--- a/input/metadata/default_metadata.json
+++ b/input/metadata/default_metadata.json
@@ -3117,7 +3117,7 @@
           "manure_separator": {
             "type": "string",
             "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-            "pattern": "^(screw press|sand lane|rotary screen|none)$"
+            "pattern": "^(screw press|rotary screen|none)$"
           },
           "manure_treatment_methods": {
             "type": "string",
@@ -3196,7 +3196,7 @@
             "manure_separator_type": {
               "type": "string",
               "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-              "pattern": "^(screw press|sand lane|rotary screen|none)$"
+              "pattern": "^(screw press|rotary screen|none)$"
             },
             "percent_dry_solids": {
               "type": "number"

--- a/input/metadata/multi_crop_metadata.json
+++ b/input/metadata/multi_crop_metadata.json
@@ -3115,7 +3115,7 @@
           "manure_treatment_methods": {
             "type": "string",
             "description": "Manure Treatment Methods -- Select the Manure Treatment Methods.",
-            "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion|other)$"
+            "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion and lagoon|anaerobic digestion and lagoon with separator)$"
           }
         }
       },
@@ -3223,7 +3223,7 @@
             "manure_treatment_type": {
               "type": "string",
               "description": "Manure Treatment Methods -- Select the Manure Treatment Methods.",
-              "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion|other)$"
+              "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion and lagoon|anaerobic digestion and lagoon with separator)$"
             },
             "total_solids_removal_efficiency_for_treatment": {
               "type": "number"

--- a/input/metadata/multi_crop_metadata.json
+++ b/input/metadata/multi_crop_metadata.json
@@ -3110,7 +3110,7 @@
           "manure_separator": {
             "type": "string",
             "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-            "pattern": "^(screw press|sand lane|rotary screen|none)$"
+            "pattern": "^(screw press|rotary screen|none)$"
           },
           "manure_treatment_methods": {
             "type": "string",
@@ -3189,7 +3189,7 @@
             "manure_separator_type": {
               "type": "string",
               "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-              "pattern": "^(screw press|sand lane|rotary screen|none)$"
+              "pattern": "^(screw press|rotary screen|none)$"
             },
             "percent_dry_solids": {
               "type": "number"

--- a/input/metadata/multi_crop_metadata.json
+++ b/input/metadata/multi_crop_metadata.json
@@ -3100,7 +3100,7 @@
           "bedding_type": {
             "type": "string",
             "description": "Bedding Type -- The material used for bedding pack.",
-            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
+            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB sawdust)$"
           },
           "manure_handler": {
             "type": "string",
@@ -3127,7 +3127,7 @@
             "bedding_type": {
               "type": "string",
               "description": "Bedding Type -- The material used for bedding pack.",
-              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
+              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB sawdust)$"
             },
             "bedding_mass_per_day": {
               "type": "number"

--- a/input/metadata/multi_crop_metadata.json
+++ b/input/metadata/multi_crop_metadata.json
@@ -3100,17 +3100,17 @@
           "bedding_type": {
             "type": "string",
             "description": "Bedding Type -- The material used for bedding pack.",
-            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|Other)$"
+            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
           },
           "manure_handler": {
             "type": "string",
             "description": "Manure Handling Method -- Method for cleaning barn alleyways.",
-            "pattern": "^(flush system|alley scraper|manual scraping|tillage|manual skid steer scraping|harrowing)$"
+            "pattern": "^(flush system|alley scraper|manual scraping|tillage|harrowing)$"
           },
           "manure_separator": {
             "type": "string",
             "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-            "pattern": "^(screw press|sand lane|rotary screen|none|other)$"
+            "pattern": "^(screw press|sand lane|rotary screen|none)$"
           },
           "manure_treatment_methods": {
             "type": "string",
@@ -3127,7 +3127,7 @@
             "bedding_type": {
               "type": "string",
               "description": "Bedding Type -- The material used for bedding pack.",
-              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|Other)$"
+              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
             },
             "bedding_mass_per_day": {
               "type": "number"
@@ -3161,7 +3161,7 @@
             "manure_handler_type": {
               "type": "string",
               "description": "Manure Handling Method -- Method for cleaning barn alleyways.",
-              "pattern": "^(flush system|alley scraper|manual scraping|tillage|manual skid steer scraping)$"
+              "pattern": "^(flush system|alley scraper|manual scraping|tillage)$"
             },
             "cleaning_water_use_rate": {
               "type": "number"
@@ -3189,7 +3189,7 @@
             "manure_separator_type": {
               "type": "string",
               "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-              "pattern": "^(screw press|sand lane|rotary screen|none|other)$"
+              "pattern": "^(screw press|sand lane|rotary screen|none)$"
             },
             "percent_dry_solids": {
               "type": "number"

--- a/input/metadata/swat_metadata.json
+++ b/input/metadata/swat_metadata.json
@@ -3115,7 +3115,7 @@
           "manure_treatment_methods": {
             "type": "string",
             "description": "Manure Treatment Methods -- Select the Manure Treatment Methods.",
-            "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion|other)$"
+            "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion and lagoon|anaerobic digestion and lagoon with separator)$"
           }
         }
       },
@@ -3223,7 +3223,7 @@
             "manure_treatment_type": {
               "type": "string",
               "description": "Manure Treatment Methods -- Select the Manure Treatment Methods.",
-              "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion|other)$"
+              "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion and lagoon|anaerobic digestion and lagoon with separator)$"
             },
             "total_solids_removal_efficiency_for_treatment": {
               "type": "number"

--- a/input/metadata/swat_metadata.json
+++ b/input/metadata/swat_metadata.json
@@ -3110,7 +3110,7 @@
           "manure_separator": {
             "type": "string",
             "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-            "pattern": "^(screw press|sand lane|rotary screen|none)$"
+            "pattern": "^(screw press|rotary screen|none)$"
           },
           "manure_treatment_methods": {
             "type": "string",
@@ -3189,7 +3189,7 @@
             "manure_separator_type": {
               "type": "string",
               "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-              "pattern": "^(screw press|sand lane|rotary screen|none)$"
+              "pattern": "^(screw press|rotary screen|none)$"
             },
             "percent_dry_solids": {
               "type": "number"

--- a/input/metadata/swat_metadata.json
+++ b/input/metadata/swat_metadata.json
@@ -3100,7 +3100,7 @@
           "bedding_type": {
             "type": "string",
             "description": "Bedding Type -- The material used for bedding pack.",
-            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
+            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB sawdust)$"
           },
           "manure_handler": {
             "type": "string",
@@ -3127,7 +3127,7 @@
             "bedding_type": {
               "type": "string",
               "description": "Bedding Type -- The material used for bedding pack.",
-              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
+              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB sawdust)$"
             },
             "bedding_mass_per_day": {
               "type": "number"

--- a/input/metadata/swat_metadata.json
+++ b/input/metadata/swat_metadata.json
@@ -3100,17 +3100,17 @@
           "bedding_type": {
             "type": "string",
             "description": "Bedding Type -- The material used for bedding pack.",
-            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|Other)$"
+            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
           },
           "manure_handler": {
             "type": "string",
             "description": "Manure Handling Method -- Method for cleaning barn alleyways.",
-            "pattern": "^(flush system|alley scraper|manual scraping|tillage|manual skid steer scraping|harrowing)$"
+            "pattern": "^(flush system|alley scraper|manual scraping|tillage|harrowing)$"
           },
           "manure_separator": {
             "type": "string",
             "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-            "pattern": "^(screw press|sand lane|rotary screen|none|other)$"
+            "pattern": "^(screw press|sand lane|rotary screen|none)$"
           },
           "manure_treatment_methods": {
             "type": "string",
@@ -3127,7 +3127,7 @@
             "bedding_type": {
               "type": "string",
               "description": "Bedding Type -- The material used for bedding pack.",
-              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|Other)$"
+              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
             },
             "bedding_mass_per_day": {
               "type": "number"
@@ -3161,7 +3161,7 @@
             "manure_handler_type": {
               "type": "string",
               "description": "Manure Handling Method -- Method for cleaning barn alleyways.",
-              "pattern": "^(flush system|alley scraper|manual scraping|tillage|manual skid steer scraping)$"
+              "pattern": "^(flush system|alley scraper|manual scraping|tillage)$"
             },
             "cleaning_water_use_rate": {
               "type": "number"
@@ -3189,7 +3189,7 @@
             "manure_separator_type": {
               "type": "string",
               "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-              "pattern": "^(screw press|sand lane|rotary screen|none|other)$"
+              "pattern": "^(screw press|sand lane|rotary screen|none)$"
             },
             "percent_dry_solids": {
               "type": "number"

--- a/input/metadata/testing_metadata.json
+++ b/input/metadata/testing_metadata.json
@@ -3115,7 +3115,7 @@
           "manure_treatment_methods": {
             "type": "string",
             "description": "Manure Treatment Methods -- Select the Manure Treatment Methods.",
-            "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion|other)$"
+            "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion and lagoon|anaerobic digestion and lagoon with separator)$"
           }
         }
       },
@@ -3223,7 +3223,7 @@
             "manure_treatment_type": {
               "type": "string",
               "description": "Manure Treatment Methods -- Select the Manure Treatment Methods.",
-              "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion|other)$"
+              "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion and lagoon|anaerobic digestion and lagoon with separator)$"
             },
             "total_solids_removal_efficiency_for_treatment": {
               "type": "number"

--- a/input/metadata/testing_metadata.json
+++ b/input/metadata/testing_metadata.json
@@ -3110,7 +3110,7 @@
           "manure_separator": {
             "type": "string",
             "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-            "pattern": "^(screw press|sand lane|rotary screen|none)$"
+            "pattern": "^(screw press|rotary screen|none)$"
           },
           "manure_treatment_methods": {
             "type": "string",
@@ -3189,7 +3189,7 @@
             "manure_separator_type": {
               "type": "string",
               "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-              "pattern": "^(screw press|sand lane|rotary screen|none)$"
+              "pattern": "^(screw press|rotary screen|none)$"
             },
             "percent_dry_solids": {
               "type": "number"

--- a/input/metadata/testing_metadata.json
+++ b/input/metadata/testing_metadata.json
@@ -3100,7 +3100,7 @@
           "bedding_type": {
             "type": "string",
             "description": "Bedding Type -- The material used for bedding pack.",
-            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
+            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB sawdust)$"
           },
           "manure_handler": {
             "type": "string",
@@ -3127,7 +3127,7 @@
             "bedding_type": {
               "type": "string",
               "description": "Bedding Type -- The material used for bedding pack.",
-              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
+              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB sawdust)$"
             },
             "bedding_mass_per_day": {
               "type": "number"

--- a/input/metadata/testing_metadata.json
+++ b/input/metadata/testing_metadata.json
@@ -3100,17 +3100,17 @@
           "bedding_type": {
             "type": "string",
             "description": "Bedding Type -- The material used for bedding pack.",
-            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|Other)$"
+            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
           },
           "manure_handler": {
             "type": "string",
             "description": "Manure Handling Method -- Method for cleaning barn alleyways.",
-            "pattern": "^(flush system|alley scraper|manual scraping|tillage|manual skid steer scraping|harrowing)$"
+            "pattern": "^(flush system|alley scraper|manual scraping|tillage|harrowing)$"
           },
           "manure_separator": {
             "type": "string",
             "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-            "pattern": "^(screw press|sand lane|rotary screen|none|other)$"
+            "pattern": "^(screw press|sand lane|rotary screen|none)$"
           },
           "manure_treatment_methods": {
             "type": "string",
@@ -3127,7 +3127,7 @@
             "bedding_type": {
               "type": "string",
               "description": "Bedding Type -- The material used for bedding pack.",
-              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|Other)$"
+              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
             },
             "bedding_mass_per_day": {
               "type": "number"
@@ -3161,7 +3161,7 @@
             "manure_handler_type": {
               "type": "string",
               "description": "Manure Handling Method -- Method for cleaning barn alleyways.",
-              "pattern": "^(flush system|alley scraper|manual scraping|tillage|manual skid steer scraping)$"
+              "pattern": "^(flush system|alley scraper|manual scraping|tillage)$"
             },
             "cleaning_water_use_rate": {
               "type": "number"
@@ -3189,7 +3189,7 @@
             "manure_separator_type": {
               "type": "string",
               "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-              "pattern": "^(screw press|sand lane|rotary screen|none|other)$"
+              "pattern": "^(screw press|sand lane|rotary screen|none)$"
             },
             "percent_dry_solids": {
               "type": "number"

--- a/input/metadata/user_defined_ration.json
+++ b/input/metadata/user_defined_ration.json
@@ -3107,7 +3107,7 @@
           "bedding_type": {
             "type": "string",
             "description": "Bedding Type -- The material used for bedding pack.",
-            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
+            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB sawdust)$"
           },
           "manure_handler": {
             "type": "string",
@@ -3134,7 +3134,7 @@
             "bedding_type": {
               "type": "string",
               "description": "Bedding Type -- The material used for bedding pack.",
-              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
+              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB sawdust)$"
             },
             "bedding_mass_per_day": {
               "type": "number"

--- a/input/metadata/user_defined_ration.json
+++ b/input/metadata/user_defined_ration.json
@@ -3122,7 +3122,7 @@
           "manure_treatment_methods": {
             "type": "string",
             "description": "Manure Treatment Methods -- Select the Manure Treatment Methods.",
-            "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion|other)$"
+            "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion and lagoon|anaerobic digestion and lagoon with separator)$"
           }
         }
       },
@@ -3230,7 +3230,7 @@
             "manure_treatment_type": {
               "type": "string",
               "description": "Manure Treatment Methods -- Select the Manure Treatment Methods.",
-              "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion|other)$"
+              "pattern": "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion and lagoon|anaerobic digestion and lagoon with separator)$"
             },
             "total_solids_removal_efficiency_for_treatment": {
               "type": "number"

--- a/input/metadata/user_defined_ration.json
+++ b/input/metadata/user_defined_ration.json
@@ -3107,17 +3107,17 @@
           "bedding_type": {
             "type": "string",
             "description": "Bedding Type -- The material used for bedding pack.",
-            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|Other)$"
+            "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
           },
           "manure_handler": {
             "type": "string",
             "description": "Manure Handling Method -- Method for cleaning barn alleyways.",
-            "pattern": "^(flush system|alley scraper|manual scraping|tillage|manual skid steer scraping|harrowing)$"
+            "pattern": "^(flush system|alley scraper|manual scraping|tillage|harrowing)$"
           },
           "manure_separator": {
             "type": "string",
             "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-            "pattern": "^(screw press|sand lane|rotary screen|none|other)$"
+            "pattern": "^(screw press|sand lane|rotary screen|none)$"
           },
           "manure_treatment_methods": {
             "type": "string",
@@ -3134,7 +3134,7 @@
             "bedding_type": {
               "type": "string",
               "description": "Bedding Type -- The material used for bedding pack.",
-              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|Other)$"
+              "pattern": "^(Sand|Straw|Sawdust|Manure_solids|CBPB_sawdust)$"
             },
             "bedding_mass_per_day": {
               "type": "number"
@@ -3168,7 +3168,7 @@
             "manure_handler_type": {
               "type": "string",
               "description": "Manure Handling Method -- Method for cleaning barn alleyways.",
-              "pattern": "^(flush system|alley scraper|manual scraping|tillage|manual skid steer scraping)$"
+              "pattern": "^(flush system|alley scraper|manual scraping|tillage)$"
             },
             "cleaning_water_use_rate": {
               "type": "number"
@@ -3196,7 +3196,7 @@
             "manure_separator_type": {
               "type": "string",
               "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-              "pattern": "^(screw press|sand lane|rotary screen|none|other)$"
+              "pattern": "^(screw press|sand lane|rotary screen|none)$"
             },
             "percent_dry_solids": {
               "type": "number"

--- a/input/metadata/user_defined_ration.json
+++ b/input/metadata/user_defined_ration.json
@@ -3117,7 +3117,7 @@
           "manure_separator": {
             "type": "string",
             "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-            "pattern": "^(screw press|sand lane|rotary screen|none)$"
+            "pattern": "^(screw press|rotary screen|none)$"
           },
           "manure_treatment_methods": {
             "type": "string",
@@ -3196,7 +3196,7 @@
             "manure_separator_type": {
               "type": "string",
               "description": "Manure Separator Type -- The type of solid-liquid separator equipment to separate coarse fibrous solids/sand",
-              "pattern": "^(screw press|sand lane|rotary screen|none)$"
+              "pattern": "^(screw press|rotary screen|none)$"
             },
             "percent_dry_solids": {
               "type": "number"


### PR DESCRIPTION
PR to address issue #1134 to update metadata manure patterns in both the manure manager config sections and the manure management scenarios sections.

For each of the metadata files:
1. `bedding_type` has had "other" pattern removed and "CBPB sawdust" pattern added. 
2. `manure_handler` has had "manual skid steer scraping" pattern removed.
3. `manure_separator` has had "other" and "sand lane" patterns removed.
4. `manure_treatment_methods` now has the following patterns to match from: "^(slurry storage underfloor|slurry storage outdoor|open lots|compost bedded pack barn|anaerobic lagoon|anaerobic digestion and lagoon|anaerobic digestion and lagoon with separator)$"