### PR TITLE
Remove double counted animals from housing emissions equations

### DIFF
--- a/RUFAS/routines/manure/gas_emissions/calculator.py
+++ b/RUFAS/routines/manure/gas_emissions/calculator.py
@@ -329,17 +329,15 @@ class GasEmissionsCalculator:
 
         .. math::
 
-            E_{CH_4} = num\\_animals \\times max(0, 0.13 * T_{barn}) \\times barn\\_area / 1000
+            E_{CH_4} = max(0, 0.13 * T_{barn}) \\times barn\\_area / 1000
 
         where:
 
             :math:`E_{CH_4}` is the methane housing emission in kg :math:`CH_4/day`,
 
-            :math:`T_{barn}` is the barn temperature in :math:`^{\\circ}C`,
+            :math:`T_{barn}` is the barn temperature in :math:`^{\\circ}C`, and
 
-            :math:`barn\\_area` is the barn area per animal based on housing type in :math:`m^2`, and
-
-            :math:`num\\_animals` is the number of animals in the pen.
+            :math:`barn\\_area` is the barn area per animal based on housing type in :math:`m^2`.
 
         Parameters
         ----------
@@ -375,17 +373,15 @@ class GasEmissionsCalculator:
 
         .. math::
 
-            E_{CO_2} = num\\_animals \\times max(0, 0.0065 + 0.0192 * T_{barn}) \\times barn\\_area / 1000
+            E_{CO_2} = max(0, 0.0065 + 0.0192 * T_{barn}) \\times barn\\_area / 1000
 
         where:
 
             :math:`E_{CO_2}` is the carbon dioxide housing emission in kg :math:`CO_2/day`,
 
-            :math:`T_{barn}` is the barn temperature in :math:`^{\\circ}C`,
+            :math:`T_{barn}` is the barn temperature in :math:`^{\\circ}C`, and
 
-            :math:`barn\\_area` is the barn area per animal based on housing type in :math:`m^2`, and
-
-            :math:`num\\_animals` is the number of animals in the pen.
+            :math:`barn\\_area` is the barn area per animal based on housing type in :math:`m^2`.
 
         Parameters
         ----------

--- a/RUFAS/routines/manure/gas_emissions/calculator.py
+++ b/RUFAS/routines/manure/gas_emissions/calculator.py
@@ -319,7 +319,7 @@ class GasEmissionsCalculator:
         return modified_hours * (max_temp - min_temp) / 2 + (max_temp + min_temp) / 2
 
     @classmethod
-    def housing_methane_emission(cls, num_animals: int, barn_area: float, barn_temp: float) -> float:
+    def housing_methane_emission(cls, barn_area: float, barn_temp: float) -> float:
         """
         Calculate housing methane emissions from manure handlers.
 
@@ -343,8 +343,6 @@ class GasEmissionsCalculator:
 
         Parameters
         ----------
-        num_animals : int
-            Number of animals in the pen (unitless).
         barn_area : float
             Barn area per animal based on housing type (:math:`m^2`).
         barn_temp : float
@@ -358,19 +356,16 @@ class GasEmissionsCalculator:
         Raises
         ------
         ValueError
-            If the number of animals or barn area is less than 0.
+            If the barn area is less than 0.
 
         """
-        if num_animals < 0:
-            raise ValueError("Number of animals must be greater than or equal to 0.")
-
         if barn_area < 0:
             raise ValueError("Barn area must be greater than or equal to 0.")
 
-        return num_animals * max(0.0, 0.13 * barn_temp) * barn_area / 1000
+        return max(0.0, 0.13 * barn_temp) * barn_area / 1000
 
     @classmethod
-    def housing_carbon_dioxide_emission(cls, num_animals: int, barn_area: float, barn_temp: float) -> float:
+    def housing_carbon_dioxide_emission(cls, barn_area: float, barn_temp: float) -> float:
         """
         Calculate carbon dioxide housing emission.
 
@@ -394,8 +389,6 @@ class GasEmissionsCalculator:
 
         Parameters
         ----------
-        num_animals : int
-            Number of animals in the pen (unitless).
         barn_area : float
             Barn area per animal based on housing type (:math:`m^2`).
         barn_temp : float
@@ -412,13 +405,10 @@ class GasEmissionsCalculator:
             If the number of animals or barn area is less than 0.
 
         """
