### PR TITLE
closing graphs after plotting in GG

### DIFF
--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -162,7 +162,7 @@ class GraphGenerator:
             self._save_graph(
                 graph_details, filter_file_name, graphics_dir
             )
-
+            matplotlib.pyplot.close()
             return all_logs
         except Exception:
             raise


### PR DESCRIPTION
This PR closes #1045 

This PR adds a line in `GraphGenerator.generate_graph()` to close the graph after plotting to prevent the warning message.