### PR TITLE
Reduce time spent in IM's get_data()

### DIFF
--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -1094,7 +1094,7 @@ class InputManager:
         om.add_warning("Validation: data fixed", warning_message, info_map)
         return True
 
-    # @lru_cache(maxsize=128)
+    @lru_cache(maxsize=128)
     def get_data(self, data_address: str) -> Any:
         """
         Get the requested data from the pool.

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from functools import reduce
+from functools import reduce, lru_cache
 import json
 import os
 import re
@@ -1094,9 +1094,26 @@ class InputManager:
         om.add_warning("Validation: data fixed", warning_message, info_map)
         return True
 
+    # @lru_cache(maxsize=128)
     def get_data(self, data_address: str) -> Any:
         """
         Get the requested data from the pool.
+
+        Notes
+        -----
+        To improve efficiency, the results of this function are cached using the lru_cache decorator.
+        This means that if the function is called with the same arguments, the result will be returned from the cache
+        instead of being recomputed. The cache has a maximum size of 128, meaning that only the 128 most recent calls
+        are cached. If the cache is full, the least recently used result is discarded.
+
+        As with all caching, it is important to be aware of the potential for stale data. If the data in the pool
+        changes after a result has been cached, the cached result may no longer be valid. In this case, it is
+        necessary to clear the cache using the clear_cache method. Currently, the input manager does not allow
+        modifying the data pool after loading, so this is not a concern yet. However, if the input manager is
+        extended to allow modifying the data pool, it will be important to update the cache accordingly.
+
+        Even when the data pool is not stale, an important assumption here is the method's idempotence. For the caching
+        to work as intended, the method must always return the same result when called with the same arguments.
 
         Parameters
         ----------

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -2890,6 +2890,7 @@ def test_add_variable_to_pool_valid(
     mock_input_manager._validate_tabular_element = input_manager_original_method_states["_validate_tabular_element"]
     mock_input_manager.get_data.cache_clear()
 
+
 @pytest.mark.parametrize(
     "variable_name, data, properties_blob_key, starting_im_pool, is_dict_variable",
     [
@@ -3046,6 +3047,7 @@ def test_add_variable_to_pool_invalid(
     mock_input_manager._validate_tabular_element = input_manager_original_method_states["_validate_tabular_element"]
     mock_input_manager.get_data.cache_clear()
 
+
 @pytest.mark.parametrize(
     "variable_name, data, properties_blob_key, starting_im_pool, is_dict_variable",
     [
@@ -3200,6 +3202,7 @@ def test_add_variable_to_pool_eager_termination(
     mock_input_manager._validate_dict_element = input_manager_original_method_states["_validate_dict_element"]
     mock_input_manager._validate_tabular_element = input_manager_original_method_states["_validate_tabular_element"]
     mock_input_manager.get_data.cache_clear()
+
 
 @pytest.mark.parametrize(
     "variable_name, data, properties_blob_key",

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -2888,7 +2888,7 @@ def test_add_variable_to_pool_valid(
     mock_input_manager._add_variable_to_pool = input_manager_original_method_states["_add_variable_to_pool"]
     mock_input_manager._validate_dict_element = input_manager_original_method_states["_validate_dict_element"]
     mock_input_manager._validate_tabular_element = input_manager_original_method_states["_validate_tabular_element"]
-
+    mock_input_manager.get_data.cache_clear()
 
 @pytest.mark.parametrize(
     "variable_name, data, properties_blob_key, starting_im_pool, is_dict_variable",
@@ -3044,7 +3044,7 @@ def test_add_variable_to_pool_invalid(
     mock_input_manager._add_variable_to_pool = input_manager_original_method_states["_add_variable_to_pool"]
     mock_input_manager._validate_dict_element = input_manager_original_method_states["_validate_dict_element"]
     mock_input_manager._validate_tabular_element = input_manager_original_method_states["_validate_tabular_element"]
-
+    mock_input_manager.get_data.cache_clear()
 
 @pytest.mark.parametrize(
     "variable_name, data, properties_blob_key, starting_im_pool, is_dict_variable",
@@ -3199,7 +3199,7 @@ def test_add_variable_to_pool_eager_termination(
     mock_input_manager._add_variable_to_pool = input_manager_original_method_states["_add_variable_to_pool"]
     mock_input_manager._validate_dict_element = input_manager_original_method_states["_validate_dict_element"]
     mock_input_manager._validate_tabular_element = input_manager_original_method_states["_validate_tabular_element"]
-
+    mock_input_manager.get_data.cache_clear()
 
 @pytest.mark.parametrize(
     "variable_name, data, properties_blob_key",


### PR DESCRIPTION
In this PR, I want to cache the results of repeated calls to IM's `get_data()` by using one of the built-in features, LRU caching and memoization, which could also be implemented from scratch. This caching helps reduce recomputation time but requires that data be not stale. The cache needs to be manually cleared if later on we decide to allow dynamic changes to the input data pool while the simulation is running.

The current implementation of `get_data()` has two bottlenecks: 1) retrieval of nested data (which is not too bad because the input data we have are no more than a constant number of levels deep (say, 10) and mostly shallow anyway) and 2) deep copying of returned data (more serious).

Although the number of calls to get_data() stays the same, only those that actually need to walk through the data pool will get logged, hence, the apparent significant reduction in the number of function calls. 

There are two data access patterns I see when retrieving the data from the input manager: 1) retrieve one big blob of data once, save it, look things up when needed, and 2) retrieve individual pieces of data directly. The first pattern is efficient if the data never changes but extra memory is needed. The second pattern will make lots of independent calls but always get fresh input data. I think both patterns are valid and the input manager should be robust enough to handle both styles. 