### PR TITLE
Account for Precipitation in Outdoor Manure Storages

### DIFF
--- a/RUFAS/routines/manure/constants_and_units/gas_emission_constants.py
+++ b/RUFAS/routines/manure/constants_and_units/gas_emission_constants.py
@@ -284,14 +284,17 @@ class GasEmissionConstants:
     NITROUS_OXIDE_EMISSION_FACTOR_KG_NITROUS_OXIDE_N_PER_KG_MANURE_N: (Dict)[ManureTreatmentType, Dict[str, float]] = {
         ManureTreatmentType.SLURRY_STORAGE_OUTDOOR: {
             ManureCoverEnum.COVER.value: 0.005,
+            ManureCoverEnum.CRUST.value: 0.005,
             ManureCoverEnum.NO_COVER.value: 0.0,
         },
         ManureTreatmentType.SLURRY_STORAGE_UNDERFLOOR: {
             ManureCoverEnum.COVER.value: 0.005,
+            ManureCoverEnum.CRUST.value: 0.005,
             ManureCoverEnum.NO_COVER.value: 0.0,
         },
         ManureTreatmentType.ANAEROBIC_LAGOON: {
             ManureCoverEnum.COVER.value: 0.005,
+            ManureCoverEnum.CRUST.value: 0.005,
             ManureCoverEnum.NO_COVER.value: 0.0,
         },
         ManureTreatmentType.ANAEROBIC_DIGESTION: {ManureCoverEnum.NOT_APPLICABLE.value: 0.0006},

--- a/RUFAS/routines/manure/enums/ManureCoverEnum.py
+++ b/RUFAS/routines/manure/enums/ManureCoverEnum.py
@@ -10,11 +10,18 @@ class ManureCoverEnum(Enum):
     Attributes:
     ----------
     COVER: str
-        The enum member that indicates the presence of a cover in the manure treatment or storage system.
+        The enum member that indicates the presence of an impermeable, human-made cover
+        in the manure treatment or storage system.
+    CRUST: str
+        The enum member that indicates the presence of a naturally-formed crust in the manure
+        treatment or storage system.
     NO_COVER: str
-        The enum member that indicates the absence of a cover in the manure treatment or storage system.
+        The enum member that indicates the absence of a cover or crust in the manure treatment or storage system.
+    NOT_APPLICABLE: "N/A"
+        The enum member that indicates a cover is not applicable to the manure treatment or storage system.
     """
 
     COVER = "cover"
+    CRUST = "crust"
     NO_COVER = "no cover"
     NOT_APPLICABLE = "N/A"

--- a/RUFAS/routines/manure/manure_treatments/anaerobic_lagoon.py
+++ b/RUFAS/routines/manure/manure_treatments/anaerobic_lagoon.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 from typing import Tuple
 
+from RUFAS.routines.manure.enums.ManureCoverEnum import ManureCoverEnum
 from RUFAS.routines.manure.constants_and_units.gas_emission_constants import GasEmissionConstants
 from RUFAS.routines.manure.constants_and_units.manure_constants import ManureConstants
 from RUFAS.routines.manure.gas_emissions.calculator import (
@@ -208,7 +209,10 @@ class AnaerobicLagoon(BaseManureTreatment):
             The adjusted final manure volume.
 
         """
-        return current_day_final_manure_volume + self.precipitation_volume
+        if self.config.manure_cover == ManureCoverEnum.NO_COVER.value:
+            return current_day_final_manure_volume + self.precipitation_volume
+        else:
+            return current_day_final_manure_volume
 
     @property
     def sludge_accumulation_volume(self) -> float:

--- a/RUFAS/routines/manure/manure_treatments/anaerobic_lagoon.py
+++ b/RUFAS/routines/manure/manure_treatments/anaerobic_lagoon.py
@@ -209,7 +209,7 @@ class AnaerobicLagoon(BaseManureTreatment):
             The adjusted final manure volume.
 
         """
-        if self.config.manure_cover == ManureCoverEnum.NO_COVER.value:
+        if self.config.manure_cover in [ManureCoverEnum.NO_COVER.value, ManureCoverEnum.CRUST.value]:
             return current_day_final_manure_volume + self.precipitation_volume
         else:
             return current_day_final_manure_volume

--- a/RUFAS/routines/manure/manure_treatments/anaerobic_lagoon.py
+++ b/RUFAS/routines/manure/manure_treatments/anaerobic_lagoon.py
@@ -369,10 +369,7 @@ class AnaerobicLagoon(BaseManureTreatment):
 
         """
         if self._current_pen is not None and self._current_pen.num_animals is not None:
-            return (
-                self._current_pen.num_animals
-                * GasEmissionConstants.DEFAULT_STORAGE_AREA_PER_ANIMAL
-            )
+            return self._current_pen.num_animals * GasEmissionConstants.DEFAULT_STORAGE_AREA_PER_ANIMAL
         else:
             return 0.0
 

--- a/RUFAS/routines/manure/manure_treatments/anaerobic_lagoon.py
+++ b/RUFAS/routines/manure/manure_treatments/anaerobic_lagoon.py
@@ -231,7 +231,10 @@ class AnaerobicLagoon(BaseManureTreatment):
             Flushing water volume, m^3
 
         """
-        return self._manure_handler_daily_output.cleaning_water_volume
+        if self._manure_handler_daily_output:
+            return self._manure_handler_daily_output.cleaning_water_volume
+        else:
+            return 0.0
 
     @property
     def volume_needed(self):

--- a/RUFAS/routines/manure/manure_treatments/anaerobic_lagoon.py
+++ b/RUFAS/routines/manure/manure_treatments/anaerobic_lagoon.py
@@ -359,7 +359,8 @@ class AnaerobicLagoon(BaseManureTreatment):
         """
         Calculate and return the surface area of the lagoon in square meters (m^2).
 
-        The surface area is calculated as the product of the lagoon's width and length.
+        The surface area is calculated as the product of the number of animals in the pen
+        and the DEFAULT_STORAGE_AREA_PER_ANIMAL constant.
 
         Returns
         -------
@@ -367,7 +368,13 @@ class AnaerobicLagoon(BaseManureTreatment):
             Lagoon surface area in square meters (:math:`m^2`).
 
         """
-        return self.lagoon_width * self.lagoon_length
+        if self._current_pen is not None and self._current_pen.num_animals is not None:
+            return (
+                self._current_pen.num_animals
+                * GasEmissionConstants.DEFAULT_STORAGE_AREA_PER_ANIMAL
+            )
+        else:
+            return 0.0
 
     def _calc_modeled_lagoon_volume(self) -> float:
         """

--- a/RUFAS/routines/manure/manure_treatments/base_manure_treatment.py
+++ b/RUFAS/routines/manure/manure_treatments/base_manure_treatment.py
@@ -310,7 +310,7 @@ class BaseManureTreatment(ABC):
         manure_treatment_type : ManureTreatmentType
             The type of manure treatment.
         manure_cover : str
-            The type of cover for the manure. Options are: cover, no cover, and N/A.
+            The type of cover for the manure. Options are: cover, crust, no cover, and N/A.
         manure_nitrogen_kg_N_per_day
             The amount of manure nitrogen entering the manure treatment and storage system (kg N/day).
 

--- a/RUFAS/routines/manure/manure_treatments/manure_treatment_configs.py
+++ b/RUFAS/routines/manure/manure_treatments/manure_treatment_configs.py
@@ -66,7 +66,7 @@ class ManureTreatmentConfig:
 
     manure_cover: str
         Indicates the presence or absence of a cover in the manure treatment or storage system.
-        When used in the case of a slurry storage system (underfloor or outdoors) the cover
+        When used in the case of a slurry storage system (underfloor or outdoors) the manure cover
         refers to the presence of a natural crust.
     """
 
@@ -105,7 +105,7 @@ class DefaultManureTreatmentConfigFactory:
         phosphorus_removal_efficiency_for_treatment=0.05,  # # Between 5-30%
         potassium_removal_efficiency_for_treatment=0.05,  # # Between 5-30%
         storage_time_period=120,
-        manure_cover=ManureCoverEnum.NO_COVER.value,
+        manure_cover=ManureCoverEnum.CRUST.value,
     )
 
     SLURRY_STORAGE_OUTDOOR_CONFIG = ManureTreatmentConfig(
@@ -117,7 +117,7 @@ class DefaultManureTreatmentConfigFactory:
         potassium_removal_efficiency_for_treatment=0.05,  # # Between 5-30%
         storage_time_period=120,
         freeboard_input=0.3048,
-        manure_cover=ManureCoverEnum.NO_COVER.value,
+        manure_cover=ManureCoverEnum.CRUST.value,
     )
 
     ANAEROBIC_DIGESTION_CONFIG = ManureTreatmentConfig(

--- a/RUFAS/routines/manure/manure_treatments/slurry_storage_outdoor.py
+++ b/RUFAS/routines/manure/manure_treatments/slurry_storage_outdoor.py
@@ -175,8 +175,11 @@ class SlurryStorageOutdoor(BaseManureTreatment):
 
         """
         if self._current_pen is not None and self._current_pen.num_animals is not None:
-            return (self._get_current_day_rainfall() * self._current_pen.num_animals
-                    * GasEmissionConstants.DEFAULT_STORAGE_AREA_PER_ANIMAL)
+            return (
+                self._get_current_day_rainfall()
+                * self._current_pen.num_animals
+                * GasEmissionConstants.DEFAULT_STORAGE_AREA_PER_ANIMAL
+            )
         else:
             return 0
 

--- a/RUFAS/routines/manure/manure_treatments/slurry_storage_outdoor.py
+++ b/RUFAS/routines/manure/manure_treatments/slurry_storage_outdoor.py
@@ -4,6 +4,7 @@ from typing import Tuple
 
 import math
 
+from RUFAS.routines.manure.enums.ManureCoverEnum import ManureCoverEnum
 from RUFAS.routines.manure.constants_and_units.gas_emission_constants import GasEmissionConstants
 from RUFAS.routines.manure.constants_and_units.manure_constants import ManureConstants
 from RUFAS.routines.manure.gas_emissions.calculator import (
@@ -69,7 +70,10 @@ class SlurryStorageOutdoor(BaseManureTreatment):
             The minimum treatment volume, m^3.
 
         """
-        return self.wastewater_volume * self.storage_time_period
+        if isinstance(self.storage_time_period, int):
+            return self.wastewater_volume * self.storage_time_period
+        else:
+            return 0.0
 
     @property
     def total_pit_volume(self) -> float:
@@ -182,6 +186,26 @@ class SlurryStorageOutdoor(BaseManureTreatment):
         """
         return self.freeboard_input * self.pit_surface_area
 
+    def _adjust_final_manure_volume(self, current_day_final_manure_volume: float) -> float:
+        """
+        Adjust the final manure volume to account for the precipitation and the storage time period.
+
+        Parameters
+        ----------
+        current_day_final_manure_volume : float
+            The final manure volume for the current simulation day (:math:`m^3`).
+
+        Returns
+        -------
+        float
+            The adjusted final manure volume.
+
+        """
+        if self.config.manure_cover == ManureCoverEnum.NO_COVER.value:
+            return current_day_final_manure_volume + self.precipitation_volume
+        else:
+            return current_day_final_manure_volume
+
     def calc_methane_emission(
         self,
         accumulated_liquid_manure_total_volatile_solids: float,
@@ -269,6 +293,9 @@ class SlurryStorageOutdoor(BaseManureTreatment):
         """
         daily_input = self._current_manure_treatment_daily_input
         daily_output = self._initialize_daily_output_during_update(daily_input)
+        adjusted_daily_final_manure_volume = self._adjust_final_manure_volume(daily_output.daily_final_manure_volume)
+        daily_output.set_daily_final_manure_volume(adjusted_daily_final_manure_volume)
+
         self._adjust_accumulated_output(daily_output)
 
         # fmt: off

--- a/RUFAS/routines/manure/manure_treatments/slurry_storage_outdoor.py
+++ b/RUFAS/routines/manure/manure_treatments/slurry_storage_outdoor.py
@@ -208,7 +208,7 @@ class SlurryStorageOutdoor(BaseManureTreatment):
             The adjusted final manure volume.
 
         """
-        if self.config.manure_cover == ManureCoverEnum.NO_COVER.value:
+        if self.config.manure_cover in [ManureCoverEnum.NO_COVER.value, ManureCoverEnum.CRUST.value]:
             return current_day_final_manure_volume + self.precipitation_volume
         else:
             return current_day_final_manure_volume

--- a/RUFAS/routines/manure/manure_treatments/slurry_storage_outdoor.py
+++ b/RUFAS/routines/manure/manure_treatments/slurry_storage_outdoor.py
@@ -146,11 +146,20 @@ class SlurryStorageOutdoor(BaseManureTreatment):
     def pit_surface_area(self) -> float:
         """Calculate the surface area of the pit.
 
+        The surface area is calculated as the product of the number of animals in the pen
+        and the DEFAULT_STORAGE_AREA_PER_ANIMAL constant.
+
         Returns:
             The surface area of the pit, m^2.
 
         """
-        return self.pit_width * self.pit_length
+        if self._current_pen is not None and self._current_pen.num_animals is not None:
+            return (
+                self._current_pen.num_animals
+                * GasEmissionConstants.DEFAULT_STORAGE_AREA_PER_ANIMAL
+            )
+        else:
+            return 0
 
     @property
     def pit_volume(self) -> float:
@@ -174,14 +183,7 @@ class SlurryStorageOutdoor(BaseManureTreatment):
             The additional pit volume needed for precipitation, m^3.
 
         """
-        if self._current_pen is not None and self._current_pen.num_animals is not None:
-            return (
-                self._get_current_day_rainfall()
-                * self._current_pen.num_animals
-                * GasEmissionConstants.DEFAULT_STORAGE_AREA_PER_ANIMAL
-            )
-        else:
-            return 0
+        return self._get_current_day_rainfall() * self.pit_surface_area
 
     @property
     def freeboard_volume(self):

--- a/RUFAS/routines/manure/manure_treatments/slurry_storage_outdoor.py
+++ b/RUFAS/routines/manure/manure_treatments/slurry_storage_outdoor.py
@@ -154,10 +154,7 @@ class SlurryStorageOutdoor(BaseManureTreatment):
 
         """
         if self._current_pen is not None and self._current_pen.num_animals is not None:
-            return (
-                self._current_pen.num_animals
-                * GasEmissionConstants.DEFAULT_STORAGE_AREA_PER_ANIMAL
-            )
+            return self._current_pen.num_animals * GasEmissionConstants.DEFAULT_STORAGE_AREA_PER_ANIMAL
         else:
             return 0
 

--- a/RUFAS/routines/manure/manure_treatments/slurry_storage_outdoor.py
+++ b/RUFAS/routines/manure/manure_treatments/slurry_storage_outdoor.py
@@ -251,7 +251,7 @@ class SlurryStorageOutdoor(BaseManureTreatment):
         num_animals: int,
         accumulated_manure_volume: float,
         accumulated_manure_total_ammoniacal_nitrogen: float,
-    ) -> Tuple[float, float]:
+    ) -> float:
         """Calculates the ammonia emission from the outdoor slurry storage treatment system.
 
         Parameters
@@ -267,9 +267,8 @@ class SlurryStorageOutdoor(BaseManureTreatment):
 
         Returns
         -------
-        Tuple[float, float]
-            A tuple of the ammonia emission from the outdoor slurry storage in kg and the accumulated total ammoniacal
-            nitrogen in the treatment system after the ammonia emission is calculated, kg.
+        float
+            The ammonia emission from the outdoor slurry storage in kg.
 
         """
         ammonia_loss = GasEmissionsCalculator.storage_ammonia_emission(
@@ -292,7 +291,8 @@ class SlurryStorageOutdoor(BaseManureTreatment):
 
         """
         daily_input = self._current_manure_treatment_daily_input
-        daily_output = self._initialize_daily_output_during_update(daily_input)
+        if daily_input:
+            daily_output = self._initialize_daily_output_during_update(daily_input)
         adjusted_daily_final_manure_volume = self._adjust_final_manure_volume(daily_output.daily_final_manure_volume)
         daily_output.set_daily_final_manure_volume(adjusted_daily_final_manure_volume)
 

--- a/RUFAS/routines/manure/manure_treatments/slurry_storage_outdoor.py
+++ b/RUFAS/routines/manure/manure_treatments/slurry_storage_outdoor.py
@@ -174,7 +174,11 @@ class SlurryStorageOutdoor(BaseManureTreatment):
             The additional pit volume needed for precipitation, m^3.
 
         """
-        return self._get_current_day_rainfall() * self.pit_surface_area
+        if self._current_pen is not None and self._current_pen.num_animals is not None:
+            return (self._get_current_day_rainfall() * self._current_pen.num_animals
+                    * GasEmissionConstants.DEFAULT_STORAGE_AREA_PER_ANIMAL)
+        else:
+            return 0
 
     @property
     def freeboard_volume(self):

--- a/input/data/manure/manure_management.json
+++ b/input/data/manure/manure_management.json
@@ -266,7 +266,7 @@
       "potassium_removal_efficiency_for_treatment": 0.00,
       "storage_time_period": 120,
       "freeboard_input": 0.3048,
-      "manure_cover": "cover"
+      "manure_cover": "no cover"
     },
     {
       "manure_treatment_type": "anaerobic lagoon",

--- a/input/data/manure/manure_management.json
+++ b/input/data/manure/manure_management.json
@@ -254,7 +254,7 @@
       "phosphorus_removal_efficiency_for_treatment": 0.0,
       "potassium_removal_efficiency_for_treatment": 0.0,
       "storage_time_period": 120,
-      "manure_cover": "cover"
+      "manure_cover": "crust"
     },
     {
       "manure_treatment_type": "slurry storage outdoor",
@@ -266,7 +266,7 @@
       "potassium_removal_efficiency_for_treatment": 0.00,
       "storage_time_period": 120,
       "freeboard_input": 0.3048,
-      "manure_cover": "cover"
+      "manure_cover": "crust"
     },
     {
       "manure_treatment_type": "anaerobic lagoon",

--- a/input/data/manure/manure_management.json
+++ b/input/data/manure/manure_management.json
@@ -266,7 +266,7 @@
       "potassium_removal_efficiency_for_treatment": 0.00,
       "storage_time_period": 120,
       "freeboard_input": 0.3048,
-      "manure_cover": "no cover"
+      "manure_cover": "cover"
     },
     {
       "manure_treatment_type": "anaerobic lagoon",

--- a/input/metadata/properties/default.json
+++ b/input/metadata/properties/default.json
@@ -4538,8 +4538,8 @@
         },
         "manure_cover": {
           "type": "string",
-          "description": "Indicates the presence or absence of a cover in the manure treatment or storage system. When used in the case of a slurry storage system (underfloor or outdoors) the cover refers to the presence of a natural crust. For the anaerobic diesgtion treatment, this property should be set to N/A.",
-          "pattern": "(cover|no cover|N/A)",
+          "description": "Indicates the presence or absence of a cover in the manure treatment or storage system. A cover referes to a human made cover where as a crust is naturally formed. For the anaerobic diesgtion treatment, this property should be set to N/A.",
+          "pattern": "(cover|crust|no cover|N/A)",
           "default": "no cover"
         },
         "hydraulic_retention_time": {

--- a/tests/test_manure_module/enums/test_manure_cover_enum.py
+++ b/tests/test_manure_module/enums/test_manure_cover_enum.py
@@ -8,9 +8,11 @@ def test_manure_cover_enum() -> None:
 
     # Assert
     assert ManureCoverEnum.COVER.value == "cover"
+    assert ManureCoverEnum.CRUST.value == "crust"
     assert ManureCoverEnum.NO_COVER.value == "no cover"
     assert ManureCoverEnum.NOT_APPLICABLE.value == "N/A"
 
     assert ManureCoverEnum.COVER == ManureCoverEnum("cover")
+    assert ManureCoverEnum.CRUST == ManureCoverEnum("crust")
     assert ManureCoverEnum.NO_COVER == ManureCoverEnum("no cover")
     assert ManureCoverEnum.NOT_APPLICABLE == ManureCoverEnum("N/A")

--- a/tests/test_manure_module/test_manure_manager_constants.py
+++ b/tests/test_manure_module/test_manure_manager_constants.py
@@ -91,16 +91,25 @@ def test_gas_emission_constants() -> None:
     ][ManureCoverEnum.COVER.value] == approx(0.005)
     assert GasEmissionConstants.NITROUS_OXIDE_EMISSION_FACTOR_KG_NITROUS_OXIDE_N_PER_KG_MANURE_N[
         ManureTreatmentType.SLURRY_STORAGE_OUTDOOR
+    ][ManureCoverEnum.CRUST.value] == approx(0.005)
+    assert GasEmissionConstants.NITROUS_OXIDE_EMISSION_FACTOR_KG_NITROUS_OXIDE_N_PER_KG_MANURE_N[
+        ManureTreatmentType.SLURRY_STORAGE_OUTDOOR
     ][ManureCoverEnum.NO_COVER.value] == approx(0.0)
     assert GasEmissionConstants.NITROUS_OXIDE_EMISSION_FACTOR_KG_NITROUS_OXIDE_N_PER_KG_MANURE_N[
         ManureTreatmentType.SLURRY_STORAGE_UNDERFLOOR
     ][ManureCoverEnum.COVER.value] == approx(0.005)
+    assert GasEmissionConstants.NITROUS_OXIDE_EMISSION_FACTOR_KG_NITROUS_OXIDE_N_PER_KG_MANURE_N[
+        ManureTreatmentType.SLURRY_STORAGE_UNDERFLOOR
+    ][ManureCoverEnum.CRUST.value] == approx(0.005)
     assert GasEmissionConstants.NITROUS_OXIDE_EMISSION_FACTOR_KG_NITROUS_OXIDE_N_PER_KG_MANURE_N[
         ManureTreatmentType.SLURRY_STORAGE_UNDERFLOOR
     ][ManureCoverEnum.NO_COVER.value] == approx(0.0)
     assert GasEmissionConstants.NITROUS_OXIDE_EMISSION_FACTOR_KG_NITROUS_OXIDE_N_PER_KG_MANURE_N[
         ManureTreatmentType.ANAEROBIC_LAGOON
     ][ManureCoverEnum.COVER.value] == approx(0.005)
+    assert GasEmissionConstants.NITROUS_OXIDE_EMISSION_FACTOR_KG_NITROUS_OXIDE_N_PER_KG_MANURE_N[
+        ManureTreatmentType.ANAEROBIC_LAGOON
+    ][ManureCoverEnum.CRUST.value] == approx(0.005)
     assert GasEmissionConstants.NITROUS_OXIDE_EMISSION_FACTOR_KG_NITROUS_OXIDE_N_PER_KG_MANURE_N[
         ManureTreatmentType.ANAEROBIC_LAGOON
     ][ManureCoverEnum.NO_COVER.value] == approx(0.0)

--- a/tests/test_manure_module/test_manure_treatments.py
+++ b/tests/test_manure_module/test_manure_treatments.py
@@ -1623,7 +1623,7 @@ def test_slurry_storage_outdoor_pit_volume(mocker: MockFixture) -> None:
         (MagicMock(num_animals=100), 100, 1000.0 * GasEmissionConstants.DEFAULT_STORAGE_AREA_PER_ANIMAL),
         (None, None, 0),
         (MagicMock(num_animals=None), None, 0),
-    ]
+    ],
 )
 def test_slurry_storage_outdoor_precipitation_volume(mocker, current_pen, num_animals, expected_volume):
     """Unit test for precipitation_volume() in slurry_storage_outdoor.py, with different pen and animal scenarios."""
