### PR TITLE
Updates Github Action to Fetch Main Mypy Error Count From README

### DIFF
--- a/.github/workflows/combined_format_lint_test_mypy.yml
+++ b/.github/workflows/combined_format_lint_test_mypy.yml
@@ -151,7 +151,13 @@ jobs:
         if: github.ref != 'refs/heads/main'
         run: |
           git checkout main
+          # Print the relevant part of README for debugging
+          cat README.md
           error_count=$(grep -oP 'Mypy-\K\d+(?= errors)' README.md)
+          if [ -z "$error_count" ]; then
+            echo "Error count not found in README.md"
+            exit 1
+          fi
           echo "Mypy error count on main branch: $error_count"
           echo $error_count > mypy_main_branch_error_count.txt
 

--- a/.github/workflows/combined_format_lint_test_mypy.yml
+++ b/.github/workflows/combined_format_lint_test_mypy.yml
@@ -147,12 +147,13 @@ jobs:
         id: set_current_branch_error_count
         run: echo "error_count=$(cat mypy_current_branch_error_count.txt)" >> $GITHUB_OUTPUT
 
-      - name: Run mypy on the main branch
+      - name: Extract mypy error count from README
         if: github.ref != 'refs/heads/main'
         run: |
           git checkout main
-          python -m mypy . 2>&1 | tee mypy_main_branch_report.txt || true
-          grep -c "error:" mypy_main_branch_report.txt > mypy_main_branch_error_count.txt
+          error_count=$(grep -oP 'Mypy-\K\d+(?= errors)' README.md)
+          echo "Mypy error count on main branch: $error_count"
+          echo $error_count > mypy_main_branch_error_count.txt
 
       - name: Set main branch error count as output
         id: set_main_branch_error_count

--- a/.github/workflows/combined_format_lint_test_mypy.yml
+++ b/.github/workflows/combined_format_lint_test_mypy.yml
@@ -151,15 +151,14 @@ jobs:
         if: github.ref != 'refs/heads/main'
         run: |
           git checkout main
-          # Use awk to extract the error count, ensuring only numbers are captured
-          error_count=$(awk -F'-' '/Mypy/{gsub(/[^0-9]/, "", $2); print $2}' README.md)
+          # Use awk to match and extract only the first set of digits before any non-digit characters
+          error_count=$(awk -F'-' '/Mypy/{match($2, /[0-9]+/); print substr($2, RSTART, RLENGTH)}' README.md)
           if [ -z "$error_count" ]; then
             echo "Error count not found in README.md"
             exit 1
           fi
           echo "Mypy error count on main branch: $error_count"
           echo $error_count > mypy_main_branch_error_count.txt
-
       - name: Set main branch error count as output
         id: set_main_branch_error_count
         if: github.ref != 'refs/heads/main'

--- a/.github/workflows/combined_format_lint_test_mypy.yml
+++ b/.github/workflows/combined_format_lint_test_mypy.yml
@@ -151,8 +151,8 @@ jobs:
         if: github.ref != 'refs/heads/main'
         run: |
           git checkout main
-          # Use awk to extract the error count directly
-          error_count=$(awk -F'-' '/Mypy/{split($2,a," "); print a[1]}' README.md)
+          # Use awk to extract the error count, ensuring only numbers are captured
+          error_count=$(awk -F'-' '/Mypy/{gsub(/[^0-9]/, "", $2); print $2}' README.md)
           if [ -z "$error_count" ]; then
             echo "Error count not found in README.md"
             exit 1

--- a/.github/workflows/combined_format_lint_test_mypy.yml
+++ b/.github/workflows/combined_format_lint_test_mypy.yml
@@ -151,8 +151,8 @@ jobs:
         if: github.ref != 'refs/heads/main'
         run: |
           git checkout main
-          # Use basic regex with grep and cut to extract the error count
-          error_count=$(grep 'Mypy' README.md | grep -o '[0-9]\+ errors' | cut -d ' ' -f 1)
+          # Use awk to extract the error count directly
+          error_count=$(awk -F'-' '/Mypy/{split($2,a," "); print a[1]}' README.md)
           if [ -z "$error_count" ]; then
             echo "Error count not found in README.md"
             exit 1

--- a/.github/workflows/combined_format_lint_test_mypy.yml
+++ b/.github/workflows/combined_format_lint_test_mypy.yml
@@ -151,9 +151,8 @@ jobs:
         if: github.ref != 'refs/heads/main'
         run: |
           git checkout main
-          # Print the relevant part of README for debugging
-          cat README.md
-          error_count=$(grep -oP 'Mypy-\K\d+(?= errors)' README.md)
+          # Use basic regex with grep and cut to extract the error count
+          error_count=$(grep 'Mypy' README.md | grep -o '[0-9]\+ errors' | cut -d ' ' -f 1)
           if [ -z "$error_count" ]; then
             echo "Error count not found in README.md"
             exit 1


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Rather than running a second full mypy on main, we instead will get the current mypy count from the README on main which will already have the most updated main mypy error count.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1710

- [N/A] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.
      
How big are the changes in the PR? Would you nominate it for a major version upgrade?
- [ ] Yes
- [x] No

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
This changes the method for getting and setting the mypy error count for main to use for comparison to the PR branch. Instead of running mypy on the entire main branch, we can extract the mypy error count in the README file on main.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
This will reduce the Github Actions runtime by only running mypy on the PR branch and doing a much quicker fetch of the mypy error count on main from the README.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
This replaces the previous `Run mypy on the main branch` GHA step with an action to get the mypy error count from main from the README on main. 
Here is what the new action does:
1. checkout main.
2. get the error count from the README file using grep/regex.
3. set the extracted mypy error count from the README to `mypy_main_branch_error_count.txt` as it was in the previous version of the action that ran mypy on main.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
I will use the newly updated Github Actions wiki technique of setting up a test-main branch to ensure this worked as intended. Carried out in #1721:
1. Set up test-main branch.
2. Switched all refs to main in GH Action to test-main.
3. Created a new branch off test-main called test-test-main.
4. Added 2 mypy errors to the code and pushed those changes to the test-test-main PR.
5. Merged in test-test-main to test-main.
6. Successfully updates the README with the updated mypy error count.