### PR TITLE
Fixing percolation order

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3593%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3594%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 
 # Vision

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-3593%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3593%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3594%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 
 # Vision

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3594%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3595%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 
 # Vision

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3594%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3593%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 
 # Vision

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-3593%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)

--- a/RUFAS/routines/field/field/field.py
+++ b/RUFAS/routines/field/field/field.py
@@ -1389,8 +1389,10 @@ class Field:
 
         remaining_evapotranspirative_demand = self._evaporate_from_crop_canopies(full_evapotranspirative_demand)
 
-        self.soil.infiltration.infiltrate(water_reaching_soil)
         self.soil.percolation.percolate(self.field_data.seasonal_high_water_table)
+        self.soil.infiltration.infiltrate(water_reaching_soil)
+        self.soil.percolation.percolate_infiltrated_water()
+
         self.soil.soil_erosion.erode(
             self.field_data.field_size,
             0.02,

--- a/RUFAS/routines/field/soil/layer_data.py
+++ b/RUFAS/routines/field/soil/layer_data.py
@@ -921,6 +921,7 @@ class LayerData:
         SWAT 2:3.2.1, 2
 
         """
+
         return max(0.0, self.water_content - self.field_capacity_content)
 
     @property

--- a/RUFAS/routines/field/soil/percolation.py
+++ b/RUFAS/routines/field/soil/percolation.py
@@ -86,7 +86,7 @@ class Percolation:
             else:
                 self.data.soil_layers[layer_number].water_content += percolated_water
 
-    def percolate_infiltrated_water(self) -> int | None:
+    def percolate_infiltrated_water(self) -> None:
         """
         Percolates infiltrated water into the soil profile.
 
@@ -106,7 +106,6 @@ class Percolation:
         """
 
         water_remaining_to_percolate = self.data.infiltrated_water
-        top_layer_to_percolate = None
         for index, layer in enumerate(self.data.soil_layers):
             acceptable_percolation = layer.acceptable_percolation_amount
             if water_remaining_to_percolate > acceptable_percolation:
@@ -116,11 +115,9 @@ class Percolation:
             else:
                 layer.water_content += water_remaining_to_percolate
                 water_remaining_to_percolate = 0.0
-                top_layer_to_percolate = index + 1
                 break
         if water_remaining_to_percolate > 0.0:
             self.data.vadose_zone_layer.water_content += water_remaining_to_percolate
-        return top_layer_to_percolate
 
     # --- Static methods ---
     @staticmethod

--- a/RUFAS/routines/field/soil/percolation.py
+++ b/RUFAS/routines/field/soil/percolation.py
@@ -90,12 +90,6 @@ class Percolation:
         """
         Percolates infiltrated water into the soil profile.
 
-        Returns
-        -------
-        int | None
-            The index of the topmost soil which has not had water percolated out of it, or None if all layers in the
-            soil profile have had water percolated out.
-
         Notes
         -----
         The amount of water allowed to infiltrate the soil on any given day is based on the available capacity of the

--- a/RUFAS/routines/field/soil/percolation.py
+++ b/RUFAS/routines/field/soil/percolation.py
@@ -52,15 +52,12 @@ class Percolation:
         SWAT sections 2:3.1 and 2
 
         """
-        top_layer_to_percolate = self._percolate_infiltrated_water()
 
-        if top_layer_to_percolate is None:
-            return
-
+        self.data.set_vectorized_layer_attribute("percolated_water", [0.0] * len(self.data.soil_layers))
         layer_count = len(self.data.soil_layers)
         deepest_layer = layer_count - 1
 
-        for layer_number in reversed(range(top_layer_to_percolate, layer_count)):
+        for layer_number in reversed(range(0, layer_count)):
             current_layer = self.data.soil_layers[layer_number]
 
             if layer_number < deepest_layer:
@@ -77,11 +74,11 @@ class Percolation:
             if can_percolate:
                 percolated_water = self._percolate_between_layers(self.data.time_step, current_layer, layer_below)
                 current_layer.water_content -= percolated_water
-                current_layer.percolated_water = percolated_water
+                current_layer.percolated_water += percolated_water
             else:
                 current_layer.percolated_water = 0.0
 
-        for layer_number in range(top_layer_to_percolate + 1, layer_count + 1):
+        for layer_number in range(1, layer_count + 1):
             layer_above = self.data.soil_layers[layer_number - 1]
             percolated_water = layer_above.percolated_water
             if layer_number == deepest_layer + 1:
@@ -89,7 +86,7 @@ class Percolation:
             else:
                 self.data.soil_layers[layer_number].water_content += percolated_water
 
-    def _percolate_infiltrated_water(self) -> int | None:
+    def percolate_infiltrated_water(self) -> int | None:
         """
         Percolates infiltrated water into the soil profile.
 
@@ -107,7 +104,7 @@ class Percolation:
         that is put below a layer as being percolated by it.
 
         """
-        self.data.set_vectorized_layer_attribute("percolated_water", [0.0] * len(self.data.soil_layers))
+
         water_remaining_to_percolate = self.data.infiltrated_water
         top_layer_to_percolate = None
         for index, layer in enumerate(self.data.soil_layers):
@@ -115,11 +112,11 @@ class Percolation:
             if water_remaining_to_percolate > acceptable_percolation:
                 layer.water_content += acceptable_percolation
                 water_remaining_to_percolate -= acceptable_percolation
-                layer.percolated_water = water_remaining_to_percolate
+                layer.percolated_water += water_remaining_to_percolate
             else:
                 layer.water_content += water_remaining_to_percolate
                 water_remaining_to_percolate = 0.0
-                top_layer_to_percolate = index
+                top_layer_to_percolate = index + 1
                 break
         if water_remaining_to_percolate > 0.0:
             self.data.vadose_zone_layer.water_content += water_remaining_to_percolate
@@ -251,7 +248,7 @@ class Percolation:
         SWAT Section 2:3.2
 
         """
-        if upper_layer.excess_water_available <= 0:
+        if upper_layer.water_content <= upper_layer.field_capacity_content:
             return 0
         else:
             percolation_time = Percolation._determine_percolation_travel_time(
@@ -259,10 +256,10 @@ class Percolation:
                 upper_layer.field_capacity_content,
                 upper_layer.saturated_hydraulic_conductivity,
             )
+            water_to_percolate = upper_layer.excess_water_available
             amount_to_percolate = Percolation._determine_percolation_to_next_layer(
-                upper_layer.excess_water_available, time_step, percolation_time
+                water_to_percolate, time_step, percolation_time
             )
-
             #  Limit the maximum amount of water allowed to percolate so that lower layer cannot become overly saturated
             if amount_to_percolate > lower_layer.acceptable_percolation_amount:
                 amount_to_percolate = lower_layer.acceptable_percolation_amount

--- a/RUFAS/routines/field/soil/soil.py
+++ b/RUFAS/routines/field/soil/soil.py
@@ -156,6 +156,7 @@ class Soil:
         """
         self.percolation.percolate(has_seasonal_high_water_table)
         self.infiltration.infiltrate(rainfall, weighting_coefficient, potential_evapotranspiration)
+        self.percolation.percolate_infiltrated_water()
         self.evaporation.evaporate(maximum_soil_evaporation)
         self.soil_erosion.erode(field_size, minimum_cover_management_factor, residue, rainfall)
         self.phosphorus_cycling.cycle_phosphorus(rainfall, self.data.accumulated_runoff, field_size, avg_air_temp)

--- a/RUFAS/routines/field/soil/soil.py
+++ b/RUFAS/routines/field/soil/soil.py
@@ -154,8 +154,8 @@ class Soil:
         profile depend on how much water enters and moves through the soil profile.
 
         """
-        self.infiltration.infiltrate(rainfall, weighting_coefficient, potential_evapotranspiration)
         self.percolation.percolate(has_seasonal_high_water_table)
+        self.infiltration.infiltrate(rainfall, weighting_coefficient, potential_evapotranspiration)
         self.evaporation.evaporate(maximum_soil_evaporation)
         self.soil_erosion.erode(field_size, minimum_cover_management_factor, residue, rainfall)
         self.phosphorus_cycling.cycle_phosphorus(rainfall, self.data.accumulated_runoff, field_size, avg_air_temp)

--- a/tests/soil_crop_tests/field_tests/test_field.py
+++ b/tests/soil_crop_tests/field_tests/test_field.py
@@ -2250,6 +2250,7 @@ def test_cycle_water(
 
         incorp.soil.infiltration.infiltrate = MagicMock()
         incorp.soil.percolation.percolate = MagicMock()
+        incorp.soil.percolation.percolate_infiltrated_water = MagicMock()
         incorp.soil.soil_erosion.erode = MagicMock()
         incorp.soil.phosphorus_cycling.cycle_phosphorus = MagicMock()
         incorp.soil.nitrogen_cycling.cycle_nitrogen = MagicMock()
@@ -2291,6 +2292,7 @@ def test_cycle_water(
         incorp._evaporate_from_crop_canopies.assert_called_once_with(33.5)
         incorp.soil.infiltration.infiltrate.assert_called_once_with(2.0)
         incorp.soil.percolation.percolate.assert_called_once_with(high_water_table)
+        incorp.soil.percolation.percolate_infiltrated_water.assert_called_once()
         incorp.soil.soil_erosion.erode.assert_called_once_with(field_size, 0.02, residue, expected_total_water)
         incorp.soil.phosphorus_cycling.cycle_phosphorus.assert_called_once_with(2.0, runoff, field_size, mean_temp)
         incorp.soil.nitrogen_cycling.cycle_nitrogen.assert_called_once_with(field_size)

--- a/tests/soil_crop_tests/soil_tests/test_percolation.py
+++ b/tests/soil_crop_tests/soil_tests/test_percolation.py
@@ -139,36 +139,36 @@ def test_percolate_between_layers(
     "infiltration,water_contents,acceptable_percolation_amounts,percolated_water,expected_water,expected_layer",
     [
         (
-                10.0,
-                [5.0, 5.0, 5.0, 5.0],
-                [3.0] * 4,
-                [7.0, 4.0, 1.0, 0.0],
-                [8.0, 8.0, 8.0, 6.0, 0.0],
-                4,
+            10.0,
+            [5.0, 5.0, 5.0, 5.0],
+            [3.0] * 4,
+            [7.0, 4.0, 1.0, 0.0],
+            [8.0, 8.0, 8.0, 6.0, 0.0],
+            4,
         ),
         (
-                4.0,
-                [5.0, 5.0, 5.0, 5.0],
-                [3.0] * 4,
-                [1.0, 0.0, 0.0, 0.0],
-                [8.0, 6.0, 5.0, 5.0, 0.0],
-                2,
+            4.0,
+            [5.0, 5.0, 5.0, 5.0],
+            [3.0] * 4,
+            [1.0, 0.0, 0.0, 0.0],
+            [8.0, 6.0, 5.0, 5.0, 0.0],
+            2,
         ),
         (
-                8.5,
-                [6.0, 12.4, 19.3, 18.0],
-                [1.3, 2.4, 5.0, 4.7],
-                [7.2, 4.8, 0.0, 0.0],
-                [7.3, 14.8, 24.1, 18.0, 0.0],
-                3,
+            8.5,
+            [6.0, 12.4, 19.3, 18.0],
+            [1.3, 2.4, 5.0, 4.7],
+            [7.2, 4.8, 0.0, 0.0],
+            [7.3, 14.8, 24.1, 18.0, 0.0],
+            3,
         ),
         (
-                20.0,
-                [5.0, 5.0, 5.0, 5.0],
-                [3.0] * 4,
-                [17.0, 14.0, 11.0, 8.0],
-                [8.0, 8.0, 8.0, 8.0, 8.0],
-                None,
+            20.0,
+            [5.0, 5.0, 5.0, 5.0],
+            [3.0] * 4,
+            [17.0, 14.0, 11.0, 8.0],
+            [8.0, 8.0, 8.0, 8.0, 8.0],
+            None,
         ),
         (20.0, [8.0, 8.0, 8.0, 8.0], [0.0] * 4, [20.0] * 4, [8.0, 8.0, 8.0, 8.0, 20.0], None),
         (1.0, [5.0] * 4, [2.0] * 4, [0.0] * 4, [6.0, 5.0, 5.0, 5.0, 0.0], 1),
@@ -247,9 +247,6 @@ def test_percolate(
     mock_soil_data.infiltrated_water = infiltration
     incorp = Percolation(mock_soil_data)
 
-    #mock_infiltrated_water = mocker.patch.object(
-    #    incorp, "percolate_infiltrated_water", return_value=top_layer_percolated
-    #)
     with (
         patch(
             "RUFAS.routines.field.soil.percolation.Percolation._determine_if_percolation_allowed",

--- a/tests/soil_crop_tests/soil_tests/test_percolation.py
+++ b/tests/soil_crop_tests/soil_tests/test_percolation.py
@@ -70,10 +70,10 @@ def test_determine_percolation_to_next_layer(drainable_water, time_step, travel_
     ],
 )
 def test_determine_if_percolation_allowed(
-        water_content,
-        field_capacity_content,
-        saturated_capacity_content,
-        high_seasonal_water_table,
+    water_content,
+    field_capacity_content,
+    saturated_capacity_content,
+    high_seasonal_water_table,
 ):
     """tests _determine_if_percolation_allowed() in percolation.py"""
     observe = Percolation._determine_if_percolation_allowed(
@@ -85,7 +85,7 @@ def test_determine_if_percolation_allowed(
     if not high_seasonal_water_table:
         assert observe is True
     elif (
-            water_content > (field_capacity_content + (0.5 * (saturated_capacity_content - field_capacity_content)))
+        water_content > (field_capacity_content + (0.5 * (saturated_capacity_content - field_capacity_content)))
     ) and high_seasonal_water_table:
         assert observe is True
     else:
@@ -97,12 +97,12 @@ def test_determine_if_percolation_allowed(
     [(30, 3, 10, 10, 5, 0), (30, 3, 2, 3, 10, 3), (30, -5, 10, 10, 5, 0)],
 )
 def test_percolate_between_layers(
-        time_step: float,
-        water_content: float,
-        field_capacity_content: float,
-        amount_to_percolate: float,
-        acceptable_percolation_amount: float,
-        expected: float,
+    time_step: float,
+    water_content: float,
+    field_capacity_content: float,
+    amount_to_percolate: float,
+    acceptable_percolation_amount: float,
+    expected: float,
 ) -> None:
     """this function tests _percolate_between_layers() in Percolation.py"""
     upper_data = LayerData(top_depth=0, bottom_depth=20, field_size=1.33)
@@ -113,9 +113,8 @@ def test_percolate_between_layers(
         field_size=1.33,
     )
     with (
-        patch.object(upper_data, 'water_content', water_content),
-        patch.object(LayerData, 'field_capacity_content', new_callable=PropertyMock) as
-        mock_field_capacity_content,
+        patch.object(upper_data, "water_content", water_content),
+        patch.object(LayerData, "field_capacity_content", new_callable=PropertyMock) as mock_field_capacity_content,
         patch(
             "RUFAS.routines.field.soil.layer_data.LayerData.acceptable_percolation_amount",
             new_callable=PropertyMock,
@@ -139,48 +138,48 @@ def test_percolate_between_layers(
     "infiltration,water_contents,acceptable_percolation_amounts,percolated_water,expected_water,expected_layer",
     [
         (
-                10.0,
-                [5.0, 5.0, 5.0, 5.0],
-                [3.0] * 4,
-                [7.0, 4.0, 1.0, 0.0],
-                [8.0, 8.0, 8.0, 6.0, 0.0],
-                4,
+            10.0,
+            [5.0, 5.0, 5.0, 5.0],
+            [3.0] * 4,
+            [7.0, 4.0, 1.0, 0.0],
+            [8.0, 8.0, 8.0, 6.0, 0.0],
+            4,
         ),
         (
-                4.0,
-                [5.0, 5.0, 5.0, 5.0],
-                [3.0] * 4,
-                [1.0, 0.0, 0.0, 0.0],
-                [8.0, 6.0, 5.0, 5.0, 0.0],
-                2,
+            4.0,
+            [5.0, 5.0, 5.0, 5.0],
+            [3.0] * 4,
+            [1.0, 0.0, 0.0, 0.0],
+            [8.0, 6.0, 5.0, 5.0, 0.0],
+            2,
         ),
         (
-                8.5,
-                [6.0, 12.4, 19.3, 18.0],
-                [1.3, 2.4, 5.0, 4.7],
-                [7.2, 4.8, 0.0, 0.0],
-                [7.3, 14.8, 24.1, 18.0, 0.0],
-                3,
+            8.5,
+            [6.0, 12.4, 19.3, 18.0],
+            [1.3, 2.4, 5.0, 4.7],
+            [7.2, 4.8, 0.0, 0.0],
+            [7.3, 14.8, 24.1, 18.0, 0.0],
+            3,
         ),
         (
-                20.0,
-                [5.0, 5.0, 5.0, 5.0],
-                [3.0] * 4,
-                [17.0, 14.0, 11.0, 8.0],
-                [8.0, 8.0, 8.0, 8.0, 8.0],
-                None,
+            20.0,
+            [5.0, 5.0, 5.0, 5.0],
+            [3.0] * 4,
+            [17.0, 14.0, 11.0, 8.0],
+            [8.0, 8.0, 8.0, 8.0, 8.0],
+            None,
         ),
         (20.0, [8.0, 8.0, 8.0, 8.0], [0.0] * 4, [20.0] * 4, [8.0, 8.0, 8.0, 8.0, 20.0], None),
         (1.0, [5.0] * 4, [2.0] * 4, [0.0] * 4, [6.0, 5.0, 5.0, 5.0, 0.0], 1),
     ],
 )
 def test_percolate_infiltrated_water(
-        infiltration: float,
-        water_contents: list[float],
-        acceptable_percolation_amounts: list[float],
-        percolated_water: list[float],
-        expected_water: list[float],
-        expected_layer: int | None,
+    infiltration: float,
+    water_contents: list[float],
+    acceptable_percolation_amounts: list[float],
+    percolated_water: list[float],
+    expected_water: list[float],
+    expected_layer: int | None,
 ) -> None:
     """Tests that extreme levels of infiltration are handled correctly."""
     layers = []
@@ -197,9 +196,9 @@ def test_percolate_infiltrated_water(
     soil_data.infiltrated_water = infiltration
     percolation = Percolation(soil_data)
     with patch(
-            "RUFAS.routines.field.soil.layer_data.LayerData.acceptable_percolation_amount",
-            new_callable=PropertyMock,
-            side_effect=acceptable_percolation_amounts,
+        "RUFAS.routines.field.soil.layer_data.LayerData.acceptable_percolation_amount",
+        new_callable=PropertyMock,
+        side_effect=acceptable_percolation_amounts,
     ):
         actual = percolation.percolate_infiltrated_water()
 
@@ -234,22 +233,22 @@ def mock_soil_data() -> SoilData:
     ],
 )
 def test_percolate(
-        mocker: MockerFixture,
-        can_percolate: bool,
-        seasonal_high_water_table: bool,
-        infiltration: float,
-        top_layer_percolated: int | None,
-        expected_water: List[float],
-        expected_call_count: int,
-        mock_soil_data: SoilData,
+    mocker: MockerFixture,
+    can_percolate: bool,
+    seasonal_high_water_table: bool,
+    infiltration: float,
+    top_layer_percolated: int | None,
+    expected_water: List[float],
+    expected_call_count: int,
+    mock_soil_data: SoilData,
 ) -> None:
     """Tests the main routine of percolation.py and check that it updates all values correctly."""
     mock_soil_data.infiltrated_water = infiltration
     incorp = Percolation(mock_soil_data)
 
-    #mock_infiltrated_water = mocker.patch.object(
+    # mock_infiltrated_water = mocker.patch.object(
     #    incorp, "percolate_infiltrated_water", return_value=top_layer_percolated
-    #)
+    # )
     with (
         patch(
             "RUFAS.routines.field.soil.percolation.Percolation._determine_if_percolation_allowed",
@@ -268,7 +267,7 @@ def test_percolate(
     ):
         incorp.percolate(seasonal_high_water_table)
 
-    #mock_infiltrated_water.assert_called_once_with()
+    # mock_infiltrated_water.assert_called_once_with()
     assert percolation_allowed.call_count == expected_call_count
     actual_percolation = mock_soil_data.get_vectorized_layer_attribute("percolated_water")
     if can_percolate:

--- a/tests/soil_crop_tests/soil_tests/test_percolation.py
+++ b/tests/soil_crop_tests/soil_tests/test_percolation.py
@@ -70,10 +70,10 @@ def test_determine_percolation_to_next_layer(drainable_water, time_step, travel_
     ],
 )
 def test_determine_if_percolation_allowed(
-        water_content,
-        field_capacity_content,
-        saturated_capacity_content,
-        high_seasonal_water_table,
+    water_content,
+    field_capacity_content,
+    saturated_capacity_content,
+    high_seasonal_water_table,
 ):
     """tests _determine_if_percolation_allowed() in percolation.py"""
     observe = Percolation._determine_if_percolation_allowed(
@@ -85,7 +85,7 @@ def test_determine_if_percolation_allowed(
     if not high_seasonal_water_table:
         assert observe is True
     elif (
-            water_content > (field_capacity_content + (0.5 * (saturated_capacity_content - field_capacity_content)))
+        water_content > (field_capacity_content + (0.5 * (saturated_capacity_content - field_capacity_content)))
     ) and high_seasonal_water_table:
         assert observe is True
     else:
@@ -97,12 +97,12 @@ def test_determine_if_percolation_allowed(
     [(30, 3, 10, 10, 5, 0), (30, 3, 2, 3, 10, 3), (30, -5, 10, 10, 5, 0)],
 )
 def test_percolate_between_layers(
-        time_step: float,
-        water_content: float,
-        field_capacity_content: float,
-        amount_to_percolate: float,
-        acceptable_percolation_amount: float,
-        expected: float,
+    time_step: float,
+    water_content: float,
+    field_capacity_content: float,
+    amount_to_percolate: float,
+    acceptable_percolation_amount: float,
+    expected: float,
 ) -> None:
     """this function tests _percolate_between_layers() in Percolation.py"""
     upper_data = LayerData(top_depth=0, bottom_depth=20, field_size=1.33)
@@ -113,9 +113,8 @@ def test_percolate_between_layers(
         field_size=1.33,
     )
     with (
-        patch.object(upper_data, 'water_content', water_content),
-        patch.object(LayerData, 'field_capacity_content', new_callable=PropertyMock) as
-        mock_field_capacity_content,
+        patch.object(upper_data, "water_content", water_content),
+        patch.object(LayerData, "field_capacity_content", new_callable=PropertyMock) as mock_field_capacity_content,
         patch(
             "RUFAS.routines.field.soil.layer_data.LayerData.acceptable_percolation_amount",
             new_callable=PropertyMock,
@@ -175,12 +174,12 @@ def test_percolate_between_layers(
     ],
 )
 def test_percolate_infiltrated_water(
-        infiltration: float,
-        water_contents: list[float],
-        acceptable_percolation_amounts: list[float],
-        percolated_water: list[float],
-        expected_water: list[float],
-        expected_layer: int | None,
+    infiltration: float,
+    water_contents: list[float],
+    acceptable_percolation_amounts: list[float],
+    percolated_water: list[float],
+    expected_water: list[float],
+    expected_layer: int | None,
 ) -> None:
     """Tests that extreme levels of infiltration are handled correctly."""
     layers = []
@@ -197,9 +196,9 @@ def test_percolate_infiltrated_water(
     soil_data.infiltrated_water = infiltration
     percolation = Percolation(soil_data)
     with patch(
-            "RUFAS.routines.field.soil.layer_data.LayerData.acceptable_percolation_amount",
-            new_callable=PropertyMock,
-            side_effect=acceptable_percolation_amounts,
+        "RUFAS.routines.field.soil.layer_data.LayerData.acceptable_percolation_amount",
+        new_callable=PropertyMock,
+        side_effect=acceptable_percolation_amounts,
     ):
         actual = percolation.percolate_infiltrated_water()
 
@@ -234,14 +233,14 @@ def mock_soil_data() -> SoilData:
     ],
 )
 def test_percolate(
-        mocker: MockerFixture,
-        can_percolate: bool,
-        seasonal_high_water_table: bool,
-        infiltration: float,
-        top_layer_percolated: int | None,
-        expected_water: List[float],
-        expected_call_count: int,
-        mock_soil_data: SoilData,
+    mocker: MockerFixture,
+    can_percolate: bool,
+    seasonal_high_water_table: bool,
+    infiltration: float,
+    top_layer_percolated: int | None,
+    expected_water: List[float],
+    expected_call_count: int,
+    mock_soil_data: SoilData,
 ) -> None:
     """Tests the main routine of percolation.py and check that it updates all values correctly."""
     mock_soil_data.infiltrated_water = infiltration
@@ -265,7 +264,7 @@ def test_percolate(
     ):
         incorp.percolate(seasonal_high_water_table)
 
-    #mock_infiltrated_water.assert_called_once_with()
+    # mock_infiltrated_water.assert_called_once_with()
     assert percolation_allowed.call_count == expected_call_count
     actual_percolation = mock_soil_data.get_vectorized_layer_attribute("percolated_water")
     if can_percolate:

--- a/tests/soil_crop_tests/soil_tests/test_percolation.py
+++ b/tests/soil_crop_tests/soil_tests/test_percolation.py
@@ -265,7 +265,6 @@ def test_percolate(
     ):
         incorp.percolate(seasonal_high_water_table)
 
-    #mock_infiltrated_water.assert_called_once_with()
     assert percolation_allowed.call_count == expected_call_count
     actual_percolation = mock_soil_data.get_vectorized_layer_attribute("percolated_water")
     if can_percolate:

--- a/tests/soil_crop_tests/soil_tests/test_percolation.py
+++ b/tests/soil_crop_tests/soil_tests/test_percolation.py
@@ -70,10 +70,10 @@ def test_determine_percolation_to_next_layer(drainable_water, time_step, travel_
     ],
 )
 def test_determine_if_percolation_allowed(
-    water_content,
-    field_capacity_content,
-    saturated_capacity_content,
-    high_seasonal_water_table,
+        water_content,
+        field_capacity_content,
+        saturated_capacity_content,
+        high_seasonal_water_table,
 ):
     """tests _determine_if_percolation_allowed() in percolation.py"""
     observe = Percolation._determine_if_percolation_allowed(
@@ -85,7 +85,7 @@ def test_determine_if_percolation_allowed(
     if not high_seasonal_water_table:
         assert observe is True
     elif (
-        water_content > (field_capacity_content + (0.5 * (saturated_capacity_content - field_capacity_content)))
+            water_content > (field_capacity_content + (0.5 * (saturated_capacity_content - field_capacity_content)))
     ) and high_seasonal_water_table:
         assert observe is True
     else:
@@ -93,15 +93,16 @@ def test_determine_if_percolation_allowed(
 
 
 @pytest.mark.parametrize(
-    "time_step,excess_water_available,amount_to_percolate,acceptable_percolation_amount,expected",
-    [(30, 3, 10, 5, 5), (30, 3, 3, 10, 3), (30, -5, 10, 5, 0)],
+    "time_step,water_content,field_capacity_content,amount_to_percolate,acceptable_percolation_amount,expected",
+    [(30, 3, 10, 10, 5, 0), (30, 3, 2, 3, 10, 3), (30, -5, 10, 10, 5, 0)],
 )
 def test_percolate_between_layers(
-    time_step: float,
-    excess_water_available: float,
-    amount_to_percolate: float,
-    acceptable_percolation_amount: float,
-    expected: float,
+        time_step: float,
+        water_content: float,
+        field_capacity_content: float,
+        amount_to_percolate: float,
+        acceptable_percolation_amount: float,
+        expected: float,
 ) -> None:
     """this function tests _percolate_between_layers() in Percolation.py"""
     upper_data = LayerData(top_depth=0, bottom_depth=20, field_size=1.33)
@@ -112,21 +113,20 @@ def test_percolate_between_layers(
         field_size=1.33,
     )
     with (
-        patch(
-            "RUFAS.routines.field.soil.layer_data.LayerData.excess_water_available",
-            new_callable=PropertyMock,
-            return_value=excess_water_available,
-        ),
+        patch.object(upper_data, 'water_content', water_content),
+        patch.object(LayerData, 'field_capacity_content', new_callable=PropertyMock) as
+        mock_field_capacity_content,
         patch(
             "RUFAS.routines.field.soil.layer_data.LayerData.acceptable_percolation_amount",
             new_callable=PropertyMock,
             return_value=acceptable_percolation_amount,
         ),
     ):
+        mock_field_capacity_content.return_value = field_capacity_content
         Percolation._determine_percolation_travel_time = MagicMock()
         Percolation._determine_percolation_to_next_layer = MagicMock(return_value=amount_to_percolate)
         result = Percolation._percolate_between_layers(time_step, upper_data, lower_data)
-        if excess_water_available <= 0:
+        if water_content <= field_capacity_content:
             assert result == expected
         else:
             assert Percolation._determine_percolation_travel_time.call_count == 1
@@ -139,48 +139,48 @@ def test_percolate_between_layers(
     "infiltration,water_contents,acceptable_percolation_amounts,percolated_water,expected_water,expected_layer",
     [
         (
-            10.0,
-            [5.0, 5.0, 5.0, 5.0],
-            [3.0] * 4,
-            [7.0, 4.0, 1.0, 0.0],
-            [8.0, 8.0, 8.0, 6.0, 0.0],
-            3,
+                10.0,
+                [5.0, 5.0, 5.0, 5.0],
+                [3.0] * 4,
+                [7.0, 4.0, 1.0, 0.0],
+                [8.0, 8.0, 8.0, 6.0, 0.0],
+                4,
         ),
         (
-            4.0,
-            [5.0, 5.0, 5.0, 5.0],
-            [3.0] * 4,
-            [1.0, 0.0, 0.0, 0.0],
-            [8.0, 6.0, 5.0, 5.0, 0.0],
-            1,
+                4.0,
+                [5.0, 5.0, 5.0, 5.0],
+                [3.0] * 4,
+                [1.0, 0.0, 0.0, 0.0],
+                [8.0, 6.0, 5.0, 5.0, 0.0],
+                2,
         ),
         (
-            8.5,
-            [6.0, 12.4, 19.3, 18.0],
-            [1.3, 2.4, 5.0, 4.7],
-            [7.2, 4.8, 0.0, 0.0],
-            [7.3, 14.8, 24.1, 18.0, 0.0],
-            2,
+                8.5,
+                [6.0, 12.4, 19.3, 18.0],
+                [1.3, 2.4, 5.0, 4.7],
+                [7.2, 4.8, 0.0, 0.0],
+                [7.3, 14.8, 24.1, 18.0, 0.0],
+                3,
         ),
         (
-            20.0,
-            [5.0, 5.0, 5.0, 5.0],
-            [3.0] * 4,
-            [17.0, 14.0, 11.0, 8.0],
-            [8.0, 8.0, 8.0, 8.0, 8.0],
-            None,
+                20.0,
+                [5.0, 5.0, 5.0, 5.0],
+                [3.0] * 4,
+                [17.0, 14.0, 11.0, 8.0],
+                [8.0, 8.0, 8.0, 8.0, 8.0],
+                None,
         ),
         (20.0, [8.0, 8.0, 8.0, 8.0], [0.0] * 4, [20.0] * 4, [8.0, 8.0, 8.0, 8.0, 20.0], None),
-        (1.0, [5.0] * 4, [2.0] * 4, [0.0] * 4, [6.0, 5.0, 5.0, 5.0, 0.0], 0),
+        (1.0, [5.0] * 4, [2.0] * 4, [0.0] * 4, [6.0, 5.0, 5.0, 5.0, 0.0], 1),
     ],
 )
 def test_percolate_infiltrated_water(
-    infiltration: float,
-    water_contents: list[float],
-    acceptable_percolation_amounts: list[float],
-    percolated_water: list[float],
-    expected_water: list[float],
-    expected_layer: int | None,
+        infiltration: float,
+        water_contents: list[float],
+        acceptable_percolation_amounts: list[float],
+        percolated_water: list[float],
+        expected_water: list[float],
+        expected_layer: int | None,
 ) -> None:
     """Tests that extreme levels of infiltration are handled correctly."""
     layers = []
@@ -197,11 +197,11 @@ def test_percolate_infiltrated_water(
     soil_data.infiltrated_water = infiltration
     percolation = Percolation(soil_data)
     with patch(
-        "RUFAS.routines.field.soil.layer_data.LayerData.acceptable_percolation_amount",
-        new_callable=PropertyMock,
-        side_effect=acceptable_percolation_amounts,
+            "RUFAS.routines.field.soil.layer_data.LayerData.acceptable_percolation_amount",
+            new_callable=PropertyMock,
+            side_effect=acceptable_percolation_amounts,
     ):
-        actual = percolation._percolate_infiltrated_water()
+        actual = percolation.percolate_infiltrated_water()
 
     assert actual == expected_layer
     for index, layer in enumerate(percolation.data.soil_layers):
@@ -228,28 +228,28 @@ def mock_soil_data() -> SoilData:
     [
         (True, True, 0.0, 0, [7.0, 50.0, 100.0, 3.0], 3),
         (False, False, 0.0, 0, [10.0, 50.0, 100.0, 0.0], 3),
-        (True, False, 1.0, 2, [10.0, 50.0, 97.0, 3.0], 1),
-        (True, False, 10.0, None, [10.0, 50.0, 100.0, 0.0], 0),
-        (True, False, 0.0, 1, [10.0, 47.0, 100.0, 3.0], 2),
+        (True, False, 1.0, 2, [7.0, 50.0, 100.0, 3.0], 3),
+        (True, False, 10.0, None, [7.0, 50.0, 100.0, 3.0], 3),
+        (True, False, 0.0, 1, [7.0, 50.0, 100.0, 3.0], 3),
     ],
 )
 def test_percolate(
-    mocker: MockerFixture,
-    can_percolate: bool,
-    seasonal_high_water_table: bool,
-    infiltration: float,
-    top_layer_percolated: int | None,
-    expected_water: List[float],
-    expected_call_count: int,
-    mock_soil_data: SoilData,
+        mocker: MockerFixture,
+        can_percolate: bool,
+        seasonal_high_water_table: bool,
+        infiltration: float,
+        top_layer_percolated: int | None,
+        expected_water: List[float],
+        expected_call_count: int,
+        mock_soil_data: SoilData,
 ) -> None:
     """Tests the main routine of percolation.py and check that it updates all values correctly."""
     mock_soil_data.infiltrated_water = infiltration
     incorp = Percolation(mock_soil_data)
 
-    mock_infiltrated_water = mocker.patch.object(
-        incorp, "_percolate_infiltrated_water", return_value=top_layer_percolated
-    )
+    #mock_infiltrated_water = mocker.patch.object(
+    #    incorp, "percolate_infiltrated_water", return_value=top_layer_percolated
+    #)
     with (
         patch(
             "RUFAS.routines.field.soil.percolation.Percolation._determine_if_percolation_allowed",
@@ -268,7 +268,7 @@ def test_percolate(
     ):
         incorp.percolate(seasonal_high_water_table)
 
-    mock_infiltrated_water.assert_called_once_with()
+    #mock_infiltrated_water.assert_called_once_with()
     assert percolation_allowed.call_count == expected_call_count
     actual_percolation = mock_soil_data.get_vectorized_layer_attribute("percolated_water")
     if can_percolate:

--- a/tests/soil_crop_tests/soil_tests/test_percolation.py
+++ b/tests/soil_crop_tests/soil_tests/test_percolation.py
@@ -70,10 +70,10 @@ def test_determine_percolation_to_next_layer(drainable_water, time_step, travel_
     ],
 )
 def test_determine_if_percolation_allowed(
-        water_content,
-        field_capacity_content,
-        saturated_capacity_content,
-        high_seasonal_water_table,
+    water_content,
+    field_capacity_content,
+    saturated_capacity_content,
+    high_seasonal_water_table,
 ):
     """tests _determine_if_percolation_allowed() in percolation.py"""
     observe = Percolation._determine_if_percolation_allowed(
@@ -85,7 +85,7 @@ def test_determine_if_percolation_allowed(
     if not high_seasonal_water_table:
         assert observe is True
     elif (
-            water_content > (field_capacity_content + (0.5 * (saturated_capacity_content - field_capacity_content)))
+        water_content > (field_capacity_content + (0.5 * (saturated_capacity_content - field_capacity_content)))
     ) and high_seasonal_water_table:
         assert observe is True
     else:
@@ -97,12 +97,12 @@ def test_determine_if_percolation_allowed(
     [(30, 3, 10, 10, 5, 0), (30, 3, 2, 3, 10, 3), (30, -5, 10, 10, 5, 0)],
 )
 def test_percolate_between_layers(
-        time_step: float,
-        water_content: float,
-        field_capacity_content: float,
-        amount_to_percolate: float,
-        acceptable_percolation_amount: float,
-        expected: float,
+    time_step: float,
+    water_content: float,
+    field_capacity_content: float,
+    amount_to_percolate: float,
+    acceptable_percolation_amount: float,
+    expected: float,
 ) -> None:
     """this function tests _percolate_between_layers() in Percolation.py"""
     upper_data = LayerData(top_depth=0, bottom_depth=20, field_size=1.33)
@@ -113,9 +113,8 @@ def test_percolate_between_layers(
         field_size=1.33,
     )
     with (
-        patch.object(upper_data, 'water_content', water_content),
-        patch.object(LayerData, 'field_capacity_content', new_callable=PropertyMock) as
-        mock_field_capacity_content,
+        patch.object(upper_data, "water_content", water_content),
+        patch.object(LayerData, "field_capacity_content", new_callable=PropertyMock) as mock_field_capacity_content,
         patch(
             "RUFAS.routines.field.soil.layer_data.LayerData.acceptable_percolation_amount",
             new_callable=PropertyMock,
@@ -175,12 +174,12 @@ def test_percolate_between_layers(
     ],
 )
 def test_percolate_infiltrated_water(
-        infiltration: float,
-        water_contents: list[float],
-        acceptable_percolation_amounts: list[float],
-        percolated_water: list[float],
-        expected_water: list[float],
-        expected_layer: int | None,
+    infiltration: float,
+    water_contents: list[float],
+    acceptable_percolation_amounts: list[float],
+    percolated_water: list[float],
+    expected_water: list[float],
+    expected_layer: int | None,
 ) -> None:
     """Tests that extreme levels of infiltration are handled correctly."""
     layers = []
@@ -197,9 +196,9 @@ def test_percolate_infiltrated_water(
     soil_data.infiltrated_water = infiltration
     percolation = Percolation(soil_data)
     with patch(
-            "RUFAS.routines.field.soil.layer_data.LayerData.acceptable_percolation_amount",
-            new_callable=PropertyMock,
-            side_effect=acceptable_percolation_amounts,
+        "RUFAS.routines.field.soil.layer_data.LayerData.acceptable_percolation_amount",
+        new_callable=PropertyMock,
+        side_effect=acceptable_percolation_amounts,
     ):
         actual = percolation.percolate_infiltrated_water()
 
@@ -234,14 +233,14 @@ def mock_soil_data() -> SoilData:
     ],
 )
 def test_percolate(
-        mocker: MockerFixture,
-        can_percolate: bool,
-        seasonal_high_water_table: bool,
-        infiltration: float,
-        top_layer_percolated: int | None,
-        expected_water: List[float],
-        expected_call_count: int,
-        mock_soil_data: SoilData,
+    mocker: MockerFixture,
+    can_percolate: bool,
+    seasonal_high_water_table: bool,
+    infiltration: float,
+    top_layer_percolated: int | None,
+    expected_water: List[float],
+    expected_call_count: int,
+    mock_soil_data: SoilData,
 ) -> None:
     """Tests the main routine of percolation.py and check that it updates all values correctly."""
     mock_soil_data.infiltrated_water = infiltration

--- a/tests/soil_crop_tests/soil_tests/test_percolation.py
+++ b/tests/soil_crop_tests/soil_tests/test_percolation.py
@@ -200,9 +200,8 @@ def test_percolate_infiltrated_water(
         new_callable=PropertyMock,
         side_effect=acceptable_percolation_amounts,
     ):
-        actual = percolation.percolate_infiltrated_water()
-
-    assert actual == expected_layer
+        percolation.percolate_infiltrated_water()
+        
     for index, layer in enumerate(percolation.data.soil_layers):
         assert pytest.approx(layer.water_content) == expected_water[index]
         assert pytest.approx(layer.percolated_water) == percolated_water[index]

--- a/tests/soil_crop_tests/soil_tests/test_percolation.py
+++ b/tests/soil_crop_tests/soil_tests/test_percolation.py
@@ -201,7 +201,7 @@ def test_percolate_infiltrated_water(
         side_effect=acceptable_percolation_amounts,
     ):
         percolation.percolate_infiltrated_water()
-        
+
     for index, layer in enumerate(percolation.data.soil_layers):
         assert pytest.approx(layer.water_content) == expected_water[index]
         assert pytest.approx(layer.percolated_water) == percolated_water[index]

--- a/tests/soil_crop_tests/soil_tests/test_soil.py
+++ b/tests/soil_crop_tests/soil_tests/test_soil.py
@@ -66,6 +66,7 @@ def test_daily_soil_water_routine(
     soil = Soil(field_size=50)
     soil.infiltration.infiltrate = MagicMock()
     soil.percolation.percolate = MagicMock()
+    soil.percolation.percolate_infiltrated_water = MagicMock()
     soil.evaporation.evaporate = MagicMock()
     soil.soil_erosion.erode = MagicMock()
     soil.phosphorus_cycling.cycle_phosphorus = MagicMock()
@@ -85,6 +86,7 @@ def test_daily_soil_water_routine(
 
     soil.infiltration.infiltrate.assert_called_once_with(rainfall, weighting_coefficient, potential_evapotranspiration)
     soil.percolation.percolate.assert_called_once_with(has_seasonal_high_water_table)
+    soil.percolation.percolate_infiltrated_water.assert_called_once()
     soil.evaporation.evaporate.assert_called_once_with(maximum_soil_evaporation)
     soil.soil_erosion.erode.assert_called_once_with(field_size, minimum_cover_management_factor, residue, rainfall)
     soil.phosphorus_cycling.cycle_phosphorus.assert_called_once_with(


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
This PR changes the order of operations of the soil water percolation and infiltration routines. Previously soil water would infiltrate the soil and then percolate through the layers. This causes some challenges with the soil water mass balance accounting.

Now percolation will happen at the begining of the day which will essentially percolate yesterday's soil water and then new water will be applied and infiltrated into the soil and through the soil layers.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.
      
How big are the changes in the PR? Would you nominate it for a major version upgrade?
- [ ] Yes
- [x] No

### What
<!-- Add more detail about the changes that are being made in the pull request. -->


### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
Original order causes challenges with the soil water mass balance accounting.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Use this filter and assess the mass balance of the soil water additions and losses: 

[csv_soil_water.txt](https://github.com/RuminantFarmSystems/MASM/files/15490241/csv_soil_water.txt)
