### PR TITLE
[IM] Hotfix: adding UTF specification to Pandas' `read_csv`

### DIFF
--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -254,7 +254,7 @@ class InputManager:
         om.add_log("open_csv_file", f"Attempting to open {file_path}.", info_map)
         try:
             with open(file_path, "r") as csv_file:
-                data_frame = pd.read_csv(csv_file)
+                data_frame = pd.read_csv(csv_file, encoding='utf16')
                 data_dict = {column: data_frame[column].tolist() for column in data_frame.columns}
                 if not data_frame.empty:
                     om.add_log(

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -254,7 +254,7 @@ class InputManager:
         om.add_log("open_csv_file", f"Attempting to open {file_path}.", info_map)
         try:
             with open(file_path, "r") as csv_file:
-                data_frame = pd.read_csv(csv_file, encoding='utf16')
+                data_frame = pd.read_csv(csv_file, encoding="utf16")
                 data_dict = {column: data_frame[column].tolist() for column in data_frame.columns}
                 if not data_frame.empty:
                     om.add_log(


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Input Manager loads CSV files using UTF-16 encoding.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.

### Testing
The call to `read_csv()` is not explicitly tested in `test_input_manager.py`, so no tests need to be updated as part of this hotfix.
