### PR TITLE
Revert "Exclude info maps when adding elements to OM pool with GNU arg `-i` set"

### DIFF
--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -104,8 +104,6 @@ class OutputManager(object):
             self.warnings_pool: Dict[str, OutputManager.pool_element_type] = {}
             self.errors_pool: Dict[str, OutputManager.pool_element_type] = {}
             self.logs_pool: Dict[str, OutputManager.pool_element_type] = {}
-            self._exclude_info_maps_flag = False
-
             self.__metadata_prefix: str = ""
             self.__supported_filter_types_prefixes: Dict[str, str] = {
                 "csv": "csv_",
@@ -136,27 +134,15 @@ class OutputManager(object):
         value: Any,
         info_map: Dict[str, Any],
     ) -> None:
-        """
-        Adds value and info map at key in the given pool.
-
-        Parameters
-        ----------
-        pool : Dict[str, Dict[str, List[Dict[str, Any]]]
-            The pool to add the value and info_map to.
-        key : str
-            The key to add the value and info_map at.
-        value : Any
-            The value to be added to the pool.
-        info_map : Dict[str, Any]
-            The info map to be added to the pool.
-        """
-
+        """Adds value and info map at key in the given pool."""
         key_not_exists_in_pool = pool.get(key) is None
         if key_not_exists_in_pool:
             pool[key] = self._pool_element_factory()
-        if not self._exclude_info_maps_flag:
-            reduced_info_map = {k: v for k, v in info_map.items() if k not in ["class", "function"]}
-            pool[key]["info_maps"].append(reduced_info_map)
+        # reduced_info_map is identical to info_map without the class key and
+        # the function key; as they are already stored in element key and
+        # having them increases the final file size.
+        reduced_info_map = {k: info_map[k] for k in info_map.keys() - {"class", "function"}}
+        pool[key]["info_maps"].append(reduced_info_map)
 
         if isinstance(value, (int, bool, float, str)):
             pool[key]["values"].append(value)
@@ -1077,10 +1063,10 @@ class OutputManager(object):
 
             parsable_dicts = []
 
-            if not exclude_info_maps and "info_maps" in variable_data:
+            if not exclude_info_maps:
                 parsable_dicts.append("info_maps")
 
-            is_variable_nested = isinstance(variable_data["values"][0], dict)
+            is_variable_nested = isinstance(variable_data["values"][0], Dict)
             if is_variable_nested:
                 parsable_dicts.append("values")
             else:
@@ -1275,15 +1261,3 @@ class OutputManager(object):
         if self.__log_verbose >= LogVerbosity.CREDITS:
             errors_count, warnings_count, logs_count = self._get_errors_warnings_logs_counts()
             sys.stdout.write(f"{errors_count} error(s), {warnings_count} warning(s), and {logs_count} log(s) found.\n")
-
-    def set_exclude_info_maps_flag(self, exclude_info_maps: bool) -> None:
-        """
-        Sets the exclude_info_maps flag to the given value.
-
-        Parameters
-        ----------
-        exclude_info_maps : bool
-            The value to set the exclude_info_maps flag to.
-        """
-
-        self._exclude_info_maps_flag = exclude_info_maps

