### PR TITLE
Data_padder_units

### DIFF
--- a/RUFAS/routines/animal/animal_module_reporter.py
+++ b/RUFAS/routines/animal/animal_module_reporter.py
@@ -29,7 +29,7 @@ class AnimalModuleReporter:
         thing_to_add: Any,
         simulation_day: int,
         info_map: Dict[str, Any],
-        units: Dict[str, str] | MeasurementUnits | str
+        units: Dict[str, str | MeasurementUnits] | MeasurementUnits | str
     ) -> None:
         """
         Pads a variable in OutputManager for entries that it "missed" relative to another variable.
@@ -57,6 +57,9 @@ class AnimalModuleReporter:
             The day of the simulation.
         info_map: Dict[str, Any]
             The info_map to use when padding.
+        units: Dict[str, str | MeasurementUnits] | MeasurementUnits | str
+            Units for the variable being added, in the format provided in the main call to add_variable,
+            (e.g. the one following the call of data_padder).
 
         """
         if simulation_day > 0 and reference_variable in om.variables_pool:
@@ -347,8 +350,8 @@ class AnimalModuleReporter:
             del ration_per_animal["status"]
             del ration_per_animal["objective"]
             ration_total = {}
-            ration_total["dry_matter_intake_total"] = 0
-            ration_total["byproducts_total"] = 0
+            ration_total["dry_matter_intake_total"] = 0.0
+            ration_total["byproducts_total"] = 0.0
             for key in ration_per_animal.keys():
                 if key != "status" and key != "objective":
                     ration_total[key] = pen.ration_per_animal[key] * len(pen.animals_in_pen)
@@ -508,7 +511,10 @@ class AnimalModuleReporter:
         for manure_property, manure_value in pen.manure.items():
             reference_variable = f"{classname}.{funcname}.pen_0_daily_{str(manure_property)}"
             variable_to_add = f"{classname}.{funcname}.pen_{pen.id}_daily_{str(manure_property)}"
-            AnimalModuleReporter.data_padder(reference_variable, variable_to_add, 0, simulation_day, info_map, manure_value_units)
+            AnimalModuleReporter.data_padder(reference_variable, variable_to_add, 0,
+                                             simulation_day,
+                                             info_map,
+                                             manure_value_units)
             om.add_variable(
                 f"pen_{pen.id}_daily_{str(manure_property)}",
                 manure_value,

--- a/RUFAS/routines/animal/animal_module_reporter.py
+++ b/RUFAS/routines/animal/animal_module_reporter.py
@@ -29,7 +29,7 @@ class AnimalModuleReporter:
         thing_to_add: Any,
         simulation_day: int,
         info_map: Dict[str, Any],
-        units: Dict[str, str] | MeasurementUnits | str
+        units: Dict[str, str] | MeasurementUnits | str,
     ) -> None:
         """
         Pads a variable in OutputManager for entries that it "missed" relative to another variable.
@@ -232,7 +232,7 @@ class AnimalModuleReporter:
                 {},
                 simulation_day,
                 info_map,
-                nutrient_amount_units
+                nutrient_amount_units,
             )
             om.add_variable(
                 f"ration_nutrient_amount_pen_{pen.id}_{pen.animal_combination.name}",
@@ -245,7 +245,7 @@ class AnimalModuleReporter:
                 0,
                 simulation_day,
                 info_map,
-                MeasurementUnits.KILOGRAMS
+                MeasurementUnits.KILOGRAMS,
             )
             om.add_variable(
                 f"MEdiet_pen_{pen.id}_{pen.animal_combination.name}",
@@ -285,7 +285,7 @@ class AnimalModuleReporter:
                 {},
                 simulation_day,
                 info_map,
-                ration_per_animal_units
+                ration_per_animal_units,
             )
             om.add_variable(
                 f"ration_per_animal_for_pen_{pen.id}_{pen.animal_combination.name}",
@@ -306,10 +306,7 @@ class AnimalModuleReporter:
                     "forage_NDF": MeasurementUnits.PERCENT.value,
                 }
                 ration_supply_report = RationReporter.report_ration_supply(
-                    pen.ration_per_animal,
-                    feed.available_feeds,
-                    ration_report,
-                    pen.avg_nutrient_rqmts["avg_BW"]
+                    pen.ration_per_animal, feed.available_feeds, ration_report, pen.avg_nutrient_rqmts["avg_BW"]
                 )
                 AnimalModuleReporter.data_padder(
                     f"{classname}.{funcname}.ration_supply_report_for_pen_0_CALF",
@@ -317,7 +314,7 @@ class AnimalModuleReporter:
                     {},
                     simulation_day,
                     info_map,
-                    ration_supply_report_units
+                    ration_supply_report_units,
                 )
                 om.add_variable(
                     f"ration_supply_report_for_pen_{pen.id}_{pen.animal_combination.name}",
@@ -368,7 +365,7 @@ class AnimalModuleReporter:
                 {},
                 animal_manager.simulation_day,
                 info_map,
-                ration_total_units
+                ration_total_units,
             )
             om.add_variable(
                 f"ration_daily_feed_totals_for_pen_{pen.id}_{pen.animal_combination.name}",
@@ -508,7 +505,9 @@ class AnimalModuleReporter:
         for manure_property, manure_value in pen.manure.items():
             reference_variable = f"{classname}.{funcname}.pen_0_daily_{str(manure_property)}"
             variable_to_add = f"{classname}.{funcname}.pen_{pen.id}_daily_{str(manure_property)}"
-            AnimalModuleReporter.data_padder(reference_variable, variable_to_add, 0, simulation_day, info_map, manure_value_units)
+            AnimalModuleReporter.data_padder(
+                reference_variable, variable_to_add, 0, simulation_day, info_map, manure_value_units
+            )
             om.add_variable(
                 f"pen_{pen.id}_daily_{str(manure_property)}",
                 manure_value,
@@ -768,12 +767,9 @@ class AnimalModuleReporter:
         for pen in pen_list:
             variable_to_add = f"{classname}.{funcname}.number_of_animals_in_pen_{pen.id}_{pen.animal_combination.name}"
             reference_variable = f"{classname}.{funcname}.number_of_animals_in_pen_0_CALF"
-            AnimalModuleReporter.data_padder(reference_variable,
-                                             variable_to_add,
-                                             0,
-                                             simulation_day,
-                                             info_map,
-                                             MeasurementUnits.ANIMALS.value)
+            AnimalModuleReporter.data_padder(
+                reference_variable, variable_to_add, 0, simulation_day, info_map, MeasurementUnits.ANIMALS.value
+            )
             om.add_variable(
                 f"number_of_animals_in_pen_{pen.id}_{pen.animal_combination.name}",
                 len(pen.animals_in_pen),

--- a/RUFAS/routines/animal/animal_module_reporter.py
+++ b/RUFAS/routines/animal/animal_module_reporter.py
@@ -29,7 +29,7 @@ class AnimalModuleReporter:
         thing_to_add: Any,
         simulation_day: int,
         info_map: Dict[str, Any],
-        units: Dict[str, str] | MeasurementUnits
+        units: Dict[str, str] | MeasurementUnits | str
     ) -> None:
         """
         Pads a variable in OutputManager for entries that it "missed" relative to another variable.

