### PR TITLE
[IM] Quick fix for `IM._filter_input_data_by_metadata()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Testing](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml)
 [![Linting](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml)
 [![Coverage](https://img.shields.io/badge/coverage-94%25-green)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/coverage_pytest-cov.yml)
-[![Mypy](https://img.shields.io/badge/mypy-4426%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
+[![Mypy](https://img.shields.io/badge/mypy-4427%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Testing](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/testing_pytest.yml)
 [![Linting](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml/badge.svg)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/lint_flake8.yml)
 [![Coverage](https://img.shields.io/badge/coverage-94%25-green)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/coverage_pytest-cov.yml)
-[![Mypy](https://img.shields.io/badge/mypy-4424%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
+[![Mypy](https://img.shields.io/badge/mypy-4426%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/mypy_type_checker.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -336,6 +336,44 @@ class InputManager:
 
         return self.elements_counter.invalid_elements == 0
 
+    def _filter_input_array_data_by_metadata(self,
+                                             input_array_data: List[Any],
+                                             metadata_properties: Dict[str, Any]) -> List[Any]:
+        """
+        Filter input array data based on provided metadata properties.
+
+        Parameters:
+        -----------
+        input_array_data : List[Any]
+            The input array data to be filtered.
+
+        metadata_properties : Dict[str, Any]
+            The dictionary containing metadata properties used as a filter for input_array_data.
+        """
+        if len(input_array_data) == 0:
+            return input_array_data
+
+        filtered_array_data = []
+
+        if isinstance(input_array_data[0], dict):
+            for array_element in input_array_data:
+                nested_input_data = self._filter_input_data_by_metadata(
+                    array_element, metadata_properties["properties"])
+                if nested_input_data:
+                    filtered_array_data.append(nested_input_data)
+
+        elif isinstance(input_array_data[0], list):
+            for array_element in input_array_data:
+                nested_input_data = self._filter_input_array_data_by_metadata(
+                    array_element, metadata_properties["properties"])
+                if nested_input_data:
+                    filtered_array_data.append(nested_input_data)
+
+        elif isinstance(input_array_data[0], (int | float | str | bool)):
+            return input_array_data
+
+        return filtered_array_data
+
     def _filter_input_data_by_metadata(
         self, input_data: Dict[str, Any], metadata_properties: Dict[str, Any]
     ) -> Dict[str, Any]:
@@ -361,6 +399,12 @@ class InputManager:
                     nested_input_data = self._filter_input_data_by_metadata(value, metadata_properties[key])
                     if nested_input_data:
                         filtered_input_data[key] = nested_input_data
+                if isinstance(metadata_properties[key], dict) and isinstance(value, list):
+                    array_input_data = self._filter_input_array_data_by_metadata(
+                        value, metadata_properties[key])
+                    if array_input_data:
+                        filtered_input_data[key] = array_input_data
+
                 else:
                     filtered_input_data[key] = value
 

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -355,24 +355,21 @@ class InputManager:
 
         filtered_array_data = []
 
-        if isinstance(input_array_data[0], dict):
-            for array_element in input_array_data:
+        for array_element in input_array_data:
+            if isinstance(array_element, dict):
                 nested_input_data = self._filter_input_data_by_metadata(
                     array_element, metadata_properties["properties"]
                 )
                 if nested_input_data:
                     filtered_array_data.append(nested_input_data)
-
-        elif isinstance(input_array_data[0], list):
-            for array_element in input_array_data:
+            elif isinstance(array_element, list):
                 nested_input_data = self._filter_input_array_data_by_metadata(
                     array_element, metadata_properties["properties"]
                 )
                 if nested_input_data:
                     filtered_array_data.append(nested_input_data)
-
-        elif isinstance(input_array_data[0], (int | float | str | bool)):
-            return input_array_data
+            elif isinstance(array_element, (int | float | str | bool)):
+                filtered_array_data.append(array_element)
 
         return filtered_array_data
 

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -346,7 +346,6 @@ class InputManager:
         -----------
         input_array_data : List[Any]
             The input array data to be filtered.
-
         metadata_properties : Dict[str, Any]
             The dictionary containing metadata properties used as a filter for input_array_data.
         """

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -336,9 +336,9 @@ class InputManager:
 
         return self.elements_counter.invalid_elements == 0
 
-    def _filter_input_array_data_by_metadata(self,
-                                             input_array_data: List[Any],
-                                             metadata_properties: Dict[str, Any]) -> List[Any]:
+    def _filter_input_array_data_by_metadata(
+        self, input_array_data: List[Any], metadata_properties: Dict[str, Any]
+    ) -> List[Any]:
         """
         Filter input array data based on provided metadata properties.
 
@@ -358,14 +358,16 @@ class InputManager:
         if isinstance(input_array_data[0], dict):
             for array_element in input_array_data:
                 nested_input_data = self._filter_input_data_by_metadata(
-                    array_element, metadata_properties["properties"])
+                    array_element, metadata_properties["properties"]
+                )
                 if nested_input_data:
                     filtered_array_data.append(nested_input_data)
 
         elif isinstance(input_array_data[0], list):
             for array_element in input_array_data:
                 nested_input_data = self._filter_input_array_data_by_metadata(
-                    array_element, metadata_properties["properties"])
+                    array_element, metadata_properties["properties"]
+                )
                 if nested_input_data:
                     filtered_array_data.append(nested_input_data)
 
@@ -400,8 +402,7 @@ class InputManager:
                     if nested_input_data:
                         filtered_input_data[key] = nested_input_data
                 if isinstance(metadata_properties[key], dict) and isinstance(value, list):
-                    array_input_data = self._filter_input_array_data_by_metadata(
-                        value, metadata_properties[key])
+                    array_input_data = self._filter_input_array_data_by_metadata(value, metadata_properties[key])
                     if array_input_data:
                         filtered_input_data[key] = array_input_data
 

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -396,12 +396,14 @@ class InputManager:
             if key in metadata_properties:
                 if isinstance(metadata_properties[key], dict) and isinstance(value, dict):
                     nested_input_data: Dict[str, Any] = self._filter_input_data_by_metadata(
-                        value, metadata_properties[key])
+                        value, metadata_properties[key]
+                    )
                     if nested_input_data:
                         filtered_input_data[key] = nested_input_data
                 elif isinstance(metadata_properties[key], dict) and isinstance(value, list):
                     array_input_data: List[Any] = self._filter_input_array_data_by_metadata(
-                        value, metadata_properties[key])
+                        value, metadata_properties[key]
+                    )
                     if array_input_data:
                         filtered_input_data[key] = array_input_data
                 else:

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -399,12 +399,11 @@ class InputManager:
                     nested_input_data = self._filter_input_data_by_metadata(value, metadata_properties[key])
                     if nested_input_data:
                         filtered_input_data[key] = nested_input_data
-                if isinstance(metadata_properties[key], dict) and isinstance(value, list):
+                elif isinstance(metadata_properties[key], dict) and isinstance(value, list):
                     array_input_data = self._filter_input_array_data_by_metadata(
                         value, metadata_properties[key])
                     if array_input_data:
                         filtered_input_data[key] = array_input_data
-
                 else:
                     filtered_input_data[key] = value
 

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -353,17 +353,17 @@ class InputManager:
         if len(input_array_data) == 0:
             return input_array_data
 
-        filtered_array_data = []
+        filtered_array_data: List[Any] = []
 
         for array_element in input_array_data:
             if isinstance(array_element, dict):
-                nested_input_data = self._filter_input_data_by_metadata(
+                nested_input_data: Dict[str, Any] = self._filter_input_data_by_metadata(
                     array_element, metadata_properties["properties"]
                 )
                 if nested_input_data:
                     filtered_array_data.append(nested_input_data)
             elif isinstance(array_element, list):
-                nested_input_data = self._filter_input_array_data_by_metadata(
+                nested_input_data: List[Any] = self._filter_input_array_data_by_metadata(
                     array_element, metadata_properties["properties"]
                 )
                 if nested_input_data:
@@ -391,15 +391,17 @@ class InputManager:
         metadata_properties : Dict[str, Any]
             The dictionary containing metadata properties used as a filter for input_data.
         """
-        filtered_input_data = {}
+        filtered_input_data: Dict[str, Any] = {}
         for key, value in input_data.items():
             if key in metadata_properties:
                 if isinstance(metadata_properties[key], dict) and isinstance(value, dict):
-                    nested_input_data = self._filter_input_data_by_metadata(value, metadata_properties[key])
+                    nested_input_data: Dict[str, Any] = self._filter_input_data_by_metadata(
+                        value, metadata_properties[key])
                     if nested_input_data:
                         filtered_input_data[key] = nested_input_data
                 elif isinstance(metadata_properties[key], dict) and isinstance(value, list):
-                    array_input_data = self._filter_input_array_data_by_metadata(value, metadata_properties[key])
+                    array_input_data: List[Any] = self._filter_input_array_data_by_metadata(
+                        value, metadata_properties[key])
                     if array_input_data:
                         filtered_input_data[key] = array_input_data
                 else:

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -295,40 +295,32 @@ def test_filter_input_data_by_metadata(
         ),
         (
             [{"a": 1, "b": "A", "c": True}, {"a": 2, "b": "B", "c": False}, {"a": 3, "b": "C", "c": True}],
-            {"type": "array", "properties": {
-                "type": "object",
-                "a": {"type": "number"},
-                "b": {"type": "string"},
-                "c": {"type": "bool"}
-            }},
-            [{"a": 1, "b": "A", "c": True}, {"a": 2, "b": "B", "c": False}, {"a": 3, "b": "C", "c": True}]
+            {
+                "type": "array",
+                "properties": {
+                    "type": "object",
+                    "a": {"type": "number"},
+                    "b": {"type": "string"},
+                    "c": {"type": "bool"},
+                },
+            },
+            [{"a": 1, "b": "A", "c": True}, {"a": 2, "b": "B", "c": False}, {"a": 3, "b": "C", "c": True}],
         ),
         (
             [{"a": 1, "b": "A", "c": True}, {"a": 2, "b": "B", "c": False}, {"a": 3, "b": "C", "c": True}],
-            {"type": "array", "properties": {
-                "type": "object",
-                "a": {"type": "number"},
-                "b": {"type": "string"}
-            }},
-            [{"a": 1, "b": "A"}, {"a": 2, "b": "B"}, {"a": 3, "b": "C"}]
+            {"type": "array", "properties": {"type": "object", "a": {"type": "number"}, "b": {"type": "string"}}},
+            [{"a": 1, "b": "A"}, {"a": 2, "b": "B"}, {"a": 3, "b": "C"}],
         ),
         (
-                [[1, 2, 3, 1.1, 2.2, 3.3]],
-                {"type": "array", "properties": {
-                    "type": "number"
-                }},
-                [[1, 2, 3, 1.1, 2.2, 3.3]],
+            [[1, 2, 3, 1.1, 2.2, 3.3]],
+            {"type": "array", "properties": {"type": "number"}},
+            [[1, 2, 3, 1.1, 2.2, 3.3]],
         ),
         (
             [[1, 2, 3], [1.1, 2.2, 3.3]],
-            {"type": "array", "properties": {
-                "type": "array",
-                "properties": {
-                    "type": "number"
-                }
-            }},
+            {"type": "array", "properties": {"type": "array", "properties": {"type": "number"}}},
             [[1, 2, 3], [1.1, 2.2, 3.3]],
-        )
+        ),
     ],
 )
 def test_filter_input_array_data_by_metadata(

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -38,6 +38,7 @@ def input_manager_original_method_states(
         "_load_data_from_json": mock_input_manager._load_data_from_json,
         "_load_data_from_csv": mock_input_manager._load_data_from_csv,
         "_populate_pool": mock_input_manager._populate_pool,
+        "_filter_input_array_data_by_metadata": mock_input_manager._filter_input_array_data_by_metadata,
         "_filter_input_data_by_metadata": mock_input_manager._filter_input_data_by_metadata,
         "_get_variable_modifiability": mock_input_manager._get_variable_modifiability,
         "_log_missing_data": mock_input_manager._log_missing_data,
@@ -256,6 +257,16 @@ def test_start_data_processing(
             {"key1": {"nested_key1": {"default": "value2"}}},
             {"key1": {"nested_key1": "value1"}},
         ),
+        (
+            {"key1": {"nested_key1": ["value1", "value2"], "nested_key2": "value2"}},
+            {"key1": {"nested_key1": {"type": "array", "properties": {"default": "value1"}}}},
+            {"key1": {"nested_key1": ["value1", "value2"]}},
+        ),
+        (
+            {"key1": {"nested_key1": [{"key3": 1, "key4": 2}, {"key3": 3, "key4": 4}], "nested_key2": "value2"}},
+            {"key1": {"nested_key1": {"type": "array", "properties": {"key3": {"default": 2}}}}},
+            {"key1": {"nested_key1": [{"key3": 1}, {"key3": 3}]}},
+        ),
     ],
 )
 def test_filter_input_data_by_metadata(
@@ -271,6 +282,68 @@ def test_filter_input_data_by_metadata(
 
     mock_input_manager._filter_input_data_by_metadata = input_manager_original_method_states[
         "_filter_input_data_by_metadata"
+    ]
+
+
+@pytest.mark.parametrize(
+    "input_data, metadata_properties, expected_result",
+    [
+        (
+            [],
+            {"key1": {"default": "value3"}},
+            [],
+        ),
+        (
+            [{"a": 1, "b": "A", "c": True}, {"a": 2, "b": "B", "c": False}, {"a": 3, "b": "C", "c": True}],
+            {"type": "array", "properties": {
+                "type": "object",
+                "a": {"type": "number"},
+                "b": {"type": "string"},
+                "c": {"type": "bool"}
+            }},
+            [{"a": 1, "b": "A", "c": True}, {"a": 2, "b": "B", "c": False}, {"a": 3, "b": "C", "c": True}]
+        ),
+        (
+            [{"a": 1, "b": "A", "c": True}, {"a": 2, "b": "B", "c": False}, {"a": 3, "b": "C", "c": True}],
+            {"type": "array", "properties": {
+                "type": "object",
+                "a": {"type": "number"},
+                "b": {"type": "string"}
+            }},
+            [{"a": 1, "b": "A"}, {"a": 2, "b": "B"}, {"a": 3, "b": "C"}]
+        ),
+        (
+                [[1, 2, 3, 1.1, 2.2, 3.3]],
+                {"type": "array", "properties": {
+                    "type": "number"
+                }},
+                [[1, 2, 3, 1.1, 2.2, 3.3]],
+        ),
+        (
+            [[1, 2, 3], [1.1, 2.2, 3.3]],
+            {"type": "array", "properties": {
+                "type": "array",
+                "properties": {
+                    "type": "number"
+                }
+            }},
+            [[1, 2, 3], [1.1, 2.2, 3.3]],
+        )
+    ],
+)
+def test_filter_input_array_data_by_metadata(
+    mock_input_manager: InputManager,
+    input_data: List[Any],
+    metadata_properties: Dict[str, Any],
+    expected_result: List[Any],
+    input_manager_original_method_states: Dict[str, Callable],
+) -> None:
+    """Unit test for function _filter_input_array_data_by_metadata() in file input_manager.py"""
+    filtered_input_data = mock_input_manager._filter_input_array_data_by_metadata(input_data, metadata_properties)
+    assert filtered_input_data == expected_result
+
+    mock_input_manager._filter_input_array_data_by_metadata = input_manager_original_method_states[
+        "_filter_input_array_data_by_metadata"
     ]
 
 


### PR DESCRIPTION
This PR fixes `InputManager._filter_input_data_by_metadata()`

<!-- Provide a short summary of this pull request's changes. -->
This PR solves the issue of running `ARL_metadata` on the main branch, resulting in an error.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Previously, `InputManager._filter_input_data_by_metadata()` only checked for the nested dictionary situation; it does not account for arrays. For input data containing an array of objects, it will only check if this array (at the top level) exists in the metadata; it won't go into each element of the array to check if all the keys for the dictionary element are present in the metadata.

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.

### What
<!-- Add more details about the changes that are being made to the pull request. -->
This PR modifies `InputManager._filter_input_data_by_metadata()` to handle arrays in the input data. A new function, `_filter_input_array_data_by_metadata()` is added to help filter input array data based on provided metadata properties.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
To help filter input with array data

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Loop through every element in the array to ensure they are defined in the metadata.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Unit tests are updated to account for all possible input situations.