### PR TITLE
[IM] Encoding changed to UTF-8 from UTF-16

### DIFF
--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -253,8 +253,8 @@ class InputManager:
         }
         om.add_log("open_csv_file", f"Attempting to open {file_path}.", info_map)
         try:
-            with open(file_path, "r") as csv_file:
-                data_frame = pd.read_csv(csv_file, encoding="utf16")
+            with open(file_path, "r", encoding="utf-8") as csv_file:
+                data_frame = pd.read_csv(csv_file)
                 data_dict = {column: data_frame[column].tolist() for column in data_frame.columns}
                 if not data_frame.empty:
                     om.add_log(


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
This is an actual fix to the Input Manager loading CSV files with an incorrect encoding in the method `_load_data_from_csv`. Instead of using UTF-16 in Pandas `read_csv` method, Python's `open` method has been modified to use UTF-8

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
- On a Windows machine
- Switch to this branch
- Modify the weather file in `default_metadata.json` to use `barnyard_100yr.csv`.
- Run the simulation.
- Also, to verify that other encodings _do not_ work, try changing the encoding in `open` to UTF-16 and/or removing the encoding in `open` and trying both UTF-8 and 16 in the Pandas `read_csv` call in Input Manager's `_load_data_from_csv()` method.