-        if num_animals < 0:
-            raise ValueError("Number of animals must be greater than or equal to 0.")
-
         if barn_area < 0:
             raise ValueError("Barn area must be greater than or equal to 0.")
 
-        return num_animals * max(0.0, 0.0065 + 0.0192 * barn_temp) * barn_area / 1000
+        return max(0.0, 0.0065 + 0.0192 * barn_temp) * barn_area / 1000
 
     @classmethod
     def housing_ammonia_emission(

--- a/RUFAS/routines/manure/gas_emissions/calculator.py
+++ b/RUFAS/routines/manure/gas_emissions/calculator.py
@@ -337,7 +337,7 @@ class GasEmissionsCalculator:
 
             :math:`T_{barn}` is the barn temperature in :math:`^{\\circ}C`, and
 
-            :math:`barn\\_area` is the barn area per animal based on housing type in :math:`m^2`.
+            :math:`barn\\_area` is the total barn area based on the pen type and number of stalls in :math:`m^2`.
 
         Parameters
         ----------
@@ -381,7 +381,7 @@ class GasEmissionsCalculator:
 
             :math:`T_{barn}` is the barn temperature in :math:`^{\\circ}C`, and
 
-            :math:`barn\\_area` is the barn area per animal based on housing type in :math:`m^2`.
+            :math:`barn\\_area` is the total barn area based on the pen type and number of stalls in :math:`m^2`.
 
         Parameters
         ----------

--- a/RUFAS/routines/manure/manure_handlers/manure_handler_classes.py
+++ b/RUFAS/routines/manure/manure_handlers/manure_handler_classes.py
@@ -131,13 +131,11 @@ class BaseManureHandler:
             return ManureHandlerDailyOutput()
 
         housing_methane_emission = GasEmissionsCalculator.housing_methane_emission(
-            num_animals=pen.num_animals,
             barn_area=pen.barn_area_from_pen_type,
             barn_temp=self._get_current_day_average_temperature_in_celsius(),
         )
 
         housing_carbon_dioxide_emission = GasEmissionsCalculator.housing_carbon_dioxide_emission(
-            num_animals=pen.num_animals,
             barn_area=pen.barn_area_from_pen_type,
             barn_temp=self._get_current_day_average_temperature_in_celsius(),
         )

--- a/RUFAS/routines/manure/pen_manure/manure_manager_pen.py
+++ b/RUFAS/routines/manure/pen_manure/manure_manager_pen.py
@@ -128,7 +128,7 @@ class ManureManagerPen:
         Returns
         -------
         float
-            Barn area per animal (:math:`m^2/animal`).
+            Barn surface area (:math:`m^2`).
 
         Raises
         ------

--- a/RUFAS/routines/manure/pen_manure/manure_manager_pen.py
+++ b/RUFAS/routines/manure/pen_manure/manure_manager_pen.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple
+from typing import List, NamedTuple
 from typing import Set
 
 from RUFAS.routines.animal.life_cycle.animal_base import AnimalBase
@@ -11,27 +11,41 @@ from RUFAS.routines.animal.animal_combinations import AnimalCombination
 class ManureManagerPen:
     """
     A modified version of the Pen class in the animal module. This class extracts
-    some relevant information from the  original Pen class and then adds some
+    some relevant information from the original Pen class and then adds some
     extra attributes that can be used in the gas emissions equations.
 
     Attributes
-        id: Pen id.
-        animals_in_pen: A dictionary of animal ids as the key and animal objects as the value in this pen
-        num_animals: The number of animals in this pen.
-        num_lactating_cows: The number of lactating cows in this pen.
-        classes_in_pen: Set of unique animal classes in this pen.
-        animal_combination: An AnimalCombination enum that describes the current
-            animal makeup in this pen.
-        housing_type: The type of housing used for this pen.
-        bedding_type: The type of bedding used for this pen.
-        pen_type: The type of pen used for this pen.
-        manure_handler: The type of manure handler used for this pen.
-        manure_separator: The type of manure separator used for this pen.
-        manure_separator_after_digestion: The second manure separator used on manure generated from this pen.
-        manure_treatment: The type of manure treatment(s) used for this pen.
-        manure_density: The manure density used for calculating manure volume, kg/m^3.
-        manure: The manure data extracted from the animal module and converted to usable
-            form for the manure module.
+    ----------
+    id : int
+        Pen id.
+    animals_in_pen : Dict[int, AnimalBase]
+        A dictionary of animal ids as the key and animal objects as the value in this pen
+    num_animals : int
+        The number of animals in this pen.
+    num_lactating_cows : int
+        The number of lactating cows in this pen.
+    classes_in_pen : Set[str]
+        Set of unique animal classes in this pen.
+    animal_combination : AnimalCombination
+        An AnimalCombination enum that describes the current animal makeup in this pen.
+    housing_type : str
+        The type of housing used for this pen.
+    bedding_type : str
+        The type of bedding used for this pen.
+    pen_type : str
+        The type of pen used for this pen.
+    manure_handler : str
+        The type of manure handler used for this pen.
+    manure_separator : str
+        The type of manure separator used for this pen.
+    manure_separator_after_digestion : str
+        The second manure separator used on manure generated from this pen.
+    manure_treatment : str
+        The type of manure treatment(s) used for this pen.
+    manure_density : float
+        The manure density used for calculating manure volume, kg/m^3.
+    manure : PenManure
+        The manure data extracted from the animal module and converted to usable form for the manure module.
 
     """
 
@@ -41,8 +55,10 @@ class ManureManagerPen:
         The newly created object does not store any reference to the passed-in argument
         and only performs a read on it.
 
-        Args:
-            pen: A Pen object from the animal module.
+        Parameters
+        ----------
+        pen : Pen
+            A Pen object from the animal module.
 
         """
         self.id: int = pen.id
@@ -65,15 +81,19 @@ class ManureManagerPen:
         self.num_stalls = pen.num_stalls
 
     @classmethod
-    def count_lactating_cows(cls, animal_combination: AnimalCombination, animals_in_pen: [AnimalBase]) -> int:
+    def count_lactating_cows(cls, animal_combination: AnimalCombination, animals_in_pen: List[AnimalBase]) -> int:
         """Counts the number of lactating cows in the pen.
 
-        Args:
-            animal_combination: An AnimalCombination enum that describes the current
-                animal makeup in this pen.
-            animals_in_pen: A list of animal objects in this pen.
+        Parameters
+        ----------
+        animal_combination : AnimalCombination
+            An AnimalCombination enum that describes the current animal makeup in this pen.
+        animals_in_pen : List[AnimalBase]
+            A list of animal objects in this pen.
 
-        Returns:
+        Returns
+        -------
+        int
             The number of lactating cows in the pen.
 
         """

--- a/tests/test_manure_module/test_gas_emissions_calculator.py
+++ b/tests/test_manure_module/test_gas_emissions_calculator.py
@@ -334,32 +334,21 @@ def test_ambient_temp(mocker: MockerFixture) -> None:
 
 
 @pytest.mark.parametrize(
-    "num_animals, barn_area, barn_temp, expected, error_message",
+    "barn_area, barn_temp, expected, error_message",
     [
         (
-            10,
             100.0,
             25.0,
-            10 * (0.0065 + 0.0192 * 25.0) * 100.0 / 1000,
+            (0.0065 + 0.0192 * 25.0) * 100.0 / 1000,
             None,
         ),  # Standard case
-        (0, 100.0, 25.0, 0, None),  # Edge case: no animals
-        (10, 0.0, 25.0, 0, None),  # Edge case: no area
-        (10, 100.0, -20.0, 0, None),  # Edge case: negative barn_temp
-        (
-            -1,
-            100.0,
-            25.0,
-            ValueError,
-            "Number of animals must be greater than or equal to 0.",
-        ),
-        # Exception case: negative number of animals
-        (10, -100.0, 25.0, ValueError, "Barn area must be greater than or equal to 0."),
+        (0.0, 25.0, 0, None),  # Edge case: no area
+        (100.0, -20.0, 0, None),  # Edge case: negative barn_temp
+        (-100.0, 25.0, ValueError, "Barn area must be greater than or equal to 0."),
         # Exception case: negative barn area
     ],
 )
 def test_housing_carbon_dioxide_emission(
-    num_animals: int,
     barn_area: float,
     barn_temp: float,
     expected: float | Exception,
@@ -375,9 +364,9 @@ def test_housing_carbon_dioxide_emission(
     # Act and assert
     if isinstance(expected, type) and issubclass(expected, Exception):
         with pytest.raises(expected, match=error_message):  # type: ignore
-            GasEmissionsCalculator.housing_carbon_dioxide_emission(num_animals, barn_area, barn_temp)
+            GasEmissionsCalculator.housing_carbon_dioxide_emission(barn_area, barn_temp)
     else:
-        actual = GasEmissionsCalculator.housing_carbon_dioxide_emission(num_animals, barn_area, barn_temp)
+        actual = GasEmissionsCalculator.housing_carbon_dioxide_emission(barn_area, barn_temp)
         assert actual == pytest.approx(expected)
 
 
@@ -529,32 +518,21 @@ def test_methane_emission_for_anaerobic_lagoon() -> None:
 
 
 @pytest.mark.parametrize(
-    "num_animals, barn_area, barn_temp, expected, error_message",
+    "barn_area, barn_temp, expected, error_message",
     [
         (
-            10,
             100.0,
             30.0,
-            10 * max(0.0, 0.13 * 30.0) * 100.0 / 1000,
+            max(0.0, 0.13 * 30.0) * 100.0 / 1000,
             None,
         ),  # Standard case
-        (0, 100.0, 30.0, 0, None),  # Edge case: no animals
-        (10, 0.0, 30.0, 0, None),  # Edge case: no area
-        (10, 100.0, -20.0, 0, None),  # Edge case: negative barn_temp
-        # Exception case: negative number of animals
-        (
-            -1,
-            100.0,
-            30.0,
-            ValueError,
-            "Number of animals must be greater than or equal to 0.",
-        ),
+        (0.0, 30.0, 0, None),  # Edge case: no area
+        (100.0, -20.0, 0, None),  # Edge case: negative barn_temp
         # Exception case: negative barn area
-        (10, -100.0, 30.0, ValueError, "Barn area must be greater than or equal to 0."),
+        (-100.0, 30.0, ValueError, "Barn area must be greater than or equal to 0."),
     ],
 )
 def test_housing_methane_emission(
-    num_animals: int,
     barn_area: float,
     barn_temp: float,
     expected: float | Exception,
@@ -570,9 +548,9 @@ def test_housing_methane_emission(
     # Act and assert
     if isinstance(expected, type) and issubclass(expected, Exception):
         with pytest.raises(expected, match=error_message):  # type: ignore
-            GasEmissionsCalculator.housing_methane_emission(num_animals, barn_area, barn_temp)
+            GasEmissionsCalculator.housing_methane_emission(barn_area, barn_temp)
     else:
-        actual = GasEmissionsCalculator.housing_methane_emission(num_animals, barn_area, barn_temp)
+        actual = GasEmissionsCalculator.housing_methane_emission(barn_area, barn_temp)
         assert actual == pytest.approx(expected)
 
 

--- a/tests/test_manure_module/test_manure_handlers.py
+++ b/tests/test_manure_module/test_manure_handlers.py
@@ -376,12 +376,10 @@ def test_manure_handler_daily_update(mocker: MockerFixture) -> None:
         temp=current_day_avg_tempC,
     )
     patch_for_calc_housing_methane_emission.assert_called_once_with(
-        num_animals=num_animals,
         barn_area=barn_area_from_pen_type,
         barn_temp=current_day_avg_tempC,
     )
     patch_for_calc_housing_carbon_dioxide_emission.assert_called_once_with(
-        num_animals=num_animals,
         barn_area=barn_area_from_pen_type,
         barn_temp=current_day_avg_tempC,
     )


### PR DESCRIPTION
Closes #1268

This removes the num animals from the two housing emissions equations in `calculator.py`.

- [x] num_animals removed from `housing_methane_emission()` and `housing_carbon_dioxide_emission()` function params.
- [x] Updates args for places these functions are called within the codebase (`manure_handler_classes.py` and the test suite).
- [x] Updates some docstrings formatting and content.