### PR TITLE
Update storage methane eq

### DIFF
--- a/RUFAS/routines/manure/constants_and_units/gas_emission_constants.py
+++ b/RUFAS/routines/manure/constants_and_units/gas_emission_constants.py
@@ -9,6 +9,10 @@ from RUFAS.routines.manure.manure_treatments.manure_treatment_types import (
 
 class GasEmissionConstants:
     """Constants used in gas emission calculations."""
+    HOUR_TO_DAY_CONVERSION_FACTOR = 24 
+    """
+    The conversion factor from hours to days.
+    """
 
     DEGRADABLE_VOLATILE_SOLIDS_RATE_CORRECTING_FACTOR: float = 1.0
     """

--- a/RUFAS/routines/manure/constants_and_units/gas_emission_constants.py
+++ b/RUFAS/routines/manure/constants_and_units/gas_emission_constants.py
@@ -9,7 +9,8 @@ from RUFAS.routines.manure.manure_treatments.manure_treatment_types import (
 
 class GasEmissionConstants:
     """Constants used in gas emission calculations."""
-    HOUR_TO_DAY_CONVERSION_FACTOR = 24 
+
+    HOUR_TO_DAY_CONVERSION_FACTOR = 24
     """
     The conversion factor from hours to days.
     """

--- a/RUFAS/routines/manure/gas_emissions/calculator.py
+++ b/RUFAS/routines/manure/gas_emissions/calculator.py
@@ -97,23 +97,21 @@ class GasEmissionsCalculator:
             non_degradable_volatile_solids_fraction,
         ) = cls._volatile_solid_component_fractions(total_volatile_solids)
 
-        methane_emission_from_degradable_volatile_solids = (
+        methane_emission_from_degradable_volatile_solids = GasEmissionConstants.HOUR_TO_DAY_CONVERSION_FACTOR * (
             (
                 degradable_volatile_solids_fraction
                 * GasEmissionConstants.DEGRADABLE_VOLATILE_SOLIDS_RATE_CORRECTING_FACTOR
                 * arrhenius_exponent
             )
             * total_volatile_solids
-            * GeneralConstants.GRAMS_TO_KG
         )
-        methane_emission_from_non_degradable_volatile_solids = (
+        methane_emission_from_non_degradable_volatile_solids = GasEmissionConstants.HOUR_TO_DAY_CONVERSION_FACTOR * (
             (
                 non_degradable_volatile_solids_fraction
                 * GasEmissionConstants.NON_DEGRADABLE_VOLATILE_SOLIDS_RATE_CORRECTING_FACTOR
                 * arrhenius_exponent
             )
             * total_volatile_solids
-            * GeneralConstants.GRAMS_TO_KG
         )
 
         methane_emission = (

--- a/RUFAS/routines/manure/gas_emissions/calculator.py
+++ b/RUFAS/routines/manure/gas_emissions/calculator.py
@@ -98,26 +98,22 @@ class GasEmissionsCalculator:
         ) = cls._volatile_solid_component_fractions(total_volatile_solids)
 
         methane_emission_from_degradable_volatile_solids = GasEmissionConstants.HOUR_TO_DAY_CONVERSION_FACTOR * (
-            (
-                degradable_volatile_solids_fraction
-                * GasEmissionConstants.DEGRADABLE_VOLATILE_SOLIDS_RATE_CORRECTING_FACTOR
-                * arrhenius_exponent
-            )
+            degradable_volatile_solids_fraction
+            * GasEmissionConstants.DEGRADABLE_VOLATILE_SOLIDS_RATE_CORRECTING_FACTOR
+            * arrhenius_exponent
             * total_volatile_solids
         )
         methane_emission_from_non_degradable_volatile_solids = GasEmissionConstants.HOUR_TO_DAY_CONVERSION_FACTOR * (
-            (
-                non_degradable_volatile_solids_fraction
-                * GasEmissionConstants.NON_DEGRADABLE_VOLATILE_SOLIDS_RATE_CORRECTING_FACTOR
-                * arrhenius_exponent
-            )
+            non_degradable_volatile_solids_fraction
+            * GasEmissionConstants.NON_DEGRADABLE_VOLATILE_SOLIDS_RATE_CORRECTING_FACTOR
+            * arrhenius_exponent
             * total_volatile_solids
         )
 
         methane_emission = (
             methane_emission_from_degradable_volatile_solids + methane_emission_from_non_degradable_volatile_solids
         )
-
+        
         return methane_emission
 
     @classmethod

--- a/RUFAS/routines/manure/gas_emissions/calculator.py
+++ b/RUFAS/routines/manure/gas_emissions/calculator.py
@@ -23,8 +23,8 @@ class GasEmissionsCalculator:
 
         .. math::
 
-            E_{CH_4} = 1/1000 \\cdot VS_{d} \\cdot b_{1} \\cdot e^{lnA - \\frac{E}{RT}}
-            + 1/1000 \\cdot VS_{nd} \\cdot b_{2} \\cdot e^{lnA - \\frac{E}{RT}}
+            E_{CH_4} = 24 \\cdot e^{lnA - \\frac{E}{RT}} \\cdot VS_{d} \\cdot b_{1}
+            + 24 \\cdot e^{lnA - \\frac{E}{RT}} \\cdot VS_{nd} \\cdot b_{2}
 
         where:
 
@@ -38,7 +38,7 @@ class GasEmissionsCalculator:
 
             :math:`b_{2}` is the non-degradable volatile solids rate correcting factor (0.01, unitless),
 
-            :math:`lnA` is the natural log of the Arrhenius constant (31.2, unitless),
+            :math:`lnA` is the natural log of the Arrhenius constant (31.2, $\frac{\text{kg VS}}{\text{h}}^{-1}$),
 
             :math:`E` is the activation energy (81,000.0 J/mol),
 
@@ -98,15 +98,15 @@ class GasEmissionsCalculator:
         ) = cls._volatile_solid_component_fractions(total_volatile_solids)
 
         methane_emission_from_degradable_volatile_solids = GasEmissionConstants.HOUR_TO_DAY_CONVERSION_FACTOR * (
-            degradable_volatile_solids_fraction
+            arrhenius_exponent 
+            * degradable_volatile_solids_fraction
             * GasEmissionConstants.DEGRADABLE_VOLATILE_SOLIDS_RATE_CORRECTING_FACTOR
-            * arrhenius_exponent
             * total_volatile_solids
         )
         methane_emission_from_non_degradable_volatile_solids = GasEmissionConstants.HOUR_TO_DAY_CONVERSION_FACTOR * (
-            non_degradable_volatile_solids_fraction
+            arrhenius_exponent
+            * non_degradable_volatile_solids_fraction
             * GasEmissionConstants.NON_DEGRADABLE_VOLATILE_SOLIDS_RATE_CORRECTING_FACTOR
-            * arrhenius_exponent
             * total_volatile_solids
         )
 

--- a/RUFAS/routines/manure/gas_emissions/calculator.py
+++ b/RUFAS/routines/manure/gas_emissions/calculator.py
@@ -113,7 +113,7 @@ class GasEmissionsCalculator:
         methane_emission = (
             methane_emission_from_degradable_volatile_solids + methane_emission_from_non_degradable_volatile_solids
         )
-        
+
         return methane_emission
 
     @classmethod

--- a/RUFAS/routines/manure/gas_emissions/calculator.py
+++ b/RUFAS/routines/manure/gas_emissions/calculator.py
@@ -98,7 +98,7 @@ class GasEmissionsCalculator:
         ) = cls._volatile_solid_component_fractions(total_volatile_solids)
 
         methane_emission_from_degradable_volatile_solids = GasEmissionConstants.HOUR_TO_DAY_CONVERSION_FACTOR * (
-            arrhenius_exponent 
+            arrhenius_exponent
             * degradable_volatile_solids_fraction
             * GasEmissionConstants.DEGRADABLE_VOLATILE_SOLIDS_RATE_CORRECTING_FACTOR
             * total_volatile_solids

--- a/tests/test_manure_module/test_gas_emissions_calculator.py
+++ b/tests/test_manure_module/test_gas_emissions_calculator.py
@@ -743,10 +743,10 @@ def test_volatile_solid_component_fractions(
     "total_volatile_solids, temp, expected, error_message",
     [
         # Standard case
-        (1.0, 20.0, 1.54, None),
-        (10.0, 20.0, 15.4, None),
+        (1.0, 20.0, 1.585, None),
+        (10.0, 20.0, 15.85, None),
         # Case when temperature is not provided, default should be used
-        (1.0, None, 1.54, None),
+        (1.0, None, 1.585, None),
         # Exception case: Zero total volatile solids
         (0.0, 20.0, ValueError, "Total volatile solids must be positive. Total volatile solids provided: 0.0"),
         # Exception case: Negative total volatile solids

--- a/tests/test_manure_module/test_gas_emissions_calculator.py
+++ b/tests/test_manure_module/test_gas_emissions_calculator.py
@@ -743,10 +743,10 @@ def test_volatile_solid_component_fractions(
     "total_volatile_solids, temp, expected, error_message",
     [
         # Standard case
-        (1.0, 20.0, 0.000202, None),
-        (10.0, 20.0, 0.00202, None),
+        (1.0, 20.0, 1.54, None),
+        (10.0, 20.0, 15.4, None),
         # Case when temperature is not provided, default should be used
-        (1.0, None, 0.000202, None),
+        (1.0, None, 1.54, None),
         # Exception case: Zero total volatile solids
         (0.0, 20.0, ValueError, "Total volatile solids must be positive. Total volatile solids provided: 0.0"),
         # Exception case: Negative total volatile solids

--- a/tests/test_manure_module/test_gas_emissions_calculator.py
+++ b/tests/test_manure_module/test_gas_emissions_calculator.py
@@ -743,10 +743,10 @@ def test_volatile_solid_component_fractions(
     "total_volatile_solids, temp, expected, error_message",
     [
         # Standard case
-        (1.0, 20.0, 1.585, None),
-        (10.0, 20.0, 15.85, None),
+        (1.0, 20.0, 1.55838924852, None),
+        (10.0, 20.0, 15.583892485199996, None),
         # Case when temperature is not provided, default should be used
-        (1.0, None, 1.585, None),
+        (1.0, None, 1.55838924852, None),
         # Exception case: Zero total volatile solids
         (0.0, 20.0, ValueError, "Total volatile solids must be positive. Total volatile solids provided: 0.0"),
         # Exception case: Negative total volatile solids
@@ -776,11 +776,11 @@ def test_methane_emission_from_slurry_storage(
     # Arrange
     patch_for_arrhenius_exponent = mocker.patch(
         "RUFAS.routines.manure.gas_emissions.calculator.GasEmissionsCalculator._arrhenius_exponent",
-        return_value=0.2,  # Dummy return value
+        return_value=0.128579971,  # Dummy return value
     )
     patch_for_volatile_solid_components = mocker.patch(
         "RUFAS.routines.manure.gas_emissions.calculator.GasEmissionsCalculator._volatile_solid_component_fractions",
-        return_value=(1.0, 1.0) if total_volatile_solids != 0.0 else (0.0, 0.0),  # Dummy return value
+        return_value=(0.5, 0.5) if total_volatile_solids != 0.0 else (0.0, 0.0),  # Dummy return value
     )
 
     # Act and assert


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

This PR acts as a quick fix for the storage methane equation. We changed from the Sommer 2004 equation to Chianese 2009 equation after consulting Alan Rotz. 

More details on the comparison between the two equations can be found in issue #1271.   

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.

### What
<!-- Add more detail about the changes that are being made in the pull request. -->

More details can be found in issue #1271. We added the hour to day conversion factor of 24 to convert the hourly CH4 emission to daily emission following the Chianese 2009 equation. 

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->

We noticed that the estimated storage methane is lower than what has been reported in the literature. After some troubleshooting and consultation with Alan Rotz, we decided to update the equation in the code. 

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->

We updated the `methane_emission_from_slurry_storage` function in the `calculator.py` file.  

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->

Output and plot `ManureTreatmentDailyOutput_Pen_3_LAC_COW.storage_methane`. 