@@ -1636,7 +1636,7 @@ def test_slurry_storage_outdoor_precipitation_volume(mocker, current_pen, num_an
     rainfall = 10.0
     mocker.patch(
         "RUFAS.routines.manure.manure_treatments.slurry_storage_outdoor.SlurryStorageOutdoor._get_current_day_rainfall",
-        return_value=rainfall
+        return_value=rainfall,
     )
     slurry_storage_outdoor._current_pen = current_pen
 

--- a/tests/test_manure_module/test_manure_treatments.py
+++ b/tests/test_manure_module/test_manure_treatments.py
@@ -1884,9 +1884,11 @@ def test_anaerobic_lagoon_daily_update_helper(mocker: MockFixture) -> None:
     [
         (1, 100, AnaerobicLagoon, "cover"),
         (100, 100, AnaerobicLagoon, "no cover"),
+        (100, 100, AnaerobicLagoon, "crust"),
         (101, 100, AnaerobicLagoon, "cover"),
         (1, 100, SlurryStorageOutdoor, "cover"),
         (100, 100, SlurryStorageOutdoor, "no cover"),
+        (100, 100, SlurryStorageOutdoor, "crust"),
         (101, 100, SlurryStorageOutdoor, "cover"),
     ],
 )
@@ -1928,7 +1930,7 @@ def test_adjust_final_manure_volume(
     actual_adjusted_final_manure_volume = treatment._adjust_final_manure_volume(current_day_final_manure_volume)
 
     # Assert
-    if manure_cover == "no cover":
+    if manure_cover == "no cover" or manure_cover == "crust":
         patch_for_precipitation_volume_property.assert_called_once()
     else:
         patch_for_precipitation_volume_property.assert_not_called()
@@ -1936,7 +1938,7 @@ def test_adjust_final_manure_volume(
         expected_adjusted_final_manure_volume = current_day_final_manure_volume + precipitation_volume
         assert actual_adjusted_final_manure_volume == expected_adjusted_final_manure_volume
     else:
-        if manure_cover == "no cover":
+        if manure_cover == "no cover" or manure_cover == "crust":
             patch_for_precipitation_volume_property.assert_called_once()
             assert actual_adjusted_final_manure_volume == current_day_final_manure_volume + precipitation_volume
         else:

--- a/tests/test_manure_module/test_manure_treatments.py
+++ b/tests/test_manure_module/test_manure_treatments.py
@@ -1877,49 +1877,64 @@ def test_anaerobic_lagoon_daily_update_helper(mocker: MockFixture) -> None:
 
 
 @pytest.mark.parametrize(
-    "simulation_day, storage_time_period",
+    "simulation_day, storage_time_period, manure_treatment, manure_cover",
     [
-        (1, 100),
-        (100, 100),
-        (101, 100),
+        (1, 100, AnaerobicLagoon, "cover"),
+        (100, 100, AnaerobicLagoon, "no cover"),
+        (101, 100, AnaerobicLagoon, "cover"),
+        (1, 100, SlurryStorageOutdoor, "cover"),
+        (100, 100, SlurryStorageOutdoor, "no cover"),
+        (101, 100, SlurryStorageOutdoor, "cover"),
     ],
 )
-def test_adjust_final_manure_volume(simulation_day: int, storage_time_period: int, mocker: MockFixture) -> None:
+def test_adjust_final_manure_volume(simulation_day: int, storage_time_period: int,
+                                    manure_treatment: Type[AnaerobicLagoon | SlurryStorageOutdoor], manure_cover: str,
+                                    mocker: MockFixture) -> None:
     """Unit test for _adjust_final_manure_volume() in anaerobic_lagoon.py."""
     # Arrange
-    anaerobic_lagoon = AnaerobicLagoon(
+    manure_treatment_config = mocker.MagicMock()
+    manure_treatment_config.__setattr__("manure_cover", manure_cover)
+    treatment = manure_treatment(
         weather=mocker.MagicMock(),
         time=mocker.MagicMock(),
-        manure_treatment_config=mocker.MagicMock(),
+        manure_treatment_config=manure_treatment_config,
     )
-    anaerobic_lagoon._sim_day = simulation_day
-    anaerobic_lagoon.storage_time_period = storage_time_period
+    treatment._sim_day = simulation_day
+    treatment.storage_time_period = storage_time_period
     current_day_final_manure_volume = 10.0
     precipitation_volume = 20.0
-    patch_for_precipitation_volume_property = mocker.patch(
-        "RUFAS.routines.manure.manure_treatments.anaerobic_lagoon." "AnaerobicLagoon.precipitation_volume",
-        new_callable=PropertyMock,
-        return_value=precipitation_volume,
-    )
-    flushing_volume = 30.0
-    patch_for_flushing_volume_property = mocker.patch(
-        "RUFAS.routines.manure.manure_treatments.anaerobic_lagoon." "AnaerobicLagoon.flushing_volume",
-        new_callable=PropertyMock,
-        return_value=flushing_volume,
-    )
+    if manure_treatment == AnaerobicLagoon:
+        patch_for_precipitation_volume_property = mocker.patch(
+            "RUFAS.routines.manure.manure_treatments.anaerobic_lagoon." "AnaerobicLagoon.precipitation_volume",
+            new_callable=PropertyMock,
+            return_value=precipitation_volume,
+        )
+    else:
+        patch_for_precipitation_volume_property = mocker.patch(
+            "RUFAS.routines.manure.manure_treatments.slurry_storage_outdoor."
+            "SlurryStorageOutdoor.precipitation_volume",
+            new_callable=PropertyMock,
+            return_value=precipitation_volume,
+        )
 
     # Act
-    actual_adjusted_final_manure_volume = anaerobic_lagoon._adjust_final_manure_volume(current_day_final_manure_volume)
+    actual_adjusted_final_manure_volume = treatment._adjust_final_manure_volume(current_day_final_manure_volume)
 
     # Assert
-    patch_for_precipitation_volume_property.assert_called_once()
+    if manure_cover == "no cover":
+        patch_for_precipitation_volume_property.assert_called_once()
+    else:
+        patch_for_precipitation_volume_property.assert_not_called()
     if simulation_day % storage_time_period > 1:
-        patch_for_flushing_volume_property.assert_called_once()
-        expected_adjusted_final_manure_volume = current_day_final_manure_volume + precipitation_volume - flushing_volume
+        expected_adjusted_final_manure_volume = current_day_final_manure_volume + precipitation_volume
         assert actual_adjusted_final_manure_volume == expected_adjusted_final_manure_volume
     else:
-        patch_for_flushing_volume_property.assert_not_called()
-        assert actual_adjusted_final_manure_volume == current_day_final_manure_volume + precipitation_volume
+        if manure_cover == "no cover":
+            patch_for_precipitation_volume_property.assert_called_once()
+            assert actual_adjusted_final_manure_volume == current_day_final_manure_volume + precipitation_volume
+        else:
+            patch_for_precipitation_volume_property.assert_not_called()
+            assert actual_adjusted_final_manure_volume == current_day_final_manure_volume
 
 
 def test_sludge_accumulation_volume_property(mocker: MockFixture) -> None:

--- a/tests/test_manure_module/test_manure_treatments.py
+++ b/tests/test_manure_module/test_manure_treatments.py
@@ -1887,9 +1887,13 @@ def test_anaerobic_lagoon_daily_update_helper(mocker: MockFixture) -> None:
         (101, 100, SlurryStorageOutdoor, "cover"),
     ],
 )
-def test_adjust_final_manure_volume(simulation_day: int, storage_time_period: int,
-                                    manure_treatment: Type[AnaerobicLagoon | SlurryStorageOutdoor], manure_cover: str,
-                                    mocker: MockFixture) -> None:
+def test_adjust_final_manure_volume(
+    simulation_day: int,
+    storage_time_period: int,
+    manure_treatment: Type[AnaerobicLagoon | SlurryStorageOutdoor],
+    manure_cover: str,
+    mocker: MockFixture,
+) -> None:
     """Unit test for _adjust_final_manure_volume() in anaerobic_lagoon.py."""
     # Arrange
     manure_treatment_config = mocker.MagicMock()

--- a/tests/test_manure_module/test_manure_treatments.py
+++ b/tests/test_manure_module/test_manure_treatments.py
@@ -1,6 +1,6 @@
 import dataclasses
 import math
-from typing import Type, Tuple
+from typing import Any, Type, Tuple
 
 from mock import MagicMock
 import pytest
@@ -1312,8 +1312,15 @@ def test_slurry_storage_outdoor_wastewater_volume(mocker: MockFixture) -> None:
     assert actual_wastewater_volume == 0.0
 
 
-def test_slurry_storage_outdoor_treatment_volume(mocker: MockFixture) -> None:
-    """Unit test for _treatment_volume() in slurry_storage_outdoor.py."""
+@pytest.mark.parametrize("storage_time_period, expected_treatment_volume", [
+    (120, 100.0 * 120),
+    (None, 0.0),
+    (120.5, 0.0),
+    ("one hundred twenty", 0.0)
+])
+def test_slurry_storage_outdoor_treatment_volume(mocker: MockFixture, storage_time_period: Any,
+                                                 expected_treatment_volume: float) -> None:
+    """Unit test for treatment_volume property in slurry_storage_outdoor.py."""
     # Arrange
     slurry_storage_outdoor = SlurryStorageOutdoor(
         weather=mocker.MagicMock(),
@@ -1326,14 +1333,15 @@ def test_slurry_storage_outdoor_treatment_volume(mocker: MockFixture) -> None:
         new_callable=PropertyMock,
         return_value=wastewater_volume,
     )
-    slurry_storage_outdoor.storage_time_period = storage_time_period = 120
+    slurry_storage_outdoor.storage_time_period = storage_time_period
 
     # Act
     actual_treatment_volume = slurry_storage_outdoor.treatment_volume
 
     # Assert
-    assert actual_treatment_volume == wastewater_volume * storage_time_period
-    patch_for_wastewater_volume.assert_called_once()
+    assert actual_treatment_volume == expected_treatment_volume
+    if isinstance(storage_time_period, int):
+        patch_for_wastewater_volume.assert_called_once()
 
 
 def test_slurry_storage_outdoor_total_pit_volume(mocker: MockFixture) -> None:
@@ -1545,27 +1553,20 @@ def test_slurry_storage_outdoor_pit_surface_area(mocker: MockFixture) -> None:
         time=mocker.MagicMock(),
         manure_treatment_config=mocker.MagicMock(),
     )
