### PR TITLE
Added method to correctly update average body weight of each pen

### DIFF
--- a/RUFAS/routines/animal/animal_manager.py
+++ b/RUFAS/routines/animal/animal_manager.py
@@ -64,7 +64,7 @@ class AnimalManager:
         Parameters
         ----------
         scenario : AnimalGroupingScenario
-                The scenario to set the animal grouping scenario to.
+            The scenario to set the animal grouping scenario to.
 
         Returns
         -------
@@ -1179,7 +1179,17 @@ class AnimalManager:
         """
 
         for pen in self.all_pens:
-            pen.calc_avg_growth()
+            pen.calc_average_growth()
+
+    def calc_avg_body_weight(self) -> None:
+        """
+        Calls each pen's method to calculate the average growth of animals in
+        the pen. This is part of the routines that happen every
+        ration interval.
+        """
+
+        for pen in self.all_pens:
+            pen.calc_average_body_weight()
 
     def sum_daily_milk(self, cows: List[Cow]) -> float:
         """
@@ -1748,6 +1758,7 @@ class AnimalManager:
             self.daily_p_update()
             self._update_phosphorus_concentrations()
             self.record_pen_history()
+            self.calc_avg_body_weight()
 
             if self.end_ration_interval():
                 self.reset_milk_production_reduction()

--- a/RUFAS/routines/animal/animal_module_reporter.py
+++ b/RUFAS/routines/animal/animal_module_reporter.py
@@ -858,6 +858,9 @@ class AnimalModuleReporter:
         AnimalModuleReporter.report_daily_ration(animal_manager, available_feeds)
         AnimalModuleReporter.report_daily_pen_total(animal_manager.simulation_day, animal_manager.all_pens)
         AnimalModuleReporter.report_305d_milk(animal_manager)
+        AnimalModuleReporter.report_daily_pen_avg_BW(animal_manager.simulation_day, animal_manager.all_pens)
+        AnimalModuleReporter.report_daily_pen_avg_DMIest(animal_manager.simulation_day, animal_manager.all_pens)
+
         for pen in animal_manager.all_pens:
             AnimalModuleReporter.report_pen_manure_properties(pen, animal_manager.simulation_day)
             if pen.animal_combination.name == "LAC_COW":
@@ -897,3 +900,39 @@ class AnimalModuleReporter:
             "sold_cows",
             total_days,
         )
+
+    @classmethod
+    def report_daily_pen_avg_BW(cls, simulation_day: int, pen_list: List[Pen]) -> None:
+        classname = AnimalModuleReporter.__name__
+        funcname = AnimalModuleReporter.report_daily_pen_avg_BW.__name__
+        info_map = {
+            "class": classname,
+            "function": funcname,
+        }
+        for pen in pen_list:
+            variable_to_add = f"{classname}.{funcname}.avg_BW_in_pen_{pen.id}_{pen.animal_combination.name}"
+            reference_variable = f"{classname}.{funcname}.avg_BW_in_pen_0_CALF"
+            AnimalModuleReporter.data_padder(reference_variable, variable_to_add, 0, simulation_day, info_map)
+            om.add_variable(
+                f"avg_BW_in_pen_{pen.id}_{pen.animal_combination.name}",
+                pen.avg_BW,
+                info_map,
+            )
+
+    @classmethod
+    def report_daily_pen_avg_DMIest(cls, simulation_day: int, pen_list: List[Pen]) -> None:
+        classname = AnimalModuleReporter.__name__
+        funcname = AnimalModuleReporter.report_daily_pen_avg_BW.__name__
+        info_map = {
+            "class": classname,
+            "function": funcname,
+        }
+        for pen in pen_list:
+            variable_to_add = f"{classname}.{funcname}.avg_DMIest_in_pen_{pen.id}_{pen.animal_combination.name}"
+            reference_variable = f"{classname}.{funcname}.avg_DMIest_in_pen_0_CALF"
+            AnimalModuleReporter.data_padder(reference_variable, variable_to_add, 0, simulation_day, info_map)
+            om.add_variable(
+                f"avg_DMIest_in_pen_{pen.id}_{pen.animal_combination.name}",
+                pen.avg_DMIest,
+                info_map,
+            )

