### PR TITLE
Exclude main from automatic merge of Black formatting.

### DIFF
--- a/.github/workflows/lint_flake8.yml
+++ b/.github/workflows/lint_flake8.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies and run lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Linting
+name: Formatting and Linting
 
 on:
   push:

--- a/.github/workflows/lint_flake8.yml
+++ b/.github/workflows/lint_flake8.yml
@@ -42,6 +42,7 @@ jobs:
       run: |
         black --line-length=120 ${{ env.FILES }}
     - name: Commit and push formatting changes
+      if: ${{ github.ref != 'refs/heads/main' }}
       env:
         BRANCH_NAME: ${{ github.head_ref || github.ref }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint_flake8.yml
+++ b/.github/workflows/lint_flake8.yml
@@ -39,11 +39,11 @@ jobs:
                         grep -E "\.txt$|\.json$|\.csv$"  |
                         tr "\n" " ")" >> "$GITHUB_ENV"
     - name: Format code with Black
-      if: ${{ github.ref != 'refs/heads/main' }}
+      if: ${{ env.FILES != '' && github.ref != 'refs/heads/main' }}
       run: |
         black --line-length=120 ${{ env.FILES }}
     - name: Commit and push formatting changes
-      if: ${{ github.ref != 'refs/heads/main' }}
+      if: ${{ env.FILES != '' && github.ref != 'refs/heads/main' }}
       env:
         BRANCH_NAME: ${{ github.head_ref || github.ref }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint_flake8.yml
+++ b/.github/workflows/lint_flake8.yml
@@ -39,6 +39,7 @@ jobs:
                         grep -E "\.txt$|\.json$|\.csv$"  |
                         tr "\n" " ")" >> "$GITHUB_ENV"
     - name: Format code with Black
+      if: ${{ github.ref != 'refs/heads/main' }}
       run: |
         black --line-length=120 ${{ env.FILES }}
     - name: Commit and push formatting changes

--- a/.github/workflows/lint_flake8.yml
+++ b/.github/workflows/lint_flake8.yml
@@ -53,7 +53,6 @@ jobs:
         git add -A
         git commit -m "Apply Black Formatting" --allow-empty
         git remote set-url origin https://${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
-
         CLEAN_BRANCH_NAME=${BRANCH_NAME/refs\/heads\//}
         git push -f origin HEAD:$CLEAN_BRANCH_NAME
     - name: Lint with flake8


### PR DESCRIPTION
Currently the Github Action script to automatically run Black on the code will subsequently attempt to merge those formatted changes into the branch on which it is run.

This is in conflict with the protections we have on main from being able to merge without approvals.

When the original PR is merged into main, the code has already been formatted by Black. There won't be any further changes from another run of Black on this same code. 

Therefore, this PR removes the automatic-merge when the branch is main. This should prevent this error from happening and not lose any formatting done by Black.

Additionally came across an error where the script will fail if Black is asked to be run when there are no .py files changed. I've updated the script to not run when there are no .py files changed to prevent this error.