-    pit_width = 10.0
-    patch_for_pit_width = mocker.patch(
-        "RUFAS.routines.manure.manure_treatments.slurry_storage_outdoor.SlurryStorageOutdoor.pit_width",
-        new_callable=PropertyMock,
-        return_value=pit_width,
-    )
-    pit_length = 30.0
-    patch_for_pit_length = mocker.patch(
-        "RUFAS.routines.manure.manure_treatments.slurry_storage_outdoor.SlurryStorageOutdoor.pit_length",
-        new_callable=PropertyMock,
-        return_value=pit_length,
-    )
-    expected_pit_surface_area = pit_width * pit_length
+
+    current_pen = mocker.MagicMock(num_animals=100)
+    mocker.patch.object(slurry_storage_outdoor, '_current_pen',
+                        new_callable=mocker.PropertyMock, return_value=current_pen)
+
+    expected_area_per_animal = GasEmissionConstants.DEFAULT_STORAGE_AREA_PER_ANIMAL
+    expected_pit_surface_area = 100 * expected_area_per_animal
 
     # Act
+    slurry_storage_outdoor._current_pen.num_animals = 100
     actual_pit_surface_area = slurry_storage_outdoor.pit_surface_area
 
     # Assert
     assert actual_pit_surface_area == expected_pit_surface_area
