### PR TITLE
Include units in csv column names

### DIFF
--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -11,9 +11,9 @@ from typing import Any, Dict, List, Union, Tuple
 import pandas as pd
 from deprecated.sphinx import deprecated
 
-from RUFAS.units import MeasurementUnits
 from RUFAS.graph_generator import GraphGenerator
 from RUFAS.report_generator import ReportGenerator
+from RUFAS.units import MeasurementUnits
 from RUFAS.util import Utility
 
 
@@ -537,24 +537,61 @@ class OutputManager(object):
             A list of (column_name, column_data) tuples.
 
         """
-        column_list = []
-        mandatory_fields = ["values", "info_maps"] if "info_maps" in data_dict else ["values"]
-        for field in mandatory_fields:
-            data_list = data_dict[field]
-            if data_list and isinstance(data_list[0], dict):
-                csv_column_lists: Dict[str, List[Any]] = {subkey: [] for item in data_list for subkey in item.keys()}
-                for nested_dictionary in data_list:
-                    for subkey, value in nested_dictionary.items():
-                        csv_column_lists[subkey].append(value)
 
-                for subkey in csv_column_lists.keys():
-                    column_title = f"{variable_name}.{subkey}"
-                    column_list.append(pd.Series(csv_column_lists[subkey], dtype=object, name=column_title))
-            else:
-                column_title = f"{variable_name}"
-                column_list.append(pd.Series(data_list, dtype=object, name=column_title))
+        column_list = []
+        units = data_dict["info_maps"][0]["units"] if data_dict.get("info_maps", []) else None
+        data_list = data_dict["values"]
+        if data_list and isinstance(data_list[0], dict):
+            csv_column_lists: Dict[str, List[Any]] = {subkey: [] for item in data_list for subkey in item.keys()}
+            for nested_dictionary in data_list:
+                for subkey, value in nested_dictionary.items():
+                    csv_column_lists[subkey].append(value)
+
+            for subkey in csv_column_lists.keys():
+                column_title = f"{variable_name}.{subkey}{self._get_units_substr(variable_name, units, subkey)}"
+                column_list.append(pd.Series(csv_column_lists[subkey], dtype=object, name=column_title))
+        else:
+            column_title = f"{variable_name}{self._get_units_substr(variable_name, units)}"
+            column_list.append(pd.Series(data_list, dtype=object, name=column_title))
 
         return column_list
+
+    def _get_units_substr(
+        self, variable_name: str, units: str | Dict[str, str] | None, subkey: str | None = None
+    ) -> str:
+        """Get the units substring for a column title.
+
+        Parameters
+        ----------
+        variable_name : str
+            The name of the variable or group of variables associated with the units.
+        units : str | Dict[str, str] | None
+            The units associated with the data.
+        subkey : str | None, optional
+            The subkey to retrieve the units for, if units is a dictionary. Default is None.
+
+        Returns
+        -------
+        str
+            The formatted units substring for the column title.
+        """
+
+        if not isinstance(units, dict):
+            return f"_{units}" if units else ""
+
+        if subkey not in units:
+            if subkey is not None:
+                self.add_error(
+                    "units_key_error",
+                    f"Key '{subkey}' not found in the units dictionary for variable '{variable_name}'.",
+                    info_map={
+                        "class": self.__class__.__name__,
+                        "function": self._get_units_substr.__name__,
+                    },
+                )
+            return ""
+
+        return f"_{units[subkey]}"
 
     def _dict_to_file_csv(self, data_dict: Dict[str, Any], path: str) -> None:
         """Saves a dictionary to a csv file.

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -606,7 +606,7 @@ class OutputManager(object):
         if subkey is None:
             self.add_error(
                 "units_subkey_missing",
-                f"Subkey is required when units is a dictionary for variable '{variable_name}'.",
+                f"Variable {variable_name} has the 'units' property as a dictionary, please specify a key.",
                 info_map={
                     "class": self.__class__.__name__,
                     "function": self._get_units_substr.__name__,

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -599,7 +599,7 @@ class OutputManager(object):
         """
 
         if not isinstance(units, dict):
-            return f"_({units})" if units else ""
+            return f" ({units})" if units else ""
 
         if subkey not in units:
             if subkey is not None:
@@ -613,7 +613,7 @@ class OutputManager(object):
                 )
             return ""
 
-        return f"_({units[subkey]})"
+        return f" ({units[subkey]})"
 
     def _dict_to_file_csv(self, data_dict: Dict[str, Any], path: str) -> None:
         """Saves a dictionary to a csv file.

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -606,7 +606,8 @@ class OutputManager(object):
         if subkey is None:
             self.add_error(
                 "units_subkey_missing",
-                f"Variable {variable_name} has a dictionary for its 'units' property, but the 'values' associated with this variable are not dictionaries themselves.",
+                f"Variable {variable_name} has a dictionary for its 'units' property, "
+                f"but the 'values' associated with this variable are not dictionaries themselves.",
                 info_map={
                     "class": self.__class__.__name__,
                     "function": self._get_units_substr.__name__,

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -606,7 +606,7 @@ class OutputManager(object):
         if subkey is None:
             self.add_error(
                 "units_subkey_missing",
-                f"Variable {variable_name} has the 'units' property as a dictionary, please specify a key.",
+                f"Variable {variable_name} has a dictionary for its 'units' property, but the 'values' associated with this variable are not dictionaries themselves.",
                 info_map={
                     "class": self.__class__.__name__,
                     "function": self._get_units_substr.__name__,

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -586,10 +586,20 @@ class OutputManager(object):
         -------
         str
             The formatted units substring for the column title.
+
+        Examples
+        --------
+        >>> output_manager = OutputManager()
+        >>> output_manager._get_units_substr("temperature", "C")
+        '_(C)'
+        >>> output_manager._get_units_substr("velocity", {"magnitude": "m/s", "direction": "degrees"}, "magnitude")
+        '_(m/s)'
+        >>> output_manager._get_units_substr("velocity", {"magnitude": "m/s", "direction": "degrees"}, "direction")
+        '_(degrees)'
         """
 
         if not isinstance(units, dict):
-            return f"_{units}" if units else ""
+            return f"_({units})" if units else ""
 
         if subkey not in units:
             if subkey is not None:
@@ -603,7 +613,7 @@ class OutputManager(object):
                 )
             return ""
 
-        return f"_{units[subkey]}"
+        return f"_({units[subkey]})"
 
     def _dict_to_file_csv(self, data_dict: Dict[str, Any], path: str) -> None:
         """Saves a dictionary to a csv file.

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -591,29 +591,42 @@ class OutputManager(object):
         --------
         >>> output_manager = OutputManager()
         >>> output_manager._get_units_substr("temperature", "C")
-        '_(C)'
+        ' (C)'
         >>> output_manager._get_units_substr("velocity", {"magnitude": "m/s", "direction": "degrees"}, "magnitude")
-        '_(m/s)'
+        ' (m/s)'
         >>> output_manager._get_units_substr("velocity", {"magnitude": "m/s", "direction": "degrees"}, "direction")
-        '_(degrees)'
+        ' (degrees)'
+        >>> output_manager._get_units_substr("coordinates", {"x": "m", "y": "m"})
+        ''
         """
 
         if not isinstance(units, dict):
             return f" ({units})" if units else ""
 
-        if subkey not in units:
-            if subkey is not None:
-                self.add_error(
-                    "units_key_error",
-                    f"Key '{subkey}' not found in the units dictionary for variable '{variable_name}'.",
-                    info_map={
-                        "class": self.__class__.__name__,
-                        "function": self._get_units_substr.__name__,
-                    },
-                )
+        if subkey is None:
+            self.add_error(
+                "units_subkey_missing",
+                f"Subkey is required when units is a dictionary for variable '{variable_name}'.",
+                info_map={
+                    "class": self.__class__.__name__,
+                    "function": self._get_units_substr.__name__,
+                },
+            )
             return ""
 
-        return f" ({units[subkey]})"
+        if subkey in units:
+            return f" ({units[subkey]})"
+
+        self.add_error(
+            "units_key_error",
+            f"Key '{subkey}' not found in the units dictionary for variable '{variable_name}'.",
+            info_map={
+                "class": self.__class__.__name__,
+                "function": self._get_units_substr.__name__,
+            },
+        )
+
+        return ""
 
     def _dict_to_file_csv(self, data_dict: Dict[str, Any], path: str) -> None:
         """Saves a dictionary to a csv file.

--- a/RUFAS/routines/animal/animal_module_reporter.py
+++ b/RUFAS/routines/animal/animal_module_reporter.py
@@ -222,6 +222,12 @@ class AnimalModuleReporter:
                 "phosphorus": MeasurementUnits.PERCENT_OF_DRY_MATTER.value,
                 "potassium": MeasurementUnits.PERCENT_OF_DRY_MATTER.value,
                 "N": MeasurementUnits.PERCENT_OF_DRY_MATTER.value,
+                "as_fed": MeasurementUnits.PERCENT.value,
+                "EE": MeasurementUnits.PERCENT_OF_DRY_MATTER.value,
+                "starch": MeasurementUnits.PERCENT_OF_DRY_MATTER.value,
+                "TDN": MeasurementUnits.PERCENT_OF_DRY_MATTER.value,
+                "DE": MeasurementUnits.PERCENT_OF_DRY_MATTER.value,
+                "calcium": MeasurementUnits.PERCENT_OF_DRY_MATTER.value,
             }
             classname = AnimalModuleReporter.__name__
             funcname = AnimalModuleReporter.report_ration_interval_data.__name__
@@ -299,6 +305,9 @@ class AnimalModuleReporter:
                     "fat": MeasurementUnits.GRAMS.value,
                     "fat_percentage": MeasurementUnits.PERCENT.value,
                     "forage_NDF": MeasurementUnits.PERCENT.value,
+                    "forage_NDF_percent": MeasurementUnits.PERCENT_OF_DRY_MATTER.value,
+                    "metabolizable_protein": MeasurementUnits.GRAMS.value,
+
                 }
                 ration_supply_report = RationReporter.report_ration_supply(
                     pen.ration_per_animal,

--- a/RUFAS/routines/animal/animal_module_reporter.py
+++ b/RUFAS/routines/animal/animal_module_reporter.py
@@ -474,7 +474,7 @@ class AnimalModuleReporter:
                 om.add_variable(
                     f'{output_data_dict["prefix"]}_{str(manure_property)}',
                     manure_value,
-                    dict(info_map, **{"units": manure_value_units}),
+                    dict(info_map, **{"units": manure_value_units[manure_property]}),
                 )
 
     @classmethod

--- a/RUFAS/routines/animal/animal_module_reporter.py
+++ b/RUFAS/routines/animal/animal_module_reporter.py
@@ -307,7 +307,6 @@ class AnimalModuleReporter:
                     "forage_NDF": MeasurementUnits.PERCENT.value,
                     "forage_NDF_percent": MeasurementUnits.PERCENT_OF_DRY_MATTER.value,
                     "metabolizable_protein": MeasurementUnits.GRAMS.value,
-
                 }
                 ration_supply_report = RationReporter.report_ration_supply(
                     pen.ration_per_animal,

--- a/RUFAS/routines/animal/animal_module_reporter.py
+++ b/RUFAS/routines/animal/animal_module_reporter.py
@@ -522,7 +522,7 @@ class AnimalModuleReporter:
             om.add_variable(
                 f"pen_{pen.id}_daily_{str(manure_property)}",
                 manure_value,
-                dict(info_map, **{"units": manure_value_units}),
+                dict(info_map, **{"units": manure_value_units[manure_property]}),
             )
 
     @classmethod

--- a/RUFAS/simulation_engine.py
+++ b/RUFAS/simulation_engine.py
@@ -76,11 +76,12 @@ class SimulationEngine:
             "type": MeasurementUnits.UNITLESS.value,
             "amount": MeasurementUnits.KILOGRAMS.value,
         }
-        om.add_variable(
-            "available_feeds_on_final_day",
-            available_feeds_on_final_day,
-            dict(info_map, **{"units": available_feeds_units}),
-        )
+        for available_feed in available_feeds_on_final_day:
+            om.add_variable(
+                "available_feeds_on_final_day",
+                available_feed,
+                dict(info_map, **{"units": available_feeds_units}),
+            )
         t_end_sim = timer.time()
 
         om.add_log("Simulation complete", "Simulation Completed.", info_map)

--- a/tests/animal_module_tests/test_animal_reporter.py
+++ b/tests/animal_module_tests/test_animal_reporter.py
@@ -378,16 +378,18 @@ def test_report_daily_pen_total(mocker: MockerFixture) -> None:
 def test_report_animal_module_manure() -> None:
     test_output_dict = {
         "prefix": "dummy",
-        "manure": {"property1": 100, "property2": 200},
+        "manure": {"urea": 100, "urine": 200},
     }
     test_dict = {"example": test_output_dict}
 
     AnimalModuleReporter.report_animal_module_manure(test_dict)
 
-    for i in range(1, 2):
-        assert om.variables_pool[f"AnimalModuleReporter.report_animal_module_manure.dummy_property{i}"]["values"] == [
-            100 * i
-        ]
+    # for i in range(1, 2):
+    #     assert om.variables_pool[f"AnimalModuleReporter.report_animal_module_manure.dummy_property{i}"]["values"] == [
+    #         100 * i
+    #     ]
+    assert om.variables_pool["AnimalModuleReporter.report_animal_module_manure.dummy_urea"]["values"] == [100]
+    assert om.variables_pool["AnimalModuleReporter.report_animal_module_manure.dummy_urine"]["values"] == [200]
 
 
 def test_report_life_cycle_manager_data(mocker: MockerFixture) -> None:

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -191,7 +191,7 @@ def test_get_units_substr(
     elif expected_error == "units_subkey_missing":
         patch_for_add_error.assert_called_once_with(
             "units_subkey_missing",
-            f"Subkey is required when units is a dictionary for variable '{variable_name}'.",
+            f"Variable {variable_name} has the 'units' property as a dictionary, please specify a key.",
             info_map=info_map,
         )
     else:

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -191,7 +191,7 @@ def test_get_units_substr(
     elif expected_error == "units_subkey_missing":
         patch_for_add_error.assert_called_once_with(
             "units_subkey_missing",
-            f"Variable {variable_name} has the 'units' property as a dictionary, please specify a key.",
+            f"Variable {variable_name} has a dictionary for its 'units' property, but the 'values' associated with this variable are not dictionaries themselves.",
             info_map=info_map,
         )
     else:

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -191,7 +191,8 @@ def test_get_units_substr(
     elif expected_error == "units_subkey_missing":
         patch_for_add_error.assert_called_once_with(
             "units_subkey_missing",
-            f"Variable {variable_name} has a dictionary for its 'units' property, but the 'values' associated with this variable are not dictionaries themselves.",
+            f"Variable {variable_name} has a dictionary for its 'units' property, "
+            f"but the 'values' associated with this variable are not dictionaries themselves.",
             info_map=info_map,
         )
     else:

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -155,6 +155,7 @@ def test_dict_to_csv_column_list(
         ("empty_units", "", None, "", None),
         ("nested_units", {"value": "kg", "error": "kg"}, "value", " (kg)", None),
         ("nested_units", {"value": "kg", "error": "kg"}, "uncertainty", "", "units_key_error"),
+        ("coordinates", {"x": "m", "y": "m"}, None, "", "units_subkey_missing"),
     ],
 )
 def test_get_units_substr(
@@ -166,9 +167,14 @@ def test_get_units_substr(
     mocker: MockerFixture,
 ) -> None:
     """Unit test for the _get_units_substr() method in the file output_manager.py"""
+
     # Arrange
     output_manager = OutputManager()
     patch_for_add_error = mocker.patch.object(output_manager, "add_error")
+    info_map = {
+        "class": output_manager.__class__.__name__,
+        "function": "_get_units_substr",
+    }
 
     # Act
     result = output_manager._get_units_substr(variable_name, units, subkey)
@@ -176,15 +182,17 @@ def test_get_units_substr(
     # Assert
     assert result == expected_result
 
-    if expected_error:
-        expected_info_map = {
-            "class": output_manager.__class__.__name__,
-            "function": "_get_units_substr",
-        }
+    if expected_error == "units_key_error":
         patch_for_add_error.assert_called_once_with(
             "units_key_error",
             f"Key '{subkey}' not found in the units dictionary for variable '{variable_name}'.",
-            info_map=expected_info_map,
+            info_map=info_map,
+        )
+    elif expected_error == "units_subkey_missing":
+        patch_for_add_error.assert_called_once_with(
+            "units_subkey_missing",
+            f"Subkey is required when units is a dictionary for variable '{variable_name}'.",
+            info_map=info_map,
         )
     else:
         patch_for_add_error.assert_not_called()

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -4,14 +4,15 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable, Dict, List
 
+import pandas as pd
 import pytest
 from mock import mock_open, patch
 from mock.mock import MagicMock, call
 from pytest import raises
 from pytest_mock.plugin import MockerFixture
 
-from RUFAS.units import MeasurementUnits
 from RUFAS.output_manager import LogVerbosity, OutputManager
+from RUFAS.units import MeasurementUnits
 
 
 def test_get_prefix() -> None:
@@ -42,41 +43,131 @@ def test_set_log_verbose(mock_output_manager: OutputManager, log_verbose: LogVer
     assert mock_output_manager._OutputManager__log_verbose == log_verbose
 
 
-def test_dict_to_csv_column_list(mock_output_manager: OutputManager) -> None:
+@pytest.mark.parametrize(
+    "variable_name, data, expected_result",
+    [
+        (
+            "temperature",
+            {"values": [25.0, 30.0, 35.0], "info_maps": [{"units": "Celsius"}]},
+            [pd.Series([25.0, 30.0, 35.0], name="temperature_Celsius", dtype=object)],
+        ),
+        (
+            "position",
+            {
+                "values": [
+                    {"x": 1.0, "y": 2.0},
+                    {"x": 3.0, "y": 4.0},
+                    {"x": 5.0, "y": 6.0},
+                ],
+                "info_maps": [{"units": {"x": "m", "y": "m"}}],
+            },
+            [
+                pd.Series([1.0, 3.0, 5.0], name="position.x_m", dtype=object),
+                pd.Series([2.0, 4.0, 6.0], name="position.y_m", dtype=object),
+            ],
+        ),
+        (
+            "measurements",
+            {
+                "values": [
+                    {"value": 10.5, "error": 0.1},
+                    {"value": 20.3, "error": 0.2},
+                    {"value": 15.7, "error": 0.15},
+                ],
+                "info_maps": [{"units": {"value": "kg", "error": "kg"}}],
+            },
+            [
+                pd.Series([10.5, 20.3, 15.7], name="measurements.value_kg", dtype=object),
+                pd.Series([0.1, 0.2, 0.15], name="measurements.error_kg", dtype=object),
+            ],
+        ),
+        (
+            "pressure",
+            {"values": [100.0, 200.0, 300.0]},
+            [pd.Series([100.0, 200.0, 300.0], name="pressure", dtype=object)],
+        ),
+        (
+            "empty_data",
+            {"values": [], "info_maps": []},
+            [pd.Series([], name="empty_data", dtype=object)],
+        ),
+    ],
+)
+def test_dict_to_csv_column_list(
+    variable_name: str,
+    data: Dict[str, List[Any]],
+    expected_result: List[pd.Series],
+) -> None:
     """Unit test for the function _dict_to_csv_column_list in the file output_manager.py"""
-    data = {
-        "values": [1.0, True, "test", {"key": 1}],
-    }
-    result = mock_output_manager._dict_to_csv_column_list("dummy_variable_name", data)
-    v = result[0]
-    assert v.to_list() == data["values"]
 
-    data["info_maps"] = [{"map1": "value1", "map2": 1}, {"map1": "value2", "map2": 2}]
-    result = mock_output_manager._dict_to_csv_column_list("dummy_variable_name", data)
-    assert len(result) == 3
-    data_series = result[0]
-    map1_series = result[1]
-    map2_series = result[2]
-    assert data_series.name == "dummy_variable_name"
-    assert data_series.to_list() == data["values"]
-    assert map1_series.name == "dummy_variable_name.map1"
-    assert map1_series.to_list() == ["value1", "value2"]
-    assert map2_series.name == "dummy_variable_name.map2"
-    assert map2_series.to_list() == [1, 2]
+    # Arrange
+    output_manager = OutputManager()
+    expected_length = len(expected_result)
+
+    # Act
+    result = output_manager._dict_to_csv_column_list(variable_name, data)
+
+    # Assert
+    assert len(result) == expected_length
+
+    for i, series in enumerate(result):
+        assert series.equals(expected_result[i])
+
+        if i == 0 and data.get("info_maps", []):
+            units = data["info_maps"][0].get("units")
+            if isinstance(units, dict):
+                for subkey in units:
+                    assert f"_{units[subkey]}" in series.name
+            elif units:
+                assert f"_{units}" in series.name
+
+    # Cleanup
+    output_manager.flush_pools()
 
 
-def test_dict_to_csv_column_list_empty_list(mock_output_manager: OutputManager) -> None:
-    """Unit test for the function _dict_to_csv_column_list in the file output_manager.py"""
-    data = {"values": [], "info_maps": []}
-    result = mock_output_manager._dict_to_csv_column_list("dummy_variable_name", data)
+@pytest.mark.parametrize(
+    "variable_name, units, subkey, expected_result, expected_error",
+    [
+        ("temperature", "Celsius", None, "_Celsius", None),
+        ("position", {"x": "m", "y": "m"}, "x", "_m", None),
+        ("position", {"x": "m", "y": "m"}, "z", "", "units_key_error"),
+        ("pressure", None, None, "", None),
+        ("empty_units", "", None, "", None),
+        ("nested_units", {"value": "kg", "error": "kg"}, "value", "_kg", None),
+        ("nested_units", {"value": "kg", "error": "kg"}, "uncertainty", "", "units_key_error"),
+    ],
+)
+def test_get_units_substr(
+    variable_name: str,
+    units: str | Dict[str, str] | None,
+    subkey: str | None,
+    expected_result: str,
+    expected_error: str | None,
+    mocker: MockerFixture,
+) -> None:
+    """Unit test for the _get_units_substr() method in the file output_manager.py"""
+    # Arrange
+    output_manager = OutputManager()
+    patch_for_add_error = mocker.patch.object(output_manager, "add_error")
 
-    assert len(result) == 2
-    series = result[0]
-    assert series.name == "dummy_variable_name"
-    assert series.to_list() == []
-    series = result[1]
-    assert series.name == "dummy_variable_name"
-    assert series.to_list() == []
+    # Act
+    result = output_manager._get_units_substr(variable_name, units, subkey)
+
+    # Assert
+    assert result == expected_result
+
+    if expected_error:
+        expected_info_map = {
+            "class": output_manager.__class__.__name__,
+            "function": "_get_units_substr",
+        }
+        patch_for_add_error.assert_called_once_with(
+            "units_key_error",
+            f"Key '{subkey}' not found in the units dictionary for variable '{variable_name}'.",
+            info_map=expected_info_map,
+        )
+    else:
+        patch_for_add_error.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -84,7 +175,7 @@ def test_dict_to_csv_column_list_empty_list(mock_output_manager: OutputManager) 
     [
         (
             {"var1": {"values": [1.0, True, "test"], "info_maps": []}},
-            f"var1,var1{os.linesep}1.0,{os.linesep}True,{os.linesep}test,{os.linesep}",
+            f"var1{os.linesep}1.0{os.linesep}True{os.linesep}test{os.linesep}",
             True,
         ),
         (
@@ -96,10 +187,10 @@ def test_dict_to_csv_column_list_empty_list(mock_output_manager: OutputManager) 
             {
                 "var1": {
                     "values": [1, 2, 3],
-                    "info_maps": [{"v": 1}, {"v": 2}, {"v": 3}],
+                    "info_maps": [{"units": "m"}, {"units": "m"}, {"units": "m"}],
                 }
             },
-            f"var1,var1.v{os.linesep}1,1{os.linesep}2,2{os.linesep}3,3{os.linesep}",
+            f"var1_m{os.linesep}1{os.linesep}2{os.linesep}3{os.linesep}",
             True,
         ),
         (
@@ -110,21 +201,21 @@ def test_dict_to_csv_column_list_empty_list(mock_output_manager: OutputManager) 
         (
             {
                 "var1": {
-                    "values": [1],
-                    "info_maps": [{"map1": "value1"}, {"map1": "value2"}],
+                    "values": [1, 2],
+                    "info_maps": [{"units": "unitless"}, {"units": "unitless"}],
                 }
             },
-            f"var1,var1.map1{os.linesep}1,value1{os.linesep},value2{os.linesep}",
+            f"var1_unitless{os.linesep}1{os.linesep}2{os.linesep}",
             True,
         ),
         (
             {
                 "var1": {
                     "values": [{"v1": 1, "v2": 1}, {"v1": 2, "v2": 2}],
-                    "info_maps": [{"map1": "value1"}, {"map1": "value2"}],
+                    "info_maps": [{"units": {"v1": "m", "v2": "s"}}, {"units": {"v1": "m", "v2": "s"}}],
                 }
             },
-            f"var1.v1,var1.v2,var1.map1{os.linesep}1,1,value1{os.linesep}2,2,value2{os.linesep}",
+            f"var1.v1_m,var1.v2_s{os.linesep}1,1{os.linesep}2,2{os.linesep}",
             True,
         ),
         (
@@ -137,25 +228,24 @@ def test_dict_to_csv_column_list_empty_list(mock_output_manager: OutputManager) 
                     ],
                     "info_maps": [
                         {
-                            "subkey1": 1,
-                            "subkey2": "Hello",
-                            "subkey3": [1, 2, 3],
-                            "subkey4": {"nestedkey1": "World", "nestedkey2": [4, 5, 6]},
+                            "units": {
+                                "key1": "random1",
+                                "key2": "random2",
+                            }
                         },
                         {
-                            "subkey1": 2,
-                            "subkey2": "Hi",
-                            "subkey3": [4, 5, 6],
-                            "subkey4": {"nestedkey1": "There", "nestedkey2": [7, 8, 9]},
+                            "units": {
+                                "key1": "random1",
+                                "key2": "random2",
+                            }
                         },
                     ],
                 }
             },
-            f"simple_key.key1,simple_key.key2,simple_key.subkey1,simple_key.subkey2,"
-            f"simple_key.subkey3,simple_key.subkey4{os.linesep}"
-            f"1,\"[1, 1]\",1,Hello,\"[1, 2, 3]\",\"{{'nestedkey1': 'World', 'nestedkey2': [4, 5, 6]}}\"{os.linesep}"
-            f"2,\"[2, 2]\",2,Hi,\"[4, 5, 6]\",\"{{'nestedkey1': 'There', 'nestedkey2': [7, 8, 9]}}\"{os.linesep}"
-            f'3,"[3, 3]",,,,{os.linesep}',
+            f"simple_key.key1_random1,simple_key.key2_random2{os.linesep}"
+            f"1,\"[1, 1]\"{os.linesep}"
+            f"2,\"[2, 2]\"{os.linesep}"
+            f"3,\"[3, 3]\"{os.linesep}",
             True,
         ),
         (
@@ -170,24 +260,23 @@ def test_dict_to_csv_column_list_empty_list(mock_output_manager: OutputManager) 
             {
                 "simple_key1": {
                     "values": [1, 2, 3],
-                    "info_maps": [{"subkey1": "Farm", "subkey2": "Field"}],
+                    "info_maps": [
+                        {"subkey1": "Farm", "subkey2": "Field", "units": "random"},
+                        {"subkey1": "Farm", "subkey2": "Field", "units": "random"},
+                        {"subkey1": "Farm", "subkey2": "Field", "units": "random"},
+                    ],
                 },
                 "simple_key2": {
                     "values": [4, 5, 6, 8, 9],
                     "info_maps": [
-                        {
-                            "subkey1": "Tractor",
-                        }
+                        {"subkey1": "Tractor", "units": "random"},
+                        {"subkey1": "Tractor", "units": "random"},
+                        {"subkey1": "Tractor", "units": "random"},
                     ],
                 },
             },
-            f"simple_key1,simple_key1.subkey1,simple_key1.subkey2,simple_key2,"
-            f"simple_key2.subkey1{os.linesep}"
-            f"1,Farm,Field,4,Tractor{os.linesep}"
-            f"2,,,5,{os.linesep}"
-            f"3,,,6,{os.linesep}"
-            f",,,8,{os.linesep}"
-            f",,,9,{os.linesep}",
+            f"simple_key1_random,simple_key2_random{os.linesep}"
+            f"1,4{os.linesep}2,5{os.linesep}3,6{os.linesep},8{os.linesep},9{os.linesep}",
             True,
         ),
         ({}, "", False),

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -263,9 +263,9 @@ def test_get_units_substr(
                 }
             },
             f"simple_key.key1_random1,simple_key.key2_random2{os.linesep}"
-            f"1,\"[1, 1]\"{os.linesep}"
-            f"2,\"[2, 2]\"{os.linesep}"
-            f"3,\"[3, 3]\"{os.linesep}",
+            f'1,"[1, 1]"{os.linesep}'
+            f'2,"[2, 2]"{os.linesep}'
+            f'3,"[3, 3]"{os.linesep}',
             True,
         ),
         (

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -137,9 +137,9 @@ def test_dict_to_csv_column_list(
             units = data["info_maps"][0].get("units")
             if isinstance(units, dict):
                 for subkey in units:
-                    assert f"_({units[subkey]})" in series.name
+                    assert f" ({units[subkey]})" in series.name
             elif units:
-                assert f"_({units})" in series.name
+                assert f" ({units})" in series.name
 
     # Cleanup
     output_manager.flush_pools()
@@ -148,12 +148,12 @@ def test_dict_to_csv_column_list(
 @pytest.mark.parametrize(
     "variable_name, units, subkey, expected_result, expected_error",
     [
-        ("temperature", "Celsius", None, "_(Celsius)", None),
-        ("position", {"x": "m", "y": "m"}, "x", "_(m)", None),
+        ("temperature", "Celsius", None, " (Celsius)", None),
+        ("position", {"x": "m", "y": "m"}, "x", " (m)", None),
         ("position", {"x": "m", "y": "m"}, "z", "", "units_key_error"),
         ("pressure", None, None, "", None),
         ("empty_units", "", None, "", None),
-        ("nested_units", {"value": "kg", "error": "kg"}, "value", "_(kg)", None),
+        ("nested_units", {"value": "kg", "error": "kg"}, "value", " (kg)", None),
         ("nested_units", {"value": "kg", "error": "kg"}, "uncertainty", "", "units_key_error"),
     ],
 )
@@ -210,7 +210,7 @@ def test_get_units_substr(
                     "info_maps": [{"units": "m"}, {"units": "m"}, {"units": "m"}],
                 }
             },
-            f"var1_(m){os.linesep}1{os.linesep}2{os.linesep}3{os.linesep}",
+            f"var1 (m){os.linesep}1{os.linesep}2{os.linesep}3{os.linesep}",
             True,
         ),
         (
@@ -225,7 +225,7 @@ def test_get_units_substr(
                     "info_maps": [{"units": "unitless"}, {"units": "unitless"}],
                 }
             },
-            f"var1_(unitless){os.linesep}1{os.linesep}2{os.linesep}",
+            f"var1 (unitless){os.linesep}1{os.linesep}2{os.linesep}",
             True,
         ),
         (
@@ -235,7 +235,7 @@ def test_get_units_substr(
                     "info_maps": [{"units": {"v1": "m", "v2": "s"}}, {"units": {"v1": "m", "v2": "s"}}],
                 }
             },
-            f"var1.v1_(m),var1.v2_(s){os.linesep}1,1{os.linesep}2,2{os.linesep}",
+            f"var1.v1 (m),var1.v2 (s){os.linesep}1,1{os.linesep}2,2{os.linesep}",
             True,
         ),
         (
@@ -249,20 +249,20 @@ def test_get_units_substr(
                     "info_maps": [
                         {
                             "units": {
-                                "key1": "random1",
-                                "key2": "random2",
+                                "key1": "random unit 1",
+                                "key2": "random unit 2",
                             }
                         },
                         {
                             "units": {
-                                "key1": "random1",
-                                "key2": "random2",
+                                "key1": "random unit 1",
+                                "key2": "random unit 2",
                             }
                         },
                     ],
                 }
             },
-            f"simple_key.key1_(random1),simple_key.key2_(random2){os.linesep}"
+            f"simple_key.key1 (random unit 1),simple_key.key2 (random unit 2){os.linesep}"
             f'1,"[1, 1]"{os.linesep}'
             f'2,"[2, 2]"{os.linesep}'
             f'3,"[3, 3]"{os.linesep}',
@@ -281,21 +281,21 @@ def test_get_units_substr(
                 "simple_key1": {
                     "values": [1, 2, 3],
                     "info_maps": [
-                        {"subkey1": "Farm", "subkey2": "Field", "units": "random"},
-                        {"subkey1": "Farm", "subkey2": "Field", "units": "random"},
-                        {"subkey1": "Farm", "subkey2": "Field", "units": "random"},
+                        {"subkey1": "Farm", "subkey2": "Field", "units": "random unit"},
+                        {"subkey1": "Farm", "subkey2": "Field", "units": "random unit"},
+                        {"subkey1": "Farm", "subkey2": "Field", "units": "random unit"},
                     ],
                 },
                 "simple_key2": {
                     "values": [4, 5, 6, 8, 9],
                     "info_maps": [
-                        {"subkey1": "Tractor", "units": "random"},
-                        {"subkey1": "Tractor", "units": "random"},
-                        {"subkey1": "Tractor", "units": "random"},
+                        {"subkey1": "Tractor", "units": "random unit"},
+                        {"subkey1": "Tractor", "units": "random unit"},
+                        {"subkey1": "Tractor", "units": "random unit"},
                     ],
                 },
             },
-            f"simple_key1_(random),simple_key2_(random){os.linesep}"
+            f"simple_key1 (random unit),simple_key2 (random unit){os.linesep}"
             f"1,4{os.linesep}2,5{os.linesep}3,6{os.linesep},8{os.linesep},9{os.linesep}",
             True,
         ),

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -137,9 +137,9 @@ def test_dict_to_csv_column_list(
             units = data["info_maps"][0].get("units")
             if isinstance(units, dict):
                 for subkey in units:
-                    assert f"_{units[subkey]}" in series.name
+                    assert f"_({units[subkey]})" in series.name
             elif units:
-                assert f"_{units}" in series.name
+                assert f"_({units})" in series.name
 
     # Cleanup
     output_manager.flush_pools()
@@ -148,12 +148,12 @@ def test_dict_to_csv_column_list(
 @pytest.mark.parametrize(
     "variable_name, units, subkey, expected_result, expected_error",
     [
-        ("temperature", "Celsius", None, "_Celsius", None),
-        ("position", {"x": "m", "y": "m"}, "x", "_m", None),
+        ("temperature", "Celsius", None, "_(Celsius)", None),
+        ("position", {"x": "m", "y": "m"}, "x", "_(m)", None),
         ("position", {"x": "m", "y": "m"}, "z", "", "units_key_error"),
         ("pressure", None, None, "", None),
         ("empty_units", "", None, "", None),
-        ("nested_units", {"value": "kg", "error": "kg"}, "value", "_kg", None),
+        ("nested_units", {"value": "kg", "error": "kg"}, "value", "_(kg)", None),
         ("nested_units", {"value": "kg", "error": "kg"}, "uncertainty", "", "units_key_error"),
     ],
 )
@@ -210,7 +210,7 @@ def test_get_units_substr(
                     "info_maps": [{"units": "m"}, {"units": "m"}, {"units": "m"}],
                 }
             },
-            f"var1_m{os.linesep}1{os.linesep}2{os.linesep}3{os.linesep}",
+            f"var1_(m){os.linesep}1{os.linesep}2{os.linesep}3{os.linesep}",
             True,
         ),
         (
@@ -225,7 +225,7 @@ def test_get_units_substr(
                     "info_maps": [{"units": "unitless"}, {"units": "unitless"}],
                 }
             },
-            f"var1_unitless{os.linesep}1{os.linesep}2{os.linesep}",
+            f"var1_(unitless){os.linesep}1{os.linesep}2{os.linesep}",
             True,
         ),
         (
@@ -235,7 +235,7 @@ def test_get_units_substr(
                     "info_maps": [{"units": {"v1": "m", "v2": "s"}}, {"units": {"v1": "m", "v2": "s"}}],
                 }
             },
-            f"var1.v1_m,var1.v2_s{os.linesep}1,1{os.linesep}2,2{os.linesep}",
+            f"var1.v1_(m),var1.v2_(s){os.linesep}1,1{os.linesep}2,2{os.linesep}",
             True,
         ),
         (
@@ -262,7 +262,7 @@ def test_get_units_substr(
                     ],
                 }
             },
-            f"simple_key.key1_random1,simple_key.key2_random2{os.linesep}"
+            f"simple_key.key1_(random1),simple_key.key2_(random2){os.linesep}"
             f'1,"[1, 1]"{os.linesep}'
             f'2,"[2, 2]"{os.linesep}'
             f'3,"[3, 3]"{os.linesep}',
@@ -295,7 +295,7 @@ def test_get_units_substr(
                     ],
                 },
             },
