### PR TITLE
Modify digester methane leakage variable name

### DIFF
--- a/RUFAS/routines/manure/manure_treatments/anaerobic_digestion.py
+++ b/RUFAS/routines/manure/manure_treatments/anaerobic_digestion.py
@@ -129,7 +129,7 @@ class AnaerobicDigestion(BaseManureTreatment):
         new_daily_output.biogas_energy_content = captured_methane_energy_content
         new_daily_output.minimum_digester_volume = minimum_digester_volume
         new_daily_output.top_cover_volume = top_cover_volume
-        new_daily_output.methane_leakage_mass = methane_leakage
+        new_daily_output.storage_methane = methane_leakage
         new_daily_output.methane_generation_volume = captured_methane_generation_volume
         new_daily_output.biogas = captured_methane_generation_mass
         return new_daily_output

--- a/RUFAS/routines/manure/manure_treatments/manure_treatment_daily_output.py
+++ b/RUFAS/routines/manure/manure_treatments/manure_treatment_daily_output.py
@@ -168,11 +168,6 @@ class ManureTreatmentDailyOutput(LiquidManurePortionProtocol):
         Amount of methane generated, m^3.
     methane_generation_volume_unit: MeasurementUnits
         Unit for methane_generation_volume.
-    methane_leakage_mass : float, default 0.0
-        Methane generated in a digester that escapes to the atmosphere through unintended leakage and is not collected
-        by the gas capture system, kg.
-    methane_leakage_mass_unit : MeasurementUnits, default MeasurementUnits.KILOGRAMS
-        Unit of methane leakage mass.
     heating_input_energy: float
         Amount of energy input to the heating system, MJ.
     heating_input_energy_unit: MeasurementUnits
@@ -309,9 +304,6 @@ class ManureTreatmentDailyOutput(LiquidManurePortionProtocol):
 
     methane_generation_volume: float = 0.0
     methane_generation_volume_unit: MeasurementUnits = MeasurementUnits.CUBIC_METERS
-
-    methane_leakage_mass: float = 0.0
-    methane_leakage_mass_unit: MeasurementUnits = MeasurementUnits.KILOGRAMS
 
     heating_input_energy: float = 0.0
     heating_input_energy_unit: MeasurementUnits = MeasurementUnits.MEGAJOULES

--- a/tests/test_manure_module/test_manure_treatments.py
+++ b/tests/test_manure_module/test_manure_treatments.py
@@ -2333,7 +2333,7 @@ def test_calc_anaerobic_digestion_daily_output(mocker: MockFixture) -> None:
     assert actual_anaerobic_digestion_daily_output.minimum_digester_volume == approx(expected_minimum_digester_volume)
     assert actual_anaerobic_digestion_daily_output.top_cover_volume == approx(expected_top_cover_volume)
     assert actual_anaerobic_digestion_daily_output.methane_generation_volume == approx(expected_captured_methane_volume)
-    assert actual_anaerobic_digestion_daily_output.methane_leakage_mass == approx(expected_methane_leakage)
+    assert actual_anaerobic_digestion_daily_output.storage_methane == approx(expected_methane_leakage)
     assert actual_anaerobic_digestion_daily_output.liquid_manure_total_volatile_solids == approx(expected_total_VS)
     assert actual_anaerobic_digestion_daily_output.liquid_manure_total_degradable_volatile_solids == approx(
         expected_VSd


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
A new output was recently created in PR #1843 representing the small fraction of methane produced in a digester that escapes the gas capture system and leaks out into the atmosphere (`methane_leakage_mass`, units = kg CH4).

With the upcoming FARM ES integration, though not an ideal long-term variable name, Kristan requested we rename this variable to `storage_methane` (also with units = kg CH4) so that it is picked up by existing filters, as other manure treatments utilize this variable name to represent methane emitted into to the atmosphere. 

Issue(s) closed by this pull request: N/A

- [ ] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.
      
How big are the changes in the PR? Would you nominate it for a major version upgrade?
- [ ] Yes
- [X] No

### What
<!-- Add more detail about the changes that are being made in the pull request. -->


### Why
<!-- Discuss why the changes in this pull request are needed or important. -->


### How
<!-- Give an explanation of how this pull request addresses needed changes. -->


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