--- a/RUFAS/routines/animal/animal_module_reporter.py
+++ b/RUFAS/routines/animal/animal_module_reporter.py
@@ -29,6 +29,7 @@ class AnimalModuleReporter:
         thing_to_add: Any,
         simulation_day: int,
         info_map: Dict[str, Any],
+        units: Dict[str, str] | MeasurementUnits
     ) -> None:
         """
         Pads a variable in OutputManager for entries that it "missed" relative to another variable.
@@ -70,7 +71,7 @@ class AnimalModuleReporter:
                     om.add_variable(
                         short_variable_to_add,
                         thing_to_add,
-                        info_map=info_map,
+                        info_map=dict(info_map, **{"units": units}),
                     )
 
     @classmethod
@@ -231,6 +232,7 @@ class AnimalModuleReporter:
                 {},
                 simulation_day,
                 info_map,
+                nutrient_amount_units
             )
             om.add_variable(
                 f"ration_nutrient_amount_pen_{pen.id}_{pen.animal_combination.name}",
@@ -243,6 +245,7 @@ class AnimalModuleReporter:
                 0,
                 simulation_day,
                 info_map,
+                MeasurementUnits.KILOGRAMS
             )
             om.add_variable(
                 f"MEdiet_pen_{pen.id}_{pen.animal_combination.name}",
@@ -268,6 +271,7 @@ class AnimalModuleReporter:
                 {},
                 simulation_day,
                 info_map,
+                avg_nutrient_rqmts_units,
             )
             om.add_variable(
                 f"avg_rqmts_pen_{pen.id}_{pen.animal_combination.name}",
@@ -281,6 +285,7 @@ class AnimalModuleReporter:
                 {},
                 simulation_day,
                 info_map,
+                ration_per_animal_units
             )
             om.add_variable(
                 f"ration_per_animal_for_pen_{pen.id}_{pen.animal_combination.name}",
@@ -304,7 +309,7 @@ class AnimalModuleReporter:
                     pen.ration_per_animal,
                     feed.available_feeds,
                     ration_report,
-                    pen.avg_nutrient_rqmts["avg_BW"],
+                    pen.avg_nutrient_rqmts["avg_BW"]
                 )
                 AnimalModuleReporter.data_padder(
                     f"{classname}.{funcname}.ration_supply_report_for_pen_0_CALF",
@@ -312,6 +317,7 @@ class AnimalModuleReporter:
                     {},
                     simulation_day,
                     info_map,
+                    ration_supply_report_units
                 )
                 om.add_variable(
                     f"ration_supply_report_for_pen_{pen.id}_{pen.animal_combination.name}",
@@ -362,6 +368,7 @@ class AnimalModuleReporter:
                 {},
                 animal_manager.simulation_day,
                 info_map,
+                ration_total_units
             )
             om.add_variable(
                 f"ration_daily_feed_totals_for_pen_{pen.id}_{pen.animal_combination.name}",
@@ -408,6 +415,7 @@ class AnimalModuleReporter:
             {},
             animal_manager.simulation_day,
             info_map,
+            MeasurementUnits.KILOGRAMS_CARBON_DIOXIDE_PER_KILOGRAM_DRY_MATTER.value,
         )
         om.add_variable(
             f"pen_{pen_id}_animal_{pen_animal_name}_feed_emissions",
@@ -500,7 +508,7 @@ class AnimalModuleReporter:
         for manure_property, manure_value in pen.manure.items():
             reference_variable = f"{classname}.{funcname}.pen_0_daily_{str(manure_property)}"
             variable_to_add = f"{classname}.{funcname}.pen_{pen.id}_daily_{str(manure_property)}"
-            AnimalModuleReporter.data_padder(reference_variable, variable_to_add, 0, simulation_day, info_map)
+            AnimalModuleReporter.data_padder(reference_variable, variable_to_add, 0, simulation_day, info_map, manure_value_units)
             om.add_variable(
                 f"pen_{pen.id}_daily_{str(manure_property)}",
                 manure_value,
@@ -760,7 +768,12 @@ class AnimalModuleReporter:
         for pen in pen_list:
             variable_to_add = f"{classname}.{funcname}.number_of_animals_in_pen_{pen.id}_{pen.animal_combination.name}"
             reference_variable = f"{classname}.{funcname}.number_of_animals_in_pen_0_CALF"
-            AnimalModuleReporter.data_padder(reference_variable, variable_to_add, 0, simulation_day, info_map)
+            AnimalModuleReporter.data_padder(reference_variable,
+                                             variable_to_add,
+                                             0,
+                                             simulation_day,
+                                             info_map,
+                                             MeasurementUnits.ANIMALS.value)
             om.add_variable(
                 f"number_of_animals_in_pen_{pen.id}_{pen.animal_combination.name}",
                 len(pen.animals_in_pen),

--- a/RUFAS/routines/animal/animal_module_reporter.py
+++ b/RUFAS/routines/animal/animal_module_reporter.py
@@ -29,7 +29,7 @@ class AnimalModuleReporter:
         thing_to_add: Any,
         simulation_day: int,
         info_map: Dict[str, Any],
-        units: Dict[str, str | MeasurementUnits] | MeasurementUnits | str,
+        units: Dict[str, str] | str,
     ) -> None:
         """
         Pads a variable in OutputManager for entries that it "missed" relative to another variable.
