### PR TITLE
Task extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-94%25-green)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-3545%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-3519%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3524%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3519%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-94%25-green)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-3549%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-94%25-green)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3545%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3549%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-94%25-green)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3515%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3519%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-3519%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-94%25-green)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-3545%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-3519%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-3519%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-94%25-green)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3519%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3524%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Union, Callable, Sequence
 
 import pandas as pd
-import traceback
 
 from RUFAS.output_manager import OutputManager
 from RUFAS.util import Utility

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Union, Callable, Sequence
 
 import pandas as pd
+import traceback
 
 from RUFAS.output_manager import OutputManager
 from RUFAS.util import Utility

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -322,12 +322,15 @@ class TaskManager:
         }
         task_id = args["task_id"]
         output_manager = OutputManager()
-        pre_validation_handlers = {TaskType.INPUT_DATA_AUDIT: TaskManager._input_data_audit_tasks,
-                                   TaskType.COMPARE_METADATA_PROPERTIES:
-                                       TaskManager._compare_metadata_properties_tasks}
-        post_validation_handlers = {TaskType.HERD_INITIALIZATION: TaskManager._herd_init_tasks,
-                                    TaskType.SIMULATION_SINGLE_RUN: TaskManager._simulation_engine_run_tasks,
-                                    TaskType.POST_PROCESSING: TaskManager._postprocessing_tasks}
+        pre_validation_handlers = {
+            TaskType.INPUT_DATA_AUDIT: TaskManager._input_data_audit_tasks,
+            TaskType.COMPARE_METADATA_PROPERTIES: TaskManager._compare_metadata_properties_tasks,
+        }
+        post_validation_handlers = {
+            TaskType.HERD_INITIALIZATION: TaskManager._herd_init_tasks,
+            TaskType.SIMULATION_SINGLE_RUN: TaskManager._simulation_engine_run_tasks,
+            TaskType.POST_PROCESSING: TaskManager._postprocessing_tasks,
+        }
         try:
             output_manager.run_startup_sequence(
                 LogVerbosity(args["log_verbosity"]),
@@ -344,8 +347,14 @@ class TaskManager:
 
             handler = pre_validation_handlers.get(task_type)
             if handler:
-                TaskManager.call_handler(handler, args=args, input_manager=input_manager, output_manager=output_manager,
-                                         task_id=task_id, produce_graphics=produce_graphics)
+                TaskManager.call_handler(
+                    handler,
+                    args=args,
+                    input_manager=input_manager,
+                    output_manager=output_manager,
+                    task_id=task_id,
+                    produce_graphics=produce_graphics,
+                )
                 return
             # if args["task_type"] == TaskType.INPUT_DATA_AUDIT:
             #     TaskManager.handle_input_data_audit(args, input_manager, output_manager, False)
@@ -372,8 +381,14 @@ class TaskManager:
 
             handler = post_validation_handlers.get(task_type)
             if handler:
-                TaskManager.call_handler(handler, args=args, input_manager=input_manager, output_manager=output_manager,
-                                         task_id=task_id, produce_graphics=produce_graphics)
+                TaskManager.call_handler(
+                    handler,
+                    args=args,
+                    input_manager=input_manager,
+                    output_manager=output_manager,
+                    task_id=task_id,
+                    produce_graphics=produce_graphics,
+                )
                 return
 
             # if args["task_type"] == TaskType.HERD_INITIALIZATION:
@@ -575,9 +590,12 @@ class TaskManager:
         TaskManager.handle_post_processing(args, input_manager, output_manager, task_id, produce_graphics, True)
 
     @staticmethod
-    def _postprocessing_tasks(args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager,
-                              task_id: Any, produce_graphics: bool) -> None:
+    def _postprocessing_tasks(
+        args: Dict[str, Any],
+        input_manager: InputManager,
+        output_manager: OutputManager,
+        task_id: Any,
+        produce_graphics: bool,
+    ) -> None:
         """Handler for all methods related to postprocessing."""
-        TaskManager.handle_post_processing(
-            args, input_manager, output_manager, task_id, produce_graphics, True, True
-        )
+        TaskManager.handle_post_processing(args, input_manager, output_manager, task_id, produce_graphics, True, True)

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -511,8 +511,9 @@ class TaskManager:
         output_manager.add_log("Random seed used", f"Seeded libaries with {random_seed=}", info_map)
 
     @staticmethod
-    def _input_data_audit_tasks(args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager,
-                               task_id: Any) -> None:
+    def _input_data_audit_tasks(
+        args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager, task_id: Any
+    ) -> None:
         TaskManager.handle_input_data_audit(args, input_manager, output_manager, False)
         TaskManager.handle_post_processing(args, input_manager, output_manager, task_id)
 
@@ -521,4 +522,3 @@ class TaskManager:
         input_manager.compare_metadata_properties(
             args["properties_file_path"], args["comparison_properties_file_path"], args["logs_directory"]
         )
-

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -1,6 +1,5 @@
 from enum import Enum
 from functools import partial
-import inspect
 import multiprocessing
 import numpy
 from pathlib import Path

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -326,16 +326,15 @@ class TaskManager:
         }
         task_id = args["task_id"]
         output_manager = OutputManager()
