### PR TITLE
Update animal_module_reporter.py

### DIFF
--- a/RUFAS/routines/animal/animal_module_reporter.py
+++ b/RUFAS/routines/animal/animal_module_reporter.py
@@ -166,8 +166,10 @@ class AnimalModuleReporter:
         }
         for pen in animal_manager.all_pens:
             ration_per_animal = pen.ration_per_animal.copy()
-            del ration_per_animal["status"]
-            del ration_per_animal["objective"]
+            if 'status' in ration_per_animal:
+                del ration_per_animal["status"]
+            if 'objective' in ration_per_animal:
+                del ration_per_animal["objective"]
             ration_total = {}
             ration_total["dry_matter_intake_total"] = 0
             for key in ration_per_animal.keys():


### PR DESCRIPTION
This PR is to address issue #1142. It seems that there is an attempt to delete the key 'status' from the ration_per_animal dictionary, but that key doesn't exist in the dictionary, resulting in a KeyError.

Our solution is to check if the 'status' key exists before attempting to delete it. In this PR, we added the if statement for both 'status' and 'objective'. 

To validate the change, first grab the input files of farm 13 in pilot testing cohort 2 and run it on the main branch to repeat the error and then use this updated branch to run the same input files and you should expect no errors. 

Yet, we still need to review the code where the `ration_per_animal dictionary` is constructed or modified to understand why the 'status' key might be missing when it's expected. A comment from Joe: 'I think it's because it's inherited from a previous formulation or other animal'. 