### PR TITLE
Processing data_origin keys in the info_maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Testing](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml)
 [![Linting](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml)
 [![Coverage](https://img.shields.io/badge/coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/coverage_pytest-cov.yml)
-[![Mypy](https://img.shields.io/badge/mypy-4642%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
+[![Mypy](https://img.shields.io/badge/mypy-4639%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Testing](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml)
 [![Linting](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml)
 [![Coverage](https://img.shields.io/badge/coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/coverage_pytest-cov.yml)
-[![Mypy](https://img.shields.io/badge/mypy-4680%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
+[![Mypy](https://img.shields.io/badge/mypy-4642%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -6,7 +6,7 @@ import sys
 from copy import deepcopy
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, Tuple
 
 import pandas as pd
 from deprecated.sphinx import deprecated
@@ -55,7 +55,7 @@ class LogVerbosity(Enum):
             return False
         return False
 
-    def __str__(self) -> bool:
+    def __str__(self) -> str:
         if self.value == "none":
             return "NONE"
         return self.value[:-1].upper()
@@ -379,6 +379,7 @@ class OutputManager(object):
         self.add_log("save_dict_file_try", f"Attempting to save to {path}.", info_map)
         try:
             with open(path, "w") as json_file:
+                data_dict = self._add_detailed_data_origin(data_dict)
                 if minify_output_file:
                     json.dump(
                         Utility.make_serializable(data_dict, max_depth=3),
@@ -394,6 +395,89 @@ class OutputManager(object):
                 self.add_log("save_dict_file_success", f"Successfully saved to {path}.", info_map)
         except Exception as e:
             raise e
+
+    def _add_detailed_data_origin(self, data_dict: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Adds a `detailed_data_origins` list to each sub-dictionary that has information about data origins.
+
+        Notes
+        -----
+        This method iterates over each key in the provided dictionary. For keys that correspond to
+        dictionaries containing `info_maps` and `values` keys with matching lengths, it creates a new list
+        named `detailed_data_origins`. This list contains details about the data origin, including the class name,
+        function name, and the key itself, paired with each corresponding value from the `values` list.
+        The format used for detailing the origin is "[class_name.function_name]->[key]",
+        where `class_name` and `function_name` are derived from the `data_origin`
+        entries within `info_maps`.
+
+        Parameters
+        ----------
+        data_dict : Dict[str, Any]
+            The input dictionary containing keys that may map to other dictionaries with `info_maps` and `values` keys.
+            `info_maps` should contain a list of dictionaries, each with a `data_origin` key indicating the source
+            of the data. `values` should contain a list of values corresponding to these origins.
+
+        Returns
+        -------
+        Dict[str, Any]
+            The modified dictionary with a `detailed_data_origins` list added to each sub-dictionary that meets the
+            criteria. This list provides detailed information on the origin of each value.
+
+        Examples
+        --------
+        >>> example_data_dict = {
+        ...     "AnimalModuleReporter.report_daily_animal_population.num_animals": {
+        ...         "info_maps": [
+        ...             {"data_origin": [["AnimalManager", "daily_updates"]], "units": "animals"},
+        ...             {"data_origin": [["AnimalManager", "daily_updates"]], "units": "animals"}
+        ...         ],
+        ...         "values": [193, 194]
+        ...     }
+        ... }
+        >>> output_manager = OutputManager()
+        >>> modified_data_dict = output_manager._add_detailed_data_origin(example_data_dict)
+        >>> assert modified_data_dict[
+        ...     "AnimalModuleReporter.report_daily_animal_population.num_animals"]["detailed_data_origins"
+        ... ] == [
+        ...    [("[AnimalManager.daily_updates]->[AnimalModuleReporter.report_daily_animal_population.num_animals]",
+        ...     193)],
+        ...    [("[AnimalManager.daily_updates]->[AnimalModuleReporter.report_daily_animal_population.num_animals]",
+        ...     194)]
+        ... ]
+        """
+
+        for key in data_dict:
+            if not isinstance(data_dict[key], dict):
+                continue
+
+            sub_data_dict = data_dict[key]
+            if "info_maps" not in sub_data_dict or "values" not in sub_data_dict:
+                continue
+
+            if len(sub_data_dict["info_maps"]) != len(sub_data_dict["values"]):
+                continue
+
+            data_origins: List[List[Tuple[str, str]]] = []
+            for info_map in sub_data_dict["info_maps"]:
+                if "data_origin" not in info_map:
+                    break
+                data_origins.append(info_map["data_origin"])
+
+            if len(data_origins) != len(sub_data_dict["values"]):
+                continue
+
+            detailed_data_origins: List[List[Tuple[str, Any]]] = []
+            for index, value in enumerate(sub_data_dict["values"]):
+                detailed_origin_for_value = []
+                for origin in data_origins[index]:
+                    class_name, function_name = origin
+                    origin_key = f"[{class_name}.{function_name}]->[{key}]"
+                    detailed_origin_for_value.append((origin_key, value))
+                detailed_data_origins.append(detailed_origin_for_value)
+
+            sub_data_dict["detailed_data_origins"] = detailed_data_origins
+
+        return data_dict
 
     def _dict_to_csv_column_list(self, variable_name: str, data_dict: Dict[str, List[Any]]) -> List[pd.Series]:
         """Turns a dictionary to a list of csv columns.

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -382,13 +382,13 @@ class OutputManager(object):
                 data_dict = self._add_detailed_data_origin(data_dict)
                 if minify_output_file:
                     json.dump(
-                        Utility.make_serializable(data_dict, max_depth=3),
+                        Utility.make_serializable(data_dict, max_depth=4),
                         json_file,
                         separators=(",", ":"),
                     )
                 else:
                     json.dump(
-                        Utility.make_serializable(data_dict, max_depth=3),
+                        Utility.make_serializable(data_dict, max_depth=4),
                         json_file,
                         indent=2,
                     )

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -1873,3 +1873,82 @@ def test_get_error_and_warning_counts(
 
     # Act and Assert
     assert om.get_error_and_warning_counts() == expected
+
+
+@pytest.mark.parametrize(
+    "input_data,expected",
+    [
+        # Basic test case with a single data_origin per value
+        (
+            {
+                "ModuleA.variable_x": {
+                    "info_maps": [
+                        {"data_origin": [["SourceClassA", "method_a"]], "units": "units_a"},
+                        {"data_origin": [["SourceClassA", "method_a"]], "units": "units_a"},
+                    ],
+                    "values": [10, 20],
+                }
+            },
+            {
+                "ModuleA.variable_x": {
+                    "info_maps": [
+                        {"data_origin": [["SourceClassA", "method_a"]], "units": "units_a"},
+                        {"data_origin": [["SourceClassA", "method_a"]], "units": "units_a"},
+                    ],
+                    "values": [10, 20],
+                    "detailed_data_origins": [
+                        [("[SourceClassA.method_a]->[ModuleA.variable_x]", 10)],
+                        [("[SourceClassA.method_a]->[ModuleA.variable_x]", 20)],
+                    ],
+                }
+            },
+        ),
+        # Test case with multiple data_origin entries for a single value
+        (
+            {
+                "ModuleB.variable_y": {
+                    "info_maps": [
+                        {
+                            "data_origin": [["SourceClassB", "method_b"], ["SourceClassC", "method_c"]],
+                            "units": "units_b",
+                        },
+                        {"data_origin": [["SourceClassB", "method_b"]], "units": "units_b"},
+                    ],
+                    "values": [30, 40],
+                }
+            },
+            {
+                "ModuleB.variable_y": {
+                    "info_maps": [
+                        {
+                            "data_origin": [["SourceClassB", "method_b"], ["SourceClassC", "method_c"]],
+                            "units": "units_b",
+                        },
+                        {"data_origin": [["SourceClassB", "method_b"]], "units": "units_b"},
+                    ],
+                    "values": [30, 40],
+                    "detailed_data_origins": [
+                        [
+                            ("[SourceClassB.method_b]->[ModuleB.variable_y]", 30),
+                            ("[SourceClassC.method_c]->[ModuleB.variable_y]", 30),
+                        ],
+                        [("[SourceClassB.method_b]->[ModuleB.variable_y]", 40)],
+                    ],
+                }
+            },
+        ),
+    ],
+)
+def test_add_detailed_data_origin(input_data: Dict[str, Dict[str, Any]], expected: Dict[str, Dict[str, Any]]) -> None:
+    """
+    Unit test for the _add_detailed_data_origin() method in OutputManager class
+    """
+
+    # Arrange
+    output_manager = OutputManager()
+
+    # Act
+    result = output_manager._add_detailed_data_origin(input_data)
+
+    # Assert
+    assert result == expected

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -1937,6 +1937,53 @@ def test_get_error_and_warning_counts(
                 }
             },
         ),
+        (
+            {
+                "ModuleC.non_dict": "This is a string, not a dict",
+            },
+            {
+                "ModuleC.non_dict": "This is a string, not a dict",
+            },
+        ),
+        # Missing both keys
+        (
+            {
+                "ModuleD.missing_both": {
+                    "other_key": "some_value",
+                }
+            },
+            {
+                "ModuleD.missing_both": {
+                    "other_key": "some_value",
+                }
+            },
+        ),
+        # Missing `info_maps` key
+        (
+            {
+                "ModuleE.missing_info_maps": {
+                    "values": [50, 60],
+                }
+            },
+            {
+                "ModuleE.missing_info_maps": {
+                    "values": [50, 60],
+                }
+            },
+        ),
+        # Missing `values` key
+        (
+            {
+                "ModuleF.missing_values": {
+                    "info_maps": [{"data_origin": [["ClassX", "method_x"]]}],
+                }
+            },
+            {
+                "ModuleF.missing_values": {
+                    "info_maps": [{"data_origin": [["ClassX", "method_x"]]}],
+                }
+            },
+        ),
     ],
 )
 def test_add_detailed_data_origin(input_data: Dict[str, Dict[str, Any]], expected: Dict[str, Dict[str, Any]]) -> None:


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
In this PR, I wanted to do a pre-processing step for the data origins of some variables in the output manager by making them more visible. I added an extra key called "detailed_data_origins" alongside the existing ones - "info_maps" and "values". I paired up each data origin with its corresponding value.

This won't apply to variables that don't have data origins info.  
### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1240 

- [ ] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.

### What & Why
<!-- Add more detail about the changes that are being made in the pull request. -->
It seems that info about data origins is helpful but it is not obvious how we can make them more accessible or usable. So I think the goal of this PR is to get something going and it helps to have all the data origins info in one place.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
I formatted the new keys following this pattern: `[origin_class.origin_function]->[current_key]`, where `current_key` has this format `downstream_class.downstream_function.variable_name`. I could extract the variable name but it is still uncertain to me whether I can assume this pattern if suffixes somehow get involved. Similarly, the use of prefixes affects whether we can reliably replace the downstream class and functions with the origin counterparts.

If there are multiple data origins, each origin will point directly toward the current key, instead of daisy-chaining them, though this could be changed, e.g, `[[origin_class_1.origin_function_1]->[current_key], [origin_class_2.origin_function_2]->[current_key]]`

Without doing extra work, this pre-processing work is already compatible with the excluding info maps command-line option (`-i`). When info maps are excluded, there is no data about data origins to be processed.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->

I tried the following json specs file to see how things looked. Currently, this only works for json output format.

```
AnimalModuleReporter.report_daily_animal_population.num_animals
AnimalModuleReporter.report_ration_interval_data.avg_rqmts_pen_1_GROWING
```