-    patch_for_pit_width.assert_called_once()
-    patch_for_pit_length.assert_called_once()
 
 
 def test_slurry_storage_outdoor_pit_volume(mocker: MockFixture) -> None:
@@ -1965,7 +1966,11 @@ def test_sludge_accumulation_volume_property(mocker: MockFixture) -> None:
     assert actual_sludge_accumulation_volume == expected_sludge_accumulation_volume
 
 
-def test_flushing_volume_property(mocker: MockFixture) -> None:
+@pytest.mark.parametrize("daily_output, expected_flushing_volume", [
+    (MagicMock(cleaning_water_volume=10.0), 10.0),
+    (None, 0.0)
+])
+def test_flushing_volume_property(mocker: MockFixture, daily_output, expected_flushing_volume: float) -> None:
     """Unit test for flushing_volume property in anaerobic_lagoon.py."""
     # Arrange
     anaerobic_lagoon = AnaerobicLagoon(
@@ -1973,9 +1978,7 @@ def test_flushing_volume_property(mocker: MockFixture) -> None:
         time=mocker.MagicMock(),
         manure_treatment_config=mocker.MagicMock(),
     )
-    expected_flushing_volume = 10.0
-    anaerobic_lagoon._manure_handler_daily_output = mocker.MagicMock()
-    anaerobic_lagoon._manure_handler_daily_output.cleaning_water_volume = expected_flushing_volume
+    anaerobic_lagoon._manure_handler_daily_output = daily_output
 
     # Act
     actual_flushing_volume = anaerobic_lagoon.flushing_volume
