### PR TITLE
User defined ration percentage sum warning fix

### DIFF
--- a/RUFAS/routines/feed/feed.py
+++ b/RUFAS/routines/feed/feed.py
@@ -138,7 +138,7 @@ class Feed:
             for dict in self.user_defined_ration_percentages["growing"]
         }
         if not math.isclose(
-            sum(udrm.calf_ration.values()),
+            sum(udrm.growing_ration.values()),
             target_user_defined_ration_percentage_sum,
             abs_tol=user_defined_ration_percentage_sum_tolerance,
         ):
@@ -153,7 +153,7 @@ class Feed:
             for dict in self.user_defined_ration_percentages["close_up"]
         }
         if not math.isclose(
-            sum(udrm.calf_ration.values()),
+            sum(udrm.close_up_ration.values()),
             target_user_defined_ration_percentage_sum,
             abs_tol=user_defined_ration_percentage_sum_tolerance,
         ):
@@ -168,7 +168,7 @@ class Feed:
             for dict in self.user_defined_ration_percentages["lac_cow"]
         }
         if not math.isclose(
-            sum(udrm.calf_ration.values()),
+            sum(udrm.lactating_cow_ration.values()),
             target_user_defined_ration_percentage_sum,
             abs_tol=user_defined_ration_percentage_sum_tolerance,
         ):

--- a/input/data/feed/default_feed.json
+++ b/input/data/feed/default_feed.json
@@ -114,7 +114,7 @@
         "calf": [
             {
                 "feed_type": 202,
-                "ration_percentage": 49
+                "ration_percentage": 50
             },
             {
                 "feed_type": 216,
@@ -124,7 +124,7 @@
         "growing": [
             {
                 "feed_type": 2,
-                "ration_percentage": 3.3
+                "ration_percentage": 3.4
             },
             {
                 "feed_type": 44,
@@ -158,7 +158,7 @@
         "close_up": [
             {
                 "feed_type": 2,
-                "ration_percentage": 3.81
+                "ration_percentage": 3.8
             },
             {
                 "feed_type": 44,
@@ -192,7 +192,7 @@
         "lac_cow": [
             {
                 "feed_type": 2,
-                "ration_percentage": 11.7001
+                "ration_percentage": 11.7
             },
             {
                 "feed_type": 44,


### PR DESCRIPTION
Quick fix for mistake I made in PR #1385. 

The mistake: I hadn't pasted in the correct names for the duplicated code checking the sums. Since the rest of those error messages were correct, I fooled myself when testing that all error messages were flagged at the same time. Quick fix, now works as expected.