### PR TITLE
removed use of populated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Testing](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml)
 [![Linting](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml)
 [![Coverage](https://img.shields.io/badge/coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/coverage_pytest-cov.yml)
-[![Mypy](https://img.shields.io/badge/mypy-4447%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
+[![Mypy](https://img.shields.io/badge/mypy-4443%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Testing](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml)
 [![Linting](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml)
 [![Coverage](https://img.shields.io/badge/coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/coverage_pytest-cov.yml)
-[![Mypy](https://img.shields.io/badge/mypy-4448%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
+[![Mypy](https://img.shields.io/badge/mypy-4447%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/RUFAS/routines/animal/animal_manager.py
+++ b/RUFAS/routines/animal/animal_manager.py
@@ -1166,7 +1166,7 @@ class AnimalManager:
 
         """
         for pen in self.all_pens:
-            if pen.populated:
+            if pen.is_populated:
                 pen.calc_manure(feed, methane_model)
             else:
                 pen.reset_manure()
@@ -1230,7 +1230,7 @@ class AnimalManager:
 
         """
         for pen in self.all_pens:
-            if pen.populated:
+            if pen.is_populated:
                 pen.call_p_rqmts()
 
     def daily_p_update(self) -> None:
@@ -1239,7 +1239,7 @@ class AnimalManager:
         update. This method is called daily.
         """
         for pen in self.all_pens:
-            if pen.populated:
+            if pen.is_populated:
                 pen.daily_p_update()
 
     def end_ration_interval(self) -> bool:

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -86,9 +86,6 @@ class Pen:
     classes_in_pen : set
         The set (no repeats) of all the classes to which the animals in the pen belong.
 
-    populated : bool
-        True iff there is at least 1 animal in the pen, and false otherwise.
-
     avg_DBW : float
         The average daily change in (delta) body weight of the animals in the pen.
         Used for ration formulation.
@@ -227,8 +224,6 @@ class Pen:
         self.avg_p_animal = 0.0
 
         self.animals_in_pen = {}
-        # TODO: To be removed. Use the property 'is_populated' instead. GitHub Issue #1207
-        self.populated = False
 
         self.classes_in_pen = set()
 
@@ -378,12 +373,6 @@ class Pen:
         for animal in new_animals:
             self.animals_in_pen[animal.id] = animal
 
-    def update_pen_populated(self) -> None:
-        """
-        Updates whether the pen is populated
-        """
-        self.populated = len(self.animals_in_pen) != 0
-
     def update_animal_combination(self, animal_combination: AnimalCombination) -> None:
         """
         Sets the pen's animal combination to animal_combination
@@ -418,7 +407,6 @@ class Pen:
         """
 
         self.add_new_animals(new_animals)
-        self.update_pen_populated()
         self.calc_daily_walking_dist()
         self.update_animal_combination(animal_combination)
         self.update_classes_in_pen()
@@ -520,7 +508,7 @@ class Pen:
         Calculates the average growth of the animals in the pen.
         """
 
-        if not self.populated:
+        if not self.is_populated:
             return
 
         total_growth = 0
@@ -711,7 +699,6 @@ class Pen:
         # and animals are to be added to it, there are previous initial values
         # that are non-zero.
         self.animals_in_pen = {}
-        self.populated = False
         self.avg_p_animal = 0
 
     def subset_class_feeds(self, feed):

--- a/tests/animal_module_tests/test_animal_manager.py
+++ b/tests/animal_module_tests/test_animal_manager.py
@@ -1904,8 +1904,8 @@ def test_calc_manure_excretion(mocker: MockerFixture) -> None:
     mock_pen_0.calc_manure = MagicMock()
     mock_pen_1 = MagicMock()
     mock_pen_1.reset_manure = MagicMock()
-    mock_pen_0.populated = True
-    mock_pen_1.populated = False
+    mock_pen_0.is_populated = True
+    mock_pen_1.is_populated = False
     mocked_pens = [mock_pen_0, mock_pen_1]
 
     mocker.patch("RUFAS.routines.animal.animal_manager.AnimalManager.__init__", return_value=None)
@@ -1972,8 +1972,8 @@ def test_calc_p_rqmts(mocker: MockerFixture) -> None:
     mock_pen_0.call_p_rqmts = MagicMock()
     mock_pen_1 = MagicMock()
     mock_pen_1.call_p_rqmts = MagicMock()
-    mock_pen_0.populated = True
-    mock_pen_1.populated = False
+    mock_pen_0.is_populated = True
+    mock_pen_1.is_populated = False
     mock_pens = [mock_pen_0, mock_pen_1]
     mock_animal_manager.all_pens = mock_pens
     # Act
@@ -1991,8 +1991,8 @@ def test_daily_p_update(mocker: MockerFixture) -> None:
     mock_pen_0.daily_p_update = MagicMock()
     mock_pen_1 = MagicMock()
     mock_pen_1.daily_p_update = MagicMock()
-    mock_pen_0.populated = True
-    mock_pen_1.populated = False
+    mock_pen_0.is_populated = True
+    mock_pen_1.is_populated = False
     mock_pens = [mock_pen_0, mock_pen_1]
     mock_animal_manager.all_pens = mock_pens
     # Act

--- a/tests/animal_module_tests/test_pen.py
+++ b/tests/animal_module_tests/test_pen.py
@@ -176,20 +176,6 @@ def test_add_new_animals(
 
 
 @pytest.mark.parametrize(
-    "pen_to_test, expected_pen_populated",
-    [
-        (lazy_fixture("pen"), False),
-        (lazy_fixture("pen_with_animals"), True),
-    ],
-)
-def test_update_pen_populated(pen_to_test: Pen, expected_pen_populated: bool) -> None:
-    """Unit test for function update_pen_populated in file routines/animal/pen.py"""
-    pen_to_test.update_pen_populated()
-
-    assert pen_to_test.populated == expected_pen_populated
-
-
-@pytest.mark.parametrize(
     "pen_to_test, expected_stocking_density",
     [
         (lazy_fixture("pen"), 0),
@@ -223,7 +209,6 @@ def test_update_animals(pen: Pen, mocker: MockerFixture) -> None:
     """Unit test for function update_animals in file routines/animal/pen.py"""
 
     mocker.patch("RUFAS.routines.animal.pen.Pen.add_new_animals")
-    mocker.patch("RUFAS.routines.animal.pen.Pen.update_pen_populated")
     mocker.patch("RUFAS.routines.animal.pen.Pen.update_animal_combination")
     mocker.patch("RUFAS.routines.animal.pen.Pen.calc_daily_walking_dist")
     mocker.patch("RUFAS.routines.animal.pen.Pen.update_classes_in_pen")
@@ -231,7 +216,6 @@ def test_update_animals(pen: Pen, mocker: MockerFixture) -> None:
     pen.update_animals(MagicMock(), MagicMock())
 
     pen.add_new_animals.assert_called_once()
-    pen.update_pen_populated.assert_called_once()
     pen.update_animal_combination.assert_called_once()
     pen.calc_daily_walking_dist.assert_called_once()
     pen.update_classes_in_pen.assert_called_once()
@@ -381,22 +365,20 @@ def avg_calf_daily_growth_values(calf_daily_growth_values: List[float]) -> float
 
 
 @pytest.mark.parametrize(
-    "pen_animals, pen_populated, expected",
+    "pen_animals, expected",
     [
         (
             lazy_fixture("mock_calves_with_daily_growth"),
-            True,
             lazy_fixture("avg_calf_daily_growth_values"),
         ),
-        ([], False, 0),
+        ([], 0),
     ],
 )
-def test_calc_avg_growth(pen: Pen, pen_animals, pen_populated, expected) -> None:
+def test_calc_avg_growth(pen: Pen, pen_animals, expected) -> None:
     """Unit test for function calc_avg_growth in file routines/animal/pen.py"""
     for animal in pen_animals:
         pen.animals_in_pen[animal.id] = animal
     # pen.animals_in_pen = pen_animals
-    pen.populated = pen_populated
     pen.calc_avg_growth()
 
     actual = pen.avg_growth
@@ -427,13 +409,13 @@ def test_clear(pen: Pen) -> None:
     """Unit test for function clear in file routines/animal/pen.py"""
     calves = {0: MagicMock()}
     pen.animals_in_pen = calves
-    pen.populated = True
+    assert pen.is_populated is True
     pen.avg_p_animal = 1.0
 
     pen.clear()
 
     assert pen.animals_in_pen == {}
-    assert pen.populated is False
+    assert pen.is_populated is False
     assert pen.avg_p_animal == 0
 
 


### PR DESCRIPTION
### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1207

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
This pull request replaces `populated` with the `is_populated` property in `pen.py` which is calculated dynamically. It also updates the tests and every other file in which `populated` is called to reflect this change 


### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
This is an enhancement and design decision for animal module that originated from the animal module TODOs because the two properties were basically duplicates


### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
This PR addresses the needed changes by removing the instances where `populated` what called and replacing them with `is_populated` and also removing the method `update_pen_populated` since it has the same functionality as `is_populated`


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
The property `populated` was already tested prior to this PR's creation so only the tests including `is_populated` are updated. 