-            f"simple_key1_random,simple_key2_random{os.linesep}"
+            f"simple_key1_(random),simple_key2_(random){os.linesep}"
             f"1,4{os.linesep}2,5{os.linesep}3,6{os.linesep},8{os.linesep},9{os.linesep}",
             True,
         ),


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1514 

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.

### What & Why
When using csv filtering (`csv_<example>.txt`), there are additional columns such as `.prefix` and `.units` that seem redundant and use extra memory storage. This PR aims to remove those unnecessary columns and directly incorporate the units into the column names.

When the exclude-info-maps flag `-i` is used, that will disable this feature because information about units is stored in the info maps.

This feature doesn't apply to reports yet (which are also in the csv format) because there are some other considerations such as missing info maps and different combinations of aggregation operations affecting the final units. There is an open issue regarding this #1516.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->

- [x] Look for the units key in the `info_maps` dictionary if it exists. Ignore other keys in the `info_maps`.
- [x] Format the units somehow. This PR only does a simple appending of the units string to the variable name `simple_variable_name_<units>` or `<dictionary_variable_name>.subkey_<units>`.
- [x] Do some code refactoring and write/update unit tests
- [x] There are some missing units in the animal module reporter and they need to be added.


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->

To test things out, I would create a filter file `csv_examples.txt` and select simple and dictionary variables.

```
Weather.average_annual_temperature
^AnaerobicDigestion_ManureTreatmentDailyOutput_.*LAC_COW.liquid_manure_total_volatile_solids$
AnimalModuleReporter.report_ration_interval_data.ration_nutrient_amount_.*LAC_COW
```