### PR TITLE
[Util] Expanding logic to handle nested Dicts and Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-4033%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-4004%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-4024%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-4033%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-4004%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-4003%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -256,7 +256,7 @@ class TaskManager:
                 names[variable_number]: data_types[variable_number](sampled_values[sample_number, variable_number])
                 for variable_number in range(variables_count)
             }
-            new_args["input_patch"] = Utility.convert_flat_dict_to_nested_dict(new_args["input_patch"])
+            new_args["input_patch"] = Utility.flatten_keys_to_nested_structure(new_args["input_patch"])
             single_run_args.append(new_args)
 
         return single_run_args

--- a/RUFAS/util.py
+++ b/RUFAS/util.py
@@ -37,30 +37,53 @@ class Utility:
         return result
 
     @staticmethod
-    def convert_flat_dict_to_nested_dict(flat_dict: Dict[str, Any]) -> Dict[str, Any]:
+    def flatten_keys_to_nested_structure(input_dict: Dict[str, Any]) -> Dict[str, Dict | List]:
         """
-        Convert a flat dictionary with dot-separated keys into a nested dictionary structure.
+        Convert a dictionary with flat, dot-separated keys into a nested structure composed of
+        dictionaries and lists based on the keys. Numeric segments in the keys indicate list indices,
+        while non-numeric segments indicate dictionary keys.
 
         Parameters
         ----------
-        flat_dict : Dict[str, Any]
-            A dictionary with string keys that include dots to signify nested levels.
+        input_dict : Dict[str, Any]
+            A dictionary where the keys are strings that may include dots to signify hierarchical
+            levels in the resulting nested structure. Numeric key segments result in list creations,
+            and non-numeric segments result in dictionary creations.
 
         Returns
         -------
-        Dict[str, Any]
-            A nested dictionary where the structure is determined by splitting the keys on dots.
+        Dict[str, Union[Dict, list]]
+            A nested structure of dictionaries and lists derived by interpreting the flat dictionary keys.
         """
-        nested_dict = {}
-        for flat_key, value in flat_dict.items():
+        nested_structure = {}
+        for flat_key, value in input_dict.items():
             keys = flat_key.split(".")
-            current = nested_dict
-            for key in keys[:-1]:
-                if key not in current:
-                    current[key] = {}
-                current = current[key]
-            current[keys[-1]] = value
-        return nested_dict
+            current = nested_structure
+            for i, key in enumerate(keys[:-1]):
+                next_key_is_digit = keys[i + 1].isdigit() if i + 1 < len(keys) else False
+
+                if key.isdigit():
+                    key = int(key)
+                    while len(current) <= key:
+                        current.append([] if next_key_is_digit else {})
+                    current = current[key]
+                else:
+                    if isinstance(current, list):
+                        current = current[-1]
+                    if key not in current:
+                        current[key] = [] if next_key_is_digit else {}
+                    current = current[key]
+
+            last_key = keys[-1]
+            if last_key.isdigit():
+                last_key = int(last_key)
+                while len(current) <= last_key:
+                    current.append(None)
+                current[last_key] = value
+            else:
+                current[last_key] = value
+
+        return nested_structure
 
     @staticmethod
     def deep_merge(dict1: Dict[str, Any], dict2: Dict[str, Any]) -> None:

--- a/RUFAS/util.py
+++ b/RUFAS/util.py
@@ -22,7 +22,7 @@ class Utility:
             A dictionary where keys are unique keys from input dictionaries,
             and values are lists of corresponding values from input dictionaries.
         """
-        result = {}
+        result: Dict[str, List[Any]] = {}
 
         for item in list_of_dicts:
             for key, value in item.items():

--- a/RUFAS/util.py
+++ b/RUFAS/util.py
@@ -1,12 +1,8 @@
 import datetime
-import json
 import re
 import shutil
-import sys
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Tuple, Optional
-
-from RUFAS import errors
 
 
 class Utility:
@@ -37,7 +33,7 @@ class Utility:
         return result
 
     @staticmethod
-    def flatten_keys_to_nested_structure(input_dict: Dict[str, Any]) -> Dict[str, Dict | List]:
+    def flatten_keys_to_nested_structure(input_dict: Dict[str, Any]) -> Dict[str, Any]:
         """
         Convert a dictionary with flat, dot-separated keys into a nested structure composed of
         dictionaries and lists based on the keys. Numeric segments in the keys indicate list indices,
@@ -55,10 +51,10 @@ class Utility:
         Dict[str, Union[Dict, list]]
             A nested structure of dictionaries and lists derived by interpreting the flat dictionary keys.
         """
-        nested_structure = {}
+        nested_structure: Dict[str, Any] = {}
         for flat_key, value in input_dict.items():
             keys = flat_key.split(".")
-            current = nested_structure
+            current: Dict[str, Any] | List[Any] = nested_structure
             for i, key in enumerate(keys[:-1]):
                 next_key_is_digit = keys[i + 1].isdigit() if i + 1 < len(keys) else False
 
@@ -120,78 +116,6 @@ class Utility:
                 target[key] = value
 
     @staticmethod
-    def get_base_dir():
-        """
-        Gets the base directory as reference for all relative paths.
-
-        Unfrozen application - gets the project directory
-        Frozen application - gets the executable directory
-
-        Returns
-        -------
-        Path: The reference directory for all paths in the program.
-
-        """
-
-        # Frozen
-        if getattr(sys, "frozen", False):
-            #
-            # Get the executable file path
-            # Resolve to absolute path
-            # Take the parent base_dir/RUFAS_exe
-            #                 parent = base_dir/
-
-            return Path(sys.executable).resolve().parent
-
-        # Unfrozen
-        else:
-            #
-            # Get path of current file (util.py)
-            # Resolve to absolute path
-            # Get the 2nd parent  base_dir/RUFAS/util.py
-            #                     parent[0] = base_dir/RUFAS
-            #                     parent[1] = base_dir/
-            return Path(__file__).resolve().parents[1]
-
-    @staticmethod
-    def read_json_file(file_path: Path) -> Dict[Any, Any]:
-        """
-        Description:
-            Reads and interprets the JSON file at the given path. Compiles the
-            information into dictionaries used to instantiate simulation objects.
-
-        Parameters
-        ----------
-        file_path (Path): Path to the input json file
-
-        Raises
-        ------
-        InvalidJSONFileError
-            If the json file at the given path does not conform with the format required.
-
-        Returns
-        -------
-        Dict[Any, Any]
-            The data read from the json file.
-
-        """
-
-        try:
-            if file_path.suffix == ".json":
-                if not file_path.is_file():
-                    raise errors.UserInput((str(file_path), "does not exist"))
-            else:
-                raise errors.UserInput((str(file_path), "is not a JSON file"))
-
-            with file_path.open("r") as f:
-                data = json.load(f)
-
-            return data
-
-        except errors.UserInput as e:
-            print(e.msg)
-
-    @staticmethod
     def calc_average(num_values: int, cur_avg: float, new_value: float) -> Tuple[int, float]:
         """
         Calculate the new average given the number of values,
@@ -215,15 +139,17 @@ class Utility:
         return new_num_values, new_avg
 
     @staticmethod
-    def remove_items_from_list_by_indices(arr: List, removed_idx: List[int]) -> None:
+    def remove_items_from_list_by_indices(data: List[Any], indices_to_remove: List[int]) -> None:
         """
         Remove items from a list given a list of indices.
         The operation is done in-place.
 
         Parameters
         ----------
-        arr: a list of items
-        removed_idx: a list that contains indices of the items to be removed
+        data: List[Any] a list of items
+            The list to remove items from
+        indices_to_remove : List[Any]
+            The list that contains indices of the items to be removed
 
         Returns
         -------
@@ -231,9 +157,10 @@ class Utility:
 
         """
 
-        # Safer to remove elements from the back
-        for idx in sorted(removed_idx, reverse=True):
-            del arr[idx]
+        # Sort and reverse the index list before removing items to make sure items are removed from the end of the list
+        # to prevent the shifting of indices from affecting later removals.
+        for idx in sorted(indices_to_remove, reverse=True):
+            del data[idx]
 
     @staticmethod
     def percent_calculator(denominator: float) -> Callable[[float], float]:
@@ -257,7 +184,7 @@ class Utility:
         return calc
 
     @classmethod