--- a/RUFAS/routines/animal/animal_module_reporter.py
+++ b/RUFAS/routines/animal/animal_module_reporter.py
@@ -858,8 +858,10 @@ class AnimalModuleReporter:
         AnimalModuleReporter.report_daily_ration(animal_manager, available_feeds)
         AnimalModuleReporter.report_daily_pen_total(animal_manager.simulation_day, animal_manager.all_pens)
         AnimalModuleReporter.report_305d_milk(animal_manager)
-        AnimalModuleReporter.report_daily_pen_avg_BW(animal_manager.simulation_day, animal_manager.all_pens)
-        AnimalModuleReporter.report_daily_pen_avg_DMIest(animal_manager.simulation_day, animal_manager.all_pens)
+        AnimalModuleReporter.report_daily_pen_average_body_weight(animal_manager.simulation_day,
+        animal_manager.all_pens)
+        AnimalModuleReporter.report_daily_pen_average_growth(animal_manager.simulation_day,
+                                                             animal_manager.all_pens)
 
         for pen in animal_manager.all_pens:
             AnimalModuleReporter.report_pen_manure_properties(pen, animal_manager.simulation_day)
@@ -902,37 +904,39 @@ class AnimalModuleReporter:
         )
 
     @classmethod
-    def report_daily_pen_avg_BW(cls, simulation_day: int, pen_list: List[Pen]) -> None:
+    def report_daily_pen_average_body_weight(cls, simulation_day: int, pen_list: List[Pen]) -> None:
         classname = AnimalModuleReporter.__name__
-        funcname = AnimalModuleReporter.report_daily_pen_avg_BW.__name__
+        funcname = AnimalModuleReporter.report_daily_pen_average_body_weight.__name__
         info_map = {
             "class": classname,
             "function": funcname,
         }
         for pen in pen_list:
-            variable_to_add = f"{classname}.{funcname}.avg_BW_in_pen_{pen.id}_{pen.animal_combination.name}"
-            reference_variable = f"{classname}.{funcname}.avg_BW_in_pen_0_CALF"
+            variable_to_add = (
+                f"{classname}.{funcname}.average_body_weight_in_pen_{pen.id}_{pen.animal_combination.name}"
+            )
+            reference_variable = f"{classname}.{funcname}.average_body_weight_in_pen_0_CALF"
             AnimalModuleReporter.data_padder(reference_variable, variable_to_add, 0, simulation_day, info_map)
             om.add_variable(
-                f"avg_BW_in_pen_{pen.id}_{pen.animal_combination.name}",
-                pen.avg_BW,
+                f"average_body_weight_in_pen_{pen.id}_{pen.animal_combination.name}",
+                pen.average_body_weight,
                 info_map,
             )
 
     @classmethod
-    def report_daily_pen_avg_DMIest(cls, simulation_day: int, pen_list: List[Pen]) -> None:
+    def report_daily_pen_average_growth(cls, simulation_day: int, pen_list: List[Pen]) -> None:
         classname = AnimalModuleReporter.__name__
-        funcname = AnimalModuleReporter.report_daily_pen_avg_BW.__name__
+        funcname = AnimalModuleReporter.report_daily_pen_average_growth.__name__
         info_map = {
             "class": classname,
             "function": funcname,
         }
         for pen in pen_list:
-            variable_to_add = f"{classname}.{funcname}.avg_DMIest_in_pen_{pen.id}_{pen.animal_combination.name}"
-            reference_variable = f"{classname}.{funcname}.avg_DMIest_in_pen_0_CALF"
+            variable_to_add = f"{classname}.{funcname}.average_growth_in_pen_{pen.id}_{pen.animal_combination.name}"
+            reference_variable = f"{classname}.{funcname}.average_growth_in_pen_0_CALF"
             AnimalModuleReporter.data_padder(reference_variable, variable_to_add, 0, simulation_day, info_map)
             om.add_variable(
-                f"avg_DMIest_in_pen_{pen.id}_{pen.animal_combination.name}",
-                pen.avg_DMIest,
+                f"average_growth_in_pen_{pen.id}_{pen.animal_combination.name}",
+                pen.avg_growth,
                 info_map,
             )

