### PR TITLE
Refactoring the method for displaying error and warning counts

### DIFF
--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -1139,30 +1139,3 @@ class OutputManager(object):
         errors_count = sum([len(value_dict["values"]) for value_dict in self.errors_pool.values()])
         warnings_count = sum([len(value_dict["values"]) for value_dict in self.warnings_pool.values()])
         return errors_count, warnings_count
-
-    def add_to_stdout_queue(self, msg: str) -> None:
-        """
-        Adds a message to the stdout queue.
-
-        Parameters
-        ----------
-        msg : str
-            The message to be added to the stdout queue.
-        """
-
-        self._stdout_queue.append(msg)
-
-    def show_stdout_queue(self) -> None:
-        """
-        Prints all the messages in the stdout queue.
-        """
-
-        for msg in self._stdout_queue:
-            sys.stdout.write(msg)
-
-    def clear_stdout_queue(self) -> None:
-        """
-        Clears the stdout queue.
-        """
-
-        self._stdout_queue.clear()

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -114,7 +114,6 @@ class OutputManager(object):
                     "function": self.__init__.__name__,
                 },
             )
-            self._stdout_queue: List[str] = []
 
     def _pool_element_factory(self) -> pool_element_type:
         """Factory for elements added to pools"""

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -1126,7 +1126,7 @@ class OutputManager(object):
         except Exception as e:
             self.add_error("mkdir failure", f"{path=}; Exception: {str(e)}", info_map)
 
-    def get_error_warning_counts(self) -> tuple[int, int]:
+    def get_error_and_warning_counts(self) -> tuple[int, int]:
         """
         Get the total number of errors and warnings in the output manager's error and warning pools.
 

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -114,6 +114,7 @@ class OutputManager(object):
                     "function": self.__init__.__name__,
                 },
             )
+            self._stdout_queue: List[str] = []
 
     def _pool_element_factory(self) -> pool_element_type:
         """Factory for elements added to pools"""
@@ -1124,3 +1125,44 @@ class OutputManager(object):
             self.add_error("Permission Error", f"{path=}; Exception: {str(e)}", info_map)
         except Exception as e:
             self.add_error("mkdir failure", f"{path=}; Exception: {str(e)}", info_map)
+
+    def get_error_warning_counts(self) -> tuple[int, int]:
+        """
+        Get the total number of errors and warnings in the output manager's error and warning pools.
+
+        Returns
+        -------
+        tuple[int, int]
+            The total number of errors and warnings in the output manager's error and warning pools.
+        """
+
+        errors_count = sum([len(value_dict["values"]) for value_dict in self.errors_pool.values()])
+        warnings_count = sum([len(value_dict["values"]) for value_dict in self.warnings_pool.values()])
+        return errors_count, warnings_count
+
+    def add_to_stdout_queue(self, msg: str) -> None:
+        """
+        Adds a message to the stdout queue.
+
+        Parameters
+        ----------
+        msg : str
+            The message to be added to the stdout queue.
+        """
+
+        self._stdout_queue.append(msg)
+
+    def show_stdout_queue(self) -> None:
+        """
+        Prints all the messages in the stdout queue.
+        """
+
+        for msg in self._stdout_queue:
+            sys.stdout.write(msg)
+
+    def clear_stdout_queue(self) -> None:
+        """
+        Clears the stdout queue.
+        """
+
+        self._stdout_queue.clear()

--- a/RUFAS/scenario_manager.py
+++ b/RUFAS/scenario_manager.py
@@ -49,5 +49,4 @@ class MetadataPaths(TypedDict):
 
 METADATA_PATHS: List[MetadataPaths] = [
     {"prefix": "default", "path": Path("input/metadata/default_metadata.json")},
-    {"prefix": "multi_crop", "path": Path("input/metadata/multi_crop_metadata.json")},
 ]

--- a/RUFAS/scenario_manager.py
+++ b/RUFAS/scenario_manager.py
@@ -49,4 +49,5 @@ class MetadataPaths(TypedDict):
 
 METADATA_PATHS: List[MetadataPaths] = [
     {"prefix": "default", "path": Path("input/metadata/default_metadata.json")},
+    {"prefix": "multi_crop", "path": Path("input/metadata/multi_crop_metadata.json")},
 ]

--- a/RUFAS/simulation_engine.py
+++ b/RUFAS/simulation_engine.py
@@ -89,6 +89,9 @@ class SimulationEngine:
             },
         )
 
+        error_count, warning_count = om.get_error_warning_counts()
+        sys.stdout.write(f"{error_count} error(s) and {warning_count} warning(s) found.\n")
+
     def _run_simulation_main_loop(self) -> None:
         """
         The main loop for simulation.

--- a/RUFAS/simulation_engine.py
+++ b/RUFAS/simulation_engine.py
@@ -89,7 +89,7 @@ class SimulationEngine:
             },
         )
 
-        error_count, warning_count = om.get_error_warning_counts()
+        error_count, warning_count = om.get_error_and_warning_counts()
         sys.stdout.write(f"{error_count} error(s) and {warning_count} warning(s) found.\n")
 
     def _run_simulation_main_loop(self) -> None:

--- a/main.py
+++ b/main.py
@@ -69,39 +69,6 @@ def main():
         sys.stdout.write("Unexpected early termination of the simulation. Please see logs for details.\n")
 
 
-def get_error_warning_counts() -> tuple[int, int]:
-    """
-    Get the total number of errors and warnings in the output manager's error and warning pools.
-
-    Returns
-    -------
-    tuple[int, int]
-        The total number of errors and warnings in the output manager's error and warning pools.
-    """
-
-    output_manager = OutputManager()
-    errors_count = sum([len(value_dict["values"]) for value_dict in output_manager.errors_pool.values()])
-    warnings_count = sum([len(value_dict["values"]) for value_dict in output_manager.warnings_pool.values()])
-    return errors_count, warnings_count
-
-
-def show_error_warning_counts() -> None:
-    """
-    Print the total number of errors and warnings in the output manager's error and warning pools.
-    """
-
-    error_count, warning_count = get_error_warning_counts()
-    if error_count == 0 and warning_count == 0:
-        sys.stdout.write("No errors or warnings found.\n\n")
-        return
-
-    errors_label = "error" if error_count == 1 else "errors"
-    warnings_label = "warning" if warning_count == 1 else "warnings"
-
-    sys.stdout.write(f"{error_count} {errors_label} and {warning_count} {warnings_label} found.\n")
-    sys.stdout.write("Please see the log files for more details.\n\n")
-
-
 def run_rufas(
     load_pool: bool,
     produce_graphics: bool,
@@ -472,8 +439,6 @@ def execute_simulations(
         output_manager.save_results(output_dir, filters_dir, exclude_info_maps, produce_graphics, graphics_dir, csv_dir)
         input_manager.dump_get_data_logs(path=output_dir)
         output_manager.dump_all_nondata_pools(output_dir, exclude_info_maps, format_option)
-
-        show_error_warning_counts()
 
 
 class CaseInsensitiveArgumentAction(argparse.Action):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1035,4 +1035,3 @@ def test_case_insensitive_argument_action():
     for argument in arguments:
         assert hasattr(namespace, argument)
         assert getattr(namespace, argument) == value
-

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -20,8 +20,6 @@ from main import (
     run_validation,
     METADATA_PATHS,
     initialize_herd,
-    get_error_warning_counts,
-    show_error_warning_counts,
 )
 
 
@@ -1038,58 +1036,3 @@ def test_case_insensitive_argument_action():
         assert hasattr(namespace, argument)
         assert getattr(namespace, argument) == value
 
-
-@pytest.mark.parametrize(
-    "errors_pool, warnings_pool, expected",
-    [
-        ({}, {}, (0, 0)),
-        ({"key1": {"values": [1, 2, 3]}}, {}, (3, 0)),
-        ({}, {"key1": {"values": [1, 2]}}, (0, 2)),
-        ({"key1": {"values": [1]}, "key2": {"values": [2, 3]}}, {"key1": {"values": [1, 2, 3, 4]}}, (3, 4)),
-    ],
-)
-def test_get_error_warning_counts(
-    mocker: MockerFixture,
-    errors_pool: dict[str, dict[str, list]],
-    warnings_pool: dict[str, dict[str, list]],
-    expected: tuple[int, int],
-) -> None:
-    """
-    Unit test for the get_error_warning_counts() function in main.py
-    """
-
-    # Arrange
-    mock_output_manager = mocker.MagicMock()
-    mock_output_manager.errors_pool = errors_pool
-    mock_output_manager.warnings_pool = warnings_pool
-    mocker.patch("main.OutputManager", return_value=mock_output_manager)
-
-    # Act and Assert
-    assert get_error_warning_counts() == expected
-
-
-@pytest.mark.parametrize(
-    "error_count, warning_count, expected_output",
-    [
-        (0, 0, "No errors or warnings found.\n\n"),
-        (1, 0, "1 error and 0 warnings found.\nPlease see the log files for more details.\n\n"),
-        (0, 1, "0 errors and 1 warning found.\nPlease see the log files for more details.\n\n"),
-        (1, 1, "1 error and 1 warning found.\nPlease see the log files for more details.\n\n"),
-    ],
-)
-def test_show_error_warning_counts(
-    mocker: MockerFixture, capsys: pytest.CaptureFixture, error_count: int, warning_count: int, expected_output: str
-) -> None:
-    """
-    Unit test for the show_error_warning_counts() function in main.py
-    """
-
-    # Arrange
-    mocker.patch("main.get_error_warning_counts", return_value=(error_count, warning_count))
-
-    # Act
-    show_error_warning_counts()
-    captured = capsys.readouterr()
-
-    # Assert
-    assert captured.out == expected_output

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -1845,3 +1845,31 @@ def test_log_verbosity_enum_values() -> None:
     assert LogVerbosity.ERRORS.value == "errors"
     assert LogVerbosity.WARNINGS.value == "warnings"
     assert LogVerbosity.LOGS.value == "logs"
+
+
+@pytest.mark.parametrize(
+    "errors_pool, warnings_pool, expected",
+    [
+        ({}, {}, (0, 0)),
+        ({"key1": {"values": [1, 2, 3]}}, {}, (3, 0)),
+        ({}, {"key1": {"values": [1, 2]}}, (0, 2)),
+        ({"key1": {"values": [1]}, "key2": {"values": [2, 3]}}, {"key1": {"values": [1, 2, 3, 4]}}, (3, 4)),
+    ],
+)
+def test_get_error_warning_counts(
+    mocker: MockerFixture,
+    errors_pool: dict[str, dict[str, list]],
+    warnings_pool: dict[str, dict[str, list]],
+    expected: tuple[int, int],
+) -> None:
+    """
+    Unit test for the get_error_warning_counts() method in OutputManager class
+    """
+
+    # Arrange
+    om = OutputManager()
+    mocker.patch.object(om, "errors_pool", errors_pool)
+    mocker.patch.object(om, "warnings_pool", warnings_pool)
+
+    # Act and Assert
+    assert om.get_error_warning_counts() == expected

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -1856,14 +1856,14 @@ def test_log_verbosity_enum_values() -> None:
         ({"key1": {"values": [1]}, "key2": {"values": [2, 3]}}, {"key1": {"values": [1, 2, 3, 4]}}, (3, 4)),
     ],
 )
