### PR TITLE
Redo of PR 1597 with docstrings updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-4003%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-4002%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -2028,22 +2028,47 @@ class InputManager:
         file_path = os.path.join(path, file_name)
         om.dict_to_file_json(self.__get_data_logs_pool, file_path)
 
-    def dump_metadata_properties(self, output_dir: Path) -> None:
+    def save_metadata_properties(self, output_dir: Path) -> None:
         """
-        Dumps metadata properties in CSV format.
+        Saves metadata properties in CSV format.
 
         Parameters
         ----------
         output_dir : Path
             The path to the output directory where the metadata properties CSV will be saved.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the file cannot be saved at the specified path.
+        PermissionError
+            If the user does not have permission to save the file at the specified path.
+        OSError
+            For any other unexpected error that occurs while trying to save the CSV.
         """
+        info_map = {
+            "class": self.__class__.__name__,
+            "function": self.save_metadata_properties.__name__,
+        }
         records = self._parse_metadata_properties(self.__metadata["properties"])
         df = pd.DataFrame(records)
         path_to_save = os.path.join(
             output_dir,
             om.generate_file_name("InputManager_metadata_properties", extension="csv"),
         )
-        df.to_csv(path_to_save, index=False)
+        om.add_log("CSV save attempt.", f"Attempting to save metadata properties as CSV to {path_to_save}", info_map)
+        try:
+            df.to_csv(path_to_save, index=False)
+            om.add_log("Save CSV success.", f"Successfully saved to {path_to_save}.", info_map)
+        except FileNotFoundError as fnfe:
+            om.add_error("Save CSV failure.", f"Unable to save to {path_to_save} because of {fnfe}.", info_map)
+            raise fnfe
+        except PermissionError as pe:
+            om.add_error("Save CSV failure.", f"Unable to save to {path_to_save} because of {pe}.", info_map)
+            raise pe
+        except OSError as e:
+            om.add_error("Save CSV failure.", f"Unable to save to {path_to_save} because of {e}.", info_map)
+            raise e
 
     def _parse_metadata_properties(
         self, data: Dict[str, Any], prefix: str = "", sep: str = "_"
@@ -2101,7 +2126,8 @@ class InputManager:
 
         return records
 
-    def _check_property_type_primitive(self, property: dict) -> bool:
+    def _check_property_type_primitive(self, property: Dict[str, Any]) -> bool:
+        """Checks whether the property's "type" is primitive or an array of primitive types."""
         if property.get("type") in ["bool", "string", "number"]:
             return True
         elif property.get("type") == "array":

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -388,7 +388,7 @@ class TaskManager:
             f"Saving metadata properties {args['metadata_file_path']} at {args['output_directory']}",
             info_map,
         )
-        input_manager.dump_metadata_properties(args["output_directory"])
+        input_manager.save_metadata_properties(args["output_directory"])
 
         return is_data_valid
 

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -3,6 +3,7 @@ from functools import reduce
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Type, Union, Optional
 from typing import Tuple
+from unittest.mock import ANY
 
 import pandas as pd
 import pytest
@@ -68,7 +69,7 @@ def input_manager_original_method_states(
         "add_tabular_variable_to_pool": mock_input_manager.add_tabular_variable_to_pool,
         "_is_input_required_upon_initialization": mock_input_manager._is_input_required_upon_initialization,
         "_is_modifiable_during_runtime": mock_input_manager._is_modifiable_during_runtime,
-        "dump_metadata_properties": mock_input_manager.dump_metadata_properties,
+        "save_metadata_properties": mock_input_manager.save_metadata_properties,
         "_parse_metadata_properties": mock_input_manager._parse_metadata_properties,
         "_check_property_type_primitive": mock_input_manager._check_property_type_primitive,
         "_create_record": mock_input_manager._create_record,
@@ -4023,8 +4024,8 @@ def test_validate_input_by_type_value_error() -> None:
         )
 
 
-def test_dump_metadata_properties(mock_input_manager: InputManager) -> None:
-    """Tests dump_metadata_properties() function in InputManager."""
+def test_save_metadata_properties(mock_input_manager: InputManager) -> None:
+    """Tests save_metadata_properties() function in InputManager."""
     mock_records = [{"name": "example", "value": 42}]
     output_dir = Path("/fake/directory")
     metadata = {"properties": "test_properties"}
@@ -4039,12 +4040,44 @@ def test_dump_metadata_properties(mock_input_manager: InputManager) -> None:
         ) as mock_generate_file_name,
     ):
 
-        mock_input_manager.dump_metadata_properties(output_dir)
+        mock_input_manager.save_metadata_properties(output_dir)
 
         mock_parse.assert_called_once_with("test_properties")
         mock_join.assert_called_once_with(output_dir, "output.csv")
         mock_to_csv.assert_called_once_with("output.csv", index=False)
         mock_generate_file_name.assert_called_once_with("InputManager_metadata_properties", extension="csv")
+
+
+@pytest.mark.parametrize(
+    "exception, error_message",
+    [(FileNotFoundError, "No such file or directory"), (PermissionError, "Permission denied"), (OSError, "OS error")],
+)
+def test_save_metadata_properties_errors(
+    mock_input_manager: InputManager,
+    mocker: MockerFixture,
+    exception: Type[FileNotFoundError | PermissionError | OSError],
+    error_message: str,
+) -> None:
+    output_dir = Path("/example/dir")
+    expected_path = str(output_dir / "file.csv")
+    metadata = {"properties": "test_properties"}
+    mock_input_manager.meta_data = metadata
+    mock_records = [{"key": "value"}]
+
+    mock_parse = mocker.patch.object(mock_input_manager, "_parse_metadata_properties", return_value=mock_records)
+    mocker.patch("pandas.DataFrame.to_csv", side_effect=exception(error_message))
+    mocker.patch("os.path.join", return_value=expected_path)
+    mock_add_error = mocker.patch("RUFAS.output_manager.OutputManager.add_error")
+
+    with pytest.raises(exception) as exc_info:
+        mock_input_manager.save_metadata_properties(output_dir)
+
+    assert str(exc_info.value) == error_message
+
+    mock_parse.assert_called_once_with("test_properties")
+    mock_add_error.assert_called_once_with(
+        "Save CSV failure.", f"Unable to save to {expected_path} because of {error_message}.", ANY
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

Short patch to address some issues with the `save_metadata_properties()` (formerly `dump_metadata_properties()`) PR #1555. This PR updates the docstrings in the `save_metadata_properties()` method to include a Raises section for the errors raised.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1512

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.
- [X] How big are the changes in the PR? Would you nominate it for a major version upgrade? Minor, no version upgrade.

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Addressing some concerns raised by @PooyaHekmati in PR #1555:
1. IM logs have been added for attempting to save the CSV metadata properties (and exception handling has been added and had testing added as well).
2. The function to save the metadata properties as a CSV has been renamed to `save_metadata_properties()` (pka `dump_metadata_properties()`).

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
The naming is now clearer as to the functionalities each of these methods executes and it is a requirement of the IM to log its activities to OM.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
The naming was updated by searching the associated files and testing and ensuring all references were updated.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Testing has been updated to ensure coverage is maintained at the same level and that all references to functions are updated.
