### PR TITLE
Temporary replacement of residue_composition_factor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-3327%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-3327%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3328%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3327%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
  
 # Vision

--- a/RUFAS/routines/field/soil/nitrogen_cycling/mineralization_decomp.py
+++ b/RUFAS/routines/field/soil/nitrogen_cycling/mineralization_decomp.py
@@ -166,8 +166,9 @@ class MineralizationDecomposition:
         return exp(inner_term)
 
     @staticmethod
-    def _calculate_nutrient_cycling_residue_composition_factor(carbon_nitrogen_ratio: float,
-                                                               carbon_phosphorus_ratio: float) -> float:
+    def _calculate_nutrient_cycling_residue_composition_factor(
+        carbon_nitrogen_ratio: float, carbon_phosphorus_ratio: float
+    ) -> float:
         """
         Calculates the residue composition factor for use in computing the decay rate constant.
 
@@ -191,10 +192,10 @@ class MineralizationDecomposition:
         The values of the constant used to determine the nitrogen and phosphorus terms are 25 and 200, respectively.
 
         """
-        nitrogen_term = MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor( # noqa
+        nitrogen_term = MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(  # noqa
             carbon_nitrogen_ratio, 25
         )
-        phosphorus_term = MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor( # noqa
+        phosphorus_term = MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(  # noqa
             carbon_phosphorus_ratio, 200
         )
         # temporary fix

--- a/RUFAS/routines/field/soil/nitrogen_cycling/mineralization_decomp.py
+++ b/RUFAS/routines/field/soil/nitrogen_cycling/mineralization_decomp.py
@@ -166,8 +166,9 @@ class MineralizationDecomposition:
         return exp(inner_term)
 
     @staticmethod
-    def _calculate_nutrient_cycling_residue_composition_factor(carbon_nitrogen_ratio: float,
-                                                               carbon_phosphorus_ratio: float) -> float:
+    def _calculate_nutrient_cycling_residue_composition_factor(
+        carbon_nitrogen_ratio: float, carbon_phosphorus_ratio: float
+    ) -> float:
         """
         Calculates the residue composition factor for use in computing the decay rate constant.
 
@@ -191,11 +192,15 @@ class MineralizationDecomposition:
         The values of the constant used to determine the nitrogen and phosphorus terms are 25 and 200, respectively.
 
         """
-        nitrogen_term = MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(  # noqa: F841, E501
-            carbon_nitrogen_ratio, 25
+        nitrogen_term = (
+            MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(  # noqa: F841, E501
+                carbon_nitrogen_ratio, 25
+            )
         )
-        phosphorus_term = MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(  # noqa: F841, E501
-            carbon_phosphorus_ratio, 200
+        phosphorus_term = (
+            MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(  # noqa: F841, E501
+                carbon_phosphorus_ratio, 200
+            )
         )
         # temporary fix to replace the process based method for the effect of the soil C, N, and P on the decomposition
         # rate factor

--- a/RUFAS/routines/field/soil/nitrogen_cycling/mineralization_decomp.py
+++ b/RUFAS/routines/field/soil/nitrogen_cycling/mineralization_decomp.py
@@ -166,7 +166,8 @@ class MineralizationDecomposition:
         return exp(inner_term)
 
     @staticmethod
-    def _calculate_nutrient_cycling_residue_composition_factor(carbon_nitrogen_ratio, carbon_phosphorus_ratio) -> float:
+    def _calculate_nutrient_cycling_residue_composition_factor(carbon_nitrogen_ratio: float,
+                                                               carbon_phosphorus_ratio: float) -> float:
         """
         Calculates the residue composition factor for use in computing the decay rate constant.
 
@@ -190,13 +191,14 @@ class MineralizationDecomposition:
         The values of the constant used to determine the nitrogen and phosphorus terms are 25 and 200, respectively.
 
         """
-        nitrogen_term = MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(
+        nitrogen_term = MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor( # noqa
             carbon_nitrogen_ratio, 25
         )
-        phosphorus_term = MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(
+        phosphorus_term = MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor( # noqa
             carbon_phosphorus_ratio, 200
         )
-        return min(nitrogen_term, phosphorus_term, 1.0)
+        # temporary fix
+        return 1
 
     @staticmethod
     def _calculate_decay_rate_constant(

--- a/RUFAS/routines/field/soil/nitrogen_cycling/mineralization_decomp.py
+++ b/RUFAS/routines/field/soil/nitrogen_cycling/mineralization_decomp.py
@@ -191,21 +191,22 @@ class MineralizationDecomposition:
         The values of the constant used to determine the nitrogen and phosphorus terms are 25 and 200, respectively.
 
         """
-        nitrogen_term = MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor( # noqa
+        nitrogen_term = MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(  # noqa: F841, E501
             carbon_nitrogen_ratio, 25
         )
-        phosphorus_term = MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor( # noqa
+        phosphorus_term = MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(  # noqa: F841, E501
             carbon_phosphorus_ratio, 200
         )
-        # temporary fix
+        # temporary fix to replace the process based method for the effect of the soil C, N, and P on the decomposition
+        # rate factor
         return 1
 
     @staticmethod
     def _calculate_decay_rate_constant(
         fresh_organic_residue_mineralization_rate: float,
-        composition_factor: float,
+        residue_composition_factor: float,
         temp_factor: float,
-        water_factor,
+        moisture_factor,
     ) -> float:
         """
         Calculates the decay rate constant for residue.
@@ -214,11 +215,11 @@ class MineralizationDecomposition:
         ----------
         fresh_organic_residue_mineralization_rate : float
             Rate coefficient for mineralization of fresh organic nutrients from residue (unitless).
-        composition_factor : float
+        residue_composition_factor : float
             Nutrient cycling residue composition factor for the current soil layer (unitless).
         temp_factor : float
             Nutrient cycling temperature factor for the current soil layer (unitless).
-        water_factor : float
+        moisture_factor : float
             Nutrient cycling water factor for the current soil layer (unitless).
 
         Returns
@@ -235,5 +236,5 @@ class MineralizationDecomposition:
         in the SWAT Input .BSN file (see "RSDCO" on page 101) and SWAT Input CROP.DAT file (see "RSDCO_PL" on page 205).
 
         """
-        root_term = (temp_factor * water_factor) ** 0.5
-        return fresh_organic_residue_mineralization_rate * composition_factor * root_term
+        square_root_factor = (temp_factor * moisture_factor) ** 0.5
+        return fresh_organic_residue_mineralization_rate * residue_composition_factor * square_root_factor

--- a/RUFAS/routines/field/soil/nitrogen_cycling/mineralization_decomp.py
+++ b/RUFAS/routines/field/soil/nitrogen_cycling/mineralization_decomp.py
@@ -192,12 +192,12 @@ class MineralizationDecomposition:
         The values of the constant used to determine the nitrogen and phosphorus terms are 25 and 200, respectively.
 
         """
-        nitrogen_term = (
-            MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(  # noqa: F841, E501
+        nitrogen_term = (  # noqa: F841
+            MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(
                 carbon_nitrogen_ratio, 25
             )
         )
-        phosphorus_term = (
+        phosphorus_term = (  # noqa: F841
             MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(  # noqa: F841, E501
                 carbon_phosphorus_ratio, 200
             )

--- a/RUFAS/routines/field/soil/nitrogen_cycling/mineralization_decomp.py
+++ b/RUFAS/routines/field/soil/nitrogen_cycling/mineralization_decomp.py
@@ -198,12 +198,12 @@ class MineralizationDecomposition:
         phosphorus_term = MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(  # noqa
             carbon_phosphorus_ratio, 200
         )
-        # temporary fix
+        # temporary value
         return 1
 
     @staticmethod
     def _calculate_decay_rate_constant(
-        fresh_organic_residue_mineralization_rate: float,
+        fresh_organic_residue_decay_rate: float,
         composition_factor: float,
         temp_factor: float,
         water_factor,
@@ -213,7 +213,7 @@ class MineralizationDecomposition:
 
         Parameters
         ----------
-        fresh_organic_residue_mineralization_rate : float
+        fresh_organic_residue_decay_rate : float
             Rate coefficient for mineralization of fresh organic nutrients from residue (unitless).
         composition_factor : float
             Nutrient cycling residue composition factor for the current soil layer (unitless).
@@ -236,5 +236,5 @@ class MineralizationDecomposition:
         in the SWAT Input .BSN file (see "RSDCO" on page 101) and SWAT Input CROP.DAT file (see "RSDCO_PL" on page 205).
 
         """
-        root_term = (temp_factor * water_factor) ** 0.5
-        return fresh_organic_residue_mineralization_rate * composition_factor * root_term
+        factor_square_root_term = (temp_factor * water_factor) ** 0.5
+        return fresh_organic_residue_decay_rate * composition_factor * factor_square_root_term

--- a/tests/soil_crop_tests/soil_tests/nitrogen_cycling_tests/test_mineralization_decomp.py
+++ b/tests/soil_crop_tests/soil_tests/nitrogen_cycling_tests/test_mineralization_decomp.py
@@ -49,7 +49,7 @@ def test_calculate_nutrient_cycling_residue_composition_factor(
     observed = MineralizationDecomposition._calculate_nutrient_cycling_residue_composition_factor(
         nitrogen_ratio, phosphorus_ratio
     )
-    expected = min(1.0, nutrient_term)
+    expected = 1
 
     calls = [call(nitrogen_ratio, 25), call(phosphorus_ratio, 200)]
     MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor.assert_has_calls(calls)


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
This PR removes the effect of the soil C:N and soil C:P ratios which is called the `residue_composition_factor`.
### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1810

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.
      
How big are the changes in the PR? Would you nominate it for a major version upgrade?
- [ ] Yes
- [x] No

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
- The original method of `calculate_nutrient_cycling_residue_composition_factor` is kept with no quality assessment so that those temporary unused calculations won't raise flake8 errors.
- Now `calculate_nutrient_cycling_residue_composition_factor` will simply return 1 to mute its effects.
- Variable names changed to bring more clarity, `root_term` is now factor_square_root_term and `fresh_organic_residue_mineralization_rate` is now `fresh_organic_residue_decay_rate`.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
We want to replace the process based method for the effect of the soil C, N, and P on the decomposition rate factor with a fixed reasonable value 1 while SMEs evaluate the methods that represent this effect.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Setting the return value to a constant and clarify(simplify) the names.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
1. Ran with updated test suits.
2. Trust our great SMEs
