### PR TITLE
Using regexes in cross-references field during report generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Testing](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml)
 [![Linting](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml)
 [![Coverage](https://img.shields.io/badge/coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/coverage_pytest-cov.yml)
-[![Mypy](https://img.shields.io/badge/mypy-4694%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
+[![Mypy](https://img.shields.io/badge/mypy-4676%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
 
 
 # Vision

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Testing](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml)
 [![Linting](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml)
 [![Coverage](https://img.shields.io/badge/coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/coverage_pytest-cov.yml)
-[![Mypy](https://img.shields.io/badge/mypy-4689%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
+[![Mypy](https://img.shields.io/badge/mypy-4669%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Testing](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml)
 [![Linting](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml)
 [![Coverage](https://img.shields.io/badge/coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/coverage_pytest-cov.yml)
-[![Mypy](https://img.shields.io/badge/mypy-4665%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
+[![Mypy](https://img.shields.io/badge/mypy-4647%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/RUFAS/report_generator.py
+++ b/RUFAS/report_generator.py
@@ -1,3 +1,4 @@
+import re
 from typing import Dict, List, Any, Callable
 
 from RUFAS.util import Utility
@@ -138,7 +139,7 @@ class ReportGenerator:
     A class to generate reports based on filtered data and aggregation criteria and store them in a dictionary.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Initializes the ReportGenerator.
         """
@@ -197,7 +198,7 @@ class ReportGenerator:
         try:
             if "cross_references" in filter_content.keys():
                 self._check_for_missing_references(filter_content["cross_references"])
-                cross_reference_data = {ref: self.reports[ref] for ref in filter_content["cross_references"]}
+                cross_reference_data = self._get_reports_by_regex(filter_content["cross_references"])
                 cross_reference_data.update(filtered_pool)
                 report_data = self._perform_aggregations(cross_reference_data, filter_content)
             else:
@@ -266,9 +267,38 @@ class ReportGenerator:
         KeyError
             If any of the report references are missing.
         """
-        missing_references = [ref for ref in references if ref not in self.reports]
+
+        missing_references = []
+
+        for ref in references:
+            if not any(re.fullmatch(ref, report_name) for report_name in self.reports):
+                missing_references.append(ref)
+
         if missing_references:
             raise KeyError(f"Missing referenced reports: {', '.join(missing_references)}")
+
+    def _get_reports_by_regex(self, regex_patterns: List[str]) -> Dict[str, Dict[str, List[Any]]]:
+        """
+        Retrieve reports based on matching the existing report names with the given regex patterns.
+
+        Notes
+        -----
+        Each pattern is checked for a full match against the report names. A "full match"
+        means that the regex must match the entire string of the report name from start to finish,
+        without partial matches. This reduces the potential for false positives.
+
+        Parameters
+        ----------
+        regex_patterns : List[str]
+            A list of regex patterns to match with the existing report names.
+        """
+
+        matched_reports = {}
+        for pattern in regex_patterns:
+            for report_name in self.reports:
+                if re.fullmatch(pattern, report_name):
+                    matched_reports[report_name] = self.reports[report_name]
+        return matched_reports
 
     def _perform_aggregations(
         self,

--- a/RUFAS/report_generator.py
+++ b/RUFAS/report_generator.py
@@ -275,7 +275,9 @@ class ReportGenerator:
                 missing_references.append(ref)
 
         if missing_references:
-            raise KeyError(f"Missing referenced reports: {', '.join(missing_references)}")
+            raise KeyError(
+                f"Missing referenced reports matching the following pattern(s): {', '.join(missing_references)}"
+            )
 
     def _get_reports_by_regex(self, regex_patterns: List[str]) -> Dict[str, Dict[str, List[Any]]]:
         """

--- a/RUFAS/simulation_engine.py
+++ b/RUFAS/simulation_engine.py
@@ -93,9 +93,6 @@ class SimulationEngine:
             {"class": self.__class__.__name__, "function": self.simulate.__name__, "units": "days"},
         )
 
-        error_count, warning_count = om.get_error_and_warning_counts()
-        sys.stdout.write(f"{error_count} error(s) and {warning_count} warning(s) found.\n")
-
     def _run_simulation_main_loop(self) -> None:
         """
         The main loop for simulation.

--- a/main.py
+++ b/main.py
@@ -440,6 +440,9 @@ def execute_simulations(
         input_manager.dump_get_data_logs(path=output_dir)
         output_manager.dump_all_nondata_pools(output_dir, exclude_info_maps, format_option)
 
+        error_count, warning_count = output_manager.get_error_and_warning_counts()
+        sys.stdout.write(f"{error_count} error(s) and {warning_count} warning(s) found.\n")
+
 
 class CaseInsensitiveArgumentAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -757,10 +757,7 @@ def test_execute_simulations(
         ),
     ] * len(metadata_file_list)
     patch_for_stdout_write.assert_has_calls(
-        [
-            mocker.call("Simulating...\n"),
-            mocker.call("1 error(s) and 2 warning(s) found.\n")
-        ]
+        [mocker.call("Simulating...\n"), mocker.call("1 error(s) and 2 warning(s) found.\n")]
     )
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -715,6 +715,8 @@ def test_execute_simulations(
     csv_dir = Path("output/CSVs/")
     graphics_dir = Path("")
     verbose = LogVerbosity("none")
+    mock_output_manager.get_error_and_warning_counts.return_value = (1, 2)
+    patch_for_stdout_write = mocker.patch("main.sys.stdout.write")
 
     # Act
     execute_simulations(
@@ -754,10 +756,16 @@ def test_execute_simulations(
             csv_dir,
         ),
     ] * len(metadata_file_list)
+    patch_for_stdout_write.assert_has_calls(
+        [
+            mocker.call("Simulating...\n"),
+            mocker.call("1 error(s) and 2 warning(s) found.\n")
+        ]
+    )
 
 
 @pytest.mark.parametrize(
-    "produce_graphics, exlclude_info_maps, is_data_valid, terminate_simulation_post_herd_generation,"
+    "produce_graphics, exclude_info_maps, is_data_valid, terminate_simulation_post_herd_generation,"
     "initialize_herd_call_count, format_option",
     [
         (False, False, True, False, 2, "verbose"),
@@ -773,7 +781,7 @@ def test_execute_simulations(
 def test_execute_simulations_raises_exception(
     mocker: MockerFixture,
     produce_graphics: bool,
-    exlclude_info_maps: bool,
+    exclude_info_maps: bool,
     is_data_valid: bool,
     terminate_simulation_post_herd_generation: bool,
     initialize_herd_call_count: int,
@@ -814,7 +822,7 @@ def test_execute_simulations_raises_exception(
     with pytest.raises(Exception):
         execute_simulations(
             metadata_files=metadata_file_list,
-            exclude_info_maps=exlclude_info_maps,
+            exclude_info_maps=exclude_info_maps,
             produce_graphics=produce_graphics,
             graphics_dir=graphics_dir,
             format_option=format_option,
@@ -837,7 +845,7 @@ def test_execute_simulations_raises_exception(
     assert mock_output_manager.dump_all_nondata_pools.call_args_list == [
         mocker.call(
             path=output_dir,
-            exclude_info_maps=exlclude_info_maps,
+            exclude_info_maps=exclude_info_maps,
             format_option=format_option,
         )
     ]

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -638,13 +638,13 @@ def test_combine_aggregate_report_data(
         # Reports dictionary is empty
         (["ref1"], {}, KeyError, "Missing referenced reports: ref1"),
         # Regex match one reference
-        (["ref\d"], {"ref1": {}}, None, None),
+        (["ref\\d"], {"ref1": {}}, None, None),
         # Regex match multiple references
-        (["ref\d"], {"ref2": {}, "ref3": {}}, None, None),
+        (["ref\\d"], {"ref2": {}, "ref3": {}}, None, None),
         # Regex match none
-        (["ref\d+"], {"report1": {}, "report2": {}}, KeyError, r"Missing referenced reports: ref\\d+"),
+        (["ref\\d+"], {"report1": {}, "report2": {}}, KeyError, r"Missing referenced reports: ref\\d+"),
         # Complex regex pattern
-        (["ref[1-3]", "report\d{2}"], {"ref1": {}, "ref2": {}, "report01": {}}, None, None),
+        (["ref[1-3]", "report\\d{2}"], {"ref1": {}, "ref2": {}, "report01": {}}, None, None),
     ],
 )
 def test_check_for_missing_references(
@@ -679,7 +679,7 @@ def test_check_for_missing_references(
         # Match single report
         (["report1"], {"report1": {"data": []}}),
         # Match multiple reports with simple pattern
-        (["report\d"], {"report1": {"data": []}, "report2": {"data": []}}),
+        (["report\\d"], {"report1": {"data": []}, "report2": {"data": []}}),
         # Match multiple reports with complex pattern
         (["report[12]"], {"report1": {"data": []}, "report2": {"data": []}}),
         # No match
@@ -687,7 +687,7 @@ def test_check_for_missing_references(
         # Partial match not included
         (["report"], {}),
         # Match with special characters in report names
-        (["special_report-\d"], {"special_report-1": {"data": []}}),
+        (["special_report-\\d"], {"special_report-1": {"data": []}}),
     ],
 )
 def test_get_reports_by_regex(

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -627,22 +627,22 @@ def test_combine_aggregate_report_data(
         # All references are present
         (["ref1", "ref2"], {"ref1": {}, "ref2": {}}, None, None),
         # One reference is missing
-        (["ref1", "ref2"], {"ref1": {}}, KeyError, "Missing referenced reports: ref2"),
+        (["ref1", "ref2"], {"ref1": {}}, KeyError, "Missing referenced reports matching the following pattern(s): ref2"),
         # Multiple references are missing
         (
             ["ref1", "ref2", "ref3"],
             {"ref1": {}},
             KeyError,
-            "Missing referenced reports: ref2, ref3",
+            "Missing referenced reports matching the following pattern(s): ref2, ref3",
         ),
         # Reports dictionary is empty
-        (["ref1"], {}, KeyError, "Missing referenced reports: ref1"),
+        (["ref1"], {}, KeyError, "Missing referenced reports matching the following pattern(s): ref1"),
         # Regex match one reference
         (["ref\\d"], {"ref1": {}}, None, None),
         # Regex match multiple references
         (["ref\\d"], {"ref2": {}, "ref3": {}}, None, None),
         # Regex match none
-        (["ref\\d+"], {"report1": {}, "report2": {}}, KeyError, r"Missing referenced reports: ref\\d+"),
+        (["ref\\d+"], {"report1": {}, "report2": {}}, KeyError, r"Missing referenced reports matching the following pattern(s): ref\\d+"),
         # Complex regex pattern
         (["ref[1-3]", "report\\d{2}"], {"ref1": {}, "ref2": {}, "report01": {}}, None, None),
     ],

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -627,7 +627,12 @@ def test_combine_aggregate_report_data(
         # All references are present
         (["ref1", "ref2"], {"ref1": {}, "ref2": {}}, None, None),
         # One reference is missing
-        (["ref1", "ref2"], {"ref1": {}}, KeyError, "Missing referenced reports matching the following pattern(s): ref2"),
+        (
+            ["ref1", "ref2"],
+            {"ref1": {}},
+            KeyError,
+            "Missing referenced reports matching the following pattern(s): ref2",
+        ),
         # Multiple references are missing
         (
             ["ref1", "ref2", "ref3"],
@@ -642,7 +647,12 @@ def test_combine_aggregate_report_data(
         # Regex match multiple references
         (["ref\\d"], {"ref2": {}, "ref3": {}}, None, None),
         # Regex match none
-        (["ref\\d+"], {"report1": {}, "report2": {}}, KeyError, r"Missing referenced reports matching the following pattern(s): ref\\d+"),
+        (
+            ["ref\\d+"],
+            {"report1": {}, "report2": {}},
+            KeyError,
+            r"Missing referenced reports matching the following pattern(s): ref\\d+",
+        ),
         # Complex regex pattern
         (["ref[1-3]", "report\\d{2}"], {"ref1": {}, "ref2": {}, "report01": {}}, None, None),
     ],

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
+
 from typing import Dict, List, Any, Optional, Type
+
 import pytest
 from pytest_mock import MockerFixture
 
@@ -635,13 +637,21 @@ def test_combine_aggregate_report_data(
         ),
         # Reports dictionary is empty
         (["ref1"], {}, KeyError, "Missing referenced reports: ref1"),
+        # Regex match one reference
+        (["ref\d"], {"ref1": {}}, None, None),
+        # Regex match multiple references
+        (["ref\d"], {"ref2": {}, "ref3": {}}, None, None),
+        # Regex match none
+        (["ref\d+"], {"report1": {}, "report2": {}}, KeyError, r"Missing referenced reports: ref\\d+"),
+        # Complex regex pattern
+        (["ref[1-3]", "report\d{2}"], {"ref1": {}, "ref2": {}, "report01": {}}, None, None),
     ],
 )
 def test_check_for_missing_references(
     mocker: MockerFixture,
     references: List[str],
     reports: Dict[str, Dict[str, Any]],
-    expected_exception: Optional[Exception],
+    expected_exception: Optional[Type[Exception]],
     expected_message: Optional[str],
 ) -> None:
     """
@@ -655,12 +665,52 @@ def test_check_for_missing_references(
 
     if expected_exception:
         # Act and assert
-        with pytest.raises(expected_exception) as excinfo:  # type: ignore
+        with pytest.raises(expected_exception) as excinfo:
             report_generator._check_for_missing_references(references)
-        assert expected_message in str(excinfo.value)
+        assert isinstance(expected_message, str) and expected_message in str(excinfo.value)
     else:
         # Act
         report_generator._check_for_missing_references(references)
+
+
+@pytest.mark.parametrize(
+    "regex_patterns, expected_matched_reports",
+    [
+        # Match single report
+        (["report1"], {"report1": {"data": []}}),
+        # Match multiple reports with simple pattern
+        (["report\d"], {"report1": {"data": []}, "report2": {"data": []}}),
+        # Match multiple reports with complex pattern
+        (["report[12]"], {"report1": {"data": []}, "report2": {"data": []}}),
+        # No match
+        (["unmatched"], {}),
+        # Partial match not included
+        (["report"], {}),
+        # Match with special characters in report names
+        (["special_report-\d"], {"special_report-1": {"data": []}}),
+    ],
+)
+def test_get_reports_by_regex(
+    regex_patterns: List[str], expected_matched_reports: Dict[str, Dict[str, List[Any]]]
+) -> None:
+    """
+    Unit test for _get_reports_by_regex() method in report_generator.py file.
+    """
+
+    # Arrange
+    reports: Dict[str, Dict[str, List[Any]]] = {
+        "report1": {"data": []},
+        "report2": {"data": []},
+        "special_report-1": {"data": []},
+    }
+    report_generator = ReportGenerator()
+    report_generator.reports = reports
+
+    # Act
+    matched_reports = report_generator._get_reports_by_regex(regex_patterns)
+
+    # Assert
+    assert matched_reports == expected_matched_reports
 
 
 @pytest.mark.parametrize(
@@ -682,7 +732,7 @@ def test_ensure_unique_report_name_with_timestamp(
     reports: Dict[str, Dict[str, Any]],
     expected_name: str,
     timestamp_return_value: str,
-):
+) -> None:
     """
     Unit test for _ensure_unique_report_name_with_timestamp method in report_generator.py file.
     """

--- a/tests/test_simulation_engine.py
+++ b/tests/test_simulation_engine.py
@@ -65,9 +65,7 @@ def test_simulate(mocker: MockerFixture, start_time: int, end_time: int) -> None
     patch_for_output_manager.add_log.assert_called_with("total_simulation_time", expected_log_message, info_map)
     patch_for_animal_module_reporter.assert_called_once_with(simulation_engine.animal_manager, 100)
     simulation_engine.feed_manager.query_available_feeds.assert_called_once()
-    patch_for_sys_stdout_write.assert_has_calls(
-        [mocker.call("\nSimulation Completed.\n\n")]
-    )
+    patch_for_sys_stdout_write.assert_has_calls([mocker.call("\nSimulation Completed.\n\n")])
 
 
 def test_daily_simulation(mocker: MockerFixture) -> None:

--- a/tests/test_simulation_engine.py
+++ b/tests/test_simulation_engine.py
@@ -66,7 +66,7 @@ def test_simulate(mocker: MockerFixture, start_time: int, end_time: int) -> None
     patch_for_animal_module_reporter.assert_called_once_with(simulation_engine.animal_manager, 100)
     simulation_engine.feed_manager.query_available_feeds.assert_called_once()
     patch_for_sys_stdout_write.assert_has_calls(
-        [mocker.call("\nSimulation Completed.\n\n"), mocker.call("1 error(s) and 2 warning(s) found.\n")]
+        [mocker.call("\nSimulation Completed.\n\n")]
     )
 
 


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
This PR adds a new feature to the report generator that would allow using regex patterns in the "cross-references" field in the report json specification.

I also moved the call to stdout-write from simulation engine class to the main class, because I didn't see the errors from report generation included in the final tallies.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: #1257 

The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated:
[ ] 

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->

A simple example I used to test this feature out

```
{
  "multiple": [
    {
      "name": "Total housing methane, kg",
      "filters": [
        "^ManureHandlerDailyOutput_Pen_.*housing_methane$"
      ],
      "slice_start": -365,
      "vertical_aggregation": "sum",
      "horizontal_aggregation": "sum"
    },
    {
      "name": "Total storage methane, kg",
      "filters": [
        "^(?:AnaerobicDigestion_)?ManureTreatmentDailyOutput_Pen_.*storage_methane$"
      ],
      "slice_start": -365,
      "vertical_aggregation": "sum",
      "horizontal_aggregation": "sum"
    },
    {
      "name": "Total housing and storage methane, kg",
      "cross_references": [
        "Total.*methane.*"
      ],
      "horizontal_aggregation": "sum"
    }
  ]
}
```

One thing of note is the use of regex full-matching, vs. partial matching, to reduce the potential for false positives. The ignored characters should be accounted for by the special wildcard characters. For example, if I want to match the string "Total housing methane, kg_hor_agg", valid regex patterns, in this case, would be `Total.*methane.*` or `.*methane.*` whereas `methane` by itself is not enough.