-        print(output_manager)
 
         pre_validation_handlers = {
-            TaskType.INPUT_DATA_AUDIT: TaskManager._input_data_audit_tasks,
-            TaskType.COMPARE_METADATA_PROPERTIES: TaskManager._compare_metadata_properties_tasks,
+            TaskType.INPUT_DATA_AUDIT: TaskManager._handle_input_data_audit_tasks,
+            TaskType.COMPARE_METADATA_PROPERTIES: TaskManager._handle_compare_metadata_properties_tasks,
         }
         post_validation_handlers = {
-            TaskType.HERD_INITIALIZATION: TaskManager._herd_init_tasks,
-            TaskType.SIMULATION_SINGLE_RUN: TaskManager._simulation_engine_run_tasks,
-            TaskType.POST_PROCESSING: TaskManager._postprocessing_tasks,
+            TaskType.HERD_INITIALIZATION: TaskManager._handle_herd_init_tasks,
+            TaskType.SIMULATION_SINGLE_RUN: TaskManager._handle_simulation_engine_run_tasks,
+            TaskType.POST_PROCESSING: TaskManager._handle_postprocessing_tasks,
         }
         try:
             output_manager.run_startup_sequence(
@@ -535,18 +534,19 @@ class TaskManager:
         output_manager.add_log("Random seed used", f"Seeded libaries with {random_seed=}", info_map)
 
     @staticmethod
-    def _input_data_audit_tasks(
+    def _handle_input_data_audit_tasks(
         args: Dict[str, Any],
         input_manager: InputManager,
         output_manager: OutputManager,
         task_id: Any,
         produce_grahics: bool,
     ) -> None:
+        """Handler for all methods related to metadata property comparison."""
         TaskManager.handle_input_data_audit(args, input_manager, output_manager, False)
         TaskManager.handle_post_processing(args, input_manager, output_manager, task_id)
 
     @staticmethod
-    def _compare_metadata_properties_tasks(
+    def _handle_compare_metadata_properties_tasks(
         args: Dict[str, Any],
         input_manager: InputManager,
         output_manager: OutputManager,
@@ -559,7 +559,7 @@ class TaskManager:
         )
 
     @staticmethod
-    def _herd_init_tasks(
+    def _handle_herd_init_tasks(
         args: Dict[str, Any],
         input_manager: InputManager,
         output_manager: OutputManager,
@@ -572,7 +572,7 @@ class TaskManager:
         TaskManager.handle_post_processing(args, input_manager, output_manager, task_id)
 
     @staticmethod
-    def _simulation_engine_run_tasks(
+    def _handle_simulation_engine_run_tasks(
         args: Dict[str, Any],
         input_manager: InputManager,
         output_manager: OutputManager,
@@ -586,7 +586,7 @@ class TaskManager:
         TaskManager.handle_post_processing(args, input_manager, output_manager, task_id, produce_graphics, True)
 
     @staticmethod
-    def _postprocessing_tasks(
+    def _handle_postprocessing_tasks(
         args: Dict[str, Any],
         input_manager: InputManager,
         output_manager: OutputManager,

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -322,12 +322,15 @@ class TaskManager:
         }
         task_id = args["task_id"]
         output_manager = OutputManager()
-        pre_validation_handlers = {TaskType.INPUT_DATA_AUDIT: TaskManager._input_data_audit_tasks,
-                                   TaskType.COMPARE_METADATA_PROPERTIES:
-                                       TaskManager._compare_metadata_properties_tasks}
-        post_validation_handlers = {TaskType.HERD_INITIALIZATION: TaskManager._herd_init_tasks,
-                                    TaskType.SIMULATION_SINGLE_RUN: TaskManager._simulation_engine_run_tasks,
-                                    TaskType.POST_PROCESSING: TaskManager._postprocessing_tasks}
+        pre_validation_handlers = {
+            TaskType.INPUT_DATA_AUDIT: TaskManager._input_data_audit_tasks,
+            TaskType.COMPARE_METADATA_PROPERTIES: TaskManager._compare_metadata_properties_tasks,
+        }
+        post_validation_handlers = {
+            TaskType.HERD_INITIALIZATION: TaskManager._herd_init_tasks,
+            TaskType.SIMULATION_SINGLE_RUN: TaskManager._simulation_engine_run_tasks,
+            TaskType.POST_PROCESSING: TaskManager._postprocessing_tasks,
+        }
         try:
             output_manager.run_startup_sequence(
                 LogVerbosity(args["log_verbosity"]),
@@ -344,8 +347,14 @@ class TaskManager:
 
             handler = pre_validation_handlers.get(task_type)
             if handler:
-                TaskManager.call_handler(handler,args=args, input_manager=input_manager, output_manager=output_manager,
-                                         task_id=task_id, produce_graphics=produce_graphics)
+                TaskManager.call_handler(
+                    handler,
+                    args=args,
+                    input_manager=input_manager,
+                    output_manager=output_manager,
+                    task_id=task_id,
+                    produce_graphics=produce_graphics,
+                )
                 return
             # if args["task_type"] == TaskType.INPUT_DATA_AUDIT:
             #     TaskManager.handle_input_data_audit(args, input_manager, output_manager, False)
@@ -372,8 +381,14 @@ class TaskManager:
 
             handler = post_validation_handlers.get(task_type)
             if handler:
-                TaskManager.call_handler(handler,args=args, input_manager=input_manager, output_manager=output_manager,
-                                         task_id=task_id, produce_graphics=produce_graphics)
+                TaskManager.call_handler(
+                    handler,
+                    args=args,
+                    input_manager=input_manager,
+                    output_manager=output_manager,
+                    task_id=task_id,
+                    produce_graphics=produce_graphics,
+                )
                 return
 
             # if args["task_type"] == TaskType.HERD_INITIALIZATION:
@@ -574,9 +589,12 @@ class TaskManager:
         TaskManager.handle_post_processing(args, input_manager, output_manager, task_id, produce_graphics, True)
 
     @staticmethod
-    def _postprocessing_tasks(args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager,
-                              task_id: Any, produce_graphics: bool) -> None:
+    def _postprocessing_tasks(
+        args: Dict[str, Any],
+        input_manager: InputManager,
+        output_manager: OutputManager,
+        task_id: Any,
+        produce_graphics: bool,
+    ) -> None:
         """Handler for all methods related to postprocessing."""
-        TaskManager.handle_post_processing(
-            args, input_manager, output_manager, task_id, produce_graphics, True, True
-        )
+        TaskManager.handle_post_processing(args, input_manager, output_manager, task_id, produce_graphics, True, True)

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -511,8 +511,9 @@ class TaskManager:
         output_manager.add_log("Random seed used", f"Seeded libaries with {random_seed=}", info_map)
 
     @staticmethod
-    def _input_data_audit_tasks(args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager,
-                                task_id: Any) -> None:
+    def _input_data_audit_tasks(
+        args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager, task_id: Any
+    ) -> None:
         TaskManager.handle_input_data_audit(args, input_manager, output_manager, False)
         TaskManager.handle_post_processing(args, input_manager, output_manager, task_id)
 
@@ -524,16 +525,22 @@ class TaskManager:
         )
 
     @staticmethod
-    def _herd_init_tasks(args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager,
-                         task_id: Any) -> None:
+    def _herd_init_tasks(
+        args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager, task_id: Any
+    ) -> None:
         """Handler for all methods related to herd initialization."""
         args["init_herd"] = True
         TaskManager.handle_herd_initializaition(args, output_manager)
         TaskManager.handle_post_processing(args, input_manager, output_manager, task_id)
 
     @staticmethod
-    def _simulation_engine_run_tasks(args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager,
-                                     task_id: Any, produce_graphics: bool) -> None:
+    def _simulation_engine_run_tasks(
+        args: Dict[str, Any],
+        input_manager: InputManager,
+        output_manager: OutputManager,
+        task_id: Any,
+        produce_graphics: bool,
+    ) -> None:
         """Handler for all methods related to simulation run."""
         if args["input_patch"]:
             Utility.deep_merge(input_manager.pool, args["input_patch"])

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from functools import partial
+import inspect
 import multiprocessing
 import numpy
 from pathlib import Path
@@ -7,7 +8,7 @@ import random
 from SALib.sample import ff as fractional_factorial_sampler
 from SALib.sample import saltelli as saltelli_sampler
 import traceback
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Callable
 
 from RUFAS.input_manager import InputManager
 from RUFAS.output_manager import OutputManager, LogVerbosity
@@ -305,6 +306,13 @@ class TaskManager:
             pass
 
     @staticmethod
+    def call_handler(handler: Callable[..., None], **kwargs: Any) -> None:
+        """Wrapper function to call the function map with each of its arguments."""
+        sig = inspect.signature(handler)
+        filtered_params = {k: v for k, v in kwargs.items() if k in sig.parameters}
+        handler(**filtered_params)
+
+    @staticmethod
     def task(args: Dict[str, Any], produce_graphics: bool, metadata_depth_limit: int | None) -> None:
         """Executes a single task with specified arguments."""
         info_map = {
@@ -314,6 +322,12 @@ class TaskManager:
         }
         task_id = args["task_id"]
         output_manager = OutputManager()
+        pre_validation_handlers = {TaskType.INPUT_DATA_AUDIT: TaskManager._input_data_audit_tasks,
+                                   TaskType.COMPARE_METADATA_PROPERTIES:
+                                       TaskManager._compare_metadata_properties_tasks}
+        post_validation_handlers = {TaskType.HERD_INITIALIZATION: TaskManager._herd_init_tasks,
+                                    TaskType.SIMULATION_SINGLE_RUN: TaskManager._simulation_engine_run_tasks,
+                                    TaskType.POST_PROCESSING: TaskManager._postprocessing_tasks}
         try:
             output_manager.run_startup_sequence(
                 LogVerbosity(args["log_verbosity"]),
@@ -326,17 +340,23 @@ class TaskManager:
                 task_id,
             )
             input_manager = InputManager(metadata_depth_limit)
+            task_type = args.get("task_type")
 
-            if args["task_type"] == TaskType.INPUT_DATA_AUDIT:
-                TaskManager.handle_input_data_audit(args, input_manager, output_manager, False)
-                TaskManager.handle_post_processing(args, input_manager, output_manager, task_id)
+            handler = pre_validation_handlers.get(task_type)
+            if handler:
+                TaskManager.call_handler(handler,args=args, input_manager=input_manager, output_manager=output_manager,
+                                         task_id=task_id, produce_graphics=produce_graphics)
                 return
-
-            if args["task_type"] == TaskType.COMPARE_METADATA_PROPERTIES:
-                input_manager.compare_metadata_properties(
-                    args["properties_file_path"], args["comparison_properties_file_path"], args["logs_directory"]
-                )
-                return
+            # if args["task_type"] == TaskType.INPUT_DATA_AUDIT:
+            #     TaskManager.handle_input_data_audit(args, input_manager, output_manager, False)
+            #     TaskManager.handle_post_processing(args, input_manager, output_manager, task_id)
+            #     return
+            #
+            # if args["task_type"] == TaskType.COMPARE_METADATA_PROPERTIES:
+            #     input_manager.compare_metadata_properties(
+            #         args["properties_file_path"], args["comparison_properties_file_path"], args["logs_directory"]
+            #     )
+            #     return
 
             is_data_valid = TaskManager.handle_input_data_audit(args, input_manager, output_manager, True)
             if not is_data_valid:
@@ -350,21 +370,27 @@ class TaskManager:
 
             TaskManager.set_random_seed(args["random_seed"], output_manager)
 
-            if args["task_type"] == TaskType.HERD_INITIALIZATION:
-                args["init_herd"] = True
-                TaskManager.handle_herd_initializaition(args, output_manager)
-                TaskManager.handle_post_processing(args, input_manager, output_manager, task_id)
+            handler = post_validation_handlers.get(task_type)
+            if handler:
+                TaskManager.call_handler(handler,args=args, input_manager=input_manager, output_manager=output_manager,
+                                         task_id=task_id, produce_graphics=produce_graphics)
+                return
 
-            if args["task_type"] == TaskType.SIMULATION_SINGLE_RUN:
-                if args["input_patch"]:
-                    Utility.deep_merge(input_manager.pool, args["input_patch"])
-                TaskManager.handle_single_simulation_run(args, output_manager)
-                TaskManager.handle_post_processing(args, input_manager, output_manager, task_id, produce_graphics, True)
-
-            if args["task_type"] == TaskType.POST_PROCESSING:
-                TaskManager.handle_post_processing(
-                    args, input_manager, output_manager, task_id, produce_graphics, True, True
-                )
+            # if args["task_type"] == TaskType.HERD_INITIALIZATION:
+            #     args["init_herd"] = True
+            #     TaskManager.handle_herd_initializaition(args, output_manager)
+            #     TaskManager.handle_post_processing(args, input_manager, output_manager, task_id)
+            #
+            # if args["task_type"] == TaskType.SIMULATION_SINGLE_RUN:
+            #     if args["input_patch"]:
+            #         Utility.deep_merge(input_manager.pool, args["input_patch"])
+            #     TaskManager.handle_single_simulation_run(args, output_manager)
+            #     TaskManager.handle_post_processing(args, input_manager, output_manager, task_id, produce_graphics, True)
+            #
+            # if args["task_type"] == TaskType.POST_PROCESSING:
+            #     TaskManager.handle_post_processing(
+            #         args, input_manager, output_manager, task_id, produce_graphics, True, True
+            #     )
         except Exception as e:
             info_map.update(args)
             output_manager.add_error(
@@ -539,3 +565,11 @@ class TaskManager:
             Utility.deep_merge(input_manager.pool, args["input_patch"])
         TaskManager.handle_single_simulation_run(args, output_manager)
         TaskManager.handle_post_processing(args, input_manager, output_manager, task_id, produce_graphics, True)
+
+    @staticmethod
+    def _postprocessing_tasks(args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager,
+                              task_id: Any, produce_graphics: bool) -> None:
+        """Handler for all methods related to postprocessing."""
+        TaskManager.handle_post_processing(
+            args, input_manager, output_manager, task_id, produce_graphics, True, True
+        )

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -21,7 +21,7 @@ RUFAS_VERSION = "0.8"
 
 """These constants define the minimum and maximum integers that can be passed to Numpy's random.seed method."""
 NUMPY_RANDOM_SEED_LOWER_BOUND = 0
-NUMPY_RANDOM_SEED_UPPER_BOUND = 2 ** 32 - 1
+NUMPY_RANDOM_SEED_UPPER_BOUND = 2**32 - 1
 
 
 class TaskType(Enum):
@@ -57,16 +57,16 @@ class TaskManager:
         self.output_manager = OutputManager()
 
     def start(
-            self,
-            metadata_path: Path,
-            verbosity: LogVerbosity,
-            exclude_info_maps: bool,
-            output_directory: Path,
-            logs_directory: Path,
-            clear_output_directory: bool,
-            produce_graphics: bool,
-            suppress_log_files: bool,
-            metadata_depth_limit: int,
+        self,
+        metadata_path: Path,
+        verbosity: LogVerbosity,
+        exclude_info_maps: bool,
+        output_directory: Path,
+        logs_directory: Path,
+        clear_output_directory: bool,
+        produce_graphics: bool,
+        suppress_log_files: bool,
+        metadata_depth_limit: int,
     ) -> None:
         """
         Initializes and starts the task management process.
@@ -295,7 +295,7 @@ class TaskManager:
         return []
 
     def _run_tasks(
-            self, single_run_args: List[Dict[str, Any]], produce_graphics: bool, metadata_depth_limit: int
+        self, single_run_args: List[Dict[str, Any]], produce_graphics: bool, metadata_depth_limit: int
     ) -> None:
         """Runs the tasks based on the provided arguments."""
         task_with_args = partial(
@@ -306,11 +306,14 @@ class TaskManager:
             pass
 
     @staticmethod
-    def call_handler(handler: Callable[..., None], args: Dict[str, Any],
-                     input_manager: InputManager,
-                     output_manager: OutputManager,
-                     task_id: Any,
-                     produce_graphics: bool, ) -> None:
+    def call_handler(
+        handler: Callable[..., None],
+        args: Dict[str, Any],
+        input_manager: InputManager,
+        output_manager: OutputManager,
+        task_id: Any,
+        produce_graphics: bool,
+    ) -> None:
         """Wrapper function to call the function map with each of its arguments."""
         handler(args, input_manager, output_manager, task_id, produce_graphics)
 
@@ -429,7 +432,7 @@ class TaskManager:
 
     @staticmethod
     def handle_input_data_audit(
-            args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager, eager_termination: bool
+        args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager, eager_termination: bool
     ) -> bool:
         """Validates input data saves metadata properties to CSV."""
         info_map = {
@@ -455,13 +458,13 @@ class TaskManager:
 
     @staticmethod
     def handle_post_processing(
-            args: Dict[str, Any],
-            input_manager: InputManager,
-            output_manager: OutputManager,
-            task_id: str,
-            produce_graphics: bool = False,
-            save_results: bool = False,
-            load_pool_from_file: bool = False,
+        args: Dict[str, Any],
+        input_manager: InputManager,
+        output_manager: OutputManager,
+        task_id: str,
+        produce_graphics: bool = False,
+        save_results: bool = False,
+        load_pool_from_file: bool = False,
     ) -> None:
         """
         Handles post-processing tasks based on specified arguments.
@@ -534,16 +537,23 @@ class TaskManager:
 
     @staticmethod
     def _input_data_audit_tasks(
-            args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager, task_id: Any,
-            produce_grahics: bool
+        args: Dict[str, Any],
+        input_manager: InputManager,
+        output_manager: OutputManager,
+        task_id: Any,
+        produce_grahics: bool,
     ) -> None:
         TaskManager.handle_input_data_audit(args, input_manager, output_manager, False)
         TaskManager.handle_post_processing(args, input_manager, output_manager, task_id)
 
     @staticmethod
-    def _compare_metadata_properties_tasks(args: Dict[str, Any], input_manager: InputManager,
-                                           output_manager: OutputManager, task_id: Any,
-                                           produce_grahics: bool) -> None:
+    def _compare_metadata_properties_tasks(
+        args: Dict[str, Any],
+        input_manager: InputManager,
+        output_manager: OutputManager,
+        task_id: Any,
+        produce_grahics: bool,
+    ) -> None:
         """Handler for all methods related to metadata property comparison."""
         input_manager.compare_metadata_properties(
             args["properties_file_path"], args["comparison_properties_file_path"], args["logs_directory"]
@@ -551,8 +561,11 @@ class TaskManager:
 
     @staticmethod
     def _herd_init_tasks(
-            args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager, task_id: Any,
-            produce_grahics: bool
+        args: Dict[str, Any],
+        input_manager: InputManager,
+        output_manager: OutputManager,
+        task_id: Any,
+        produce_grahics: bool,
     ) -> None:
         """Handler for all methods related to herd initialization."""
         args["init_herd"] = True
@@ -561,11 +574,11 @@ class TaskManager:
 
     @staticmethod
     def _simulation_engine_run_tasks(
-            args: Dict[str, Any],
-            input_manager: InputManager,
-            output_manager: OutputManager,
-            task_id: Any,
-            produce_graphics: bool,
+        args: Dict[str, Any],
+        input_manager: InputManager,
+        output_manager: OutputManager,
+        task_id: Any,
+        produce_graphics: bool,
     ) -> None:
         """Handler for all methods related to simulation run."""
         if args["input_patch"]:
@@ -575,11 +588,11 @@ class TaskManager:
 
     @staticmethod
     def _postprocessing_tasks(
-            args: Dict[str, Any],
-            input_manager: InputManager,
-            output_manager: OutputManager,
-            task_id: Any,
-            produce_graphics: bool,
+        args: Dict[str, Any],
+        input_manager: InputManager,
+        output_manager: OutputManager,
+        task_id: Any,
+        produce_graphics: bool,
     ) -> None:
         """Handler for all methods related to postprocessing."""
         TaskManager.handle_post_processing(args, input_manager, output_manager, task_id, produce_graphics, True, True)

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -344,7 +344,7 @@ class TaskManager:
 
             handler = pre_validation_handlers.get(task_type)
             if handler:
-                TaskManager.call_handler(handler,args=args, input_manager=input_manager, output_manager=output_manager,
+                TaskManager.call_handler(handler, args=args, input_manager=input_manager, output_manager=output_manager,
                                          task_id=task_id, produce_graphics=produce_graphics)
                 return
             # if args["task_type"] == TaskType.INPUT_DATA_AUDIT:
@@ -372,7 +372,7 @@ class TaskManager:
 
             handler = post_validation_handlers.get(task_type)
             if handler:
-                TaskManager.call_handler(handler,args=args, input_manager=input_manager, output_manager=output_manager,
+                TaskManager.call_handler(handler, args=args, input_manager=input_manager, output_manager=output_manager,
                                          task_id=task_id, produce_graphics=produce_graphics)
                 return
 
@@ -385,7 +385,8 @@ class TaskManager:
             #     if args["input_patch"]:
             #         Utility.deep_merge(input_manager.pool, args["input_patch"])
             #     TaskManager.handle_single_simulation_run(args, output_manager)
-            #     TaskManager.handle_post_processing(args, input_manager, output_manager, task_id, produce_graphics, True)
+            #     TaskManager.handle_post_processing(args, input_manager, output_manager, task_id, produce_graphics,
+            #     True)
             #
             # if args["task_type"] == TaskType.POST_PROCESSING:
             #     TaskManager.handle_post_processing(

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -57,16 +57,16 @@ class TaskManager:
         self.output_manager = OutputManager()
 
     def start(
-        self,
-        metadata_path: Path,
-        verbosity: LogVerbosity,
-        exclude_info_maps: bool,
-        output_directory: Path,
-        logs_directory: Path,
-        clear_output_directory: bool,
-        produce_graphics: bool,
-        suppress_log_files: bool,
-        metadata_depth_limit: int,
+            self,
+            metadata_path: Path,
+            verbosity: LogVerbosity,
+            exclude_info_maps: bool,
+            output_directory: Path,
+            logs_directory: Path,
+            clear_output_directory: bool,
+            produce_graphics: bool,
+            suppress_log_files: bool,
+            metadata_depth_limit: int,
     ) -> None:
         """
         Initializes and starts the task management process.
@@ -134,7 +134,7 @@ class TaskManager:
         parsed_single_run_args, parsed_multi_run_args = self._parse_input_tasks()
         self.output_manager.add_log(
             "Task Manager parsed tasks",
-            f"Parsed {len(parsed_single_run_args)+len(parsed_multi_run_args)} tasks args.",
+            f"Parsed {len(parsed_single_run_args) + len(parsed_multi_run_args)} tasks args.",
             info_map,
         )
         expanded_args = self._expand_multi_runs_to_single_runs(parsed_multi_run_args)
@@ -145,7 +145,7 @@ class TaskManager:
             info_map,
         )
         for i in range(len(runnable_args)):
-            runnable_args[i]["task_id"] = f"{i+1}/{len(runnable_args)}"
+            runnable_args[i]["task_id"] = f"{i + 1}/{len(runnable_args)}"
         self._run_tasks(runnable_args, produce_graphics, metadata_depth_limit)
         TaskManager.handle_post_processing(
             args={
@@ -224,7 +224,7 @@ class TaskManager:
             new_args = multi_run_args.copy()
             new_args["task_type"] = TaskType.SIMULATION_SINGLE_RUN
             new_args["random_seed"] = random.randint(NUMPY_RANDOM_SEED_LOWER_BOUND, NUMPY_RANDOM_SEED_UPPER_BOUND)
-            new_args["output_prefix"] = f"{new_args['output_prefix']} run {i+1}"
+            new_args["output_prefix"] = f"{new_args['output_prefix']} run {i + 1}"
             single_run_args.append(new_args)
 
         return single_run_args
@@ -279,7 +279,7 @@ class TaskManager:
         for sample_number in range(start_sample, stop_sample):
             new_args = multi_run_args.copy()
             new_args["task_type"] = TaskType.SIMULATION_SINGLE_RUN
-            run_number = f"{sample_number+1}".zfill(digits)
+            run_number = f"{sample_number + 1}".zfill(digits)
             new_args["output_prefix"] = f"{new_args['output_prefix']} run {run_number}"
             new_args["input_patch"] = {
                 names[variable_number]: data_types[variable_number](sampled_values[sample_number, variable_number])
@@ -295,7 +295,7 @@ class TaskManager:
         return []
 
     def _run_tasks(
-        self, single_run_args: List[Dict[str, Any]], produce_graphics: bool, metadata_depth_limit: int
+            self, single_run_args: List[Dict[str, Any]], produce_graphics: bool, metadata_depth_limit: int
     ) -> None:
         """Runs the tasks based on the provided arguments."""
         task_with_args = partial(
@@ -307,10 +307,12 @@ class TaskManager:
 
     @staticmethod
     def call_handler(handler: Callable[..., None], **kwargs: Any) -> None:
+
         """Wrapper function to call the function map with each of its arguments."""
         sig = inspect.signature(handler)
         filtered_params = {k: v for k, v in kwargs.items() if k in sig.parameters}
         handler(**filtered_params)
+
 
     @staticmethod
     def task(args: Dict[str, Any], produce_graphics: bool, metadata_depth_limit: int | None) -> None:
@@ -344,7 +346,7 @@ class TaskManager:
                 RUFAS_VERSION,
                 task_id,
             )
-            print("aaaaaaaaaaaaaaaaaaaaaa")
+
             input_manager = InputManager(metadata_depth_limit)
             task_type = args.get("task_type")
 
@@ -359,18 +361,9 @@ class TaskManager:
                     produce_graphics=produce_graphics,
                 )
                 return
-            # if args["task_type"] == TaskType.INPUT_DATA_AUDIT:
-            #     TaskManager.handle_input_data_audit(args, input_manager, output_manager, False)
-            #     TaskManager.handle_post_processing(args, input_manager, output_manager, task_id)
-            #     return
-            #
-            # if args["task_type"] == TaskType.COMPARE_METADATA_PROPERTIES:
-            #     input_manager.compare_metadata_properties(
-            #         args["properties_file_path"], args["comparison_properties_file_path"], args["logs_directory"]
-            #     )
-            #     return
 
             is_data_valid = TaskManager.handle_input_data_audit(args, input_manager, output_manager, True)
+
             if not is_data_valid:
                 output_manager.add_error(
                     "No task run",
@@ -394,22 +387,6 @@ class TaskManager:
                 )
                 return
 
-            # if args["task_type"] == TaskType.HERD_INITIALIZATION:
-            #     args["init_herd"] = True
-            #     TaskManager.handle_herd_initializaition(args, output_manager)
-            #     TaskManager.handle_post_processing(args, input_manager, output_manager, task_id)
-            #
-            # if args["task_type"] == TaskType.SIMULATION_SINGLE_RUN:
-            #     if args["input_patch"]:
-            #         Utility.deep_merge(input_manager.pool, args["input_patch"])
-            #     TaskManager.handle_single_simulation_run(args, output_manager)
-            #     TaskManager.handle_post_processing(args, input_manager, output_manager, task_id, produce_graphics,
-            #     True)
-            #
-            # if args["task_type"] == TaskType.POST_PROCESSING:
-            #     TaskManager.handle_post_processing(
-            #         args, input_manager, output_manager, task_id, produce_graphics, True, True
-            #     )
         except Exception as e:
             info_map.update(args)
             output_manager.add_error(
@@ -452,7 +429,7 @@ class TaskManager:
 
     @staticmethod
     def handle_input_data_audit(
-        args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager, eager_termination: bool
+            args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager, eager_termination: bool
     ) -> bool:
         """Validates input data saves metadata properties to CSV."""
         info_map = {
@@ -478,13 +455,13 @@ class TaskManager:
 
     @staticmethod
     def handle_post_processing(
-        args: Dict[str, Any],
-        input_manager: InputManager,
-        output_manager: OutputManager,
-        task_id: str,
-        produce_graphics: bool = False,
-        save_results: bool = False,
-        load_pool_from_file: bool = False,
+            args: Dict[str, Any],
+            input_manager: InputManager,
+            output_manager: OutputManager,
+            task_id: str,
+            produce_graphics: bool = False,
+            save_results: bool = False,
+            load_pool_from_file: bool = False,
     ) -> None:
         """
         Handles post-processing tasks based on specified arguments.
@@ -557,7 +534,7 @@ class TaskManager:
 
     @staticmethod
     def _input_data_audit_tasks(
-        args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager, task_id: Any
+            args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager, task_id: Any
     ) -> None:
         TaskManager.handle_input_data_audit(args, input_manager, output_manager, False)
         TaskManager.handle_post_processing(args, input_manager, output_manager, task_id)
@@ -571,7 +548,7 @@ class TaskManager:
 
     @staticmethod
     def _herd_init_tasks(
-        args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager, task_id: Any
+            args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager, task_id: Any
     ) -> None:
         """Handler for all methods related to herd initialization."""
         args["init_herd"] = True
@@ -580,11 +557,11 @@ class TaskManager:
 
     @staticmethod
     def _simulation_engine_run_tasks(
-        args: Dict[str, Any],
-        input_manager: InputManager,
-        output_manager: OutputManager,
-        task_id: Any,
-        produce_graphics: bool,
+            args: Dict[str, Any],
+            input_manager: InputManager,
+            output_manager: OutputManager,
+            task_id: Any,
+            produce_graphics: bool,
     ) -> None:
         """Handler for all methods related to simulation run."""
         if args["input_patch"]:
@@ -594,11 +571,11 @@ class TaskManager:
 
     @staticmethod
     def _postprocessing_tasks(
-        args: Dict[str, Any],
-        input_manager: InputManager,
-        output_manager: OutputManager,
-        task_id: Any,
-        produce_graphics: bool,
+            args: Dict[str, Any],
+            input_manager: InputManager,
+            output_manager: OutputManager,
+            task_id: Any,
+            produce_graphics: bool,
     ) -> None:
         """Handler for all methods related to postprocessing."""
         TaskManager.handle_post_processing(args, input_manager, output_manager, task_id, produce_graphics, True, True)

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -7,7 +7,7 @@ import random
 from SALib.sample import ff as fractional_factorial_sampler
 from SALib.sample import saltelli as saltelli_sampler
 import traceback
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Callable
 
 from RUFAS.input_manager import InputManager
 from RUFAS.output_manager import OutputManager, LogVerbosity
@@ -509,3 +509,16 @@ class TaskManager:
 
         output_manager.add_variable("random_seed", random_seed, info_map)
         output_manager.add_log("Random seed used", f"Seeded libaries with {random_seed=}", info_map)
+
+    @staticmethod
+    def _input_data_audit_tasks(args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager,
+                               task_id: Any) -> None:
+        TaskManager.handle_input_data_audit(args, input_manager, output_manager, False)
+        TaskManager.handle_post_processing(args, input_manager, output_manager, task_id)
+
+    @staticmethod
+    def _compare_metadata_properties_tasks(args: Dict[str, Any], input_manager: InputManager) -> None:
+        input_manager.compare_metadata_properties(
+            args["properties_file_path"], args["comparison_properties_file_path"], args["logs_directory"]
+        )
+

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -327,11 +327,11 @@ class TaskManager:
         task_id = args["task_id"]
         output_manager = OutputManager()
 
-        pre_validation_handlers = {
+        validation_and_comparison_handlers = {
             TaskType.INPUT_DATA_AUDIT: TaskManager._handle_input_data_audit_tasks,
             TaskType.COMPARE_METADATA_PROPERTIES: TaskManager._handle_compare_metadata_properties_tasks,
         }
-        post_validation_handlers = {
+        simulation_and_analysis_handlers = {
             TaskType.HERD_INITIALIZATION: TaskManager._handle_herd_init_tasks,
             TaskType.SIMULATION_SINGLE_RUN: TaskManager._handle_simulation_engine_run_tasks,
             TaskType.POST_PROCESSING: TaskManager._handle_postprocessing_tasks,
@@ -351,7 +351,7 @@ class TaskManager:
             input_manager = InputManager(metadata_depth_limit)
             task_type = args.get("task_type")
 
-            handler = pre_validation_handlers.get(task_type)
+            handler = validation_and_comparison_handlers.get(task_type)
             if handler:
                 TaskManager.call_handler(
                     handler,
@@ -376,7 +376,7 @@ class TaskManager:
 
             TaskManager.set_random_seed(args["random_seed"], output_manager)
 
-            handler = post_validation_handlers.get(task_type)
+            handler = simulation_and_analysis_handlers.get(task_type)
             if handler:
                 TaskManager.call_handler(
                     handler,

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -322,6 +322,8 @@ class TaskManager:
         }
         task_id = args["task_id"]
         output_manager = OutputManager()
+        print(output_manager)
+
         pre_validation_handlers = {
             TaskType.INPUT_DATA_AUDIT: TaskManager._input_data_audit_tasks,
             TaskType.COMPARE_METADATA_PROPERTIES: TaskManager._compare_metadata_properties_tasks,
@@ -342,6 +344,7 @@ class TaskManager:
                 RUFAS_VERSION,
                 task_id,
             )
+            print("aaaaaaaaaaaaaaaaaaaaaa")
             input_manager = InputManager(metadata_depth_limit)
             task_type = args.get("task_type")
 

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -21,7 +21,7 @@ RUFAS_VERSION = "0.8"
 
 """These constants define the minimum and maximum integers that can be passed to Numpy's random.seed method."""
 NUMPY_RANDOM_SEED_LOWER_BOUND = 0
-NUMPY_RANDOM_SEED_UPPER_BOUND = 2**32 - 1
+NUMPY_RANDOM_SEED_UPPER_BOUND = 2 ** 32 - 1
 
 
 class TaskType(Enum):
@@ -306,13 +306,13 @@ class TaskManager:
             pass
 
     @staticmethod
-    def call_handler(handler: Callable[..., None], **kwargs: Any) -> None:
-
+    def call_handler(handler: Callable[..., None], args: Dict[str, Any],
+                     input_manager: InputManager,
+                     output_manager: OutputManager,
+                     task_id: Any,
+                     produce_graphics: bool, ) -> None:
         """Wrapper function to call the function map with each of its arguments."""
-        sig = inspect.signature(handler)
-        filtered_params = {k: v for k, v in kwargs.items() if k in sig.parameters}
-        handler(**filtered_params)
-
+        handler(args, input_manager, output_manager, task_id, produce_graphics)
 
     @staticmethod
     def task(args: Dict[str, Any], produce_graphics: bool, metadata_depth_limit: int | None) -> None:
@@ -534,13 +534,16 @@ class TaskManager:
 
     @staticmethod
     def _input_data_audit_tasks(
-            args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager, task_id: Any
+            args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager, task_id: Any,
+            produce_grahics: bool
     ) -> None:
         TaskManager.handle_input_data_audit(args, input_manager, output_manager, False)
         TaskManager.handle_post_processing(args, input_manager, output_manager, task_id)
 
     @staticmethod
-    def _compare_metadata_properties_tasks(args: Dict[str, Any], input_manager: InputManager) -> None:
+    def _compare_metadata_properties_tasks(args: Dict[str, Any], input_manager: InputManager,
+                                           output_manager: OutputManager, task_id: Any,
+                                           produce_grahics: bool) -> None:
         """Handler for all methods related to metadata property comparison."""
         input_manager.compare_metadata_properties(
             args["properties_file_path"], args["comparison_properties_file_path"], args["logs_directory"]
@@ -548,7 +551,8 @@ class TaskManager:
 
     @staticmethod
     def _herd_init_tasks(
-            args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager, task_id: Any
+            args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager, task_id: Any,
+            produce_grahics: bool
     ) -> None:
         """Handler for all methods related to herd initialization."""
         args["init_herd"] = True

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -7,7 +7,7 @@ import random
 from SALib.sample import ff as fractional_factorial_sampler
 from SALib.sample import saltelli as saltelli_sampler
 import traceback
-from typing import Any, Dict, List, Tuple, Callable
+from typing import Any, Dict, List, Tuple
 
 from RUFAS.input_manager import InputManager
 from RUFAS.output_manager import OutputManager, LogVerbosity
@@ -512,13 +512,30 @@ class TaskManager:
 
     @staticmethod
     def _input_data_audit_tasks(args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager,
-                               task_id: Any) -> None:
+                                task_id: Any) -> None:
         TaskManager.handle_input_data_audit(args, input_manager, output_manager, False)
         TaskManager.handle_post_processing(args, input_manager, output_manager, task_id)
 
     @staticmethod
     def _compare_metadata_properties_tasks(args: Dict[str, Any], input_manager: InputManager) -> None:
+        """Handler for all methods related to metadata property comparison."""
         input_manager.compare_metadata_properties(
             args["properties_file_path"], args["comparison_properties_file_path"], args["logs_directory"]
         )
 
+    @staticmethod
+    def _herd_init_tasks(args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager,
+                         task_id: Any) -> None:
+        """Handler for all methods related to herd initialization."""
+        args["init_herd"] = True
+        TaskManager.handle_herd_initializaition(args, output_manager)
+        TaskManager.handle_post_processing(args, input_manager, output_manager, task_id)
+
+    @staticmethod
+    def _simulation_engine_run_tasks(args: Dict[str, Any], input_manager: InputManager, output_manager: OutputManager,
+                                     task_id: Any, produce_graphics: bool) -> None:
+        """Handler for all methods related to simulation run."""
+        if args["input_patch"]:
+            Utility.deep_merge(input_manager.pool, args["input_patch"])
+        TaskManager.handle_single_simulation_run(args, output_manager)
+        TaskManager.handle_post_processing(args, input_manager, output_manager, task_id, produce_graphics, True)

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -8,6 +8,7 @@ from RUFAS.input_manager import InputManager
 from RUFAS.task_manager import TaskManager, TaskType, RUFAS_VERSION
 from RUFAS.output_manager import LogVerbosity, OutputManager
 from RUFAS.units import MeasurementUnits
+from RUFAS.util import Utility
 
 
 @pytest.fixture
@@ -236,7 +237,6 @@ def test_task(
         mock_output_manager: Generator[Any, Any, Any], task_manager: TaskManager, mocker: MockerFixture,
         task_type: TaskType, pre_validate: bool
 ) -> None:
-
     args = {
         "task_type": task_type,
         "log_verbosity": LogVerbosity.LOGS,
@@ -261,7 +261,182 @@ def test_task(
 
     if pre_validate:
         mock_handler.assert_called_once()
+        # print(mock_handler.call_args)
     else:
         mock_handle_input_data_audit.assert_called_once()
         mock_set_random_seed.assert_called_once()
         mock_handler.assert_called_once()
+        # print(mock_handler.call_args)
+
+
+def test_compare_metadata_properties_tasks(mocker: MockerFixture) -> None:
+    args = {
+        "properties_file_path": Path("fake/properties/path"),
+        "comparison_properties_file_path": Path("fake/comparison/properties/path"),
+        "logs_directory": Path("/fake/logs")
+    }
+    mock_input_manager = MagicMock(name='InputManager')
+    mock_output_manager = MagicMock(name='OutputManager')
+    produce_graphic = False
+    task_id = 6
+
+    mock_compare_metadata_properties = mocker.patch.object(
+        mock_input_manager, 'compare_metadata_properties', return_value=None
+    )
+
+    TaskManager._compare_metadata_properties_tasks(args, mock_input_manager, mock_output_manager, task_id,
+                                                   produce_graphic)
+
+    mock_compare_metadata_properties.assert_called_once_with(
+        args["properties_file_path"], args["comparison_properties_file_path"], args["logs_directory"]
+    )
+
+
+def test_herd_init_tasks() -> None:
+    args = {
+        "log_verbosity": "logs",
+        "exclude_info_maps": False,
+        "output_prefix": "test",
+        "logs_directory": "/fake/logs",
+        "task_id": 1,
+        "random_seed": 924,
+        "suppress_log_files": True,
+        "metadata_file_path": "/fake/logs",
+        "properties_file_path": "more/fake/paths"
+    }
+    task_id = 5
+
+    # Create mocks for InputManager and OutputManager
+    mock_input_manager = MagicMock(name='InputManager')
+    mock_output_manager = MagicMock(name='OutputManager')
+    produce_graphic = False
+    with patch.object(TaskManager, 'handle_herd_initializaition',
+                      return_value=None) as mock_handle_herd_initializaition, \
+            patch.object(TaskManager, 'handle_post_processing',
+                         return_value=None) as mock_handle_post_processing:
+        TaskManager._herd_init_tasks(args, mock_input_manager, mock_output_manager, task_id, produce_graphic)
+        mock_handle_herd_initializaition.assert_called_once_with(args, mock_output_manager)
+        mock_handle_post_processing.assert_called_once_with(args, mock_input_manager, mock_output_manager, task_id)
+
+
+@pytest.mark.parametrize("input_patch,produce_graphics", [
+    (True, True),
+    (False, True),
+    (False, False),
+    (True, False)
+])
+def test_simulation_engine_run_tasks(input_patch: bool, produce_graphics: bool) -> None:
+    args = {
+        "log_verbosity": "logs",
+        "exclude_info_maps": False,
+        "output_prefix": "test",
+        "logs_directory": "/fake/logs",
+        "task_id": 1,
+        "random_seed": 924,
+        "suppress_log_files": True,
+        "metadata_file_path": "/fake/logs",
+        "properties_file_path": "more/fake/paths",
+        "input_patch": input_patch
+    }
+    task_id = 5
+    mock_input_manager = MagicMock(name='InputManager')
+    mock_output_manager = MagicMock(name='OutputManager')
+    with patch.object(TaskManager, 'handle_single_simulation_run',
+                      return_value=None) as mock_handle_single_simulation_run, \
+            patch.object(TaskManager, 'handle_post_processing',
+                         return_value=None) as mock_handle_post_processing, \
+            patch.object(Utility, 'deep_merge', return_value=None) as mock_deep_merge:
+
+        TaskManager._simulation_engine_run_tasks(args, mock_input_manager, mock_output_manager, task_id,
+                                                 produce_graphics)
+        if input_patch:
+            mock_deep_merge.assert_called_once_with(mock_input_manager.pool, args["input_patch"])
+        else:
+            mock_deep_merge.assert_not_called()
+
+        mock_handle_single_simulation_run.assert_called_once_with(args, mock_output_manager)
+        mock_handle_post_processing.assert_called_once_with(args, mock_input_manager, mock_output_manager,
+                                                            task_id, produce_graphics, True)
+
+
+@pytest.mark.parametrize("produce_graphics", [
+    True,
+    False
+])
+def test_postprocessing_tasks(produce_graphics: bool) -> None:
+    args = {
+        "log_verbosity": "logs",
+        "exclude_info_maps": False,
+        "output_prefix": "test",
+        "logs_directory": "/fake/logs",
+        "task_id": 1,
+        "random_seed": 924,
+        "suppress_log_files": True,
+        "metadata_file_path": "/fake/logs",
+        "properties_file_path": "more/fake/paths"
+    }
+    task_id = 5
+    mock_input_manager = MagicMock(name='InputManager')
+    mock_output_manager = MagicMock(name='OutputManager')
+    with patch.object(TaskManager, 'handle_post_processing', return_value=None) as mock_handle_post_processing:
+        TaskManager._postprocessing_tasks(args, mock_input_manager, mock_output_manager, task_id, produce_graphics)
+        mock_handle_post_processing.assert_called_once_with(args, mock_input_manager, mock_output_manager,
+                                                            task_id, produce_graphics, True, True)
+
+
+def test_call_handler():
+    args = {
+        "log_verbosity": "logs",
+        "exclude_info_maps": False,
+        "output_prefix": "test",
+        "logs_directory": "/fake/logs",
+        "task_id": 1,
+        "random_seed": 924,
+        "suppress_log_files": True,
+        "metadata_file_path": "/fake/logs",
+        "properties_file_path": "more/fake/paths"
+    }
+    task_id = 5
+    mock_input_manager = MagicMock(name='InputManager')
+    mock_output_manager = MagicMock(name='OutputManager')
+    produce_graphics = False
+
+    # Call the call_handler method
+    with patch.object(TaskManager, '_postprocessing_tasks', return_value=None) as mock_handle_post_processing:
+        TaskManager.call_handler(mock_handle_post_processing, args=args,
+                                 input_manager=mock_input_manager,
+                                 output_manager=mock_output_manager,
+                                 task_id=task_id,
+                                 produce_graphics=produce_graphics
+                                 )
+
+        # Verify that the handler was called with the correct filtered arguments
+        print(mock_handle_post_processing.call_args)
+        mock_handle_post_processing.assert_called_once_with(args, mock_input_manager, mock_output_manager,
+                                                            task_id, produce_graphics)
+
+
+def test_input_data_audit_tasks() -> None:
+    args = {
+        "log_verbosity": LogVerbosity.LOGS,
+        "exclude_info_maps": False,
+        "output_prefix": "test",
+        "logs_directory": Path("/fake/logs"),
+        "task_id": 1,
+        "random_seed": 924,
+        "suppress_log_files": True,
+        "metadata_file_path": Path("/fake/logs"),
+        "properties_file_path": Path("more/fake/paths")
+    }
+    task_id = 5
+    im = InputManager()
+    om = OutputManager()
+    produce_graphic = False
+
+    with (patch.object(TaskManager, 'handle_input_data_audit', return_value=None) as
+          mock_handle_input_data_audit, patch.object(TaskManager, 'handle_post_processing', return_value=None)
+          as mock_handle_post_processing):
+        TaskManager._input_data_audit_tasks(args, im, om, task_id, produce_graphic)
+
+        mock_handle_input_data_audit.assert_called_once_with(args, im, om, False)
+        mock_handle_post_processing.assert_called_once_with(args, im, om, task_id)

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -416,7 +416,7 @@ def test_call_handler():
     produce_graphics = False
 
     # Call the call_handler method
-    with patch.object(TaskManager, "_postprocessing_tasks", return_value=None) as mock_handle_post_processing:
+    with patch.object(TaskManager, "_handle_postprocessing_tasks", return_value=None) as mock_handle_post_processing:
         TaskManager.call_handler(
             mock_handle_post_processing,
             args=args,

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -244,6 +244,7 @@ def test_task(
     task_type: TaskType,
     pre_validate: bool,
 ) -> None:
+    """Tests that all available tasks were able to be mapped and run"""
     args = {
         "task_type": task_type,
         "log_verbosity": LogVerbosity.LOGS,
@@ -278,6 +279,7 @@ def test_task(
 
 
 def test_compare_metadata_properties_tasks(mocker: MockerFixture) -> None:
+    """Tests that all compare metadata properties tasks were handled"""
     args = {
         "properties_file_path": Path("fake/properties/path"),
         "comparison_properties_file_path": Path("fake/comparison/properties/path"),
@@ -302,6 +304,7 @@ def test_compare_metadata_properties_tasks(mocker: MockerFixture) -> None:
 
 
 def test_herd_init_tasks() -> None:
+    """Tests that all herd initialization tasks were handled"""
     args = {
         "log_verbosity": "logs",
         "exclude_info_maps": False,
@@ -330,6 +333,7 @@ def test_herd_init_tasks() -> None:
 
 @pytest.mark.parametrize("input_patch,produce_graphics", [(True, True), (False, True), (False, False), (True, False)])
 def test_simulation_engine_run_tasks(input_patch: bool, produce_graphics: bool) -> None:
+    """Tests that all simulation engine run tasks were handled"""
     args = {
         "log_verbosity": "logs",
         "exclude_info_maps": False,
@@ -369,6 +373,7 @@ def test_simulation_engine_run_tasks(input_patch: bool, produce_graphics: bool) 
 
 @pytest.mark.parametrize("produce_graphics", [True, False])
 def test_postprocessing_tasks(produce_graphics: bool) -> None:
+    """Tests that all postprocessing tasks were handled"""
     args = {
         "log_verbosity": "logs",
         "exclude_info_maps": False,
@@ -391,6 +396,7 @@ def test_postprocessing_tasks(produce_graphics: bool) -> None:
 
 
 def test_call_handler():
+    """Tests that wrapper handler function were handled"""
     args = {
         "log_verbosity": "logs",
         "exclude_info_maps": False,
@@ -426,6 +432,7 @@ def test_call_handler():
 
 
 def test_input_data_audit_tasks() -> None:
+    """Tests that all input data audit tasks were handled"""
     args = {
         "log_verbosity": LogVerbosity.LOGS,
         "exclude_info_maps": False,

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -5,14 +5,15 @@ from pytest_mock import MockerFixture
 from pathlib import Path
 
 from RUFAS.input_manager import InputManager
-from RUFAS.task_manager import TaskManager, TaskType
-from RUFAS.output_manager import LogVerbosity
+from RUFAS.task_manager import TaskManager, TaskType, RUFAS_VERSION
+from RUFAS.output_manager import LogVerbosity, OutputManager
 from RUFAS.units import MeasurementUnits
 
 
 @pytest.fixture
 def mock_output_manager() -> Generator[Any, Any, Any]:
     with patch("RUFAS.task_manager.OutputManager") as mock:
+        print(str(mock)+"fixure")
         yield mock
 
 
@@ -46,8 +47,8 @@ def test_invalid_task_type_from_string() -> None:
 
 
 def test_task_manager_init(
-    task_manager: TaskManager,
-    mock_output_manager: Generator[Any, Any, Any],
+        task_manager: TaskManager,
+        mock_output_manager: Generator[Any, Any, Any],
 ) -> None:
     assert task_manager.output_manager is mock_output_manager
 
@@ -87,7 +88,7 @@ def test_set_random_seed(mock_output_manager: Generator[Any, Any, Any]) -> None:
 def test_set_random_seed_zero(mock_output_manager: Generator[Any, Any, Any]) -> None:
     with patch("RUFAS.task_manager.random.randint", return_value=4321) as mock_randint:
         TaskManager.set_random_seed(0, mock_output_manager)
-        mock_randint.assert_called_once_with(0, 2**32 - 1)
+        mock_randint.assert_called_once_with(0, 2 ** 32 - 1)
         mock_output_manager.add_log.assert_called_with(
             "Random seed used",
             "Seeded libaries with random_seed=4321",
@@ -97,12 +98,12 @@ def test_set_random_seed_zero(mock_output_manager: Generator[Any, Any, Any]) -> 
 
 @pytest.mark.parametrize("seed, expected", [(12345, 12345), (0, 4321)])
 def test_set_random_seed_with_parameters(
-    seed: int, expected: int, mock_output_manager: Generator[Any, Any, Any]
+        seed: int, expected: int, mock_output_manager: Generator[Any, Any, Any]
 ) -> None:
     with patch("RUFAS.task_manager.random.randint", return_value=4321) as mock_randint:
         TaskManager.set_random_seed(seed, mock_output_manager)
         if seed == 0:
-            mock_randint.assert_called_once_with(0, 2**32 - 1)
+            mock_randint.assert_called_once_with(0, 2 ** 32 - 1)
         mock_output_manager.add_log.assert_called_with(
             "Random seed used",
             f"Seeded libaries with random_seed={expected}",
@@ -165,10 +166,10 @@ def test_expand_multi_runs_to_single_runs(task_manager: TaskManager) -> None:
 
 @pytest.mark.parametrize("suppress_logs", [True, False])
 def test_handle_post_processing(
-    task_manager: TaskManager,
-    mock_output_manager: Generator[Any, Any, Any],
-    suppress_logs: bool,
-    mocker: MockerFixture,
+        task_manager: TaskManager,
+        mock_output_manager: Generator[Any, Any, Any],
+        suppress_logs: bool,
+        mocker: MockerFixture,
 ) -> None:
     args = {
         "filters_directory": Path("/fake/filters"),
@@ -198,7 +199,8 @@ def test_handle_post_processing(
 
 @pytest.mark.parametrize("suppress_logs", [True, False])
 def test_input_data_audit(
-    mock_output_manager: Generator[Any, Any, Any], task_manager: TaskManager, suppress_logs: bool, mocker: MockerFixture
+        mock_output_manager: Generator[Any, Any, Any], task_manager: TaskManager, suppress_logs: bool,
+        mocker: MockerFixture
 ) -> None:
     args = {
         "metadata_file_path": Path("/fake/metadata"),
@@ -224,3 +226,60 @@ def test_input_data_audit(
         mock_save_metadata_properties.assert_called_once()
     else:
         mock_save_metadata_properties.assert_not_called()
+
+
+@pytest.mark.parametrize("task_type,pre_validate", [[TaskType.INPUT_DATA_AUDIT, True],
+                                                    [TaskType.COMPARE_METADATA_PROPERTIES, True],
+                                                    [TaskType.COMPARE_METADATA_PROPERTIES, False],
+                                                    [TaskType.SIMULATION_SINGLE_RUN, False],
+                                                    [TaskType.POST_PROCESSING, False]])
+def test_task(
+        mock_output_manager: Generator[Any, Any, Any], task_manager: TaskManager, mocker: MockerFixture,
+        task_type: TaskType, pre_validate: bool
+) -> None:
+
+    args = {
+        "task_type": task_type,
+        "log_verbosity": LogVerbosity.LOGS,
+        "exclude_info_maps": False,
+        "output_prefix": "test",
+        "logs_directory": Path("/fake/logs"),
+        "task_id": 1,
+        "random-seed": 924
+    }
+    #mock_run_startup = mocker.patch.object(OutputManager, "run_startup_sequence", return_value=None)
+    mock_im_init = mocker.patch.object(InputManager, "__init__", return_value=None)
+    pre_validation_handlers = {
+        TaskType.INPUT_DATA_AUDIT: TaskManager._input_data_audit_tasks,
+        TaskType.COMPARE_METADATA_PROPERTIES: TaskManager._compare_metadata_properties_tasks,
+    }
+    post_validation_handlers = {
+        TaskType.HERD_INITIALIZATION: TaskManager._herd_init_tasks,
+        TaskType.SIMULATION_SINGLE_RUN: TaskManager._simulation_engine_run_tasks,
+        TaskType.POST_PROCESSING: TaskManager._postprocessing_tasks,
+    }
+    produce_graphics = False
+    #mock_init = mocker.patch.object(task_manager.input_manager, "__init__", return_value=None)
+    # mock_call_handler = mocker.patch.object(task_manager, "call_handler", return_value=None)
+    # mock_handle_input_data_audit = mocker.patch.object(task_manager, "handle_input_data_audit",
+    #                                                    return_value=None)
+    # mock_set_random_seed = mocker.patch.object(task_manager, "set_random_seed", return_value=None)
+    #m1 = mocker.patch.object(mock_output_manager, "run_startup_sequence", return_value=None)
+    om = OutputManager()
+    print(str(om)+"test")
+    m1 = mocker.patch.object(om, "run_startup_sequence", return_value=None)
+    task_manager.task(args, produce_graphics, 10)
+    mock_im_init.assert_called_once_with(10)
+    m1.assert_called_once_with(
+        LogVerbosity(args["log_verbosity"]), args["exclude_info_maps"], Path(""), False, Path(""),
+        args["output_prefix"], RUFAS_VERSION, args["task_id"]
+    )
+
+    if pre_validate:
+        assert mock_call_handler.assert_called_with(pre_validation_handlers.get(task_type))
+
+    else:
+        assert mock_handle_input_data_audit.assert_called_with(args, mock_input_manager, mock_output_manager,
+                                                                       True)
+        assert mock_set_random_seed.assert_called_with(args["random_seed"], mock_output_manager)
+        assert mock_call_handler.assert_called_with(post_validation_handlers.get(task_type))

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -247,7 +247,17 @@ def test_task(
         "random_seed": 924,
         "suppress_log_files": True,
         "metadata_file_path": Path("/fake/logs"),
-        "properties_file_path": Path("more/fake/paths")
+        "properties_file_path": Path("more/fake/paths"),
+        "produce_graphics": False
+    }
+    pre_validation_handlers = {
+        TaskType.INPUT_DATA_AUDIT: TaskManager._input_data_audit_tasks,
+        TaskType.COMPARE_METADATA_PROPERTIES: TaskManager._compare_metadata_properties_tasks,
+    }
+    post_validation_handlers = {
+        TaskType.HERD_INITIALIZATION: TaskManager._herd_init_tasks,
+        TaskType.SIMULATION_SINGLE_RUN: TaskManager._simulation_engine_run_tasks,
+        TaskType.POST_PROCESSING: TaskManager._postprocessing_tasks,
     }
     mock_im_init = mocker.patch.object(InputManager, "__init__", return_value=None)
     produce_graphics = False

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -5,7 +5,7 @@ from pytest_mock import MockerFixture
 from pathlib import Path
 
 from RUFAS.input_manager import InputManager
-from RUFAS.task_manager import TaskManager, TaskType, RUFAS_VERSION
+from RUFAS.task_manager import TaskManager, TaskType
 from RUFAS.output_manager import LogVerbosity, OutputManager
 from RUFAS.units import MeasurementUnits
 from RUFAS.util import Utility
@@ -250,15 +250,7 @@ def test_task(
         "properties_file_path": Path("more/fake/paths"),
         "produce_graphics": False
     }
-    pre_validation_handlers = {
-        TaskType.INPUT_DATA_AUDIT: TaskManager._input_data_audit_tasks,
-        TaskType.COMPARE_METADATA_PROPERTIES: TaskManager._compare_metadata_properties_tasks,
-    }
-    post_validation_handlers = {
-        TaskType.HERD_INITIALIZATION: TaskManager._herd_init_tasks,
-        TaskType.SIMULATION_SINGLE_RUN: TaskManager._simulation_engine_run_tasks,
-        TaskType.POST_PROCESSING: TaskManager._postprocessing_tasks,
-    }
+
     mock_im_init = mocker.patch.object(InputManager, "__init__", return_value=None)
     produce_graphics = False
 

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -13,7 +13,6 @@ from RUFAS.units import MeasurementUnits
 @pytest.fixture
 def mock_output_manager() -> Generator[Any, Any, Any]:
     with patch("RUFAS.task_manager.OutputManager") as mock:
-        print(str(mock)+"fixure")
         yield mock
 
 
@@ -230,7 +229,7 @@ def test_input_data_audit(
 
 @pytest.mark.parametrize("task_type,pre_validate", [[TaskType.INPUT_DATA_AUDIT, True],
                                                     [TaskType.COMPARE_METADATA_PROPERTIES, True],
-                                                    [TaskType.COMPARE_METADATA_PROPERTIES, False],
+                                                    [TaskType.HERD_INITIALIZATION, False],
                                                     [TaskType.SIMULATION_SINGLE_RUN, False],
                                                     [TaskType.POST_PROCESSING, False]])
 def test_task(
@@ -245,41 +244,24 @@ def test_task(
         "output_prefix": "test",
         "logs_directory": Path("/fake/logs"),
         "task_id": 1,
-        "random-seed": 924
+        "random_seed": 924,
+        "suppress_log_files": True,
+        "metadata_file_path": Path("/fake/logs"),
+        "properties_file_path": Path("more/fake/paths")
     }
-    #mock_run_startup = mocker.patch.object(OutputManager, "run_startup_sequence", return_value=None)
     mock_im_init = mocker.patch.object(InputManager, "__init__", return_value=None)
-    pre_validation_handlers = {
-        TaskType.INPUT_DATA_AUDIT: TaskManager._input_data_audit_tasks,
-        TaskType.COMPARE_METADATA_PROPERTIES: TaskManager._compare_metadata_properties_tasks,
-    }
-    post_validation_handlers = {
-        TaskType.HERD_INITIALIZATION: TaskManager._herd_init_tasks,
-        TaskType.SIMULATION_SINGLE_RUN: TaskManager._simulation_engine_run_tasks,
-        TaskType.POST_PROCESSING: TaskManager._postprocessing_tasks,
-    }
     produce_graphics = False
-    #mock_init = mocker.patch.object(task_manager.input_manager, "__init__", return_value=None)
-    # mock_call_handler = mocker.patch.object(task_manager, "call_handler", return_value=None)
-    # mock_handle_input_data_audit = mocker.patch.object(task_manager, "handle_input_data_audit",
-    #                                                    return_value=None)
-    # mock_set_random_seed = mocker.patch.object(task_manager, "set_random_seed", return_value=None)
-    #m1 = mocker.patch.object(mock_output_manager, "run_startup_sequence", return_value=None)
-    om = OutputManager()
-    print(str(om)+"test")
-    m1 = mocker.patch.object(om, "run_startup_sequence", return_value=None)
+
+    mock_handler = mocker.patch.object(TaskManager, "call_handler", return_value=None)
+    mock_handle_input_data_audit = mocker.patch.object(TaskManager, "handle_input_data_audit",
+                                                       return_value=True)
+    mock_set_random_seed = mocker.patch.object(TaskManager, "set_random_seed", return_value=None)
     task_manager.task(args, produce_graphics, 10)
     mock_im_init.assert_called_once_with(10)
-    m1.assert_called_once_with(
-        LogVerbosity(args["log_verbosity"]), args["exclude_info_maps"], Path(""), False, Path(""),
-        args["output_prefix"], RUFAS_VERSION, args["task_id"]
-    )
 
     if pre_validate:
-        assert mock_call_handler.assert_called_with(pre_validation_handlers.get(task_type))
-
+        mock_handler.assert_called_once()
     else:
-        assert mock_handle_input_data_audit.assert_called_with(args, mock_input_manager, mock_output_manager,
-                                                                       True)
-        assert mock_set_random_seed.assert_called_with(args["random_seed"], mock_output_manager)
-        assert mock_call_handler.assert_called_with(post_validation_handlers.get(task_type))
+        mock_handle_input_data_audit.assert_called_once()
+        mock_set_random_seed.assert_called_once()
+        mock_handler.assert_called_once()

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -270,12 +270,10 @@ def test_task(
 
     if pre_validate:
         mock_handler.assert_called_once()
-        # print(mock_handler.call_args)
     else:
         mock_handle_input_data_audit.assert_called_once()
         mock_set_random_seed.assert_called_once()
         mock_handler.assert_called_once()
-        # print(mock_handler.call_args)
 
 
 def test_compare_metadata_properties_tasks(mocker: MockerFixture) -> None:
@@ -426,8 +424,6 @@ def test_call_handler():
             produce_graphics=produce_graphics,
         )
 
-        # Verify that the handler was called with the correct filtered arguments
-        print(mock_handle_post_processing.call_args)
         mock_handle_post_processing.assert_called_once_with(
             args, mock_input_manager, mock_output_manager, task_id, produce_graphics
         )

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -294,7 +294,7 @@ def test_compare_metadata_properties_tasks(mocker: MockerFixture) -> None:
         mock_input_manager, "compare_metadata_properties", return_value=None
     )
 
-    TaskManager._compare_metadata_properties_tasks(
+    TaskManager._handle_compare_metadata_properties_tasks(
         args, mock_input_manager, mock_output_manager, task_id, produce_graphic
     )
 
@@ -326,7 +326,7 @@ def test_herd_init_tasks() -> None:
         patch.object(TaskManager, "handle_herd_initializaition", return_value=None) as mock_handle_herd_initializaition,
         patch.object(TaskManager, "handle_post_processing", return_value=None) as mock_handle_post_processing,
     ):
-        TaskManager._herd_init_tasks(args, mock_input_manager, mock_output_manager, task_id, produce_graphic)
+        TaskManager._handle_herd_init_tasks(args, mock_input_manager, mock_output_manager, task_id, produce_graphic)
         mock_handle_herd_initializaition.assert_called_once_with(args, mock_output_manager)
         mock_handle_post_processing.assert_called_once_with(args, mock_input_manager, mock_output_manager, task_id)
 
@@ -357,7 +357,7 @@ def test_simulation_engine_run_tasks(input_patch: bool, produce_graphics: bool) 
         patch.object(Utility, "deep_merge", return_value=None) as mock_deep_merge,
     ):
 
-        TaskManager._simulation_engine_run_tasks(
+        TaskManager._handle_simulation_engine_run_tasks(
             args, mock_input_manager, mock_output_manager, task_id, produce_graphics
         )
         if input_patch:
@@ -389,7 +389,7 @@ def test_postprocessing_tasks(produce_graphics: bool) -> None:
     mock_input_manager = MagicMock(name="InputManager")
     mock_output_manager = MagicMock(name="OutputManager")
     with patch.object(TaskManager, "handle_post_processing", return_value=None) as mock_handle_post_processing:
-        TaskManager._postprocessing_tasks(args, mock_input_manager, mock_output_manager, task_id, produce_graphics)
+        TaskManager._handle_postprocessing_tasks(args, mock_input_manager, mock_output_manager, task_id, produce_graphics)
         mock_handle_post_processing.assert_called_once_with(
             args, mock_input_manager, mock_output_manager, task_id, produce_graphics, True, True
         )
@@ -453,7 +453,7 @@ def test_input_data_audit_tasks() -> None:
         patch.object(TaskManager, "handle_input_data_audit", return_value=None) as mock_handle_input_data_audit,
         patch.object(TaskManager, "handle_post_processing", return_value=None) as mock_handle_post_processing,
     ):
-        TaskManager._input_data_audit_tasks(args, im, om, task_id, produce_graphic)
+        TaskManager._handle_input_data_audit_tasks(args, im, om, task_id, produce_graphic)
 
         mock_handle_input_data_audit.assert_called_once_with(args, im, om, False)
         mock_handle_post_processing.assert_called_once_with(args, im, om, task_id)

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -389,7 +389,9 @@ def test_postprocessing_tasks(produce_graphics: bool) -> None:
     mock_input_manager = MagicMock(name="InputManager")
     mock_output_manager = MagicMock(name="OutputManager")
     with patch.object(TaskManager, "handle_post_processing", return_value=None) as mock_handle_post_processing:
-        TaskManager._handle_postprocessing_tasks(args, mock_input_manager, mock_output_manager, task_id, produce_graphics)
+        TaskManager._handle_postprocessing_tasks(
+            args, mock_input_manager, mock_output_manager, task_id, produce_graphics
+        )
         mock_handle_post_processing.assert_called_once_with(
             args, mock_input_manager, mock_output_manager, task_id, produce_graphics, True, True
         )

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -47,8 +47,8 @@ def test_invalid_task_type_from_string() -> None:
 
 
 def test_task_manager_init(
-        task_manager: TaskManager,
-        mock_output_manager: Generator[Any, Any, Any],
+    task_manager: TaskManager,
+    mock_output_manager: Generator[Any, Any, Any],
 ) -> None:
     assert task_manager.output_manager is mock_output_manager
 
@@ -88,7 +88,7 @@ def test_set_random_seed(mock_output_manager: Generator[Any, Any, Any]) -> None:
 def test_set_random_seed_zero(mock_output_manager: Generator[Any, Any, Any]) -> None:
     with patch("RUFAS.task_manager.random.randint", return_value=4321) as mock_randint:
         TaskManager.set_random_seed(0, mock_output_manager)
-        mock_randint.assert_called_once_with(0, 2 ** 32 - 1)
+        mock_randint.assert_called_once_with(0, 2**32 - 1)
         mock_output_manager.add_log.assert_called_with(
             "Random seed used",
             "Seeded libaries with random_seed=4321",
@@ -98,12 +98,12 @@ def test_set_random_seed_zero(mock_output_manager: Generator[Any, Any, Any]) -> 
 
 @pytest.mark.parametrize("seed, expected", [(12345, 12345), (0, 4321)])
 def test_set_random_seed_with_parameters(
-        seed: int, expected: int, mock_output_manager: Generator[Any, Any, Any]
+    seed: int, expected: int, mock_output_manager: Generator[Any, Any, Any]
 ) -> None:
     with patch("RUFAS.task_manager.random.randint", return_value=4321) as mock_randint:
         TaskManager.set_random_seed(seed, mock_output_manager)
         if seed == 0:
-            mock_randint.assert_called_once_with(0, 2 ** 32 - 1)
+            mock_randint.assert_called_once_with(0, 2**32 - 1)
         mock_output_manager.add_log.assert_called_with(
             "Random seed used",
             f"Seeded libaries with random_seed={expected}",
@@ -166,10 +166,10 @@ def test_expand_multi_runs_to_single_runs(task_manager: TaskManager) -> None:
 
 @pytest.mark.parametrize("suppress_logs", [True, False])
 def test_handle_post_processing(
-        task_manager: TaskManager,
-        mock_output_manager: Generator[Any, Any, Any],
-        suppress_logs: bool,
-        mocker: MockerFixture,
+    task_manager: TaskManager,
+    mock_output_manager: Generator[Any, Any, Any],
+    suppress_logs: bool,
+    mocker: MockerFixture,
 ) -> None:
     args = {
         "filters_directory": Path("/fake/filters"),
@@ -199,8 +199,7 @@ def test_handle_post_processing(
 
 @pytest.mark.parametrize("suppress_logs", [True, False])
 def test_input_data_audit(
-        mock_output_manager: Generator[Any, Any, Any], task_manager: TaskManager, suppress_logs: bool,
-        mocker: MockerFixture
+    mock_output_manager: Generator[Any, Any, Any], task_manager: TaskManager, suppress_logs: bool, mocker: MockerFixture
 ) -> None:
     args = {
         "metadata_file_path": Path("/fake/metadata"),
@@ -228,14 +227,22 @@ def test_input_data_audit(
         mock_save_metadata_properties.assert_not_called()
 
 
-@pytest.mark.parametrize("task_type,pre_validate", [[TaskType.INPUT_DATA_AUDIT, True],
-                                                    [TaskType.COMPARE_METADATA_PROPERTIES, True],
-                                                    [TaskType.HERD_INITIALIZATION, False],
-                                                    [TaskType.SIMULATION_SINGLE_RUN, False],
-                                                    [TaskType.POST_PROCESSING, False]])
+@pytest.mark.parametrize(
+    "task_type,pre_validate",
+    [
+        [TaskType.INPUT_DATA_AUDIT, True],
+        [TaskType.COMPARE_METADATA_PROPERTIES, True],
+        [TaskType.HERD_INITIALIZATION, False],
+        [TaskType.SIMULATION_SINGLE_RUN, False],
+        [TaskType.POST_PROCESSING, False],
+    ],
+)
 def test_task(
-        mock_output_manager: Generator[Any, Any, Any], task_manager: TaskManager, mocker: MockerFixture,
-        task_type: TaskType, pre_validate: bool
+    mock_output_manager: Generator[Any, Any, Any],
+    task_manager: TaskManager,
+    mocker: MockerFixture,
+    task_type: TaskType,
+    pre_validate: bool,
 ) -> None:
     args = {
         "task_type": task_type,
@@ -248,7 +255,7 @@ def test_task(
         "suppress_log_files": True,
         "metadata_file_path": Path("/fake/logs"),
         "properties_file_path": Path("more/fake/paths"),
-        "produce_graphics": False
+        "produce_graphics": False,
     }
     pre_validation_handlers = {
         TaskType.INPUT_DATA_AUDIT: TaskManager._input_data_audit_tasks,
@@ -263,8 +270,7 @@ def test_task(
     produce_graphics = False
 
     mock_handler = mocker.patch.object(TaskManager, "call_handler", return_value=None)
-    mock_handle_input_data_audit = mocker.patch.object(TaskManager, "handle_input_data_audit",
-                                                       return_value=True)
+    mock_handle_input_data_audit = mocker.patch.object(TaskManager, "handle_input_data_audit", return_value=True)
     mock_set_random_seed = mocker.patch.object(TaskManager, "set_random_seed", return_value=None)
     task_manager.task(args, produce_graphics, 10)
     mock_im_init.assert_called_once_with(10)
@@ -283,19 +289,20 @@ def test_compare_metadata_properties_tasks(mocker: MockerFixture) -> None:
     args = {
         "properties_file_path": Path("fake/properties/path"),
         "comparison_properties_file_path": Path("fake/comparison/properties/path"),
-        "logs_directory": Path("/fake/logs")
+        "logs_directory": Path("/fake/logs"),
     }
-    mock_input_manager = MagicMock(name='InputManager')
-    mock_output_manager = MagicMock(name='OutputManager')
+    mock_input_manager = MagicMock(name="InputManager")
+    mock_output_manager = MagicMock(name="OutputManager")
     produce_graphic = False
     task_id = 6
 
     mock_compare_metadata_properties = mocker.patch.object(
-        mock_input_manager, 'compare_metadata_properties', return_value=None
+        mock_input_manager, "compare_metadata_properties", return_value=None
     )
 
-    TaskManager._compare_metadata_properties_tasks(args, mock_input_manager, mock_output_manager, task_id,
-                                                   produce_graphic)
+    TaskManager._compare_metadata_properties_tasks(
+        args, mock_input_manager, mock_output_manager, task_id, produce_graphic
+    )
 
     mock_compare_metadata_properties.assert_called_once_with(
         args["properties_file_path"], args["comparison_properties_file_path"], args["logs_directory"]
@@ -312,29 +319,24 @@ def test_herd_init_tasks() -> None:
         "random_seed": 924,
         "suppress_log_files": True,
         "metadata_file_path": "/fake/logs",
-        "properties_file_path": "more/fake/paths"
+        "properties_file_path": "more/fake/paths",
     }
     task_id = 5
 
     # Create mocks for InputManager and OutputManager
-    mock_input_manager = MagicMock(name='InputManager')
-    mock_output_manager = MagicMock(name='OutputManager')
+    mock_input_manager = MagicMock(name="InputManager")
+    mock_output_manager = MagicMock(name="OutputManager")
     produce_graphic = False
-    with patch.object(TaskManager, 'handle_herd_initializaition',
-                      return_value=None) as mock_handle_herd_initializaition, \
-            patch.object(TaskManager, 'handle_post_processing',
-                         return_value=None) as mock_handle_post_processing:
+    with (
+        patch.object(TaskManager, "handle_herd_initializaition", return_value=None) as mock_handle_herd_initializaition,
+        patch.object(TaskManager, "handle_post_processing", return_value=None) as mock_handle_post_processing,
+    ):
         TaskManager._herd_init_tasks(args, mock_input_manager, mock_output_manager, task_id, produce_graphic)
         mock_handle_herd_initializaition.assert_called_once_with(args, mock_output_manager)
         mock_handle_post_processing.assert_called_once_with(args, mock_input_manager, mock_output_manager, task_id)
 
 
-@pytest.mark.parametrize("input_patch,produce_graphics", [
-    (True, True),
-    (False, True),
-    (False, False),
-    (True, False)
-])
+@pytest.mark.parametrize("input_patch,produce_graphics", [(True, True), (False, True), (False, False), (True, False)])
 def test_simulation_engine_run_tasks(input_patch: bool, produce_graphics: bool) -> None:
     args = {
         "log_verbosity": "logs",
@@ -346,33 +348,34 @@ def test_simulation_engine_run_tasks(input_patch: bool, produce_graphics: bool) 
         "suppress_log_files": True,
         "metadata_file_path": "/fake/logs",
         "properties_file_path": "more/fake/paths",
-        "input_patch": input_patch
+        "input_patch": input_patch,
     }
     task_id = 5
-    mock_input_manager = MagicMock(name='InputManager')
-    mock_output_manager = MagicMock(name='OutputManager')
-    with patch.object(TaskManager, 'handle_single_simulation_run',
-                      return_value=None) as mock_handle_single_simulation_run, \
-            patch.object(TaskManager, 'handle_post_processing',
-                         return_value=None) as mock_handle_post_processing, \
-            patch.object(Utility, 'deep_merge', return_value=None) as mock_deep_merge:
+    mock_input_manager = MagicMock(name="InputManager")
+    mock_output_manager = MagicMock(name="OutputManager")
+    with (
+        patch.object(
+            TaskManager, "handle_single_simulation_run", return_value=None
+        ) as mock_handle_single_simulation_run,
+        patch.object(TaskManager, "handle_post_processing", return_value=None) as mock_handle_post_processing,
+        patch.object(Utility, "deep_merge", return_value=None) as mock_deep_merge,
+    ):
 
-        TaskManager._simulation_engine_run_tasks(args, mock_input_manager, mock_output_manager, task_id,
-                                                 produce_graphics)
+        TaskManager._simulation_engine_run_tasks(
+            args, mock_input_manager, mock_output_manager, task_id, produce_graphics
+        )
         if input_patch:
             mock_deep_merge.assert_called_once_with(mock_input_manager.pool, args["input_patch"])
         else:
             mock_deep_merge.assert_not_called()
 
         mock_handle_single_simulation_run.assert_called_once_with(args, mock_output_manager)
-        mock_handle_post_processing.assert_called_once_with(args, mock_input_manager, mock_output_manager,
-                                                            task_id, produce_graphics, True)
+        mock_handle_post_processing.assert_called_once_with(
+            args, mock_input_manager, mock_output_manager, task_id, produce_graphics, True
+        )
 
 
-@pytest.mark.parametrize("produce_graphics", [
-    True,
-    False
-])
+@pytest.mark.parametrize("produce_graphics", [True, False])
 def test_postprocessing_tasks(produce_graphics: bool) -> None:
     args = {
         "log_verbosity": "logs",
@@ -383,15 +386,16 @@ def test_postprocessing_tasks(produce_graphics: bool) -> None:
         "random_seed": 924,
         "suppress_log_files": True,
         "metadata_file_path": "/fake/logs",
-        "properties_file_path": "more/fake/paths"
+        "properties_file_path": "more/fake/paths",
     }
     task_id = 5
-    mock_input_manager = MagicMock(name='InputManager')
-    mock_output_manager = MagicMock(name='OutputManager')
-    with patch.object(TaskManager, 'handle_post_processing', return_value=None) as mock_handle_post_processing:
+    mock_input_manager = MagicMock(name="InputManager")
+    mock_output_manager = MagicMock(name="OutputManager")
+    with patch.object(TaskManager, "handle_post_processing", return_value=None) as mock_handle_post_processing:
         TaskManager._postprocessing_tasks(args, mock_input_manager, mock_output_manager, task_id, produce_graphics)
-        mock_handle_post_processing.assert_called_once_with(args, mock_input_manager, mock_output_manager,
-                                                            task_id, produce_graphics, True, True)
+        mock_handle_post_processing.assert_called_once_with(
+            args, mock_input_manager, mock_output_manager, task_id, produce_graphics, True, True
+        )
 
 
 def test_call_handler():
@@ -404,26 +408,29 @@ def test_call_handler():
         "random_seed": 924,
         "suppress_log_files": True,
         "metadata_file_path": "/fake/logs",
-        "properties_file_path": "more/fake/paths"
+        "properties_file_path": "more/fake/paths",
     }
     task_id = 5
-    mock_input_manager = MagicMock(name='InputManager')
-    mock_output_manager = MagicMock(name='OutputManager')
+    mock_input_manager = MagicMock(name="InputManager")
+    mock_output_manager = MagicMock(name="OutputManager")
     produce_graphics = False
 
     # Call the call_handler method
-    with patch.object(TaskManager, '_postprocessing_tasks', return_value=None) as mock_handle_post_processing:
-        TaskManager.call_handler(mock_handle_post_processing, args=args,
-                                 input_manager=mock_input_manager,
-                                 output_manager=mock_output_manager,
-                                 task_id=task_id,
-                                 produce_graphics=produce_graphics
-                                 )
+    with patch.object(TaskManager, "_postprocessing_tasks", return_value=None) as mock_handle_post_processing:
+        TaskManager.call_handler(
+            mock_handle_post_processing,
+            args=args,
+            input_manager=mock_input_manager,
+            output_manager=mock_output_manager,
+            task_id=task_id,
+            produce_graphics=produce_graphics,
+        )
 
         # Verify that the handler was called with the correct filtered arguments
         print(mock_handle_post_processing.call_args)
-        mock_handle_post_processing.assert_called_once_with(args, mock_input_manager, mock_output_manager,
-                                                            task_id, produce_graphics)
+        mock_handle_post_processing.assert_called_once_with(
+            args, mock_input_manager, mock_output_manager, task_id, produce_graphics
+        )
 
 
 def test_input_data_audit_tasks() -> None:
@@ -436,16 +443,17 @@ def test_input_data_audit_tasks() -> None:
         "random_seed": 924,
         "suppress_log_files": True,
         "metadata_file_path": Path("/fake/logs"),
-        "properties_file_path": Path("more/fake/paths")
+        "properties_file_path": Path("more/fake/paths"),
     }
     task_id = 5
     im = InputManager()
     om = OutputManager()
     produce_graphic = False
 
-    with (patch.object(TaskManager, 'handle_input_data_audit', return_value=None) as
-          mock_handle_input_data_audit, patch.object(TaskManager, 'handle_post_processing', return_value=None)
-          as mock_handle_post_processing):
+    with (
+        patch.object(TaskManager, "handle_input_data_audit", return_value=None) as mock_handle_input_data_audit,
+        patch.object(TaskManager, "handle_post_processing", return_value=None) as mock_handle_post_processing,
+    ):
         TaskManager._input_data_audit_tasks(args, im, om, task_id, produce_graphic)
 
         mock_handle_input_data_audit.assert_called_once_with(args, im, om, False)

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -13,7 +13,7 @@ from RUFAS.units import MeasurementUnits
 @pytest.fixture
 def mock_output_manager() -> Generator[Any, Any, Any]:
     with patch("RUFAS.task_manager.OutputManager") as mock:
-        print(str(mock)+"fixure")
+        print(str(mock) + "fixure")
         yield mock
 
 
@@ -47,8 +47,8 @@ def test_invalid_task_type_from_string() -> None:
 
 
 def test_task_manager_init(
-        task_manager: TaskManager,
-        mock_output_manager: Generator[Any, Any, Any],
+    task_manager: TaskManager,
+    mock_output_manager: Generator[Any, Any, Any],
 ) -> None:
     assert task_manager.output_manager is mock_output_manager
 
@@ -88,7 +88,7 @@ def test_set_random_seed(mock_output_manager: Generator[Any, Any, Any]) -> None:
 def test_set_random_seed_zero(mock_output_manager: Generator[Any, Any, Any]) -> None:
     with patch("RUFAS.task_manager.random.randint", return_value=4321) as mock_randint:
         TaskManager.set_random_seed(0, mock_output_manager)
-        mock_randint.assert_called_once_with(0, 2 ** 32 - 1)
+        mock_randint.assert_called_once_with(0, 2**32 - 1)
         mock_output_manager.add_log.assert_called_with(
             "Random seed used",
             "Seeded libaries with random_seed=4321",
@@ -98,12 +98,12 @@ def test_set_random_seed_zero(mock_output_manager: Generator[Any, Any, Any]) -> 
 
 @pytest.mark.parametrize("seed, expected", [(12345, 12345), (0, 4321)])
 def test_set_random_seed_with_parameters(
-        seed: int, expected: int, mock_output_manager: Generator[Any, Any, Any]
+    seed: int, expected: int, mock_output_manager: Generator[Any, Any, Any]
 ) -> None:
     with patch("RUFAS.task_manager.random.randint", return_value=4321) as mock_randint:
         TaskManager.set_random_seed(seed, mock_output_manager)
         if seed == 0:
-            mock_randint.assert_called_once_with(0, 2 ** 32 - 1)
+            mock_randint.assert_called_once_with(0, 2**32 - 1)
         mock_output_manager.add_log.assert_called_with(
             "Random seed used",
             f"Seeded libaries with random_seed={expected}",
@@ -166,10 +166,10 @@ def test_expand_multi_runs_to_single_runs(task_manager: TaskManager) -> None:
 
 @pytest.mark.parametrize("suppress_logs", [True, False])
 def test_handle_post_processing(
-        task_manager: TaskManager,
-        mock_output_manager: Generator[Any, Any, Any],
-        suppress_logs: bool,
-        mocker: MockerFixture,
+    task_manager: TaskManager,
+    mock_output_manager: Generator[Any, Any, Any],
+    suppress_logs: bool,
+    mocker: MockerFixture,
 ) -> None:
     args = {
         "filters_directory": Path("/fake/filters"),
@@ -199,8 +199,7 @@ def test_handle_post_processing(
 
 @pytest.mark.parametrize("suppress_logs", [True, False])
 def test_input_data_audit(
-        mock_output_manager: Generator[Any, Any, Any], task_manager: TaskManager, suppress_logs: bool,
-        mocker: MockerFixture
+    mock_output_manager: Generator[Any, Any, Any], task_manager: TaskManager, suppress_logs: bool, mocker: MockerFixture
 ) -> None:
     args = {
         "metadata_file_path": Path("/fake/metadata"),
@@ -228,14 +227,22 @@ def test_input_data_audit(
         mock_save_metadata_properties.assert_not_called()
 
 
-@pytest.mark.parametrize("task_type,pre_validate", [[TaskType.INPUT_DATA_AUDIT, True],
-                                                    [TaskType.COMPARE_METADATA_PROPERTIES, True],
-                                                    [TaskType.COMPARE_METADATA_PROPERTIES, False],
-                                                    [TaskType.SIMULATION_SINGLE_RUN, False],
-                                                    [TaskType.POST_PROCESSING, False]])
+@pytest.mark.parametrize(
+    "task_type,pre_validate",
+    [
+        [TaskType.INPUT_DATA_AUDIT, True],
+        [TaskType.COMPARE_METADATA_PROPERTIES, True],
+        [TaskType.COMPARE_METADATA_PROPERTIES, False],
+        [TaskType.SIMULATION_SINGLE_RUN, False],
+        [TaskType.POST_PROCESSING, False],
+    ],
+)
 def test_task(
-        mock_output_manager: Generator[Any, Any, Any], task_manager: TaskManager, mocker: MockerFixture,
-        task_type: TaskType, pre_validate: bool
+    mock_output_manager: Generator[Any, Any, Any],
+    task_manager: TaskManager,
+    mocker: MockerFixture,
+    task_type: TaskType,
+    pre_validate: bool,
 ) -> None:
 
     args = {
@@ -245,9 +252,9 @@ def test_task(
         "output_prefix": "test",
         "logs_directory": Path("/fake/logs"),
         "task_id": 1,
-        "random-seed": 924
+        "random-seed": 924,
     }
-    #mock_run_startup = mocker.patch.object(OutputManager, "run_startup_sequence", return_value=None)
+    # mock_run_startup = mocker.patch.object(OutputManager, "run_startup_sequence", return_value=None)
     mock_im_init = mocker.patch.object(InputManager, "__init__", return_value=None)
     pre_validation_handlers = {
         TaskType.INPUT_DATA_AUDIT: TaskManager._input_data_audit_tasks,
@@ -259,27 +266,32 @@ def test_task(
         TaskType.POST_PROCESSING: TaskManager._postprocessing_tasks,
     }
     produce_graphics = False
-    #mock_init = mocker.patch.object(task_manager.input_manager, "__init__", return_value=None)
+    # mock_init = mocker.patch.object(task_manager.input_manager, "__init__", return_value=None)
     # mock_call_handler = mocker.patch.object(task_manager, "call_handler", return_value=None)
     # mock_handle_input_data_audit = mocker.patch.object(task_manager, "handle_input_data_audit",
     #                                                    return_value=None)
     # mock_set_random_seed = mocker.patch.object(task_manager, "set_random_seed", return_value=None)
-    #m1 = mocker.patch.object(mock_output_manager, "run_startup_sequence", return_value=None)
+    # m1 = mocker.patch.object(mock_output_manager, "run_startup_sequence", return_value=None)
     om = OutputManager()
-    print(str(om)+"test")
+    print(str(om) + "test")
     m1 = mocker.patch.object(om, "run_startup_sequence", return_value=None)
     task_manager.task(args, produce_graphics, 10)
     mock_im_init.assert_called_once_with(10)
     m1.assert_called_once_with(
-        LogVerbosity(args["log_verbosity"]), args["exclude_info_maps"], Path(""), False, Path(""),
-        args["output_prefix"], RUFAS_VERSION, args["task_id"]
+        LogVerbosity(args["log_verbosity"]),
+        args["exclude_info_maps"],
+        Path(""),
+        False,
+        Path(""),
+        args["output_prefix"],
+        RUFAS_VERSION,
+        args["task_id"],
     )
 
     if pre_validate:
         assert mock_call_handler.assert_called_with(pre_validation_handlers.get(task_type))
 
     else:
-        assert mock_handle_input_data_audit.assert_called_with(args, mock_input_manager, mock_output_manager,
-                                                                       True)
+        assert mock_handle_input_data_audit.assert_called_with(args, mock_input_manager, mock_output_manager, True)
         assert mock_set_random_seed.assert_called_with(args["random_seed"], mock_output_manager)
         assert mock_call_handler.assert_called_with(post_validation_handlers.get(task_type))

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -47,8 +47,8 @@ def test_invalid_task_type_from_string() -> None:
 
 
 def test_task_manager_init(
-        task_manager: TaskManager,
-        mock_output_manager: Generator[Any, Any, Any],
+    task_manager: TaskManager,
+    mock_output_manager: Generator[Any, Any, Any],
 ) -> None:
     assert task_manager.output_manager is mock_output_manager
 
@@ -88,7 +88,7 @@ def test_set_random_seed(mock_output_manager: Generator[Any, Any, Any]) -> None:
 def test_set_random_seed_zero(mock_output_manager: Generator[Any, Any, Any]) -> None:
     with patch("RUFAS.task_manager.random.randint", return_value=4321) as mock_randint:
         TaskManager.set_random_seed(0, mock_output_manager)
-        mock_randint.assert_called_once_with(0, 2 ** 32 - 1)
+        mock_randint.assert_called_once_with(0, 2**32 - 1)
         mock_output_manager.add_log.assert_called_with(
             "Random seed used",
             "Seeded libaries with random_seed=4321",
@@ -98,12 +98,12 @@ def test_set_random_seed_zero(mock_output_manager: Generator[Any, Any, Any]) -> 
 
 @pytest.mark.parametrize("seed, expected", [(12345, 12345), (0, 4321)])
 def test_set_random_seed_with_parameters(
-        seed: int, expected: int, mock_output_manager: Generator[Any, Any, Any]
+    seed: int, expected: int, mock_output_manager: Generator[Any, Any, Any]
 ) -> None:
     with patch("RUFAS.task_manager.random.randint", return_value=4321) as mock_randint:
         TaskManager.set_random_seed(seed, mock_output_manager)
         if seed == 0:
-            mock_randint.assert_called_once_with(0, 2 ** 32 - 1)
+            mock_randint.assert_called_once_with(0, 2**32 - 1)
         mock_output_manager.add_log.assert_called_with(
             "Random seed used",
             f"Seeded libaries with random_seed={expected}",
@@ -166,10 +166,10 @@ def test_expand_multi_runs_to_single_runs(task_manager: TaskManager) -> None:
 
 @pytest.mark.parametrize("suppress_logs", [True, False])
 def test_handle_post_processing(
-        task_manager: TaskManager,
-        mock_output_manager: Generator[Any, Any, Any],
-        suppress_logs: bool,
-        mocker: MockerFixture,
+    task_manager: TaskManager,
+    mock_output_manager: Generator[Any, Any, Any],
+    suppress_logs: bool,
+    mocker: MockerFixture,
 ) -> None:
     args = {
         "filters_directory": Path("/fake/filters"),
@@ -199,8 +199,7 @@ def test_handle_post_processing(
 
 @pytest.mark.parametrize("suppress_logs", [True, False])
 def test_input_data_audit(
-        mock_output_manager: Generator[Any, Any, Any], task_manager: TaskManager, suppress_logs: bool,
-        mocker: MockerFixture
+    mock_output_manager: Generator[Any, Any, Any], task_manager: TaskManager, suppress_logs: bool, mocker: MockerFixture
 ) -> None:
     args = {
         "metadata_file_path": Path("/fake/metadata"),
@@ -228,14 +227,22 @@ def test_input_data_audit(
         mock_save_metadata_properties.assert_not_called()
 
 
-@pytest.mark.parametrize("task_type,pre_validate", [[TaskType.INPUT_DATA_AUDIT, True],
-                                                    [TaskType.COMPARE_METADATA_PROPERTIES, True],
-                                                    [TaskType.HERD_INITIALIZATION, False],
-                                                    [TaskType.SIMULATION_SINGLE_RUN, False],
-                                                    [TaskType.POST_PROCESSING, False]])
+@pytest.mark.parametrize(
+    "task_type,pre_validate",
+    [
+        [TaskType.INPUT_DATA_AUDIT, True],
+        [TaskType.COMPARE_METADATA_PROPERTIES, True],
+        [TaskType.HERD_INITIALIZATION, False],
+        [TaskType.SIMULATION_SINGLE_RUN, False],
+        [TaskType.POST_PROCESSING, False],
+    ],
+)
 def test_task(
-        mock_output_manager: Generator[Any, Any, Any], task_manager: TaskManager, mocker: MockerFixture,
-        task_type: TaskType, pre_validate: bool
+    mock_output_manager: Generator[Any, Any, Any],
+    task_manager: TaskManager,
+    mocker: MockerFixture,
+    task_type: TaskType,
+    pre_validate: bool,
 ) -> None:
     args = {
         "task_type": task_type,
@@ -247,14 +254,13 @@ def test_task(
         "random_seed": 924,
         "suppress_log_files": True,
         "metadata_file_path": Path("/fake/logs"),
-        "properties_file_path": Path("more/fake/paths")
+        "properties_file_path": Path("more/fake/paths"),
     }
     mock_im_init = mocker.patch.object(InputManager, "__init__", return_value=None)
     produce_graphics = False
 
     mock_handler = mocker.patch.object(TaskManager, "call_handler", return_value=None)
-    mock_handle_input_data_audit = mocker.patch.object(TaskManager, "handle_input_data_audit",
-                                                       return_value=True)
+    mock_handle_input_data_audit = mocker.patch.object(TaskManager, "handle_input_data_audit", return_value=True)
     mock_set_random_seed = mocker.patch.object(TaskManager, "set_random_seed", return_value=None)
     task_manager.task(args, produce_graphics, 10)
     mock_im_init.assert_called_once_with(10)
@@ -273,19 +279,20 @@ def test_compare_metadata_properties_tasks(mocker: MockerFixture) -> None:
     args = {
         "properties_file_path": Path("fake/properties/path"),
         "comparison_properties_file_path": Path("fake/comparison/properties/path"),
-        "logs_directory": Path("/fake/logs")
+        "logs_directory": Path("/fake/logs"),
     }
-    mock_input_manager = MagicMock(name='InputManager')
-    mock_output_manager = MagicMock(name='OutputManager')
+    mock_input_manager = MagicMock(name="InputManager")
+    mock_output_manager = MagicMock(name="OutputManager")
     produce_graphic = False
     task_id = 6
 
     mock_compare_metadata_properties = mocker.patch.object(
-        mock_input_manager, 'compare_metadata_properties', return_value=None
+        mock_input_manager, "compare_metadata_properties", return_value=None
     )
 
-    TaskManager._compare_metadata_properties_tasks(args, mock_input_manager, mock_output_manager, task_id,
-                                                   produce_graphic)
+    TaskManager._compare_metadata_properties_tasks(
+        args, mock_input_manager, mock_output_manager, task_id, produce_graphic
+    )
 
     mock_compare_metadata_properties.assert_called_once_with(
         args["properties_file_path"], args["comparison_properties_file_path"], args["logs_directory"]
@@ -302,29 +309,24 @@ def test_herd_init_tasks() -> None:
         "random_seed": 924,
         "suppress_log_files": True,
         "metadata_file_path": "/fake/logs",
-        "properties_file_path": "more/fake/paths"
+        "properties_file_path": "more/fake/paths",
     }
     task_id = 5
 
     # Create mocks for InputManager and OutputManager
-    mock_input_manager = MagicMock(name='InputManager')
-    mock_output_manager = MagicMock(name='OutputManager')
+    mock_input_manager = MagicMock(name="InputManager")
+    mock_output_manager = MagicMock(name="OutputManager")
     produce_graphic = False
-    with patch.object(TaskManager, 'handle_herd_initializaition',
-                      return_value=None) as mock_handle_herd_initializaition, \
-            patch.object(TaskManager, 'handle_post_processing',
-                         return_value=None) as mock_handle_post_processing:
+    with (
+        patch.object(TaskManager, "handle_herd_initializaition", return_value=None) as mock_handle_herd_initializaition,
+        patch.object(TaskManager, "handle_post_processing", return_value=None) as mock_handle_post_processing,
+    ):
         TaskManager._herd_init_tasks(args, mock_input_manager, mock_output_manager, task_id, produce_graphic)
         mock_handle_herd_initializaition.assert_called_once_with(args, mock_output_manager)
         mock_handle_post_processing.assert_called_once_with(args, mock_input_manager, mock_output_manager, task_id)
 
 
-@pytest.mark.parametrize("input_patch,produce_graphics", [
-    (True, True),
-    (False, True),
-    (False, False),
-    (True, False)
-])
+@pytest.mark.parametrize("input_patch,produce_graphics", [(True, True), (False, True), (False, False), (True, False)])
 def test_simulation_engine_run_tasks(input_patch: bool, produce_graphics: bool) -> None:
     args = {
         "log_verbosity": "logs",
@@ -336,33 +338,34 @@ def test_simulation_engine_run_tasks(input_patch: bool, produce_graphics: bool) 
         "suppress_log_files": True,
         "metadata_file_path": "/fake/logs",
         "properties_file_path": "more/fake/paths",
-        "input_patch": input_patch
+        "input_patch": input_patch,
     }
     task_id = 5
-    mock_input_manager = MagicMock(name='InputManager')
-    mock_output_manager = MagicMock(name='OutputManager')
-    with patch.object(TaskManager, 'handle_single_simulation_run',
-                      return_value=None) as mock_handle_single_simulation_run, \
-            patch.object(TaskManager, 'handle_post_processing',
-                         return_value=None) as mock_handle_post_processing, \
-            patch.object(Utility, 'deep_merge', return_value=None) as mock_deep_merge:
+    mock_input_manager = MagicMock(name="InputManager")
+    mock_output_manager = MagicMock(name="OutputManager")
+    with (
+        patch.object(
+            TaskManager, "handle_single_simulation_run", return_value=None
+        ) as mock_handle_single_simulation_run,
+        patch.object(TaskManager, "handle_post_processing", return_value=None) as mock_handle_post_processing,
+        patch.object(Utility, "deep_merge", return_value=None) as mock_deep_merge,
+    ):
 
-        TaskManager._simulation_engine_run_tasks(args, mock_input_manager, mock_output_manager, task_id,
-                                                 produce_graphics)
+        TaskManager._simulation_engine_run_tasks(
+            args, mock_input_manager, mock_output_manager, task_id, produce_graphics
+        )
         if input_patch:
             mock_deep_merge.assert_called_once_with(mock_input_manager.pool, args["input_patch"])
         else:
             mock_deep_merge.assert_not_called()
 
         mock_handle_single_simulation_run.assert_called_once_with(args, mock_output_manager)
-        mock_handle_post_processing.assert_called_once_with(args, mock_input_manager, mock_output_manager,
-                                                            task_id, produce_graphics, True)
+        mock_handle_post_processing.assert_called_once_with(
+            args, mock_input_manager, mock_output_manager, task_id, produce_graphics, True
+        )
 
 
-@pytest.mark.parametrize("produce_graphics", [
-    True,
-    False
-])
+@pytest.mark.parametrize("produce_graphics", [True, False])
 def test_postprocessing_tasks(produce_graphics: bool) -> None:
     args = {
         "log_verbosity": "logs",
@@ -373,15 +376,16 @@ def test_postprocessing_tasks(produce_graphics: bool) -> None:
         "random_seed": 924,
         "suppress_log_files": True,
         "metadata_file_path": "/fake/logs",
-        "properties_file_path": "more/fake/paths"
+        "properties_file_path": "more/fake/paths",
     }
     task_id = 5
-    mock_input_manager = MagicMock(name='InputManager')
-    mock_output_manager = MagicMock(name='OutputManager')
-    with patch.object(TaskManager, 'handle_post_processing', return_value=None) as mock_handle_post_processing:
+    mock_input_manager = MagicMock(name="InputManager")
+    mock_output_manager = MagicMock(name="OutputManager")
+    with patch.object(TaskManager, "handle_post_processing", return_value=None) as mock_handle_post_processing:
         TaskManager._postprocessing_tasks(args, mock_input_manager, mock_output_manager, task_id, produce_graphics)
-        mock_handle_post_processing.assert_called_once_with(args, mock_input_manager, mock_output_manager,
-                                                            task_id, produce_graphics, True, True)
+        mock_handle_post_processing.assert_called_once_with(
+            args, mock_input_manager, mock_output_manager, task_id, produce_graphics, True, True
+        )
 
 
 def test_call_handler():
@@ -394,26 +398,29 @@ def test_call_handler():
         "random_seed": 924,
         "suppress_log_files": True,
         "metadata_file_path": "/fake/logs",
-        "properties_file_path": "more/fake/paths"
+        "properties_file_path": "more/fake/paths",
     }
     task_id = 5
-    mock_input_manager = MagicMock(name='InputManager')
-    mock_output_manager = MagicMock(name='OutputManager')
+    mock_input_manager = MagicMock(name="InputManager")
+    mock_output_manager = MagicMock(name="OutputManager")
     produce_graphics = False
 
     # Call the call_handler method
-    with patch.object(TaskManager, '_postprocessing_tasks', return_value=None) as mock_handle_post_processing:
-        TaskManager.call_handler(mock_handle_post_processing, args=args,
-                                 input_manager=mock_input_manager,
-                                 output_manager=mock_output_manager,
-                                 task_id=task_id,
-                                 produce_graphics=produce_graphics
-                                 )
+    with patch.object(TaskManager, "_postprocessing_tasks", return_value=None) as mock_handle_post_processing:
+        TaskManager.call_handler(
+            mock_handle_post_processing,
+            args=args,
+            input_manager=mock_input_manager,
+            output_manager=mock_output_manager,
+            task_id=task_id,
+            produce_graphics=produce_graphics,
+        )
 
         # Verify that the handler was called with the correct filtered arguments
         print(mock_handle_post_processing.call_args)
-        mock_handle_post_processing.assert_called_once_with(args, mock_input_manager, mock_output_manager,
-                                                            task_id, produce_graphics)
+        mock_handle_post_processing.assert_called_once_with(
+            args, mock_input_manager, mock_output_manager, task_id, produce_graphics
+        )
 
 
 def test_input_data_audit_tasks() -> None:
@@ -426,16 +433,17 @@ def test_input_data_audit_tasks() -> None:
         "random_seed": 924,
         "suppress_log_files": True,
         "metadata_file_path": Path("/fake/logs"),
-        "properties_file_path": Path("more/fake/paths")
+        "properties_file_path": Path("more/fake/paths"),
     }
     task_id = 5
     im = InputManager()
     om = OutputManager()
     produce_graphic = False
 
-    with (patch.object(TaskManager, 'handle_input_data_audit', return_value=None) as
-          mock_handle_input_data_audit, patch.object(TaskManager, 'handle_post_processing', return_value=None)
-          as mock_handle_post_processing):
+    with (
+        patch.object(TaskManager, "handle_input_data_audit", return_value=None) as mock_handle_input_data_audit,
+        patch.object(TaskManager, "handle_post_processing", return_value=None) as mock_handle_post_processing,
+    ):
         TaskManager._input_data_audit_tasks(args, im, om, task_id, produce_graphic)
 
         mock_handle_input_data_audit.assert_called_once_with(args, im, om, False)


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
This PR extracts function into a function map so that TaskManagee.task will not violate the complexity constraint of flake8. Improves future extendability.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1713 

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.
      
How big are the changes in the PR? Would you nominate it for a major version upgrade?
- [ ] Yes
- [x] No

### What
<!-- Add more detail about the changes that are being made in the pull request. -->

- Tasks are now mapped into two dictionaries, one related to functions that do not need data validations, and one post validations.
- All tasks are moved into a static method and ensure that it has uniform signatures.
- Wrapper method `call_handler` is created to pass into tasks.
- Baseline test for `task ` is updated.
- All other related tasks' methods are tested.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
Violates flake8 complexity restrain.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
There will be no more addition of condition statements when trying to add new tasks in the future with a uniform call of the wrapper method.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->

- Tests were added.
- Run task_manager metadata with sample_tasks.json