--- a/RUFAS/routines/animal/life_cycle/cow.py
+++ b/RUFAS/routines/animal/life_cycle/cow.py
@@ -495,7 +495,9 @@ class Cow(HeiferIII):
                 ME_intake,
             )
 
-    def set_nutrient_rqmts(self, animal_grouping_scenario, nutrient_conc: dict = {}):
+    def set_nutrient_rqmts(self,
+                           animal_grouping_scenario,
+                           nutrient_conc: Dict[str, float] = {}) -> None:
         """
         Calculates this Cow's nutrient requirements.
         """

--- a/RUFAS/routines/animal/pen.py
+++ b/RUFAS/routines/animal/pen.py
@@ -17,6 +17,7 @@ from RUFAS.routines.animal.manure.general_manure import (
 )
 from RUFAS.routines.animal.ration.animal_requirements import AnimalRequirements
 from RUFAS.routines.animal.animal_combinations import AnimalCombination
+from RUFAS.routines.animal.animal_grouping_scenarios import AnimalGroupingScenario
 
 om = OutputManager()
 
@@ -89,17 +90,9 @@ class Pen:
     populated : bool
         True iff there is at least 1 animal in the pen, and false otherwise.
 
-    avg_DBW : float
-        The average daily change in (delta) body weight of the animals in the pen.
-        Used for ration formulation.
-
-    avg_BW : float
+    average_body_weight : float
         The average body weight of the animals in the pen.
         Used for ration formulation.
-
-    avg_DMIest : float
-        The average dry matter intake estimation of the animals in the pen.
-        Used for ration formulation
 
     avg_nutrient_rqmts : dict
         Contains the average nutrient requirements of the animals in the pen.
@@ -226,18 +219,16 @@ class Pen:
         self.avg_p_req = 0.0
         self.avg_p_animal = 0.0
 
-        self.animals_in_pen = {}
+        self.animals_in_pen: Dict[int, Calf | HeiferI | HeiferII | HeiferIII | Cow] = {}
         # TODO: To be removed. Use the property 'is_populated' instead. GitHub Issue #1207
         self.populated = False
 
         self.classes_in_pen = set()
 
-        self.avg_BW = 0.0
-        self.avg_DMIest = 0.0
-        self.avg_DBW = 0.0
+        self.average_body_weight = 0.0
 
-        self.avg_nutrient_rqmts = {}
-        self.avg_calf_nutrient_rqmts = {}
+        self.avg_nutrient_rqmts: Dict[str, float] = {}
+        self.avg_calf_nutrient_rqmts: Dict[str, float] = {}
         self.avg_milk = 0.0
         self.avg_CP_milk = 0.0
 
@@ -452,7 +443,11 @@ class Pen:
             animal_dict[key] += curr_manure[key]
         return manure, animal_dict
 