@@ -2230,23 +2233,13 @@ def test_anaerobic_lagoon_length(mocker: MockFixture, lagoon_width: float) -> No
     assert actual_anaerobic_lagoon_length == approx(expected_anaerobic_lagoon_length)
 
 
-@pytest.mark.parametrize(
-    "lagoon_width, lagoon_length",
-    [
-        (5.0, 15.0),  # Generic case
-        (10.0, 30.0),  # Generic case
-        (15.0, 45.0),  # Generic case
-        (0.0, 0.0),  # Zero width and length
-        (10.0, 0.0),  # Zero length
-        (0.0, 30.0),  # Zero width
-    ],
-)
-def test_anaerobic_lagoon_surface_area(mocker: MockFixture, lagoon_width: float, lagoon_length: float) -> None:
+def test_anaerobic_lagoon_surface_area(mocker: MockFixture) -> None:
     """
     Unit test for lagoon_surface_area property in anaerobic_lagoon.py.
 
     This test checks that the method correctly calculates the surface area
-    of the lagoon based on the given width and length.
+    of the lagoon based on the number of animals and the DEFAULT_STORAGE_AREA_PER_ANIMAL
+    constant.
 
     """
     # Arrange
@@ -2255,25 +2248,19 @@ def test_anaerobic_lagoon_surface_area(mocker: MockFixture, lagoon_width: float,
         time=mocker.MagicMock(),
         manure_treatment_config=mocker.MagicMock(),
     )
