### PR TITLE
Fixed recording of phosphorus from surface soil layer

### DIFF
--- a/RUFAS/routines/field/soil/phosphorus_cycling/soluble_phosphorus.py
+++ b/RUFAS/routines/field/soil/phosphorus_cycling/soluble_phosphorus.py
@@ -76,8 +76,8 @@ class SolublePhosphorus:
                 self.data.soil_layers[0].layer_thickness,
             )
             self.data.soil_layers[0].labile_inorganic_phosphorus_content -= phosphorus_runoff
-            self.data.soil_phosphorus_runoff = phosphorus_runoff * field_size
-            self.data.annual_soil_phosphorus_runoff += phosphorus_runoff * field_size
+            self.data.soil_phosphorus_runoff = phosphorus_runoff
+            self.data.annual_soil_phosphorus_runoff += phosphorus_runoff
 
         for layer_index in range(len(self.data.soil_layers)):
             current_layer = self.data.soil_layers[layer_index]

--- a/tests/soil_crop_tests/soil_tests/phosphorus_cycling_tests/test_soluble_phosphorus.py
+++ b/tests/soil_crop_tests/soil_tests/phosphorus_cycling_tests/test_soluble_phosphorus.py
@@ -203,8 +203,8 @@ def test_daily_update_routine(runoff: float, field_size: float) -> None:
     if runoff > 0:
         incorp._determine_phosphorus_runoff_from_top_soil.assert_called_once_with(runoff, field_size, 3.4, 1.4, 20)
         assert incorp.data.soil_layers[0].labile_inorganic_phosphorus_content == (3.4 - 0.9 - 1.2)
-        assert incorp.data.annual_soil_phosphorus_runoff == (0.9 * field_size)
-        assert incorp.data.soil_phosphorus_runoff == (0.9 * field_size)
+        assert incorp.data.annual_soil_phosphorus_runoff == 0.9
+        assert incorp.data.soil_phosphorus_runoff == 0.9
     else:
         incorp._determine_phosphorus_runoff_from_top_soil.assert_not_called()
         assert incorp.data.soil_layers[0].labile_inorganic_phosphorus_content == 3.4 - 1.2


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Fixes the runoff phosphorus amount being recorded by the field size (converting kg/ha to kg when it should not have been). This change has been verified by checking both the docstrings (and equations) of the methods and variables that calculate and record phosphorus runoff.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1566 

- [ ] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
This change has been tested with the C1F2 pilot farm simulations, resulting in a massive decrease in the recorded amounts of phosphorus runoff. Also, unit tests have been corrected.