-    def calc_manure(self, feed, methane_model: str):  # noqa
+    def update_pen_averages(self) -> None:
+        self.calc_average_growth() # maybe only call in animal manager?
+        self.calc_average_body_weight() # maybe add to call in animal manager?
+
+    def calc_manure(self, feed, methane_model: str) -> None:  # noqa
         """
         Calculates the manure excretion of the animals in the pen.
 
@@ -508,14 +503,14 @@ class Pen:
     def _copy_manure_template(self):
         return copy.deepcopy(self._manure_dict_template)
 
-    def reset_manure(self):
+    def reset_manure(self) -> None:
         self.manure = self._copy_manure_template()
         self.calf_total = self._copy_manure_template()
         self.heifer_total = self._copy_manure_template()
         self.dry_total = self._copy_manure_template()
         self.lactating_total = self._copy_manure_template()
 
-    def calc_avg_growth(self):
+    def calc_average_growth(self) -> None:
         """
         Calculates the average growth of the animals in the pen.
         """
@@ -528,8 +523,19 @@ class Pen:
             total_growth += animal.daily_growth
         self.avg_growth = total_growth / len(self.animals_in_pen)
 
+    def calc_average_body_weight(self) -> None:
+        """
+        Calculates and sets the average body weight of the animals in the pen.
+        """
+        if not self.populated:
+            return
+
+        self.average_body_weight = sum(animal.body_weight for animal in list(self.animals_in_pen.values())) / len(
+            self.animals_in_pen
+        )
+
     # TODO: Fix this to use AnimalType enum GitHub Issue #1209
-    def calc_daily_walking_dist(self):
+    def calc_daily_walking_dist(self) -> None:
         """
         Sets the daily walking distance for the cows in the pen (if any).
         """
@@ -538,7 +544,7 @@ class Pen:
                 if type(animal).__name__ == "Cow":
                     animal.calc_daily_walking_dist(self.vertical_dist_to_parlor, self.horizontal_dist_to_parlor)
 
-    def call_p_rqmts(self):
+    def call_p_rqmts(self) -> None:
         """
         Calls each animal's method to calculate phosphorus requirements.
         """
@@ -703,7 +709,7 @@ class Pen:
             if animal_id not in animal_ids
         }
 
-    def clear(self):
+    def clear(self) -> None:
         """
         Clears the pen attributes for re-allocation.
         """
@@ -727,7 +733,7 @@ class Pen:
 
     @staticmethod
     def _get_prefix_and_default_manure_excretion(
-        animal: Calf | HeiferI | HeiferII | HeiferIII | Cow, is_lactating_cow=False
+        animal: Calf | HeiferI | HeiferII | HeiferIII | Cow, is_lactating_cow: bool = False
     ) -> Tuple[str, AnimalManureExcretions]:
         """
         Get the prefix and default manure value for a given animal.
@@ -897,7 +903,12 @@ class Pen:
             )
 
     def _set_animal_nutrient_values(
-        self, animal, animal_grouping_scenario, feed, temp, phosphorus_concentration
+        self,
+        animal: Calf | HeiferI | HeiferII | HeiferIII | Cow,
+        animal_grouping_scenario: AnimalGroupingScenario,
+        feed,
+        temp: float,
+        phosphorus_concentration: float
     ) -> None:
         """
         Set the nutrient values for the animal.
@@ -906,10 +917,14 @@ class Pen:
         ----------
         animal : Union[Calf, HeiferI, HeiferII, HeiferIII, Cow]
             The animal to set the nutrient values for.
-        animal_grouping_scenario
-        feed
-        temp
+        animal_grouping_scenario : AnimalGroupingScenario
+            Enum of the groups of AnimalCombinations that can be in the same pens.
+        feed : Feed
+            Object of Feed Class.
+        temp: float
+            Current temperature in C.
         phosphorus_concentration : float
+            
 
         Returns
         -------
@@ -985,7 +1000,7 @@ class Pen:
             self.ration_nutrient_conc["phosphorus"],
         )
 
-    def _calc_new_ration(self, num_animals: int):
+    def _calc_new_ration(self, num_animals: int) -> Dict[str, Union[float, str]]:
         """
         Calculate the new ration for the pen based on the number of animals in the pen.
 

--- a/tests/animal_module_tests/test_animal_manager.py
+++ b/tests/animal_module_tests/test_animal_manager.py
@@ -1926,7 +1926,16 @@ def test_calc_avg_growth(animal_manager_with_mock_pens: AnimalManager) -> None:
     animal_manager_with_mock_pens.calc_avg_growth()
 
     for pen in animal_manager_with_mock_pens.all_pens:
-        pen.calc_avg_growth.assert_called_once()
+        pen.calc_average_growth.assert_called_once()
+
+
+def test_calc_avg_body_weight(animal_manager_with_mock_pens: AnimalManager) -> None:
+    """Unit test for function calc_avg_growth in file routines/animal/animal_manager.py"""
+
+    animal_manager_with_mock_pens.calc_avg_body_weight()
+
+    for pen in animal_manager_with_mock_pens.all_pens:
+        pen.calc_average_body_weight.assert_called_once()
 
 
 def test_record_pen_history(mocker: MockerFixture) -> None:

--- a/tests/animal_module_tests/test_animal_reporter.py
+++ b/tests/animal_module_tests/test_animal_reporter.py
@@ -596,6 +596,42 @@ def test_report_305d_milk(mocker: MockerFixture) -> None:
     ]
 
 
+def test_report_daily_pen_average_body_weight(mocker: MockerFixture) -> None:
+    sim_day = 100
+    pen_list = [mocker.MagicMock(), mocker.MagicMock()]
+    for idx, pen in enumerate(pen_list):
+        pen.id = idx
+        pen.animal_combination.name = 'mock'
+        pen.average_body_weight = (idx + 1) * 100
+    # act
+    AnimalModuleReporter.report_daily_pen_average_body_weight(sim_day, pen_list)
+    # assert
+    assert om.variables_pool[
+        "AnimalModuleReporter.report_daily_pen_average_body_weight.average_body_weight_in_pen_0_mock"
+    ]["values"] == [100]
+    assert om.variables_pool[
+        "AnimalModuleReporter.report_daily_pen_average_body_weight.average_body_weight_in_pen_1_mock"
+    ]["values"] == [200]
+
+
+def test_report_daily_pen_average_growth(mocker: MockerFixture) -> None:
+    sim_day = 100
+    pen_list = [mocker.MagicMock(), mocker.MagicMock()]
+    for idx, pen in enumerate(pen_list):
+        pen.id = idx
+        pen.animal_combination.name = "mock"
+        pen.avg_growth = (idx + 1) * 100
+    # act
+    AnimalModuleReporter.report_daily_pen_average_growth(sim_day, pen_list)
+    # assert
+    assert om.variables_pool["AnimalModuleReporter.report_daily_pen_average_growth.average_growth_in_pen_0_mock"][
+        "values"
+    ] == [100]
+    assert om.variables_pool["AnimalModuleReporter.report_daily_pen_average_growth.average_growth_in_pen_1_mock"][
+        "values"
+    ] == [200]
+
+
 def test_report_daily_reports(mocker: MockerFixture) -> None:
     animal_manager = mocker.MagicMock()
     animal_manager.all_pens = [mocker.MagicMock(), mocker.MagicMock()]

--- a/tests/animal_module_tests/test_pen.py
+++ b/tests/animal_module_tests/test_pen.py
@@ -391,13 +391,16 @@ def avg_calf_daily_growth_values(calf_daily_growth_values: List[float]) -> float
         ([], False, 0),
     ],
 )
-def test_calc_avg_growth(pen: Pen, pen_animals, pen_populated, expected) -> None:
+def test_calc_avg_growth(pen: Pen,
+                         pen_animals: List[MagicMock],
+                         pen_populated: bool,
+                         expected: float) -> None:
     """Unit test for function calc_avg_growth in file routines/animal/pen.py"""
     for animal in pen_animals:
         pen.animals_in_pen[animal.id] = animal
     # pen.animals_in_pen = pen_animals
     pen.populated = pen_populated
-    pen.calc_avg_growth()
+    pen.calc_average_growth()
 
     actual = pen.avg_growth
 


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1467

- [ ] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
New method to actually update the average body weight attribute.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
Pen has an average body weight attribute, but it is never updated.


### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Simple method, also cleanup of typing and docstrings for other methods/attributes this method overlaps with.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Added unit tests for new methods.

### Open questions
1) Should average pen growth be updated and reported daily?
    Previously it was neither reported or updated daily: only updated for each ration interval. In fact, this pen average was not used directly in ration formulation either, and could be removed (instead, ration formulation uses a separate pen summary statistic - though the mean is used as the default  metric, so it resolves to the same value in the default case). 

2) Should average pen body weight be reported daily, or at all? The attribute already existed, but hasn't been asked for as of yet, so instead of this PR adding the methods, we could remove both attributes instead.