@@ -57,7 +57,7 @@ class AnimalModuleReporter:
             The day of the simulation.
         info_map: Dict[str, Any]
             The info_map to use when padding.
-        units: Dict[str, str | MeasurementUnits] | MeasurementUnits | str
+        units: Dict[str, str] | str
             Units for the variable being added, in the format provided in the main call to add_variable,
             (e.g. the one following the call of data_padder).
 
@@ -248,12 +248,12 @@ class AnimalModuleReporter:
                 0,
                 simulation_day,
                 info_map,
-                MeasurementUnits.KILOGRAMS,
+                MeasurementUnits.KILOGRAMS.value,
             )
             om.add_variable(
                 f"MEdiet_pen_{pen.id}_{pen.animal_combination.name}",
                 pen.MEdiet,
-                dict(info_map, **{"units": MeasurementUnits.KILOGRAMS}),
+                dict(info_map, **{"units": MeasurementUnits.KILOGRAMS.value}),
             )
             avg_nutrient_rqmts_units = {
                 "NEmaint_requirement": MeasurementUnits.MEGACALORIES.value,
@@ -281,7 +281,7 @@ class AnimalModuleReporter:
                 pen.avg_nutrient_rqmts,
                 dict(info_map, **{"units": avg_nutrient_rqmts_units}),
             )
