### PR TITLE
Update input for manure total ammoniacal nitrogen

### DIFF
--- a/RUFAS/routines/manure/pen_manure/pen_manure.py
+++ b/RUFAS/routines/manure/pen_manure/pen_manure.py
@@ -105,14 +105,6 @@ class PenManure:
             A PenManure object.
 
         """
-        manure_mass = animal_manure["manure_mass"]  # kg
-        manure_volume = (
-            manure_mass / ManureConstants.SLURRY_MANURE_DENSITY
-        ) * GeneralConstants.CUBIC_METERS_TO_LITERS  # L
-        total_ammoniacal_nitrogen = (
-            animal_manure["total_ammoniacal_nitrogen_concentration"] / num_animals * manure_volume  # g/L  # L
-        ) * GeneralConstants.GRAMS_TO_KG  # kg
-
         if num_animals == 0:
             return cls()
 
@@ -121,9 +113,9 @@ class PenManure:
             urine=animal_manure["urine"],
             urine_nitrogen=animal_manure["urine_nitrogen"],
             urine_total_ammoniacal_nitrogen=animal_manure["urine_nitrogen"] * ManureConstants.URINE_TAN_FACTOR,
-            manure_total_ammoniacal_nitrogen=total_ammoniacal_nitrogen,
+            manure_total_ammoniacal_nitrogen=animal_manure["urine_nitrogen"] * ManureConstants.URINE_TAN_FACTOR,
             nitrogen=animal_manure["manure_nitrogen"],
-            manure_mass=manure_mass,
+            manure_mass=animal_manure["manure_mass"],
             total_solids=animal_manure["total_solids"],
             degradable_volatile_solids=animal_manure["degradable_volatile_solids"],
             non_degradable_volatile_solids=animal_manure["non_degradable_volatile_solids"],

--- a/tests/test_manure_module/test_pen_manure.py
+++ b/tests/test_manure_module/test_pen_manure.py
@@ -115,13 +115,7 @@ def test_pen_manure_init() -> None:
         enteric_methane_g=enteric_methane_g,
     )
     num_animals = 2
-    expected_total_ammoniacal_nitrogen = (
-        total_ammoniacal_nitrogen_concentration
-        / num_animals
-        * manure_mass
-        * GeneralConstants.KG_TO_GRAMS
-        / ManureConstants.MANURE_DENSITY
-    ) * GeneralConstants.GRAMS_TO_KG
+    expected_total_ammoniacal_nitrogen = urine_nitrogen * ManureConstants.URINE_TAN_FACTOR
     expected_urine_ammoniacal_nitrogen = urine_nitrogen * ManureConstants.URINE_TAN_FACTOR
 
     # Act


### PR DESCRIPTION
The previous method for estimating the mass of total ammoniacal nitrogen excreted by the animals was not in alignment with the values expected by the equations to predict ammonia emissions. Until we have a better method for predicting ammoniacal nitrogen excretion directly, we will replace the current methods with a simpler method that assumes a constant fraction of urine nitrogen is total ammoniacal nitrogen.

This PR removes the methods in `pen_manure.py` that were used to calculate the values needed for the previous method and updates the input for the `manure_total_ammoniacal_nitrogen` variable in the `PenManure` class. 