--- a/main.py
+++ b/main.py
@@ -129,7 +129,6 @@ def run_rufas(
     """
 
     output_manager = OutputManager()
-    output_manager.set_exclude_info_maps_flag(exclude_info_maps)
     output_manager.set_log_verbose(verbose)
     output_manager.print_credits()
     output_manager.create_directory(output_dir)
@@ -384,7 +383,7 @@ def execute_simulations(
         A list of custom TypedDict objects including the specified prefix for the save_results output file
         and the path to the metadata file.
     exclude_info_maps : bool
-        Flag for whether or not the user wants to include info_maps data in their results files.
+        Flag for whether or not the user wants to inlcude info_maps data in their results files.
     produce_graphics: bool
         Flag for whether or not the user wants to produce graphs at after the simulation.
     graphics_dir : Path

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -27,18 +27,8 @@ def mock_output_manager(mocker) -> OutputManager:
 
 def test_set_metadata_prefix(mock_output_manager: OutputManager) -> None:
     """Unit test for the function set_metadata_prefix in the file output_manager.py"""
-
-    # Assert before setting metadata_prefix
-    assert getattr(mock_output_manager, "_OutputManager__metadata_prefix") == ""
-
-    # Act
     mock_output_manager.set_metadata_prefix("dummy_prefix")
-
-    # Assert after setting metadata_prefix
-    assert getattr(mock_output_manager, "_OutputManager__metadata_prefix") == "dummy_prefix"
-
-    # Cleanup
-    mock_output_manager.set_metadata_prefix("")
+    assert mock_output_manager._OutputManager__metadata_prefix == "dummy_prefix"
 
 
 @pytest.mark.parametrize(
@@ -47,18 +37,8 @@ def test_set_metadata_prefix(mock_output_manager: OutputManager) -> None:
 )
 def test_set_log_verbose(mock_output_manager: OutputManager, log_verbose: LogVerbosity) -> None:
     """Unit test for the function set_log_verbose in the file output_manager.py"""
-
-    # Assert before setting log_verbose
-    assert getattr(mock_output_manager, "_OutputManager__log_verbose") == LogVerbosity.CREDITS
-
-    # Act
     mock_output_manager.set_log_verbose(log_verbose)
-
-    # Assert after setting log_verbose
-    assert getattr(mock_output_manager, "_OutputManager__log_verbose") == log_verbose
-
-    # Cleanup
-    mock_output_manager.set_log_verbose(LogVerbosity.CREDITS)
+    assert mock_output_manager._OutputManager__log_verbose == log_verbose
 
 
 def test_dict_to_csv_column_list(mock_output_manager: OutputManager) -> None:
@@ -467,78 +447,37 @@ def test_add_variable(
 
 
 @pytest.mark.parametrize(
-    "dummy_value, exclude_info_maps_flag",
-    [
-        ("dummy_value", False),
-        (2, False),
-        (3.45, False),
-        (True, False),
-        ({"key": "value"}, False),
-        ([1, 2, 3], False),
-        ("dummy_value", True),
-        (2, True),
-        (3.45, True),
-        (True, True),
-        ({"key": "value"}, True),
-        ([1, 2, 3], True),
-    ],
+    "dummy_value",
+    ["dummy_value", 2, 3.45, True],
 )
-def test_add_to_pool(
-    mock_output_manager: OutputManager,
-    dummy_value: Any,
-    exclude_info_maps_flag: bool,
-) -> None:
+def test_add_to_pool(mock_output_manager: OutputManager, dummy_value: Any) -> None:
     """Unit test for function _add_to_pool in file output_manager.py"""
-
-    # Arrange
     info_map = {
         "class": "dummy_class",
         "function": "dummy_func",
         "context": "dummy_context",
     }
     key = "dummy_key"
-    pool: Dict[str, Dict[str, Any]] = {}
-    assert not mock_output_manager._exclude_info_maps_flag
-    mock_output_manager._exclude_info_maps_flag = exclude_info_maps_flag
-
-    # Act
+    pool = {}
     mock_output_manager._add_to_pool(pool, key, dummy_value, info_map)
-
-    # Assert
+    assert pool[key] == {
+        "info_maps": [{"context": "dummy_context"}],
+        "values": [dummy_value],
+    }
     assert pool[key]["values"][0] == dummy_value
-    if isinstance(dummy_value, (int, bool, float, str)):
-        assert pool[key]["values"][0] is dummy_value
-    else:
-        assert pool[key]["values"][0] == deepcopy(dummy_value)
+    assert pool[key]["values"][0] is dummy_value
 
-    if exclude_info_maps_flag:
-        assert pool[key]["info_maps"] == []
-    else:
-        assert pool[key]["info_maps"] == [{"context": "dummy_context"}]
-
-    # Arrange
-    info_map["more_context"] = "1234567890"
-
-    # Act
-    mock_output_manager._add_to_pool(pool, key, dummy_value, info_map)
-
-    # Assert
-    assert pool[key]["values"][1] == dummy_value
-    if isinstance(dummy_value, (int, bool, float, str)):
-        assert pool[key]["values"][1] is dummy_value
-    else:
-        assert pool[key]["values"][1] == deepcopy(dummy_value)
-
-    if exclude_info_maps_flag:
-        assert pool[key]["info_maps"] == []
-    else:
-        assert pool[key]["info_maps"] == [
+    info_map["more_context"] = 1234567890
+    mock_output_manager._add_to_pool(pool, key, {dummy_value}, info_map)
+    assert pool[key] == {
+        "info_maps": [
             {"context": "dummy_context"},
-            {"context": "dummy_context", "more_context": "1234567890"},
-        ]
-
-    # Cleanup
-    mock_output_manager._exclude_info_maps_flag = False
+            {"context": "dummy_context", "more_context": 1234567890},
+        ],
+        "values": [dummy_value, {dummy_value}],
+    }
+    assert pool[key]["values"][1] == deepcopy({dummy_value})
+    assert pool[key]["values"][1] is not {dummy_value}
 
 
 def test_output_manager_singleton(mocker: MockerFixture) -> None:
@@ -2114,25 +2053,3 @@ def test_add_detailed_data_origin(input_data: Dict[str, Dict[str, Any]], expecte
 
     # Assert
     assert result == expected
-
-
-@pytest.mark.parametrize("flag_value", [False, True])
-def test_set_exclude_info_maps_flag(flag_value: bool) -> None:
-    """
-    Unit test for the set_exclude_info_maps_flag() method in OutputManager class
-    """
-
-    # Arrange
-    output_manager = OutputManager()
-
-    # Assert before
-    assert not output_manager._exclude_info_maps_flag
-
-    # Act
-    output_manager.set_exclude_info_maps_flag(flag_value)
-
-    # Assert after
-    assert output_manager._exclude_info_maps_flag == flag_value
-
-    # Cleanup
-    output_manager._exclude_info_maps_flag = False


### PR DESCRIPTION
Reverts RuminantFarmSystems/MASM#1460

The PR was merged before fully testing it; it is still pending tests from SMEs.
Also, according to @ltp23 , there are some clean-ups needed.