### PR TITLE
Emptying storage manure for anaerobic digestion and lagoon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Testing](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml)
 [![Linting](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml)
 [![Coverage](https://img.shields.io/badge/coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/coverage_pytest-cov.yml)
-[![Mypy](https://img.shields.io/badge/mypy-4686%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
+[![Mypy](https://img.shields.io/badge/mypy-4687%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Testing](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml)
 [![Linting](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml)
 [![Coverage](https://img.shields.io/badge/coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/coverage_pytest-cov.yml)
-[![Mypy](https://img.shields.io/badge/mypy-4682%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
+[![Mypy](https://img.shields.io/badge/mypy-4683%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/RUFAS/routines/manure/manure_treatments/anaerobic_digestion_and_lagoon.py
+++ b/RUFAS/routines/manure/manure_treatments/anaerobic_digestion_and_lagoon.py
@@ -83,9 +83,9 @@ class AnaerobicDigestionAndLagoon(BaseManureTreatment):
             sim_day=self._sim_day,
         )
 
-        self._adjust_accumulated_output(self.anaerobic_digestion_daily_output)
-        self._adjust_accumulated_output(anaerobic_lagoon_daily_output)
-        return anaerobic_lagoon_daily_output
+        self._accumulated_output = self._adjust_accumulated_output(self.anaerobic_digestion_daily_output)
+        self._accumulated_output = self._adjust_accumulated_output(anaerobic_lagoon_daily_output)
+        return self._accumulated_output
 
     def _adjust_accumulated_output(
         self, manure_treatment_daily_output: ManureTreatmentDailyOutput

--- a/RUFAS/routines/manure/manure_treatments/anaerobic_digestion_and_lagoon.py
+++ b/RUFAS/routines/manure/manure_treatments/anaerobic_digestion_and_lagoon.py
@@ -85,7 +85,7 @@ class AnaerobicDigestionAndLagoon(BaseManureTreatment):
 
         self._accumulated_output = self._adjust_accumulated_output(self.anaerobic_digestion_daily_output)
         self._accumulated_output = self._adjust_accumulated_output(anaerobic_lagoon_daily_output)
-        return self._accumulated_output
+        return anaerobic_lagoon_daily_output
 
     def _adjust_accumulated_output(
         self, manure_treatment_daily_output: ManureTreatmentDailyOutput

--- a/RUFAS/routines/manure/manure_treatments/anaerobic_digestion_and_lagoon.py
+++ b/RUFAS/routines/manure/manure_treatments/anaerobic_digestion_and_lagoon.py
@@ -37,7 +37,7 @@ class AnaerobicDigestionAndLagoon(BaseManureTreatment):
         manure_treatment_config: Union[ManureTreatmentConfig, Tuple[ManureTreatmentConfig, ManureTreatmentConfig]],
     ) -> None:
         super().__init__(weather, time, manure_treatment_config)
-        self.storage_time_period = self.config[0].storage_time_period
+        self.storage_time_period = self.config[1].storage_time_period
         self._anaerobic_digestion = AnaerobicDigestion(weather, time, manure_treatment_config[0])
         self.anaerobic_digestion_daily_output = None
         self._anaerobic_lagoon = AnaerobicLagoon(weather, time, manure_treatment_config[1])

--- a/RUFAS/routines/manure/manure_treatments/anaerobic_digestion_and_lagoon.py
+++ b/RUFAS/routines/manure/manure_treatments/anaerobic_digestion_and_lagoon.py
@@ -37,6 +37,7 @@ class AnaerobicDigestionAndLagoon(BaseManureTreatment):
         manure_treatment_config: Union[ManureTreatmentConfig, Tuple[ManureTreatmentConfig, ManureTreatmentConfig]],
     ) -> None:
         super().__init__(weather, time, manure_treatment_config)
+        self.storage_time_period = self.config[0].storage_time_period
         self._anaerobic_digestion = AnaerobicDigestion(weather, time, manure_treatment_config[0])
         self.anaerobic_digestion_daily_output = None
         self._anaerobic_lagoon = AnaerobicLagoon(weather, time, manure_treatment_config[1])
@@ -82,6 +83,31 @@ class AnaerobicDigestionAndLagoon(BaseManureTreatment):
             sim_day=self._sim_day,
         )
 
-        self._accumulate_daily_output(self.anaerobic_digestion_daily_output)
-        self._accumulate_daily_output(anaerobic_lagoon_daily_output)
+        self._adjust_accumulated_output(self.anaerobic_digestion_daily_output)
+        self._adjust_accumulated_output(anaerobic_lagoon_daily_output)
         return anaerobic_lagoon_daily_output
+
+    def _adjust_accumulated_output(
+        self, manure_treatment_daily_output: ManureTreatmentDailyOutput
+    ) -> ManureTreatmentDailyOutput:
+        """
+        Adjust the accumulated output by either resetting it or adding the daily output to it.
+
+        The accumulated output will be reset on the first day of every storage time period.
+
+        Parameters
+        ----------
+        manure_treatment_daily_output : ManureTreatmentDailyOutput
+            The daily output from the manure treatment system.
+
+        Returns
+        -------
+        ManureTreatmentDailyOutput
+            The adjusted accumulated output.
+
+        """
+        if self._sim_day % self.storage_time_period == 1:
+            return manure_treatment_daily_output.clone()
+        else:
+            new_accumulated_output = self._accumulated_output + manure_treatment_daily_output
+            return new_accumulated_output

--- a/tests/test_manure_module/test_manure_treatments.py
+++ b/tests/test_manure_module/test_manure_treatments.py
@@ -2797,9 +2797,9 @@ def test_anaerobic_digestion_and_lagoon_daily_update_helper(manure_separator_exi
         "_create_anaerobic_digestion_daily_output",
         return_value=mock_anaerobic_digestion_daily_output,
     )
-    patch_for_accumulate_daily_output = mocker.patch.object(
+    patch_for_adjust_accumulated_output = mocker.patch.object(
         anaerobic_digestion_and_lagoon,
-        "_accumulate_daily_output",
+        "_adjust_accumulated_output",
         return_value=None,
     )
 
@@ -2853,8 +2853,8 @@ def test_anaerobic_digestion_and_lagoon_daily_update_helper(manure_separator_exi
         )
 
     assert actual_anaerobic_lagoon_daily_output == mock_anaerobic_lagoon_daily_output
-    patch_for_accumulate_daily_output.assert_any_call(mock_anaerobic_digestion_daily_output)
-    patch_for_accumulate_daily_output.assert_any_call(mock_anaerobic_lagoon_daily_output)
+    patch_for_adjust_accumulated_output.assert_any_call(mock_anaerobic_digestion_daily_output)
+    patch_for_adjust_accumulated_output.assert_any_call(mock_anaerobic_lagoon_daily_output)
 
 
 # Test CompostBeddedPackBarn specific methods


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
This PR is a temporary fix to the issue "[Anaerobic digestion and lagoon manure storage update #1343](https://github.com/RuminantFarmSystems/MASM/issues/1343)".

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: #1343 

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
AnaerobicLagoon._adjust_accumulated_output() is copied and pasted to be added to AnaerobicDigestionAndLagoon to empty the storage manure for each storage time period.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
Temporarily fix the issue of manure storage not emptying.