-def test_get_error_warning_counts(
+def test_get_error_and_warning_counts(
     mocker: MockerFixture,
     errors_pool: dict[str, dict[str, list]],
     warnings_pool: dict[str, dict[str, list]],
     expected: tuple[int, int],
 ) -> None:
     """
-    Unit test for the get_error_warning_counts() method in OutputManager class
+    Unit test for the get_error_and_warning_counts() method in OutputManager class
     """
 
     # Arrange
@@ -1872,4 +1872,4 @@ def test_get_error_warning_counts(
     mocker.patch.object(om, "warnings_pool", warnings_pool)
 
     # Act and Assert
-    assert om.get_error_warning_counts() == expected
+    assert om.get_error_and_warning_counts() == expected

--- a/tests/test_simulation_engine.py
+++ b/tests/test_simulation_engine.py
@@ -27,6 +27,7 @@ def test_simulate(mocker: MockerFixture, start_time: int, end_time: int) -> None
 
     # Arrange
     patch_for_output_manager = mocker.patch("RUFAS.simulation_engine.om")
+    patch_for_output_manager.get_error_warning_counts.return_value = (1, 2)
     mocker.patch("RUFAS.simulation_engine.timer.time", side_effect=[start_time, end_time])
     patch_for_sys_stdout_write = mocker.patch("RUFAS.simulation_engine.sys.stdout.write")
     mocker.patch.object(SimulationEngine, "__init__", return_value=None)
@@ -53,12 +54,14 @@ def test_simulate(mocker: MockerFixture, start_time: int, end_time: int) -> None
 
     # Assert
     patch_for_run_simulation_main_loop.assert_called_once()
-    patch_for_sys_stdout_write.assert_called_once_with("\nSimulation Completed.\n\n")
     expected_simulation_time = end_time - start_time
     expected_log_message = f"Total simulation time is: {expected_simulation_time}"
     patch_for_output_manager.add_log.assert_called_with("total_simulation_time", expected_log_message, info_map)
     patch_for_animal_module_reporter.assert_called_once_with(simulation_engine.state.animal_manager, 100)
     simulation_engine.feed_manager.query_available_feeds.assert_called_once()
+    patch_for_sys_stdout_write.assert_has_calls(
+        [mocker.call("\nSimulation Completed.\n\n"), mocker.call("1 error(s) and 2 warning(s) found.\n")]
+    )
 
 
 def test_daily_simulation(mocker: MockerFixture) -> None:

--- a/tests/test_simulation_engine.py
+++ b/tests/test_simulation_engine.py
@@ -27,7 +27,7 @@ def test_simulate(mocker: MockerFixture, start_time: int, end_time: int) -> None
 
     # Arrange
     patch_for_output_manager = mocker.patch("RUFAS.simulation_engine.om")
-    patch_for_output_manager.get_error_warning_counts.return_value = (1, 2)
+    patch_for_output_manager.get_error_and_warning_counts.return_value = (1, 2)
     mocker.patch("RUFAS.simulation_engine.timer.time", side_effect=[start_time, end_time])
     patch_for_sys_stdout_write = mocker.patch("RUFAS.simulation_engine.sys.stdout.write")
     mocker.patch.object(SimulationEngine, "__init__", return_value=None)


### PR DESCRIPTION
In this small PR, I moved the method `get_error_and_warning_counts()` from `main.py` to inside the OutputManager class. This method is then called by the `simulate()` in the SimulationEngine class.

I also removed the method `show_error_warning_counts()` and kept the error count message to a minimum.

This is a follow-up PR to address additional comments from issue #1251 and the closed PR #1302