### PR TITLE
[IM] Add getter setter for metadata and pool

### DIFF
--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -78,7 +78,6 @@ class InputManager:
         self.__pool: Dict[str, Any] = {}
         self.__get_data_logs_pool: Dict[str, str] = {}
         self.elements_counter = ElementsCounter()
-        self.__original_data_exists: bool = False
 
     @property
     def meta_data(self) -> Dict[str, Any]:
@@ -88,8 +87,6 @@ class InputManager:
     @meta_data.setter
     def meta_data(self, incoming_metadata: Dict[str, Any]) -> None:
         """The setter method for __metadata"""
-        if self.__original_data_exists:
-            raise AttributeError("This instance of Input Manager is already populated.")
         self.__metadata = incoming_metadata
 
     @property
@@ -100,8 +97,6 @@ class InputManager:
     @pool.setter
     def pool(self, incoming_pool: Dict[str, Any]) -> None:
         """The setter method for __pool"""
-        if self.__original_data_exists:
-            raise AttributeError("This instance of Input Manager is already populated.")
         self.__pool = incoming_pool
 
     def start_data_processing(self, metadata_path: str, eager_termination: bool = True) -> bool:
@@ -124,7 +119,6 @@ class InputManager:
         self._load_metadata(metadata_path)
         self._load_properties()
         is_input_data_valid = self._populate_pool(eager_termination)
-        self.__original_data_exists = True
         return is_input_data_valid
 
     def _load_metadata(self, metadata_path: str) -> None:

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -76,9 +76,33 @@ class InputManager:
             InputManager.__instance = self
         self.__metadata: Dict[str, Any] = {}
         self.__pool: Dict[str, Any] = {}
-        self.__properties_used: Dict[str, Any] = {}
         self.__get_data_logs_pool: Dict[str, str] = {}
         self.elements_counter = ElementsCounter()
+        self.__original_data_exists: bool = False
+
+    @property
+    def meta_data(self) -> Dict[str, Any]:
+        """The getter method for __metadata"""
+        return self.__metadata
+
+    @meta_data.setter
+    def meta_data(self, incoming_metadata: Dict[str, Any]) -> None:
+        """The setter method for __metadata"""
+        if self.__original_data_exists:
+            raise AttributeError("This instance of Input Manager is already populated.")
+        self.__metadata = incoming_metadata
+
+    @property
+    def pool(self) -> Dict[str, Any]:
+        """The getter method for __pool"""
+        return self.__pool
+
+    @pool.setter
+    def pool(self, incoming_pool: Dict[str, Any]) -> None:
+        """The setter method for __pool"""
+        if self.__original_data_exists:
+            raise AttributeError("This instance of Input Manager is already populated.")
+        self.__pool = incoming_pool
 
     def start_data_processing(self, metadata_path: str, eager_termination: bool = True) -> bool:
         """
@@ -100,6 +124,7 @@ class InputManager:
         self._load_metadata(metadata_path)
         self._load_properties()
         is_input_data_valid = self._populate_pool(eager_termination)
+        self.__original_data_exists = True
         return is_input_data_valid
 
     def _load_metadata(self, metadata_path: str) -> None:
@@ -168,7 +193,6 @@ class InputManager:
             if not os.path.exists(properties_path):
                 raise FileNotFoundError(f"Properties file not found at {properties_path}")
 
-            self.__properties_used = self.__metadata["files"]["properties"]
             del self.__metadata["files"]["properties"]
 
             self.__metadata["properties"] = self._load_data_from_json(properties_path)

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -14,6 +14,7 @@ from RUFAS.input_manager import ElementsCounter, ElementState, InputManager, Mod
 
 @pytest.fixture
 def mock_input_manager() -> InputManager:
+    InputManager.__instance = None
     input_manager = InputManager()
     return input_manager
 
@@ -60,6 +61,18 @@ def input_manager_original_method_states(
         "_is_input_required_upon_initialization": mock_input_manager._is_input_required_upon_initialization,
         "_is_modifiable_during_runtime": mock_input_manager._is_modifiable_during_runtime,
     }
+
+
+def test_metadata_setter_getter(mock_input_manager: InputManager) -> None:
+    test_data = {"foo": "bar", "integer": 1}
+    mock_input_manager.meta_data = test_data
+    assert mock_input_manager.meta_data == test_data
+
+
+def test_pool_setter_getter(mock_input_manager: InputManager) -> None:
+    test_data = {"foo": "bar", "integer": 1}
+    mock_input_manager.pool = test_data
+    assert mock_input_manager.pool == test_data
 
 
 def test_load_properties_success(mock_input_manager: InputManager, mocker: MockerFixture) -> None:


### PR DESCRIPTION
- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.

### What
This PR adds getter and setter methods for `__metadata` and `__pool` to the Input Manager.
Also made a slight improvement in the test suite.


### Why
We need these getters and setters for SA and Task Manager, they will be used in future PRs.


### How
Used `@property` and `@<var_name>.setter` decorators. 


### Test plan
test suite