### PR TITLE
Deduplicate is_leap_year in schedule.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-3319%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-3319%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)

--- a/RUFAS/routines/field/manager/schedule.py
+++ b/RUFAS/routines/field/manager/schedule.py
@@ -1,6 +1,8 @@
 from typing import List, Any
 from copy import copy
 
+from RUFAS.util import Utility
+
 
 class Schedule:
     """
@@ -112,36 +114,11 @@ class Schedule:
         """
         dates = list(zip(years, days))
         for date in dates:
-            if not Schedule.is_leap_year(date[0]) and not 0 < date[1] <= 365:
+            if not Utility.is_leap_year(date[0]) and not 0 < date[1] <= 365:
                 return False
-            if Schedule.is_leap_year(date[0]) and not 0 < date[1] <= 366:
+            if Utility.is_leap_year(date[0]) and not 0 < date[1] <= 366:
                 return False
         return True
-
-    @staticmethod
-    def is_leap_year(year: int) -> bool:
-        """
-        Determines if the given year is a leap year.
-
-        Parameters
-        ----------
-        year: int
-            A calendar year.
-
-        Returns
-        -------
-        bool
-            True if the year is a leap year
-
-        """
-        if year % 400 == 0:
-            return True
-        elif year % 100 == 0:
-            return False
-        elif year % 4 == 0:
-            return True
-        else:
-            return False
 
     @staticmethod
     def _validate_years(years: List[int]) -> bool:

--- a/tests/soil_crop_tests/manager_tests/test_schedule.py
+++ b/tests/soil_crop_tests/manager_tests/test_schedule.py
@@ -130,12 +130,3 @@ def test_validate_pattern_parameters(name: str, skip: int, repeat: int, expected
         test._validate_pattern_parameters()
     assert str(e.value) == expected
 
-
-@pytest.mark.parametrize(
-    "year,expected",
-    [(1999, False), (2001, False), (2004, True), (2016, True), (1900, False)],
-)
-def test_is_leap_year(year: int, expected: bool) -> None:
-    """Tests that a year is correctly determined to be a leap year or non-leap year."""
-    actual = Schedule.is_leap_year(year)
-    assert actual == expected

--- a/tests/soil_crop_tests/manager_tests/test_schedule.py
+++ b/tests/soil_crop_tests/manager_tests/test_schedule.py
@@ -129,4 +129,3 @@ def test_validate_pattern_parameters(name: str, skip: int, repeat: int, expected
         test = Schedule(name, [], [], skip, repeat)
         test._validate_pattern_parameters()
     assert str(e.value) == expected
-


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
De duplicates the _is_leap_year in `schedule.py`
### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1842

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.
      
How big are the changes in the PR? Would you nominate it for a major version upgrade?
- [ ] Yes
- [x] No

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Removes the method in `schedule.py`  and routes to the one in `utils.py`.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
It's duplicated.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
1. The remaining test suits for `schedule .py` remained successful, meaning that such reroute is successful and is still correctly returning leap year.
