### PR TITLE
Revert "Replace manure module TODOs with github issues or otherwise resolves them"

### DIFF
--- a/RUFAS/routines/manure/IO_helpers/manure_manager_config_handler.py
+++ b/RUFAS/routines/manure/IO_helpers/manure_manager_config_handler.py
@@ -51,6 +51,8 @@ class ManureManagerConfigHandler:
             manure_manager_config["manure_treatment_configs"]
         )
 
+    # TODO: For the following getters, pass in an enum member instead of a string
+
     def get_custom_bedding_config(
         self, bedding_type_name: str
     ) -> Optional[BeddingConfig]:

--- a/RUFAS/routines/manure/beddings/bedding_classes.py
+++ b/RUFAS/routines/manure/beddings/bedding_classes.py
@@ -357,6 +357,7 @@ class DefaultBeddingConfigFactory:
         sand_removal_efficiency=0.0,
     )
 
+    # TODO: Use correct values for straw bedding.
     # Predefined configuration for Straw Bedding
     STRAW_BEDDING_CONFIG = BeddingConfig(
         bedding_mass_per_day=1.97,

--- a/RUFAS/routines/manure/gas_emissions/calculator.py
+++ b/RUFAS/routines/manure/gas_emissions/calculator.py
@@ -226,6 +226,7 @@ class GasEmissionsCalculator:
         )
         return degradable_volatile_solids, non_degradable_volatile_solids
 
+    # TODO: to be removed in the next PR while refactoring slurry storage treatments
     @classmethod
     def methane_emission_for_slurry_storage(
             cls,
@@ -243,8 +244,8 @@ class GasEmissionsCalculator:
             manure_total_solids: Total solids, kg.
             is_enclosed: True if manure storage is enclosed, and False if manure storage is open to air.
             temperature_celsius: temperature in Celsius, C.
-            manure_volatile_solids_fraction: Fraction (0-1) volatile solids.
-            efficiency_fraction: efficiency of process, unitless.
+            manure_volatile_solids_fraction: Fraction (0-1) volatile solids. # TODO: review this
+            efficiency_fraction: efficiency of process, unitless. # TODO: review this
 
         Returns:
             CH4 emissions from storage, kg CH4/day.
@@ -926,7 +927,7 @@ class GasEmissionsCalculator:
             num_animals: int,
             barn_area: float,
             manure_total_ammoniacal_nitrogen: float,
-            manure_mass: float,
+            manure_mass: float,  # TODO: Decide to use volume or mass
             temperature_celsius: float,
             housing_specific_constant=GasEmissionConstants.DEFAULT_HOUSING_SPECIFIC_CONSTANT,
     ) -> float:

--- a/RUFAS/routines/manure/manure_handlers/manure_handler_daily_output.py
+++ b/RUFAS/routines/manure/manure_handlers/manure_handler_daily_output.py
@@ -23,9 +23,9 @@ class ManureHandlerDailyOutput(LiquidManurePortionProtocol):
         liquid_manure_total_volatile_solids: Total amount of volatile solids, kg.
         liquid_manure_phosphorus: Amount of phosphorus excreted in manure, kg.
         liquid_manure_potassium: Amount of potassium in manure, kg.
-        housing_methane: Methane emissions from ..., kg.
-        housing_carbon_dioxide: Carbon dioxide emissions from ..., kg.
-        housing_ammonia: Ammonia emissions from ..., kg.
+        housing_methane: Methane emissions from ..., kg.  # TODO: Fill in.
+        housing_carbon_dioxide: Carbon dioxide emissions from ..., kg.  # TODO: Fill in.
+        housing_ammonia: Ammonia emissions from ..., kg.  # TODO: Fill in.
         manure_volume: Amount of raw manure, m^3.
         cleaning_water_volume: Volume of cleaning water used in main barn, m^3.
         total_bedding_volume: Total amount of bedding needed for all the animals in pen, m^3.

--- a/RUFAS/routines/manure/manure_treatments/anaerobic_digestion.py
+++ b/RUFAS/routines/manure/manure_treatments/anaerobic_digestion.py
@@ -55,7 +55,7 @@ class AnaerobicDigestion(BaseManureTreatment):
             manure_treatment_daily_input.liquid_manure_total_volatile_solids
             * 0.03
             / ManureConstants.MANURE_DENSITY
-        )
+        )  # TODO: Use constants instead
         return new_daily_output
 
     def _daily_update_helper(self) -> ManureTreatmentDailyOutput:
@@ -192,7 +192,7 @@ class AnaerobicDigestion(BaseManureTreatment):
             average_temperature_celsius: Average daily temperature, C.
 
         """
-        return max(average_temperature_celsius, 4.0)
+        return max(average_temperature_celsius, 4.0)  # TODO: Use constants instead
 
     @classmethod
     def _calc_manure_heat_capacity(
@@ -208,6 +208,7 @@ class AnaerobicDigestion(BaseManureTreatment):
             Heat capacity of manure, kJ /kg /C.
 
         """
+        # TODO: Name the constants if you can
         return (
             0.68298
             + 0.025662 * average_temperature_celsius

--- a/RUFAS/routines/manure/manure_treatments/anaerobic_lagoon.py
+++ b/RUFAS/routines/manure/manure_treatments/anaerobic_lagoon.py
@@ -63,7 +63,7 @@ class AnaerobicLagoon(BaseManureTreatment):
             manure_treatment_daily_input.liquid_manure_total_volatile_solids
             * 0.03
             / ManureConstants.MANURE_DENSITY
-        )
+        )  # TODO: Use constants instead
         return new_daily_output
 
     def _update_methane_emission(

--- a/RUFAS/routines/manure/manure_treatments/base_manure_treatment.py
+++ b/RUFAS/routines/manure/manure_treatments/base_manure_treatment.py
@@ -185,7 +185,7 @@ class BaseManureTreatment(ABC):
                 * self.config.total_solids_removal_efficiency_for_treatment
             )
             / 1000.0
-        )
+        )  # TODO: Make 1000.0 a constant
 
         return ManureTreatmentDailyOutput(
             simulation_day=simulation_day,

--- a/RUFAS/routines/manure/pen_manure/pen_manure.py
+++ b/RUFAS/routines/manure/pen_manure/pen_manure.py
@@ -76,6 +76,9 @@ class PenManure:
         """Performs any necessary unit conversion after initialization."""
         self.manure_volume = self.manure_mass / ManureConstants.MANURE_DENSITY
 
+        # Zero out any negative field
+        # TODO: This is a temporary fix. Need to find out why negative values are being generated
+        # from the animal module. Later, we should raise an exception if a negative value is found.
         for fld in fields(self):
             if getattr(self, fld.name) < 0:
                 setattr(self, fld.name, 0)


### PR DESCRIPTION
Reverts RuminantFarmSystems/MASM#1131
Removing TODOs is only possible by resolving them. When an issue is created for a TODO, it doesn't remove the TODO from the code. Instead, the issue number has to be mentioned next to the TODO in the code.