### PR TITLE
Fix info map in `_record_planting()`

### DIFF
--- a/RUFAS/routines/field/field/field.py
+++ b/RUFAS/routines/field/field/field.py
@@ -1014,7 +1014,7 @@ class Field:
         """
         info_map = {
             "class": self.__class__.__name__,
-            "function": self._plant_crop.__name__,
+            "function": self._record_planting.__name__,
             "suffix": f"field='{self.field_data.name}'",
         }
         value = {

--- a/tests/soil_crop_tests/field_tests/test_field.py
+++ b/tests/soil_crop_tests/field_tests/test_field.py
@@ -678,10 +678,8 @@ def test_record_planting(
 
         clay.assert_called_once()
 
-    actual = om.variables_pool[f"Field._plant_crop.crop_planting.field='{field_name}'"]
+    actual = om.variables_pool[f"Field._record_planting.crop_planting.field='{field_name}'"]
     assert actual["info_maps"].__contains__(expected_info_map)
-    print(actual["values"])
-    print(expected_value)
     assert actual["values"].__contains__(expected_value)
 
 


### PR DESCRIPTION
Fixes the `"function"` field in the info map of `_record_planting()`. Also removes some print statements that were used in debugging.

Now, to filter out all the field operations with the information relevant to EEE, this updated filter can be used:
```json
{
  "multiple": [
    {
      "name": "Fertilizer",
      "filters": ["Field._record_fertilizer_application.fertilizer_application.field='.*'"],
      "variables": ["mass", "application_depth", "field_size", "average_clay_percent"]
    },
    {
      "name": "Tillage",
      "filters": ["TillageApplication._record_tillage.tillage_record.field='.*'"],
      "variables": ["tillage_depth", "implement", "field_size", "average_clay_percent"]
    },
    {
      "name": "Manure",
      "filters": ["Field._record_manure_application.manure_application.field='.*'"],
      "variables": ["dry_matter_mass", "dry_matter_fraction", "application_depth", "field_size", "average_clay_percent"]
    },
    {
      "name": "Harvestings",
      "filters": ["CropManagement._record_yield.harvest_yield.field='.*'"],
      "variables": ["dry_yield", "crop", "field_size"]
    },
    {
      "name": "Plantings",
      "filters": ["Field._record_planting.crop_planting.field='.*'"],
      "variables": ["crop", "field_size", "average_clay_percent"]
    }
  ]
}
```