### PR TITLE
[Main] Total random seed control

### DIFF
--- a/input/data/config/default_config.json
+++ b/input/data/config/default_config.json
@@ -2,7 +2,7 @@
     "start_date": "2009:244",
     "end_date": "2015:264",
     "random_seed": 42,
-    "set_seed": true,
+    "set_seed": false,
     "simulate_animals": true,
     "nutrient_standard": "NASEM",
     "FIPS_county_code": 55025

--- a/input/data/config/default_config.json
+++ b/input/data/config/default_config.json
@@ -2,7 +2,7 @@
     "start_date": "2009:244",
     "end_date": "2015:264",
     "random_seed": 42,
-    "set_seed": false,
+    "set_seed": true,
     "simulate_animals": true,
     "nutrient_standard": "NASEM",
     "FIPS_county_code": 55025

--- a/input/metadata/properties/default.json
+++ b/input/metadata/properties/default.json
@@ -16,6 +16,7 @@
       "type": "number",
       "description": "The random seed",
       "minimum": 0,
+      "maximum": 4294967295,
       "default": 42
     },
     "set_seed": {

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ import argparse
 import random
 import traceback
 from pathlib import Path
-from typing import List
+from typing import List, Any
 
 import numpy
 
@@ -27,7 +27,7 @@ NUMPY_RANDOM_SEED_LOWER_BOUND = 0
 NUMPY_RANDOM_SEED_UPPER_BOUND = 2**32 - 1
 
 
-def main():
+def main() -> None:
     cmd_arguments = parse_gnu_args()
     if cmd_arguments.load_pool:
         load_pool = True
@@ -297,7 +297,7 @@ def set_random_seed(input_manager: InputManager) -> None:
     set_seed = input_manager.get_data("config.set_seed")
 
     om = OutputManager()
-    info_map = {"class": "No caller class", "function": set_random_seed.__name__}
+    info_map: dict[str, Any] = {"class": "No caller class", "function": set_random_seed.__name__}
 
     if set_seed:
         seed = input_manager.get_data("config.random_seed")

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ import argparse
 import random
 import traceback
 from pathlib import Path
-from typing import List, Any
+from typing import List
 
 import numpy
 
@@ -298,7 +298,7 @@ def set_random_seed(input_manager: InputManager) -> None:
     set_seed = input_manager.get_data("config.set_seed")
 
     om = OutputManager()
-    info_map: dict[str, Any] = {"class": "No caller class", "function": set_random_seed.__name__}
+    info_map: dict[str, str | MeasurementUnits] = {"class": "No caller class", "function": set_random_seed.__name__}
 
     if set_seed:
         seed = input_manager.get_data("config.random_seed")

--- a/main.py
+++ b/main.py
@@ -19,6 +19,12 @@ from RUFAS.output_manager import OutputManager, LogVerbosity
 from RUFAS.routines.animal.life_cycle.herd_factory import HerdFactory
 from RUFAS.scenario_manager import METADATA_PATHS, MetadataPaths
 from RUFAS.simulation_engine import SimulationEngine
+from RUFAS.units import MeasurementUnits
+
+
+"""This constants define the minimum and maximum integers that can be used to seed Numpy's `random` package."""
+NUMPY_RANDOM_SEED_LOWER_BOUND = 0
+NUMPY_RANDOM_SEED_UPPER_BOUND = 2**32 - 1
 
 
 def main():
@@ -290,15 +296,19 @@ def set_random_seed(input_manager: InputManager) -> None:
     """
     set_seed = input_manager.get_data("config.set_seed")
 
+    om = OutputManager()
+    info_map = {"class": "No caller class", "function": set_random_seed.__name__}
+
     if set_seed:
         seed = input_manager.get_data("config.random_seed")
-        om = OutputManager()
-        info_map = {"class": "No caller class", "function": set_random_seed.__name__}
         log_name = "Randomization seed set."
         log_message = f"Randomization libraries being seeded with {seed}."
         om.add_log(log_name, log_message, info_map)
     else:
-        seed = None
+        seed = random.randint(NUMPY_RANDOM_SEED_LOWER_BOUND, NUMPY_RANDOM_SEED_UPPER_BOUND)
+        info_map["units"] = MeasurementUnits.UNITLESS
+        om.add_variable("generated_random_seed", seed, info_map)
+        om.add_log("Generated random seed", f"Seeding random libaries with generated seed: {seed}", info_map)
 
     random.seed(seed)
     numpy.random.seed(seed)

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ import argparse
 import random
 import traceback
 from pathlib import Path
-from typing import List, Any
+from typing import List
 
 import numpy
 
@@ -27,7 +27,7 @@ NUMPY_RANDOM_SEED_LOWER_BOUND = 0
 NUMPY_RANDOM_SEED_UPPER_BOUND = 2**32 - 1
 
 
-def main() -> None:
+def main():
     cmd_arguments = parse_gnu_args()
     if cmd_arguments.load_pool:
         load_pool = True
@@ -297,7 +297,7 @@ def set_random_seed(input_manager: InputManager) -> None:
     set_seed = input_manager.get_data("config.set_seed")
 
     om = OutputManager()
-    info_map: dict[str, Any] = {"class": "No caller class", "function": set_random_seed.__name__}
+    info_map = {"class": "No caller class", "function": set_random_seed.__name__}
 
     if set_seed:
         seed = input_manager.get_data("config.random_seed")

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ import argparse
 import random
 import traceback
 from pathlib import Path
-from typing import List
+from typing import List, Any
 
 import numpy
 
@@ -27,7 +27,7 @@ NUMPY_RANDOM_SEED_LOWER_BOUND = 0
 NUMPY_RANDOM_SEED_UPPER_BOUND = 2**32 - 1
 
 
-def main():
+def main() -> None:
     cmd_arguments = parse_gnu_args()
     if cmd_arguments.load_pool:
         load_pool = True
@@ -298,7 +298,7 @@ def set_random_seed(input_manager: InputManager) -> None:
     set_seed = input_manager.get_data("config.set_seed")
 
     om = OutputManager()
-    info_map = {"class": "No caller class", "function": set_random_seed.__name__}
+    info_map: dict[str, Any] = {"class": "No caller class", "function": set_random_seed.__name__}
 
     if set_seed:
         seed = input_manager.get_data("config.random_seed")

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ from RUFAS.simulation_engine import SimulationEngine
 from RUFAS.units import MeasurementUnits
 
 
-"""This constants define the minimum and maximum integers that can be used to seed Numpy's `random` package."""
+"""These constants define the minimum and maximum integers that can be passed to Numpy's random.seed method."""
 NUMPY_RANDOM_SEED_LOWER_BOUND = 0
 NUMPY_RANDOM_SEED_UPPER_BOUND = 2**32 - 1
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1044,7 +1044,7 @@ def test_parse_gnu_args(mocker: MockerFixture) -> None:
     assert actual_args == "test_args"
 
 
-def test_case_insensitive_argument_action():
+def test_case_insensitive_argument_action() -> None:
     parser = argparse.ArgumentParser()
     parser.register("action", "ci_action", CaseInsensitiveArgumentAction)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -603,34 +603,41 @@ def test_run_validation(mocker: MockerFixture, is_data_valid: bool) -> None:
 
 
 @pytest.mark.parametrize(
-    "set_seed,seed,expected_seed,get_data_call_count,add_log_call_count",
+    "set_seed,seed,generated_seed,expected_seed,get_data_call_count,randint_called,add_log_call_count,"
+    "add_var_call_count",
     [
-        (True, 1, 1, 2, 1),
-        (False, 1, None, 1, 0),
+        (True, 1, 0, 1, 2, False, 1, 0),
+        (False, 1, 0, 0, 1, True, 1, 1),
     ],
 )
 def test_set_random_seed(
     mocker: MockerFixture,
     set_seed: bool,
     seed: int,
+    generated_seed: int,
     expected_seed: int,
     get_data_call_count: int,
+    randint_called: bool,
     add_log_call_count: int,
+    add_var_call_count: int,
 ) -> None:
     """Tests that the randomization libraries used in simulations are correctly seeded."""
     mock_input_manager = mocker.MagicMock(autospec=InputManager)
     mock_input_manager.get_data.side_effect = [set_seed, seed]
     mock_output_manager = mocker.MagicMock(autospec=OutputManager)
     mocker.patch("main.OutputManager", return_value=mock_output_manager)
+    mock_random_randint = mocker.patch("random.randint", return_value=generated_seed)
     mock_random_seed = mocker.patch("random.seed")
     mock_numpy_random_seed = mocker.patch("numpy.random.seed")
 
     set_random_seed(mock_input_manager)
 
     mock_input_manager.get_data.call_count == get_data_call_count
+    assert mock_random_randint.call_count == (1 if randint_called else 0)
     mock_random_seed.assert_called_once_with(expected_seed)
     mock_numpy_random_seed.assert_called_once_with(expected_seed)
     assert mock_output_manager.add_log.call_count == add_log_call_count
+    assert mock_output_manager.add_variable.call_count == add_var_call_count
 
 
 @pytest.mark.parametrize(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1044,7 +1044,7 @@ def test_parse_gnu_args(mocker: MockerFixture) -> None:
     assert actual_args == "test_args"
 
 
-def test_case_insensitive_argument_action() -> None:
+def test_case_insensitive_argument_action():
     parser = argparse.ArgumentParser()
     parser.register("action", "ci_action", CaseInsensitiveArgumentAction)
 


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
This PR records the seed used for randomization libraries in RuFaS when one is not provided in the inputs.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1523 

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
When a simulation is configured to _not_ seed random libraries with the seed provided in the inputs, a random seed is generated randomly, recorded, and used to seed the random libraries.

Also, an upper bound (${2}^{32} - 1$) has been added for `"seed"` in the config input.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
When running many random simulations, bugs can crop up intermittently. Without know the initial state of the random libraries (i.e. what they were seeded with) were in that simulation, it makes it very difficult to reproduce that bug. This PR fixes this problem by recording and logging the random seed used even if the user does not provide one.

The upper bound for `"seed"` was added because Numpy's `random.seed` method has an upper bound.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
If the user configures a simulation to run randomly (`set_seed` in the config input set to false), an integer is randomly generated in the range $[0, {2}^{32} - 1]$. This integer is logged and recorded as a variable, then used to seed the Numpy and Python `random` libraries.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
All changes to code were made in the `set_seed` method of `main`, so only the unit test for `set_seed` was updated. Also tested by running several simulations with `set_seed` set to `false` to observe the logging of the generated random seed.
