### PR TITLE
Emptying storage manure at the end of each storage time period

### DIFF
--- a/RUFAS/routines/manure/manure_treatments/slurry_storage_outdoor.py
+++ b/RUFAS/routines/manure/manure_treatments/slurry_storage_outdoor.py
@@ -249,7 +249,7 @@ class SlurryStorageOutdoor(BaseManureTreatment):
         """
         daily_input = self._current_manure_treatment_daily_input
         daily_output = self._initialize_daily_output_during_update(daily_input)
-        self._accumulate_daily_output(daily_output)
+        self._accumulated_output = self._adjust_accumulated_output(daily_output)
 
         methane_loss = self.calc_methane_emission(self._accumulated_output.liquid_manure_total_solids)
         ammonia_loss = self.calc_ammonia_emission(
@@ -302,3 +302,28 @@ class SlurryStorageOutdoor(BaseManureTreatment):
         self._accumulated_output.liquid_manure_nitrogen -= daily_output.storage_nitrous_oxide
 
         return daily_output
+
+    def _adjust_accumulated_output(
+        self, manure_treatment_daily_output: ManureTreatmentDailyOutput
+    ) -> ManureTreatmentDailyOutput:
+        """
+        Adjust the accumulated output by either resetting it or adding the daily output to it.
+
+        The accumulated output will be reset on the first day of every storage time period.
+
+        Parameters
+        ----------
+        manure_treatment_daily_output : ManureTreatmentDailyOutput
+            The daily output from the manure treatment system.
+
+        Returns
+        -------
+        ManureTreatmentDailyOutput
+            The adjusted accumulated output.
+
+        """
+        if self._sim_day % self.storage_time_period == 1:
+            return manure_treatment_daily_output.clone()
+        else:
+            new_accumulated_output = self._accumulated_output + manure_treatment_daily_output
+            return new_accumulated_output

--- a/RUFAS/routines/manure/manure_treatments/slurry_storage_underfloor.py
+++ b/RUFAS/routines/manure/manure_treatments/slurry_storage_underfloor.py
@@ -185,4 +185,3 @@ class SlurryStorageUnderfloor(BaseManureTreatment):
         else:
             new_accumulated_output = self._accumulated_output + manure_treatment_daily_output
             return new_accumulated_output
-

--- a/RUFAS/routines/manure/manure_treatments/slurry_storage_underfloor.py
+++ b/RUFAS/routines/manure/manure_treatments/slurry_storage_underfloor.py
@@ -105,7 +105,7 @@ class SlurryStorageUnderfloor(BaseManureTreatment):
         """
         daily_input = self._current_manure_treatment_daily_input
         daily_output = self._initialize_daily_output_during_update(daily_input)
-        self._accumulate_daily_output(daily_output)
+        self._accumulated_output = self._adjust_accumulated_output(daily_output)
 
         methane_loss = self.calc_methane_emission(self._accumulated_output.liquid_manure_total_solids)
 
@@ -160,3 +160,29 @@ class SlurryStorageUnderfloor(BaseManureTreatment):
         self._accumulated_output.liquid_manure_nitrogen -= daily_output.storage_nitrous_oxide
 
         return daily_output
+
+    def _adjust_accumulated_output(
+        self, manure_treatment_daily_output: ManureTreatmentDailyOutput
+    ) -> ManureTreatmentDailyOutput:
+        """
+        Adjust the accumulated output by either resetting it or adding the daily output to it.
+
+        The accumulated output will be reset on the first day of every storage time period.
+
+        Parameters
+        ----------
+        manure_treatment_daily_output : ManureTreatmentDailyOutput
+            The daily output from the manure treatment system.
+
+        Returns
+        -------
+        ManureTreatmentDailyOutput
+            The adjusted accumulated output.
+
+        """
+        if self._sim_day % self.storage_time_period == 1:
+            return manure_treatment_daily_output.clone()
+        else:
+            new_accumulated_output = self._accumulated_output + manure_treatment_daily_output
+            return new_accumulated_output
+

--- a/tests/test_manure_module/test_manure_treatments.py
+++ b/tests/test_manure_module/test_manure_treatments.py
@@ -1001,7 +1001,8 @@ def test_slurry_storage_daily_update_helper(slurry_storage_treatment_type_name: 
     mock_accumulated_output.daily_final_manure_volume = final_manure_volume = 30.0
     mock_accumulated_output.liquid_manure_total_ammoniacal_nitrogen = liquid_manure_total_ammoniacal_nitrogen = 110.0
     slurry_storage._accumulated_output = mock_accumulated_output
-    patch_for_accumulate_daily_output = mocker.patch.object(slurry_storage, "_accumulate_daily_output")
+    patch_for_accumulate_daily_output = mocker.patch.object(slurry_storage, "_adjust_accumulated_output",
+                                                            return_value=mock_accumulated_output)
 
     mock_pen = mocker.MagicMock()
     mock_pen.num_animals = num_animals = 100

--- a/tests/test_manure_module/test_manure_treatments.py
+++ b/tests/test_manure_module/test_manure_treatments.py
@@ -1001,8 +1001,9 @@ def test_slurry_storage_daily_update_helper(slurry_storage_treatment_type_name: 
     mock_accumulated_output.daily_final_manure_volume = final_manure_volume = 30.0
     mock_accumulated_output.liquid_manure_total_ammoniacal_nitrogen = liquid_manure_total_ammoniacal_nitrogen = 110.0
     slurry_storage._accumulated_output = mock_accumulated_output
-    patch_for_accumulate_daily_output = mocker.patch.object(slurry_storage, "_adjust_accumulated_output",
-                                                            return_value=mock_accumulated_output)
+    patch_for_accumulate_daily_output = mocker.patch.object(
+        slurry_storage, "_adjust_accumulated_output", return_value=mock_accumulated_output
+    )
 
     mock_pen = mocker.MagicMock()
     mock_pen.num_animals = num_animals = 100


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
This PR is a **temporary fix** to the issue "Storage manure not emptying at the end of each storage time period" #1341.
`AnaerobicLagoon._adjust_accumulated_output()` is copied and pasted to be added to `SlurryStorageOutdoor` and `SlurryStorageUnderfloor` to empty the storage manure for each storage time period.
### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: #1341 

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated