### PR TITLE
Fix Unit Conversion Error in Soil Nitrogen Removed By Water Routine

### DIFF
--- a/RUFAS/routines/field/soil/nitrogen_cycling/leaching_runoff_erosion.py
+++ b/RUFAS/routines/field/soil/nitrogen_cycling/leaching_runoff_erosion.py
@@ -392,8 +392,9 @@ class LeachingRunoffErosion:
             nitrogen_content, bulk_density, layer_thickness, field_size
         )
 
-        nitrogen_leached_in_mg_per_ha = nitrogen_content_in_mg_per_kg * extraction_coefficient \
-            * water_amount_in_liters / field_size
+        nitrogen_leached_in_mg_per_ha = (
+            nitrogen_content_in_mg_per_kg * extraction_coefficient * water_amount_in_liters / field_size
+        )
 
         nitrogen_leached_in_kg_per_ha = nitrogen_leached_in_mg_per_ha * MILLIGRAMS_TO_KILOGRAMS
 

--- a/RUFAS/routines/field/soil/nitrogen_cycling/leaching_runoff_erosion.py
+++ b/RUFAS/routines/field/soil/nitrogen_cycling/leaching_runoff_erosion.py
@@ -4,15 +4,16 @@ from math import exp, log
 from RUFAS.routines.field.crop_and_soil_constants import (
     HECTARES_TO_SQUARE_MILLIMETERS,
     CUBIC_MILLIMETERS_TO_LITERS,
+    MILLIGRAMS_TO_KILOGRAMS,
 )
 from RUFAS.routines.field.soil.soil_data import SoilData
 from RUFAS.routines.field.soil.layer_data import LayerData
 
-NITRATE_RUNOFF_COEFFICIENT = 1e-8
-AMMONIUM_RUNOFF_COEFFICIENT = 8e-6
-NITRATE_PERCOLATION_COEFFICIENT = 6e-8
-AMMONIUM_PERCOLATION_COEFFICIENT = 4e-6
-ACTIVE_ORGANIC_NITROGEN_PERCOLATION_COEFFICIENT = 5e-8
+NITRATE_RUNOFF_COEFFICIENT = 0.01
+AMMONIUM_RUNOFF_COEFFICIENT = 0.2
+NITRATE_PERCOLATION_COEFFICIENT = 0.05
+AMMONIUM_PERCOLATION_COEFFICIENT = 0.8
+ACTIVE_ORGANIC_NITROGEN_PERCOLATION_COEFFICIENT = 0.01
 
 
 class LeachingRunoffErosion:
@@ -358,7 +359,7 @@ class LeachingRunoffErosion:
         water_amount : float
             Amount of water that percolated out of the current soil layer on this day (mm).
         extraction_coefficient : float
-            Coefficient for adjusting the amount leached based on the pool leached from (L ^ -1).
+            Coefficient for adjusting the amount leached based on the pool leached from (kg/L).
         bulk_density : float
             Density of the soil layer containing the nitrogen (Megagram / cubic meter).
         layer_thickness : float
@@ -391,10 +392,9 @@ class LeachingRunoffErosion:
             nitrogen_content, bulk_density, layer_thickness, field_size
         )
 
-        nitrogen_leached_in_mg_per_kg = nitrogen_content_in_mg_per_kg * extraction_coefficient * water_amount_in_liters
+        nitrogen_leached_in_mg_per_ha = nitrogen_content_in_mg_per_kg * extraction_coefficient \
+            * water_amount_in_liters / field_size
 
-        nitrogen_leached_in_kg_per_ha = LayerData.determine_soil_nutrient_area_density(
-            nitrogen_leached_in_mg_per_kg, bulk_density, layer_thickness, field_size
-        )
+        nitrogen_leached_in_kg_per_ha = nitrogen_leached_in_mg_per_ha * MILLIGRAMS_TO_KILOGRAMS
 
         return min(nitrogen_content, nitrogen_leached_in_kg_per_ha)

--- a/RUFAS/routines/field/soil/nitrogen_cycling/leaching_runoff_erosion.py
+++ b/RUFAS/routines/field/soil/nitrogen_cycling/leaching_runoff_erosion.py
@@ -9,6 +9,10 @@ from RUFAS.routines.field.crop_and_soil_constants import (
 from RUFAS.routines.field.soil.soil_data import SoilData
 from RUFAS.routines.field.soil.layer_data import LayerData
 
+"""
+The following are empirical coefficients with the units (kg / L).
+"""
+
 NITRATE_RUNOFF_COEFFICIENT = 0.01
 AMMONIUM_RUNOFF_COEFFICIENT = 0.2
 NITRATE_PERCOLATION_COEFFICIENT = 0.05

--- a/tests/soil_crop_tests/soil_tests/nitrogen_cycling_tests/test_leaching_runoff_erosion.py
+++ b/tests/soil_crop_tests/soil_tests/nitrogen_cycling_tests/test_leaching_runoff_erosion.py
@@ -79,9 +79,7 @@ def test_calculate_nitrogen_removed_by_water(
     """Tests that the correct amount of nitrogen is determined to be removed from a soil layer."""
     n_concentration = 12.0
 
-    with (
-        patch.object(LayerData, "determine_soil_nutrient_concentration", return_value=n_concentration) as conc,
-    ):
+    with (patch.object(LayerData, "determine_soil_nutrient_concentration", return_value=n_concentration) as conc,):
         actual = LeachingRunoffErosion._calculate_nitrogen_removed_by_water(
             nitrogen, water, coefficient, bulk_density, thickness, field_size
         )

--- a/tests/soil_crop_tests/soil_tests/nitrogen_cycling_tests/test_leaching_runoff_erosion.py
+++ b/tests/soil_crop_tests/soil_tests/nitrogen_cycling_tests/test_leaching_runoff_erosion.py
@@ -62,9 +62,9 @@ def test_calculate_eroded_organic_nitrogen(
 @pytest.mark.parametrize(
     "nitrogen,water,coefficient,bulk_density,thickness,field_size,expected",
     [
-        (35, 10.33, 1.8, 1.2, 20.0, 1.3, 5.0),
-        (14.5, 6.75, 1.22, 1.9, 150.0, 2.9, 5.0),
-        (3.5, 8.332, 0.005, 1.1, 70.0, 3.5, 3.5),
+        (35, 10.33, 1.8, 1.2, 20.0, 1.3, 2.231),
+        (14.5, 6.75, 1.22, 1.9, 150.0, 2.9, 0.988),
+        (3.5, 8.332, 0.005, 1.1, 70.0, 3.5, 0.005),
     ],
 )
 def test_calculate_nitrogen_removed_by_water(
@@ -78,21 +78,16 @@ def test_calculate_nitrogen_removed_by_water(
 ) -> None:
     """Tests that the correct amount of nitrogen is determined to be removed from a soil layer."""
     n_concentration = 12.0
-    n_density = 5.0
-    expected_water_in_liters = water * field_size * 1e4
-    expected_conc_lost = n_concentration * expected_water_in_liters * coefficient
 
     with (
         patch.object(LayerData, "determine_soil_nutrient_concentration", return_value=n_concentration) as conc,
-        patch.object(LayerData, "determine_soil_nutrient_area_density", return_value=n_density) as density,
     ):
         actual = LeachingRunoffErosion._calculate_nitrogen_removed_by_water(
             nitrogen, water, coefficient, bulk_density, thickness, field_size
         )
 
-        assert actual == expected
+        assert actual == pytest.approx(expected, abs=1e-3)
         conc.assert_called_once_with(nitrogen, bulk_density, thickness, field_size)
-        density.assert_called_once_with(pytest.approx(expected_conc_lost), bulk_density, thickness, field_size)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

The function `calculate_nitrogen_removed_by_water` has a unit conversion error resulting from an incorrect unit attributed to the extraction_coefficient. This is one factor that is resulting in unrealistically high nitrogen losses to the water. This PR updates the steps to calculate nitrogen removed by water within that function and updates the associated extraction coefficients.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1613

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.
      
How big are the changes in the PR? Would you nominate it for a major version upgrade?
- [ ] Yes
- [x] No

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
The `calculate_nitrogen_removed_by_water` is simplified by removing the need to convert from the soil N concentration in mg/kg soil to an area concentration by dividing the total mg of N lost that is calculated in step 3 above by the field size. 

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->

This function sould take in the soil nitrogen content in units of kg N/ ha and the amount of water that is extracting the nitrogen in units of mm and return the amount of N that is lost from the soil in that water in units of kg N/ha.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->

The `calculate_nitrogen_removed_by_water` now has the following steps:

1. Calculates the total volume of water that is moving nitrogen in that soil layer in the whole field in units of liters (remains unchanged)
2. Calculates the concentration of nitrogen in the soil in units of mg N/ kg soil (remains unchanged)
3. Calculates the nitrogen lost to the water in units of mg N / ha  as follows: 
- `nitrogen_leached_in_mg_per_ha = nitrogen_content_in_mg_per_kg * extraction_coefficient * water_amount_in_liters /field_size`

4. Converts the nitrogen lost to water from mg N/ha to kg N/ha as follows: 
- `nitrogen_leached_in_kg_per_ha = nitrogen_leached_in_mg_per_ha * MILLIGRAMS_TO_KILOGRAMS`

5. Returns the minimum of either the soil N content or nitrogen lost (remains unchanged)

The values for the `extraction_coefficient`s used in each reference by this function are updated as well. 

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Test suite has been updated. As far as the scientific values for nitrogen loss to water being more in line with what is expected, testing and feedback will be provided by @KFosterReed and @KevinP-B.