-    def make_serializable(cls, obj, max_depth=3):
+    def make_serializable(cls, obj: object, max_depth: int = 3) -> object:
         """Converts the given object into a serializable object.
 
         Parameters
@@ -455,6 +382,8 @@ class Utility:
         for month, day_count in enumerate(cumulative_days_in_months):
             if day <= day_count:
                 return month + 1
+
+        return -1
 
     @staticmethod
     def get_timestamp(include_millis: bool = False) -> str:

--- a/RUFAS/util.py
+++ b/RUFAS/util.py
@@ -86,25 +86,38 @@ class Utility:
         return nested_structure
 
     @staticmethod
-    def deep_merge(dict1: Dict[str, Any], dict2: Dict[str, Any]) -> None:
+    def deep_merge(target: Dict[Any, Any], updates: Dict[Any, Any]) -> None:
         """
-        Recursively merges dict2 into dict1 in place.
+        Recursively merges 'updates' into 'target'. Supports deep merging for dictionaries and lists, including lists
+        that contain dictionaries and dictionaries that contain lists.
 
         Parameters
         ----------
-        dict1 : Dict[str, Any]
+        target : Dict[Any, Any]
             The primary dictionary to be updated.
-        dict2 : Dict[str, Any]
-            The dictionary containing updates to be merged into dict1.
+        updates : Dict[Any, Any]
+            The dictionary containing updates to be merged into target.
         """
-        for key in dict2:
-            if key in dict1:
-                if isinstance(dict1[key], dict) and isinstance(dict2[key], dict):
-                    Utility.deep_merge(dict1[key], dict2[key])
+        for key, value in updates.items():
+            if key in target:
+                if isinstance(value, dict) and isinstance(target[key], dict):
+                    Utility.deep_merge(target[key], value)
+                elif isinstance(value, list) and isinstance(target[key], list):
+                    if len(target[key]) < len(value):
+                        target[key].extend([None] * (len(value) - len(target[key])))
+
+                    for i, item in enumerate(value):
+                        if i < len(target[key]):
+                            if isinstance(item, dict) and isinstance(target[key][i], dict):
+                                Utility.deep_merge(target[key][i], item)
+                            else:
+                                target[key][i] = item
+                        else:
+                            target[key].append(item)
                 else:
-                    dict1[key] = dict2[key]
+                    target[key] = value
             else:
-                dict1[key] = dict2[key]
+                target[key] = value
 
     @staticmethod
     def get_base_dir():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -251,18 +251,41 @@ def test_filter_dictionary(
     assert Utility.filter_dictionary(dict_to_be_filtered, filter_patterns, filter_by_exclusion) == expected_result
 
 
-def test_convert_flat_dict_to_nested_dict() -> None:
+def flatten_keys_to_nested_structure_nested_dict() -> None:
     x = {"a.i.c": 1, "a.i.d": 2, "a.j.c": 3, "a.j.d": 4, "b.i.c": 5, "b.i.d": 6, "b.j.c": 7, "b.j.d": 8}
-    actual = Utility.convert_flat_dict_to_nested_dict(x)
+    actual = Utility.flatten_keys_to_nested_structure(x)
     expected = {
         "a": {"i": {"c": 1, "d": 2}, "j": {"c": 3, "d": 4}},
         "b": {"i": {"c": 5, "d": 6}, "j": {"c": 7, "d": 8}},
     }
     assert actual == expected
 
+
+def flatten_keys_to_nested_structure_flat_dict() -> None:
     x = {"aic": 1, "aid": 2, "ajc": 3, "ajd": 4, "bic": 5, "bid": 6, "bjc": 7, "bjd": 8}
-    actual = Utility.convert_flat_dict_to_nested_dict(x)
+    actual = Utility.flatten_keys_to_nested_structure(x)
     assert actual == x
+
+
+def flatten_keys_to_nested_structure_dict_w_list() -> None:
+    x = {
+        "a.i.0": 1,
+        "a.i.1": 2,
+        "a.j.c": 3,
+        "a.j.d": 4,
+        "b.i.c": 5,
+        "b.i.d": 6,
+        "b.j.c": 7,
+        "b.j.d.0": 8,
+        "b.j.d.1": 9,
+        "b.j.d.2": 10,
+    }
+    actual = Utility.flatten_keys_to_nested_structure(x)
+    expected = {
+        "a": {"i": [1, 2], "j": {"c": 3, "d": 4}},
+        "b": {"i": {"c": 5, "d": 6}, "j": {"c": 7, "d": [8, 9, 10]}},
+    }
+    assert actual == expected
 
 
 def test_deep_merge() -> None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,63 +2,9 @@ import re
 from typing import Any, Dict, List
 import pytest
 from pytest import approx, raises
+from pytest_mock.plugin import MockerFixture
 
 from RUFAS.util import Utility
-
-
-def test_query():
-    """Unit test for function query in file util.py"""
-    pass
-
-
-def test_get_base_dir():
-    """Unit test for function get_base_dir in file util.py"""
-    pass
-
-
-def test_read_json_file():
-    """Unit test for function read_json_file in file util.py"""
-    pass
-
-
-def test_LP_solve():
-    """Unit test for function LP_solve in file util.py"""
-    pass
-
-
-def test_create_LP_problem():
-    """Unit test for function create_LP_problem in file util.py"""
-    pass
-
-
-def test_is_correct_structure():
-    """Unit test for function is_correct_structure in file util.py"""
-    pass
-
-
-def test_generate_LP_vars():
-    """Unit test for function generate_LP_vars in file util.py"""
-    pass
-
-
-def test_add_LP_constraints():
-    """Unit test for function add_LP_constraints in file util.py"""
-    pass
-
-
-def test_solve_with_fastest_solver():
-    """Unit test for function solve_with_fastest_solver in file util.py"""
-    pass
-
-
-def test_organize_results():
-    """Unit test for function organize_results in file util.py"""
-    pass
-
-
-def test_LP_print():
-    """Unit test for function LP_print in file util.py"""
-    pass
 
 
 def test_calc_average() -> None:
@@ -325,3 +271,63 @@ def test_deep_merge_dict_w_list() -> None:
     }
     Utility.deep_merge(a, b)
     assert a == expected
+
+
+class DummyClass:
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+
+class DummyNestedClass:
+    def __init__(self, value: int) -> None:
+        self.value = DummyClass(value)
+
+
+@pytest.mark.parametrize(
+    "input_obj, depth, max_depth, expected_output",
+    [
+        (42, 0, 1, 42),
+        (3.14, 0, 1, 3.14),
+        ("test", 0, 1, "test"),
+        (True, 0, 1, True),
+        (False, 0, 1, False),
+        (None, 0, 1, None),
+        ([], 0, 1, []),
+        ((), 0, 1, ()),
+        ({}, 0, 1, {}),
+        (set(), 0, 1, []),
+        ([1, "test", True], 0, 1, [1, "test", True]),
+        ((1, "test", True), 0, 1, (1, "test", True)),
+        ({1, 2, 3}, 0, 1, [1, 2, 3]),
+        ({"a": 1, "b": 2}, 0, 1, {"a": 1, "b": 2}),
+        ({"a": [1, 2, 3], "b": {"c": 4}}, 0, 3, {"a": [1, 2, 3], "b": {"c": 4}}),
+        (["a", (1, 2), {"b": 3}], 0, 2, ["a", (1, 2), {"b": 3}]),
+        ([1, [2, [3, 4], 5], 6], 0, 2, [1, [2, "[3, 4]", 5], 6]),
+        ({"a": {"b": {"c": 42}}}, 0, 2, {"a": {"b": {"c": 42}}}),
+        (DummyClass(42), 0, 1, {"value": 42}),
+        (DummyNestedClass(42), 0, 2, {"value": {"value": 42}}),
+        ({"a": {"b": DummyClass(42)}}, 0, 3, {"a": {"b": {"value": 42}}}),
+        (
+            [42, "test", 3.14, True, None, [1, 2, 3], {"a": 1}],
+            0,
+            2,
+            [42, "test", 3.14, True, None, [1, 2, 3], {"a": 1}],
+        ),
+    ],
+)
+def test_make_serializable_recursive(
+    input_obj: object,
+    depth: int,
+    max_depth: int,
+    expected_output: object,
+    mocker: MockerFixture,
+) -> None:
+    """Unit test for function _make_serializable() in file util.py"""
+    # Arrange
+    _ = mocker.patch.object(Utility, "_get_str", side_effect=lambda x: str(x))
+
+    # Act
+    result = Utility._make_serializable(input_obj, depth, max_depth)
+
+    # Assert
+    assert result == expected_output

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -251,7 +251,7 @@ def test_filter_dictionary(
     assert Utility.filter_dictionary(dict_to_be_filtered, filter_patterns, filter_by_exclusion) == expected_result
 
 
-def flatten_keys_to_nested_structure_nested_dict() -> None:
+def test_flatten_keys_to_nested_structure_nested_dict() -> None:
     x = {"a.i.c": 1, "a.i.d": 2, "a.j.c": 3, "a.j.d": 4, "b.i.c": 5, "b.i.d": 6, "b.j.c": 7, "b.j.d": 8}
     actual = Utility.flatten_keys_to_nested_structure(x)
     expected = {
@@ -261,13 +261,13 @@ def flatten_keys_to_nested_structure_nested_dict() -> None:
     assert actual == expected
 
 
-def flatten_keys_to_nested_structure_flat_dict() -> None:
+def test_flatten_keys_to_nested_structure_flat_dict() -> None:
     x = {"aic": 1, "aid": 2, "ajc": 3, "ajd": 4, "bic": 5, "bid": 6, "bjc": 7, "bjd": 8}
     actual = Utility.flatten_keys_to_nested_structure(x)
     assert actual == x
 
 
-def flatten_keys_to_nested_structure_dict_w_list() -> None:
+def test_flatten_keys_to_nested_structure_dict_w_list() -> None:
     x = {
         "a.i.0": 1,
         "a.i.1": 2,
@@ -277,13 +277,15 @@ def flatten_keys_to_nested_structure_dict_w_list() -> None:
         "b.i.d": 6,
         "b.j.c": 7,
         "b.j.d.0": 8,
-        "b.j.d.1": 9,
-        "b.j.d.2": 10,
+        "b.j.d.1.x.0": 9,
+        "b.j.d.1.x.1": 10,
+        "b.j.d.1.y": 11,
+        "b.j.d.2": 12,
     }
     actual = Utility.flatten_keys_to_nested_structure(x)
     expected = {
         "a": {"i": [1, 2], "j": {"c": 3, "d": 4}},
-        "b": {"i": {"c": 5, "d": 6}, "j": {"c": 7, "d": [8, 9, 10]}},
+        "b": {"i": {"c": 5, "d": 6}, "j": {"c": 7, "d": [8, {"x": [9, 10], "y": 11}, 12]}},
     }
     assert actual == expected
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -290,7 +290,7 @@ def test_flatten_keys_to_nested_structure_dict_w_list() -> None:
     assert actual == expected
 
 
-def test_deep_merge() -> None:
+def test_deep_merge_dict() -> None:
     x = {
         "a": {"i": {"c": 1, "d": 2}, "j": {"c": 3, "d": 4}},
         "b": {"i": {"c": 5, "d": 6}, "j": {"c": 7, "d": 8}},
@@ -306,3 +306,22 @@ def test_deep_merge() -> None:
     }
     Utility.deep_merge(x, y)
     assert x == expected
+
+
+def test_deep_merge_dict_w_list() -> None:
+    a = {
+        "a": {"i": [1, 2], "j": {"c": 3, "d": 4}},
+        "b": {"i": {"c": 5, "d": 6}, "j": {"c": 7, "d": [8, {"x": [9, 10], "y": 11}, 12]}},
+    }
+
+    b = {
+        "a": {"i": [11, 12, 13]},
+        "b": {"i": {"c": 15}, "j": {"d": [8, {"x": [19, 110]}]}},
+    }
+
+    expected = {
+        "a": {"i": [11, 12, 13], "j": {"c": 3, "d": 4}},
+        "b": {"i": {"c": 15, "d": 6}, "j": {"c": 7, "d": [8, {"x": [19, 110], "y": 11}, 12]}},
+    }
+    Utility.deep_merge(a, b)
+    assert a == expected


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes N/A


- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.
      
How big are the changes in the PR? Would you nominate it for a major version upgrade?
- [ ] Yes
- [x] No

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Updates `convert_flat_dict_to_nested_dict` to `flatten_keys_to_nested_structure` and the functionality of `deep_merge` in Utility to allow handling Lists within Dicts. Also some minor clean ups to Utility.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
Two new functions were introduced to the `Utility` class in PR #1599; they only handled Dicts; however, we need to be able to handle Lists as well for tasks such as Sensitivity Analysis.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Extends the logic in  `Utility.convert_flat_dict_to_nested_dict` to be able to handle Lists well; then renames the function to `Utility.flatten_keys_to_nested_structure`. Does the same to `Utilty.deep_merge`; however, the name is still adequet.

Also, removes the methods in `Utility` that are no longer in use.

Finally, brings `test_make_serializable_recursive` from `test_misc` to `test_util` where it belongs.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Test Suite