### PR TITLE
Quick fix for missing body weight history in ration driver

### DIFF
--- a/RUFAS/routines/animal/animal_module_reporter.py
+++ b/RUFAS/routines/animal/animal_module_reporter.py
@@ -69,7 +69,7 @@ class AnimalModuleReporter:
                 current_output_length = 0
             length_difference = len(list(om.variables_pool[reference_variable].values())[0]) - current_output_length
             if length_difference > 1:
-                short_variable_to_add = full_variable_to_add[full_variable_to_add.rfind(".") + 1 :]
+                short_variable_to_add = full_variable_to_add[full_variable_to_add.rfind(".") + 1:]
                 for _ in range(0, length_difference - 1):
                     om.add_variable(
                         short_variable_to_add,
@@ -238,7 +238,7 @@ class AnimalModuleReporter:
             AnimalModuleReporter.data_padder(
                 f"{classname}.{funcname}.ration_nutrient_amount_pen_0_CALF",
                 f"{classname}.{funcname}.ration_nutrient_amount_pen_{pen.id}_{pen.animal_combination.name}",
-                {},
+                {variable: 0 for variable in nutrient_amount.keys()},
                 simulation_day,
                 info_map,
                 nutrient_amount_units,
@@ -277,7 +277,7 @@ class AnimalModuleReporter:
             AnimalModuleReporter.data_padder(
                 f"{classname}.{funcname}.avg_rqmts_pen_0_CALF",
                 f"{classname}.{funcname}.avg_rqmts_pen_{pen.id}_{pen.animal_combination.name}",
-                {},
+                {variable: 0 for variable in pen.avg_nutrient_rqmts.keys()},
                 simulation_day,
                 info_map,
                 avg_nutrient_rqmts_units,
@@ -291,7 +291,7 @@ class AnimalModuleReporter:
             AnimalModuleReporter.data_padder(
                 f"{classname}.{funcname}.ration_per_animal_for_pen_0_CALF",
                 f"{classname}.{funcname}.ration_per_animal_for_pen_{pen.id}_{pen.animal_combination.name}",
-                {},
+                {variable: 0 for variable in ration_per_animal.keys()},
                 simulation_day,
                 info_map,
                 ration_per_animal_units,
@@ -373,7 +373,7 @@ class AnimalModuleReporter:
             AnimalModuleReporter.data_padder(
                 f"{classname}.{funcname}.ration_daily_feed_totals_for_pen_0_CALF",
                 f"{classname}.{funcname}.ration_daily_feed_totals_for_pen_{pen.id}_{pen.animal_combination.name}",
-                {},
+                {variable: 0 for variable in ration_total.keys()},
                 animal_manager.simulation_day,
                 info_map,
                 ration_total_units,
@@ -420,10 +420,10 @@ class AnimalModuleReporter:
         AnimalModuleReporter.data_padder(
             f"{classname}.{funcname}.pen_0_animal_CALF_feed_emissions",
             f"{classname}.{funcname}.pen_{pen_id}_animal_{pen_animal_name}_feed_emissions",
-            {},
+            {variable: 0 for variable in daily_feed_emissions.keys()},
             animal_manager.simulation_day,
             info_map,
-            MeasurementUnits.KILOGRAMS_CARBON_DIOXIDE_PER_KILOGRAM_DRY_MATTER.value,
+            {key: MeasurementUnits.KILOGRAMS_CARBON_DIOXIDE_PER_KILOGRAM_DRY_MATTER.value for key in daily_feed_emissions.keys()}
         )
         om.add_variable(
             f"pen_{pen_id}_animal_{pen_animal_name}_feed_emissions",
@@ -517,7 +517,7 @@ class AnimalModuleReporter:
             reference_variable = f"{classname}.{funcname}.pen_0_daily_{str(manure_property)}"
             variable_to_add = f"{classname}.{funcname}.pen_{pen.id}_daily_{str(manure_property)}"
             AnimalModuleReporter.data_padder(
-                reference_variable, variable_to_add, 0, simulation_day, info_map, manure_value_units
+                reference_variable, variable_to_add, 0, simulation_day, info_map, manure_value_units[manure_property]
             )
             om.add_variable(
                 f"pen_{pen.id}_daily_{str(manure_property)}",

--- a/RUFAS/routines/animal/animal_module_reporter.py
+++ b/RUFAS/routines/animal/animal_module_reporter.py
@@ -69,7 +69,7 @@ class AnimalModuleReporter:
                 current_output_length = 0
             length_difference = len(list(om.variables_pool[reference_variable].values())[0]) - current_output_length
             if length_difference > 1:
-                short_variable_to_add = full_variable_to_add[full_variable_to_add.rfind(".") + 1:]
+                short_variable_to_add = full_variable_to_add[full_variable_to_add.rfind(".") + 1 :]
                 for _ in range(0, length_difference - 1):
                     om.add_variable(
                         short_variable_to_add,
@@ -423,7 +423,10 @@ class AnimalModuleReporter:
             {variable: 0 for variable in daily_feed_emissions.keys()},
             animal_manager.simulation_day,
             info_map,
-            {key: MeasurementUnits.KILOGRAMS_CARBON_DIOXIDE_PER_KILOGRAM_DRY_MATTER.value for key in daily_feed_emissions.keys()}
+            {
+                key: MeasurementUnits.KILOGRAMS_CARBON_DIOXIDE_PER_KILOGRAM_DRY_MATTER.value
+                for key in daily_feed_emissions.keys()
+            },
         )
         om.add_variable(
             f"pen_{pen_id}_animal_{pen_animal_name}_feed_emissions",

--- a/RUFAS/routines/animal/ration/ration_driver.py
+++ b/RUFAS/routines/animal/ration/ration_driver.py
@@ -283,33 +283,36 @@ class RationManager:
             )
         fail_summary_units = {
             "simulation_day": MeasurementUnits.SIMULATION_DAY.value,
-            "reattempt number": MeasurementUnits.UNITLESS.value,
+            "reattempt_number": MeasurementUnits.UNITLESS.value,
             "constraints_failed_dict": MeasurementUnits.UNITLESS.value,
             "ration_attempted": MeasurementUnits.UNITLESS.value,
-            "pen requirements": {
-                "NEmaint_requirement": MeasurementUnits.MEGACALORIES.value,
-                "NEa_requirement": MeasurementUnits.MEGACALORIES.value,
-                "NEg_requirement": MeasurementUnits.MEGACALORIES.value,
-                "NEpreg_requirement": MeasurementUnits.MEGACALORIES.value,
-                "NEl_requirement": MeasurementUnits.MEGACALORIES.value,
-                "MP_requirement": MeasurementUnits.GRAMS.value,
-                "Ca_requirement": MeasurementUnits.GRAMS.value,
-                "P_req": MeasurementUnits.GRAMS.value,
-                "DMIest_requirement": MeasurementUnits.KILOGRAMS.value,
-                "avg_BW": MeasurementUnits.KILOGRAMS.value,
-                "avg_milk_production_reduction_pen": MeasurementUnits.KILOGRAMS.value,
-            },
+            "NEmaint_requirement": MeasurementUnits.MEGACALORIES.value,
+            "NEa_requirement": MeasurementUnits.MEGACALORIES.value,
+            "NEg_requirement": MeasurementUnits.MEGACALORIES.value,
+            "NEpreg_requirement": MeasurementUnits.MEGACALORIES.value,
+            "NEl_requirement": MeasurementUnits.MEGACALORIES.value,
+            "MP_requirement": MeasurementUnits.GRAMS.value,
+            "Ca_requirement": MeasurementUnits.GRAMS.value,
+            "P_req": MeasurementUnits.GRAMS.value,
+            "DMIest_requirement": MeasurementUnits.KILOGRAMS.value,
+            "avg_BW": MeasurementUnits.KILOGRAMS.value,
+            "avg_milk_production_reduction_pen": MeasurementUnits.KILOGRAMS.value,
         }
         if failed_constraints is not None:
             for constr in failed_constraints:
                 constraints_failed_list.append(constr["fun"].__name__)
             animal_list = list(pen.animals_in_pen.values())
+            if not animal_list or not animal_list[0].body_weight_history:
+                simulation_day = -1
+            else:
+                simulation_day = animal_list[0].body_weight_history[-1].simulation_day
+
             fail_summary = {
-                "simulation day": animal_list[0].body_weight_history[-1].simulation_day,
-                "reattempt number": num_reattempts,
+                "simulation_day": simulation_day,
+                "reattempt_number": num_reattempts,
                 "constraints_failed_dict": constraints_failed_list,
                 "ration_attempted": cls.make_ration_from_solution(available_feeds, solution),
-                "pen requirements": pen.avg_nutrient_rqmts,
+                **pen.avg_nutrient_rqmts,
             }
             om.add_variable(
                 f"failed_constraint_summary_for_pen_{pen.id}",


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1564 

- [ ] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.

### What
<!-- Add more detail about the changes that are being made in the pull request. -->


### Why
<!-- Discuss why the changes in this pull request are needed or important. -->


### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
- In `ration_driver`, when reporting failed constraints, if body weight history is missing, I set the simulation day to -1. I'm open to different alternatives. I also denested the `pen_requirements` key in the `fail_summary_units` by removing it.
- In `animal_module_reporter`, when padding data, there needs to be an exact mapping between the units and the values.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