-            ration_per_animal_units = {key: MeasurementUnits.KILOGRAMS for key in ration_per_animal.keys()}
+            ration_per_animal_units = {key: MeasurementUnits.KILOGRAMS.value for key in ration_per_animal.keys()}
             AnimalModuleReporter.data_padder(
                 f"{classname}.{funcname}.ration_per_animal_for_pen_0_CALF",
                 f"{classname}.{funcname}.ration_per_animal_for_pen_{pen.id}_{pen.animal_combination.name}",

--- a/RUFAS/routines/animal/animal_module_reporter.py
+++ b/RUFAS/routines/animal/animal_module_reporter.py
@@ -29,7 +29,7 @@ class AnimalModuleReporter:
         thing_to_add: Any,
         simulation_day: int,
         info_map: Dict[str, Any],
-        units: Dict[str, str | MeasurementUnits] | MeasurementUnits | str
+        units: Dict[str, str | MeasurementUnits] | MeasurementUnits | str,
     ) -> None:
         """
         Pads a variable in OutputManager for entries that it "missed" relative to another variable.
@@ -508,10 +508,9 @@ class AnimalModuleReporter:
         for manure_property, manure_value in pen.manure.items():
             reference_variable = f"{classname}.{funcname}.pen_0_daily_{str(manure_property)}"
             variable_to_add = f"{classname}.{funcname}.pen_{pen.id}_daily_{str(manure_property)}"
-            AnimalModuleReporter.data_padder(reference_variable, variable_to_add, 0,
-                                             simulation_day,
-                                             info_map,
-                                             manure_value_units)
+            AnimalModuleReporter.data_padder(
+                reference_variable, variable_to_add, 0, simulation_day, info_map, manure_value_units
+            )
             om.add_variable(
                 f"pen_{pen.id}_daily_{str(manure_property)}",
                 manure_value,

--- a/input/metadata/properties/default.json
+++ b/input/metadata/properties/default.json
@@ -833,7 +833,7 @@
           "description": "Maximum Stocking Density -- The maximum ratio of the number of animals in the pen to the number of stalls in the pen",
           "type": "number",
           "minimum": 0.5,
-          "maximum": 2,
+          "maximum": 3,
           "default": 1.2
         },
         "manure_management_scenario_id": {

--- a/tests/animal_module_tests/test_animal_reporter.py
+++ b/tests/animal_module_tests/test_animal_reporter.py
@@ -68,7 +68,7 @@ def test_data_padder() -> None:
         thing_to_add=0,
         simulation_day=100,
         info_map={"class": "dummyclass", "function": "dummyfunction", "units": MeasurementUnits.ANIMALS.value},
-        units=MeasurementUnits.ANIMALS.value
+        units=MeasurementUnits.ANIMALS.value,
     )
 
     # Assert
@@ -90,7 +90,7 @@ def test_data_padder_no_data_to_pad() -> None:
         thing_to_add=0,
         simulation_day=0,
         info_map={"class": "dummyclass", "function": "dummyfunction"},
-        units={'test': 'dummy'}
+        units={"test": "dummy"},
     )
 
     # Assert

--- a/tests/animal_module_tests/test_animal_reporter.py
+++ b/tests/animal_module_tests/test_animal_reporter.py
@@ -68,6 +68,7 @@ def test_data_padder() -> None:
         thing_to_add=0,
         simulation_day=100,
         info_map={"class": "dummyclass", "function": "dummyfunction", "units": MeasurementUnits.ANIMALS.value},
+        units=MeasurementUnits.ANIMALS.value
     )
 
     # Assert
@@ -89,6 +90,7 @@ def test_data_padder_no_data_to_pad() -> None:
         thing_to_add=0,
         simulation_day=0,
         info_map={"class": "dummyclass", "function": "dummyfunction"},
+        units={'test': 'dummy'}
     )
 
     # Assert


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1531

- [ ] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Adds unit input parameter to `data_padder`

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
See tagged Issue, the method didn't include units.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Added new arg, in lieu of adding the entire info_map itself, though that would be an appropriate fix as well.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Updated existing unit tests.

### Needs help
Typing for the units: since the calls to units in the codebase are fairly diverse in their format/typing, I wasn't sure how to capture that succintly. The current `Dict[str, str | MeasurementUnits] | MeasurementUnits | str` seems to fail in some cases (even a Dict[str, str]), so I think maybe I'll need to use `Sequence` or something similar?
![image](https://github.com/RuminantFarmSystems/MASM/assets/109082924/b4fd7db7-2323-41b8-91b8-2c6982de59c2)
