### PR TITLE
Hot fix for compare-metadata task results save folder

### DIFF
--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -2355,6 +2355,7 @@ class InputManager:
             "class": self.__class__.__name__,
             "function": self.compare_metadata_properties.__name__,
         }
+        om.create_directory(output_directory)
         self._load_metadata(properties_file_path)
         properties1 = deepcopy(self.meta_data)
         self.meta_data = {}

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -4115,12 +4115,14 @@ def test_compare_metadata_properties(
 
     mock_add_log = mocker.patch("RUFAS.output_manager.OutputManager.add_log")
     mock_add_error = mocker.patch("RUFAS.output_manager.OutputManager.add_error")
+    mock_create_directory = mocker.patch("RUFAS.output_manager.OutputManager.create_directory")
 
     if file_exists:
         input_manager.compare_metadata_properties(properties_file_path, comparison_properties_file_path, output_path)
         mock_file.assert_called()
         mock_add_log.assert_called()
         mock_add_error.assert_not_called()
+        mock_create_directory.assert_called()
     else:
         with pytest.raises(error):
             input_manager.compare_metadata_properties(
@@ -4128,6 +4130,7 @@ def test_compare_metadata_properties(
             )
         mock_add_log.assert_called()
         mock_add_error.assert_called()
+        mock_create_directory.assert_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
In testing another PR, I discovered that the `COMPARE_METADATA_PROPERTIES` task was broken because the directory for the output was not being created before the results file was being attempted to be saved there.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes # N/A

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.
      
How big are the changes in the PR? Would you nominate it for a major version upgrade?
- [ ] Yes
- [x] No

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Creates the output directory within the `compare_metadata_properties()` function before attempting to save the results file there.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
It was trying to save the results file to a non-existent output folder previously.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Adds a call to `om.create_directory()` within the `compare_metadata_properties()` function.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
1. Create a copy of the `default.json` metadata properties in that same directory.
2. Change the task type for `default_task.json` to `COMPARE_METADATA_PROPERTIES`.
3. Add necessary properties and comparison properties file paths to task:

```
{
  "parallel_workers": 4,
  "tasks": [
    {
      "task_type": "COMPARE_METADATA_PROPERTIES",
      "metadata_file_path": "input/metadata/default_metadata.json",
      "properties_file_path": "input/metadata/properties/default.json",
      "comparison_properties_file_path": "input/metadata/properties/default_copy.json",
      "output_prefix": "default",
      "log_verbosity": "errors",
      "random_seed": 42
    }
  ]
}
```
4. Run it and it should successfully complete and save the resulting file to the designated output directory.