### PR TITLE
[Animal] Fixing bug in `ReproStateManager` when pregnant cow enters herd during simulation initialization.

### DIFF
--- a/RUFAS/routines/animal/life_cycle/cow.py
+++ b/RUFAS/routines/animal/life_cycle/cow.py
@@ -42,11 +42,13 @@ class MilkProductionHistory:
 class Cow(HeiferIII):
     stats = collections.defaultdict(int)
 
-    def __init__(self, args):
+    def __init__(self, args: dict[str, Any]):
         """
-        Description:
-            initialize the cow from heifer
-        Input:
+        Initialize a cow from a heifer.
+
+        Parameters
+        ----------
+        args : dict[str, Any]
             args.id: id of the animal
             args.breed: breed of the animal
             args.birth_date: the date of the simulation when the calf was born
@@ -91,6 +93,12 @@ class Cow(HeiferIII):
             args.parity: parity of the cow
             args.calving_interval: cow's most recent calving interval
             args.lactation_curve: lactation curve model choice
+
+        Notes
+        -----
+        When a cow is initialized, it is checked to see whether it is already pregnant. If it is, it is immediately
+        entered in the `PREGNANT` repro state.
+
         """
         super().__init__(args)
 
@@ -137,6 +145,8 @@ class Cow(HeiferIII):
 
         self._num_conception_rate_decreases: int = 0
         self._repro_state_manager: ReproStateManager = ReproStateManager()
+        if self.is_pregnant:
+            self._repro_state_manager.enter(ReproStateEnum.PREGNANT)
 
         self.wood_l = 0
         self.wood_m = 0

--- a/RUFAS/routines/animal/life_cycle/repro_state_manager.py
+++ b/RUFAS/routines/animal/life_cycle/repro_state_manager.py
@@ -37,7 +37,7 @@ class ReproStateManager:
         Check if the current state is in the empty state (NONE).
     """
 
-    def __init__(self, initial_states: set[ReproStateEnum] | None = None):
+    def __init__(self, initial_states: set[ReproStateEnum] | None = None) -> None:
         """
         Initialize the ReproStateManager with the given initial states.
 

--- a/RUFAS/routines/animal/life_cycle/repro_state_manager.py
+++ b/RUFAS/routines/animal/life_cycle/repro_state_manager.py
@@ -37,7 +37,7 @@ class ReproStateManager:
         Check if the current state is in the empty state (NONE).
     """
 
-    def __init__(self, initial_states: set[ReproStateEnum] | None = None) -> None:
+    def __init__(self, initial_states: set[ReproStateEnum] | None = None):
         """
         Initialize the ReproStateManager with the given initial states.
 

--- a/tests/animal_module_tests/life_cycle/test_cow.py
+++ b/tests/animal_module_tests/life_cycle/test_cow.py
@@ -33,7 +33,7 @@ def cow_args() -> dict[str, Any]:
         (True, True),
         (True, False),
         (False, True),
-    ]
+    ],
 )
 def test_init_cow(mocker: MockFixture, cow_args: dict[str, Any], pregnant: bool, in_milk: bool) -> None:
     """

--- a/tests/animal_module_tests/life_cycle/test_cow.py
+++ b/tests/animal_module_tests/life_cycle/test_cow.py
@@ -1,15 +1,64 @@
-from typing import Type
+from typing import Type, Any
 
 import pytest
 from pytest_mock import MockFixture
 
 from RUFAS.routines.animal.life_cycle import animal_constants as const
 from RUFAS.routines.animal.life_cycle.cow import Cow
+from RUFAS.routines.animal.life_cycle.heiferIII import HeiferIII
 from RUFAS.routines.animal.life_cycle.repro_protocol_enums import (
     CowReproProtocolEnum,
     ReproStateEnum,
 )
 from RUFAS.routines.animal.types.preg_check_config import PregCheckConfig
+
+
+@pytest.fixture
+def cow_args() -> dict[str, Any]:
+    """Fixture for mock Cow constructor arguments."""
+    return {
+        "calf_birth_weight": 40.0,
+        "repro_program": "dummy_program",
+        "presynch_method": "dummy_presynch",
+        "tai_method_c": "dummy_tai",
+        "resynch_method": "dummy_resynch",
+        "parity": 1,
+        "calving_interval": "dummy_interval",
+    }
+
+
+@pytest.mark.parametrize(
+    "pregnant,in_milk",
+    [
+        (True, True),
+        (True, False),
+        (False, True),
+    ]
+)
+def test_init_cow(mocker: MockFixture, cow_args: dict[str, Any], pregnant: bool, in_milk: bool) -> None:
+    """
+    Unit test for the method __init__() of the Cow class in cow.py.
+    """
+    if in_milk:
+        cow_args["days_in_milk"] = 10
+    super_constructor = mocker.patch.object(HeiferIII, "__init__")
+    is_pregnant = mocker.patch.object(Cow, "is_pregnant", new_callable=mocker.PropertyMock, return_value=pregnant)
+    set_breed_index = mocker.patch.object(Cow, "set_breed_index")
+    set_parity_index = mocker.patch.object(Cow, "set_parity_index")
+    set_lac_curve_params = mocker.patch.object(Cow, "set_lactation_curve_params")
+
+    cow = Cow(cow_args)
+
+    super_constructor.assert_called_once_with(cow_args)
+    is_pregnant.assert_called_once()
+    if pregnant:
+        cow._repro_state_manager.is_in(ReproStateEnum.PREGNANT)
+    else:
+        cow._repro_state_manager.is_in(ReproStateEnum.NONE)
+    set_breed_index.assert_called_once()
+    if in_milk:
+        set_parity_index.assert_called_once()
+        set_lac_curve_params.assert_called_once()
 
 
 def test_get_user_defined_milk_fat_percent(mocker: MockFixture) -> None:


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
The PR ensures that a Cow's state of pregnancy is initialized correctly for new cows.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1463, closes #1539 

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
When a Cow is initialized, it is checked whether or not it is pregnant. If so, then the `ReproStateManager` is entered into the `PREGNANT` state.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
When a simulation is already running, a cow is created when a HeiferIII births a calf - so newly created cows aren't pregnant. But on the first day of a simulation, cows are pulled from the animal population and put into the herd. Some of those cows may be pregnant, and this case needs to handled.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
This branch was merged into `pilot_testing_Dec2023`, and the C1F1 pilot testing scenario was successfully run 10 times with `preg_loss_rate_1` bumped up to 0.1

A unit test has been added for a `Cow`'s `init` method. It is not comprehensive, but I think it is sufficient for testing added functionality.

### Open Questions
Are there other conditions that a cow should be checked for when initialized?