### PR TITLE
Correct PR description template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,9 +2,9 @@
 
 ### Context
 <!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
-Issue(s) closed by this pull request: #
+Issue(s) closed by this pull request: closes #
 
-The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated: [ ]
+- [ ] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.
 
 ### What
 <!-- Add more detail about the changes that are being made in the pull request. -->


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
This updates the context section of the PR description template to be a little nicer to work with. Now, when issue number is written after the # the issue _should_ be linked automatically. Also there is now a tick box for updating the changelog, which sparks way more joy than adding an "x" in between square brackets.

The old: 
### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: #

The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated: [ ]

The new:
### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #

- [ ] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.

(The changelog doesn't actually need to be changed for this PR)