-    patch_for_lagoon_width_property = mocker.patch(
-        "RUFAS.routines.manure.manure_treatments.anaerobic_lagoon." "AnaerobicLagoon.lagoon_width",
-        new_callable=PropertyMock,
-        return_value=lagoon_width,
-    )
-    patch_for_lagoon_length_property = mocker.patch(
-        "RUFAS.routines.manure.manure_treatments.anaerobic_lagoon." "AnaerobicLagoon.lagoon_length",
-        new_callable=PropertyMock,
-        return_value=lagoon_length,
-    )
-    expected_anaerobic_lagoon_surface_area = lagoon_width * lagoon_length
+    current_pen = mocker.MagicMock(num_animals=100)
+    mocker.patch.object(anaerobic_lagoon, '_current_pen',
+                        new_callable=mocker.PropertyMock, return_value=current_pen)
+
+    expected_area_per_animal = GasEmissionConstants.DEFAULT_STORAGE_AREA_PER_ANIMAL
+    expected_lagoon_surface_area = 100 * expected_area_per_animal
 
     # Act
-    actual_anaerobic_lagoon_surface_area = anaerobic_lagoon.lagoon_surface_area
+    anaerobic_lagoon._current_pen.num_animals = 100
+    actual_lagoon_surface_area = anaerobic_lagoon.lagoon_surface_area
 
     # Assert
-    patch_for_lagoon_width_property.assert_called_once()
-    patch_for_lagoon_length_property.assert_called_once()
-    assert actual_anaerobic_lagoon_surface_area == approx(expected_anaerobic_lagoon_surface_area)
+    assert actual_lagoon_surface_area == expected_lagoon_surface_area
 
 
 @pytest.mark.parametrize(

--- a/tests/test_manure_module/test_manure_treatments.py
+++ b/tests/test_manure_module/test_manure_treatments.py
@@ -2,6 +2,7 @@ import dataclasses
 import math
 from typing import Type, Tuple
 
+from mock import MagicMock
 import pytest
 from mock.mock import PropertyMock, call
 from pytest import approx
@@ -1616,8 +1617,16 @@ def test_slurry_storage_outdoor_pit_volume(mocker: MockFixture) -> None:
     assert patch_for_pit_slope.call_count == 2
 
 
-def test_slurry_storage_outdoor_precipitation_volume(mocker: MockFixture) -> None:
-    """Unit test for precipitation_volume() in slurry_storage_outdoor.py."""
+@pytest.mark.parametrize(
+    "current_pen, num_animals, expected_volume",
+    [
+        (MagicMock(num_animals=100), 100, 1000.0 * GasEmissionConstants.DEFAULT_STORAGE_AREA_PER_ANIMAL),
+        (None, None, 0),
+        (MagicMock(num_animals=None), None, 0),
+    ]
+)
+def test_slurry_storage_outdoor_precipitation_volume(mocker, current_pen, num_animals, expected_volume):
+    """Unit test for precipitation_volume() in slurry_storage_outdoor.py, with different pen and animal scenarios."""
     # Arrange
     slurry_storage_outdoor = SlurryStorageOutdoor(
         weather=mocker.MagicMock(),
@@ -1625,26 +1634,20 @@ def test_slurry_storage_outdoor_precipitation_volume(mocker: MockFixture) -> Non
         manure_treatment_config=mocker.MagicMock(),
     )
     rainfall = 10.0
-    patch_for_get_current_day_rainfall = mocker.patch(
-        "RUFAS.routines.manure.manure_treatments.slurry_storage_outdoor.SlurryStorageOutdoor"
-        "._get_current_day_rainfall",
-        return_value=rainfall,
+    mocker.patch(
+        "RUFAS.routines.manure.manure_treatments.slurry_storage_outdoor.SlurryStorageOutdoor._get_current_day_rainfall",
+        return_value=rainfall
     )
-    pit_surface_area = 300.0
-    patch_for_pit_surface_area = mocker.patch(
-        "RUFAS.routines.manure.manure_treatments.slurry_storage_outdoor.SlurryStorageOutdoor.pit_surface_area",
-        new_callable=PropertyMock,
-        return_value=pit_surface_area,
-    )
-    expected_precipitation_volume = rainfall * pit_surface_area
+    slurry_storage_outdoor._current_pen = current_pen
+
+    if current_pen is not None:
+        current_pen.num_animals = num_animals
 
     # Act
     actual_precipitation_volume = slurry_storage_outdoor.precipitation_volume
 
     # Assert
-    assert actual_precipitation_volume == expected_precipitation_volume
-    patch_for_get_current_day_rainfall.assert_called_once()
-    patch_for_pit_surface_area.assert_called_once()
+    assert actual_precipitation_volume == expected_volume
 
 
 def test_slurry_storage_outdoor_freeboard_volume(mocker: MockFixture) -> None:

--- a/tests/test_manure_module/test_manure_treatments.py
+++ b/tests/test_manure_module/test_manure_treatments.py
@@ -1312,14 +1312,13 @@ def test_slurry_storage_outdoor_wastewater_volume(mocker: MockFixture) -> None:
     assert actual_wastewater_volume == 0.0
 
 
-@pytest.mark.parametrize("storage_time_period, expected_treatment_volume", [
-    (120, 100.0 * 120),
-    (None, 0.0),
-    (120.5, 0.0),
-    ("one hundred twenty", 0.0)
-])
-def test_slurry_storage_outdoor_treatment_volume(mocker: MockFixture, storage_time_period: Any,
-                                                 expected_treatment_volume: float) -> None:
+@pytest.mark.parametrize(
+    "storage_time_period, expected_treatment_volume",
+    [(120, 100.0 * 120), (None, 0.0), (120.5, 0.0), ("one hundred twenty", 0.0)],
+)
+def test_slurry_storage_outdoor_treatment_volume(
+    mocker: MockFixture, storage_time_period: Any, expected_treatment_volume: float
+) -> None:
     """Unit test for treatment_volume property in slurry_storage_outdoor.py."""
     # Arrange
     slurry_storage_outdoor = SlurryStorageOutdoor(
@@ -1555,8 +1554,9 @@ def test_slurry_storage_outdoor_pit_surface_area(mocker: MockFixture) -> None:
     )
 
     current_pen = mocker.MagicMock(num_animals=100)
-    mocker.patch.object(slurry_storage_outdoor, '_current_pen',
-                        new_callable=mocker.PropertyMock, return_value=current_pen)
+    mocker.patch.object(
+        slurry_storage_outdoor, "_current_pen", new_callable=mocker.PropertyMock, return_value=current_pen
+    )
 
     expected_area_per_animal = GasEmissionConstants.DEFAULT_STORAGE_AREA_PER_ANIMAL
     expected_pit_surface_area = 100 * expected_area_per_animal
@@ -1966,10 +1966,9 @@ def test_sludge_accumulation_volume_property(mocker: MockFixture) -> None:
     assert actual_sludge_accumulation_volume == expected_sludge_accumulation_volume
 
 
-@pytest.mark.parametrize("daily_output, expected_flushing_volume", [
-    (MagicMock(cleaning_water_volume=10.0), 10.0),
-    (None, 0.0)
-])
+@pytest.mark.parametrize(
+    "daily_output, expected_flushing_volume", [(MagicMock(cleaning_water_volume=10.0), 10.0), (None, 0.0)]
+)
 def test_flushing_volume_property(mocker: MockFixture, daily_output, expected_flushing_volume: float) -> None:
     """Unit test for flushing_volume property in anaerobic_lagoon.py."""
     # Arrange
@@ -2249,8 +2248,7 @@ def test_anaerobic_lagoon_surface_area(mocker: MockFixture) -> None:
         manure_treatment_config=mocker.MagicMock(),
     )
     current_pen = mocker.MagicMock(num_animals=100)
-    mocker.patch.object(anaerobic_lagoon, '_current_pen',
-                        new_callable=mocker.PropertyMock, return_value=current_pen)
+    mocker.patch.object(anaerobic_lagoon, "_current_pen", new_callable=mocker.PropertyMock, return_value=current_pen)
 
     expected_area_per_animal = GasEmissionConstants.DEFAULT_STORAGE_AREA_PER_ANIMAL
     expected_lagoon_surface_area = 100 * expected_area_per_animal


### PR DESCRIPTION
Try to standardize how outdoor manure treatments account for precipitation when calculating `daily_final_manure_volume` and N2O emissions based on manure cover.

<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1422

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.

### What
<!-- Add more detail about the changes that are being made in the pull request. -->

- Updates `_adjust_final_manure_volume()` method in `AnaerobicLagoon` to account for whether there is a cover in the config.

- Adds `_adjust_final_manure_volume()` method to `SlurryStorageOutdoor` class and ensured it was also taking into account the cover status from the config.

- Adds `manure_cover` option for `crust` which follows the same behavior for handling precipitation for the outdoor treatments/storages as `no cover` and follows the same behavior for handling N2O emissions as `cover`.

Updates unit testing.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->

Because both `AnaerobicLagoon` and `SlurryStorageOutdoor` are outdoor manure storages, they need to take into account precipitation when calculating `daily_final_manure_volume` and they should do it in a similar fashion.

Adding the cover option now allows distinction between a naturally occurring manure crust cover and an impermeable human-made cover.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->

One thing to note in the how is that I opted not to add this method (`_adjust_final_manure_volume()`) to the `BaseManureTreatment` class despite it being shared by these 2 manure treatment child classes. It's not shared/used by any of the other manure treatment child classes so it seemed like more of a violation of the Interface Segregation Principle than adding it to the base class would be supporting the Open-Closed Principle.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->

Testing was updated to ensure coverage extended to the method's use in `SlurryStorageOutdoor` as well as maintaining accuracy of coverage for existing usage with `AnaerobicLagoon` for the new `crust` option.

Testing was added for the N2O calculation in `gas_emissions_constants.py`.