### PR TITLE
Fixing global OM (1/2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3355%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3338%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-3337%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3338%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3337%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-3337%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -12,7 +12,6 @@ import pandas as pd
 from RUFAS.output_manager import OutputManager
 from RUFAS.util import Utility
 
-om = OutputManager()
 
 """
 Set enumerating the input data types that the Input Manager will attempt to fix while validating input data.
@@ -82,6 +81,7 @@ class InputManager:
         return cls.instance
 
     def __init__(self, metadata_depth_limit: int | None = None) -> None:
+        self.om = OutputManager()
         if InputManager.__instance is None:
             InputManager.__instance = self
             self.__metadata: Dict[str, Any] = {}
@@ -153,7 +153,7 @@ class InputManager:
             "class": self.__class__.__name__,
             "function": self._load_metadata.__name__,
         }
-        om.add_log(
+        self.om.add_log(
             "load_metadata_attempt",
             f"Attempting to load metadata from {metadata_path}.",
             info_map,
@@ -161,7 +161,7 @@ class InputManager:
         try:
             with open(metadata_path) as metadata_file:
                 self.__metadata = json.load(metadata_file)
-                om.add_log(
+                self.om.add_log(
                     "load_metadata_success",
                     f"Successfully loaded metadata from {metadata_path}",
                     info_map,
@@ -192,7 +192,7 @@ class InputManager:
         }
         try:
             properties_path = Path(self.__metadata["files"]["properties"]["path"])
-            om.add_log(
+            self.om.add_log(
                 "load_properties_attempt",
                 f"Attempting to load properties from {properties_path}",
                 info_map,
@@ -203,20 +203,20 @@ class InputManager:
             del self.__metadata["files"]["properties"]
 
             self.__metadata["properties"] = self._load_data_from_json(properties_path)
-            om.add_log(
+            self.om.add_log(
                 "load_properties_success",
                 f"Successfully loaded properties from {properties_path}",
                 info_map,
             )
 
         except FileNotFoundError as fnfe:
-            om.add_error("load_properties_file_not_found", str(fnfe), info_map)
+            self.om.add_error("load_properties_file_not_found", str(fnfe), info_map)
             raise
         except json.JSONDecodeError as jde:
-            om.add_error("load_properties_json_error", str(jde), info_map)
+            self.om.add_error("load_properties_json_error", str(jde), info_map)
             raise
         except Exception as e:
-            om.add_error("load_properties_error", f"Unexpected error: {e}", info_map)
+            self.om.add_error("load_properties_error", f"Unexpected error: {e}", info_map)
             raise
 
     def _load_data_from_json(self, file_path: Path) -> Dict[str, Any]:
@@ -243,11 +243,11 @@ class InputManager:
             "class": self.__class__.__name__,
             "function": self._load_data_from_json.__name__,
         }
-        om.add_log("open_json_file", f"Attempting to open {file_path}.", info_map)
+        self.om.add_log("open_json_file", f"Attempting to open {file_path}.", info_map)
         try:
             with open(file_path) as json_file:
                 data: Dict[str, Any] = json.load(json_file)
-                om.add_log(
+                self.om.add_log(
                     "load_data_successful",
                     f"Successfully loaded data from {file_path}.",
                     info_map,
@@ -282,13 +282,13 @@ class InputManager:
             "class": self.__class__.__name__,
             "function": self._load_data_from_csv.__name__,
         }
-        om.add_log("open_csv_file", f"Attempting to open {file_path}.", info_map)
+        self.om.add_log("open_csv_file", f"Attempting to open {file_path}.", info_map)
         try:
             with open(file_path, "r", encoding="utf-8") as csv_file:
                 data_frame = pd.read_csv(csv_file)
                 data_dict = {column: data_frame[column].tolist() for column in data_frame.columns}
                 if not data_frame.empty:
-                    om.add_log(
+                    self.om.add_log(
                         "load_data_successful",
                         f"Successfully loaded data from {file_path}.",
                         info_map,
@@ -406,7 +406,7 @@ class InputManager:
         try:
             return Modifiability.__getitem__("_".join(modifiability.strip().upper().split()))
         except KeyError:
-            om.add_warning(
+            self.om.add_warning(
                 "Unknown modifiability entry",
                 f"Unknown modifiability value of {modifiability} for variable {variable_name}. Modifiability should be "
                 f"one of {Modifiability.values()}. Using the default value: {default}",
@@ -498,11 +498,11 @@ class InputManager:
         info_map = {"class": self.__class__.__name__, "function": self._log_missing_data.__name__}
         if not called_during_initialization:
             error_msg = (f"Key {var_name} not found in data. A value is required to update variable during runtime.",)
-            om.add_error("Missing required data", error_msg, info_map)
+            self.om.add_error("Missing required data", error_msg, info_map)
             raise KeyError(error_msg)
 
         if self._is_input_required_upon_initialization(variable_name=var_name, variable_properties=variable_properties):
-            om.add_error(
+            self.om.add_error(
                 "Missing required data",
                 f"Key {var_name} not found in input data. Input value is required for this "
                 "variable upon program initialization.",
@@ -512,7 +512,7 @@ class InputManager:
                 f"Key {var_name} not found in input data. Input value is required for this "
                 "variable upon program initialization."
             )
-        om.add_warning(
+        self.om.add_warning(
             "Validation: key not found in input data -- input not required upon initialization",
             f"Key {var_name} not found in input data. Input value is not required for this "
             "variable upon program initialization, setting the variable value to None.",
@@ -644,7 +644,7 @@ class InputManager:
         )
         variable_path_str = self._convert_variable_path_to_str(variable_path)
         if not isinstance(input_data, list):
-            om.add_warning(
+            self.om.add_warning(
                 "Validation: array container is not a list",
                 f"Variable: '{variable_path_str}' is not an array but has type: {type(input_data)}. "
                 f"{properties_violation_message}",
@@ -657,7 +657,7 @@ class InputManager:
         if minimum_length is not None:
             is_in_range = variable_properties["minimum_length"] <= len(input_data)
             if not is_in_range:
-                om.add_warning(
+                self.om.add_warning(
                     "Validation: array length less than minimum",
                     f"Variable: '{variable_path_str}' has length: {len(input_data)}, less than minimum length: "
                     f"{minimum_length}. {properties_violation_message}",
@@ -668,7 +668,7 @@ class InputManager:
         if maximum_length is not None:
             is_in_range = len(input_data) <= variable_properties["maximum_length"]
             if not is_in_range:
-                om.add_warning(
+                self.om.add_warning(
                     "Validation: array length greater than maximum",
                     f"Variable: '{variable_path_str}' has length: {len(input_data)}, greater than maximum length: "
                     f"{maximum_length}. {properties_violation_message}",
@@ -792,7 +792,7 @@ class InputManager:
             f"Violates properties defined in metadata properties section" f" '{properties_blob_key}'."
         )
         if not isinstance(object_value, dict):
-            om.add_warning(
+            self.om.add_warning(
                 "Validation: object is not a dictionary",
                 f"Variable: '{variable_path_str}' is not an object but has type: {type(object_value)}. "
                 f"{properties_violation_message}",
@@ -818,7 +818,7 @@ class InputManager:
 
         extraneous_keys = [key for key in object_value.keys() if key not in variable_properties.keys()]
         for key in extraneous_keys:
-            om.add_warning(
+            self.om.add_warning(
                 "Validation: object contains extraneous data",
                 f"Variable: '{variable_path_str}' contains data at key '{key}' that is not specified in the metadata "
                 f"properties. {properties_violation_message}",
@@ -864,7 +864,7 @@ class InputManager:
                 f"Variable: '{variable_path_str}' has value: {input_data_value}, is type: "
                 f"{type(input_data_value)}. {properties_violation_message}"
             )
-            om.add_warning(warning_string, warning_message, info_map)
+            self.om.add_warning(warning_string, warning_message, info_map)
             return False
         if minimum_value is not None:
             is_in_range = minimum_value <= input_data_value
@@ -874,7 +874,7 @@ class InputManager:
                     f"Variable: '{variable_path_str}' has value: {input_data_value}, less than minimum value: "
                     f"{minimum_value: .2f}. {properties_violation_message}"
                 )
-                om.add_warning(warning_name, warning_message, info_map)
+                self.om.add_warning(warning_name, warning_message, info_map)
                 return False
         if maximum_value is not None:
             is_in_range = input_data_value <= maximum_value
@@ -884,7 +884,7 @@ class InputManager:
                     f"Variable: '{variable_path_str}' has value: {input_data_value}, greater than maximum value: "
                     f"{maximum_value: .2f}. {properties_violation_message}"
                 )
-                om.add_warning(warning_name, warning_string, info_map)
+                self.om.add_warning(warning_name, warning_string, info_map)
                 return False
 
         return True
@@ -922,7 +922,7 @@ class InputManager:
                 f"Variable: '{variable_path_str}' has value: {input_data_value}, is type: "
                 f"{type(input_data_value)}. {properties_violation_message}"
             )
-            om.add_warning(warning_name, warning_message, info_map)
+            self.om.add_warning(warning_name, warning_message, info_map)
             return False
 
         pattern_check = variable_properties.get("pattern")
@@ -934,7 +934,7 @@ class InputManager:
                     f"Variable: '{variable_path_str}' has value: '{input_data_value}', does not match pattern: "
                     f"{pattern_check}. {properties_violation_message}"
                 )
-                om.add_warning(warning_name, warning_message, info_map)
+                self.om.add_warning(warning_name, warning_message, info_map)
                 return False
 
         minimum_length = variable_properties.get("minimum_length")
@@ -947,7 +947,7 @@ class InputManager:
                     f"Variable: '{variable_path_str}' has value: '{input_data_value}', length is less than "
                     f"minimum length: {minimum_length}. {properties_violation_message}"
                 )
-                om.add_warning(warning_name, warning_message, info_map)
+                self.om.add_warning(warning_name, warning_message, info_map)
                 return False
         if maximum_length is not None:
             is_valid_string = len(input_data_value) <= variable_properties["maximum_length"]
@@ -957,7 +957,7 @@ class InputManager:
                     f"Variable: '{variable_path_str}' has value: '{input_data_value}', length is greater than "
                     f"maximum length: {maximum_length}. {properties_violation_message}"
                 )
-                om.add_warning(warning_name, warning_message, info_map)
+                self.om.add_warning(warning_name, warning_message, info_map)
                 return False
 
         return True
@@ -993,7 +993,7 @@ class InputManager:
                 f"Variable: '{variable_path_str}' has value: '{input_data_value}', is type: "
                 f"'{type(input_data_value)}'. {properties_violation_message}"
             )
-            om.add_warning(warning_name, warning_message, info_map)
+            self.om.add_warning(warning_name, warning_message, info_map)
             return False
 
         return True
@@ -1193,7 +1193,7 @@ class InputManager:
                 f"Variable: '{element_path}' has invalid value: {variable_parent[element_hierarchy[-1]]}"
                 f", and cannot be changed to a default value. {properties_violation_message}"
             )
-            om.add_error("Validation: invalid data not able to be fixed", error_message, info_map)
+            self.om.add_error("Validation: invalid data not able to be fixed", error_message, info_map)
             return False
 
         if type(variable_parent) is list:
@@ -1204,7 +1204,7 @@ class InputManager:
         warning_message = (
             f"Variable: '{element_path}' has value: {original_invalid_value}. {properties_violation_message}"
         )
-        om.add_warning("Validation: invalid data found", warning_message, info_map)
+        self.om.add_warning("Validation: invalid data found", warning_message, info_map)
 
         variable_parent[element_hierarchy[-1]] = variable_properties["default"]
 
@@ -1213,7 +1213,7 @@ class InputManager:
             f"{variable_properties['default']}. Fix enabled by default value specified in "
             f"'{properties_blob_key}'."
         )
-        om.add_warning("Validation: data fixed", warning_message, info_map)
+        self.om.add_warning("Validation: data fixed", warning_message, info_map)
         return True
 
     def get_data(self, data_address: str) -> Any:
@@ -1272,7 +1272,7 @@ class InputManager:
             self.__get_data_logs_pool[timestamp] = f"InputManager.get_data() called for {element_hierarchy}."
             return deepcopy(data_value)
         except KeyError as key_error:
-            om.add_error("Validation: data not found", str(key_error), info_map)
+            self.om.add_error("Validation: data not found", str(key_error), info_map)
 
         return None
 
@@ -1371,7 +1371,7 @@ class InputManager:
             invalid_key = element_hierarchy[-1]
             parent_address = ".".join(element_hierarchy[:-1])
 
-            om.add_error(
+            self.om.add_error(
                 "Validation: data not found:",
                 f'Cannot find "{metadata_address}", '
                 f'"{parent_address}" does not have attribute '
@@ -1459,7 +1459,7 @@ class InputManager:
             "function": self.flush_pool.__name__,
         }
         self.__pool = {}
-        om.add_log("Clear variable pool", "The pool is emptied.", info_map)
+        self.om.add_log("Clear variable pool", "The pool is emptied.", info_map)
 
     def _metadata_properties_exist(self, variable_name: str, properties_blob_key: str) -> bool:
         """
@@ -1496,14 +1496,14 @@ class InputManager:
             "function": self._metadata_properties_exist.__name__,
         }
         if not self.__metadata:
-            om.add_error(
+            self.om.add_error(
                 "No metadata loaded",
                 "No metadata is loaded to the InputManager.",
                 info_map,
             )
             raise ValueError("No metadata loaded.")
         if properties_blob_key not in self.__metadata["properties"]:
-            om.add_error(
+            self.om.add_error(
                 "No metadata found",
                 f"No metadata is found for variable '{variable_name}' with given "
                 f"properties_blob_key {properties_blob_key}. Consider adding variable "
@@ -1580,7 +1580,7 @@ class InputManager:
             elements_counter += elements_counter
 
         if elements_counter.invalid_elements > 0:
-            om.add_error(
+            self.om.add_error(
                 "Invalid variable",
                 f"Variable {variable_name} has invalid components. Only successfully validated components are "
                 f"added to InputManager pool during runtime.",
@@ -1665,10 +1665,10 @@ class InputManager:
             variable_name=variable_name, variable_properties=metadata_properties
         )
         if not is_modifiable_during_runtime and eager_termination:
-            om.add_error("IM Runtime Modification", f"{variable_name} is not modifiable during runtime.", info_map)
+            self.om.add_error("IM Runtime Modification", f"{variable_name} is not modifiable during runtime.", info_map)
             raise PermissionError(f"IM Runtime Modification Error: {variable_name} is not modifiable during runtime.")
         elif not is_modifiable_during_runtime:
-            om.add_warning("IM Runtime Modification", f"{variable_name} is not modifiable during runtime.", info_map)
+            self.om.add_warning("IM Runtime Modification", f"{variable_name} is not modifiable during runtime.", info_map)
             return False
         return True
 
@@ -1742,7 +1742,7 @@ class InputManager:
                 "class": self.__class__.__name__,
                 "function": self._add_to_pool.__name__,
             }
-            om.add_warning(
+            self.om.add_warning(
                 "Overwriting existing variable",
                 f"Variable {variable_name} already exists in InputManager pool, overwriting the old value.",
                 info_map,
@@ -1792,7 +1792,7 @@ class InputManager:
             "function": self.add_dict_variable_to_pool.__name__,
         }
         if not (isinstance(data, Dict)):
-            om.add_error(
+            self.om.add_error(
                 "Incorrect variable type",
                 f"Variable {variable_name} has type {type(data)}, does not match "
                 f"the expected type of `Dict[str, Any]`.",
@@ -1859,7 +1859,7 @@ class InputManager:
             "function": self.add_tabular_variable_to_pool.__name__,
         }
         if not (isinstance(data, Dict) or isinstance(data, List)):
-            om.add_error(
+            self.om.add_error(
                 "Incorrect variable type",
                 f"Variable {variable_name} has type {type(data)}, does not match "
                 f"the expected type of `Dict[str, List[Any]] | List[Any]`.",
@@ -1894,10 +1894,10 @@ class InputManager:
             The directory path where the JSON file will be saved.
 
         """
-        file_name = om.generate_file_name(base_name="InputManager_get_data_log", extension="json")
+        file_name = self.om.generate_file_name(base_name="InputManager_get_data_log", extension="json")
         file_path = path / file_name
-        om.create_directory(path)
-        om.dict_to_file_json(self.__get_data_logs_pool, file_path)
+        self.om.create_directory(path)
+        self.om.dict_to_file_json(self.__get_data_logs_pool, file_path)
 
     def _validate_metadata(self) -> None:
         """Checks that top-level metadata has valid and required keys and values."""
@@ -1911,16 +1911,16 @@ class InputManager:
         valid_keys = required_keys | optional_keys
         for key, data in metadata_files.items():
             if missing_keys := (required_keys - data.keys()):
-                om.add_error(
+                self.om.add_error(
                     "Metadata Validation", f"Missing required keys '{list(missing_keys)}' in '{key}'", info_map
                 )
                 raise ValueError
             if invalid_keys := (data.keys() - valid_keys):
-                om.add_error("Metadata Validation", f"Invalid keys '{list(invalid_keys)}' in '{key}'", info_map)
+                self.om.add_error("Metadata Validation", f"Invalid keys '{list(invalid_keys)}' in '{key}'", info_map)
                 raise ValueError
 
             if data["type"] not in VALID_INPUT_TYPES:
-                om.add_error(
+                self.om.add_error(
                     "Metadata Validation",
                     f"Invalid type '{data['type']}' in '{key}'. Expected one option from {VALID_INPUT_TYPES}",
                     info_map,
@@ -1928,14 +1928,14 @@ class InputManager:
                 raise ValueError
 
             if not os.path.isfile(data["path"]):
-                om.add_error("Metadata Validation", f"Invalid path '{data['path']}' in '{key}'", info_map)
+                self.om.add_error("Metadata Validation", f"Invalid path '{data['path']}' in '{key}'", info_map)
                 raise ValueError
 
             if data["properties"] is None or data["properties"] == "":
-                om.add_error("Metadata Validation", f"Properties section empty or None in '{key}'", info_map)
+                self.om.add_error("Metadata Validation", f"Properties section empty or None in '{key}'", info_map)
                 raise ValueError
 
-        om.add_log("Metadata Validation", "Top level metadata is valid.", info_map)
+        self.om.add_log("Metadata Validation", "Top level metadata is valid.", info_map)
 
     def _validate_properties(self) -> None:
         """Iteratively traverses the metadata properties to check the max depth and routes
@@ -1968,7 +1968,7 @@ class InputManager:
             current_obj, depth, path = stack.pop()
 
             if depth > self.metadata_depth_limit:
-                om.add_error(
+                self.om.add_error(
                     "Max metadata depth exceeded.",
                     f"Metadata depth exceeds maximum allowed depth of {self.metadata_depth_limit} at path {path}",
                     info_map,
@@ -1990,15 +1990,15 @@ class InputManager:
                             type_to_validator_map[value_type](path + [key], value)
                         else:
                             if value_type is not None:
-                                om.add_error(
+                                self.om.add_error(
                                     "Properties value type error",
                                     f"'type' value not in {type_to_validator_map.keys()}",
                                     info_map,
                                 )
                                 raise ValueError(f"Properties 'type' value not in {list(type_to_validator_map.keys())}")
 
-        om.add_log("Metadata properties depth", f"Max depth of metadata properties is {current_max_depth}", info_map)
-        om.add_log("Metadata properties path", f"Deepest path of metadata properties is {deepest_path}", info_map)
+        self.om.add_log("Metadata properties depth", f"Max depth of metadata properties is {current_max_depth}", info_map)
+        self.om.add_log("Metadata properties path", f"Deepest path of metadata properties is {deepest_path}", info_map)
 
     def _metadata_number_validator(self, key_path: list[str], value: dict[str, Any]) -> None:
         """Validates number type properties in metadata."""
@@ -2015,7 +2015,7 @@ class InputManager:
         has_no_default = default == "No default"
         nullable = value.get("nullable", False)
         if default is None and not nullable:
-            om.add_error(
+            self.om.add_error(
                 "Invalid metadata default number value.",
                 f"Invalid 'default' for '{key_path}': Value is not nullable and default is 'None'.",
                 info_map,
@@ -2023,7 +2023,7 @@ class InputManager:
             raise ValueError(f"Invalid 'default' for '{key_path}': Value is not nullable and default is 'None'.")
         if default is not None:
             if not isinstance(default, (int, float)) and not has_no_default:
-                om.add_error(
+                self.om.add_error(
                     "Invalid metadata default number value.",
                     f"Invalid 'default' for '{key_path}': Expected a number but got {type(default)}.",
                     info_map,
@@ -2032,21 +2032,21 @@ class InputManager:
         minimum = value.get("minimum")
         maximum = value.get("maximum")
         if minimum is not None and not isinstance(minimum, (int, float)):
-            om.add_error(
+            self.om.add_error(
                 "Invalid metadata number properties minimum.",
                 f"Invalid 'minimum' for '{key_path}': Expected a number but got {type(minimum)}.",
                 info_map,
             )
             raise ValueError(f"Invalid 'minimum' for '{key_path}': " f"Expected a number but got {type(minimum)}.")
         if maximum is not None and not isinstance(maximum, (int, float)):
-            om.add_error(
+            self.om.add_error(
                 "Invalid metadata number properties maximum.",
                 f"Invalid 'maximum' for '{key_path}': Expected a number but got {type(maximum)}.",
                 info_map,
             )
             raise ValueError(f"Invalid 'maximum' for '{key_path}': Expected a number but got {type(maximum)}.")
         if maximum is not None and minimum is not None and maximum < minimum:
-            om.add_error(
+            self.om.add_error(
                 "Invalid range of acceptable numbers.",
                 f"Invalid 'range' for key '{key_path}': 'minimum' value {minimum} is "
                 f"greater than 'maximum' value {maximum}",
@@ -2058,7 +2058,7 @@ class InputManager:
             )
         if default is not None and not has_no_default:
             if minimum is not None and default < minimum:
-                om.add_error(
+                self.om.add_error(
                     "Invalid metadata default.",
                     f"Invalid 'default' for '{key_path}': 'default' {default} is less than 'minimum' {minimum}",
                     info_map,
@@ -2067,7 +2067,7 @@ class InputManager:
                     f"Invalid 'default' for '{key_path}': 'default' {default} is " f"less than 'minimum' {minimum}"
                 )
             if maximum is not None and default > maximum:
-                om.add_error(
+                self.om.add_error(
                     "Invalid metadata default.",
                     f"Invalid 'default' for '{key_path}': 'default' {default} is greater than 'maximum' {maximum}",
                     info_map,
@@ -2089,7 +2089,7 @@ class InputManager:
         has_no_default = default == "No default"
         nullable = value.get("nullable", False)
         if default is None and not nullable:
-            om.add_error(
+            self.om.add_error(
                 "Invalid metadata default string value.",
                 f"Invalid 'default' for '{key_path}': Value is not nullable and default is 'None'",
                 info_map,
@@ -2097,7 +2097,7 @@ class InputManager:
             raise ValueError(f"Invalid 'default' for '{key_path}': Value is not nullable and default is 'None'")
         if default is not None and not has_no_default:
             if not isinstance(default, str):
-                om.add_error(
+                self.om.add_error(
                     "Invalid metadata default string value.",
                     f"Invalid 'default' for '{key_path}': Expected a string but got {type(default)}",
                     info_map,
@@ -2105,7 +2105,7 @@ class InputManager:
                 raise ValueError(f"Invalid 'default' for '{key_path}': Expected a string but got {type(default)}")
         pattern = value.get("pattern")
         if pattern is not None and not isinstance(pattern, str):
-            om.add_error(
+            self.om.add_error(
                 "Invalid metadata string properties pattern.",
                 f"Invalid 'pattern' for '{key_path}': Expected a string but got {type(pattern)}",
                 info_map,
@@ -2115,7 +2115,7 @@ class InputManager:
             if pattern is not None:
                 re.compile(pattern)
         except re.error:
-            om.add_error(
+            self.om.add_error(
                 "Invalid metadata string properties pattern.",
                 f"Invalid 'pattern' for '{key_path}': 'pattern' value '{pattern}' is not " "a valid regex pattern.",
                 info_map,
@@ -2125,7 +2125,7 @@ class InputManager:
             )
         if default != "" and default is not None and not has_no_default:
             if pattern is not None and not re.match(pattern, default):
-                om.add_error(
+                self.om.add_error(
                     "Invalid metadata default string value.",
                     f"Invalid 'default' for '{key_path}': 'default' value '{default}' does not "
                     f"match pattern {pattern}",
@@ -2151,14 +2151,14 @@ class InputManager:
         has_no_default = default == "No default"
         nullable = value.get("nullable", False)
         if default is None and not nullable:
-            om.add_error(
+            self.om.add_error(
                 "Invalid metadata default bool value.",
                 f"Invalid 'default' for '{key_path}': Value is not nullable and default is 'None'",
                 info_map,
             )
             raise ValueError(f"Invalid 'default' for '{key_path}': Value is not nullable and default is 'None'")
         if default is not None and not isinstance(default, bool) and not has_no_default:
-            om.add_error(
+            self.om.add_error(
                 "Invalid metadata default bool value.",
                 f"Invalid 'default' for '{key_path}': Expected a bool but got {type(default)}",
                 info_map,
@@ -2179,7 +2179,7 @@ class InputManager:
         minimum_length = value.get("minimum_length")
         maximum_length = value.get("maximum_length")
         if minimum_length is not None and not isinstance(minimum_length, (int, float)):
-            om.add_error(
+            self.om.add_error(
                 "Invalid metadata default array minimum length.",
                 f"Invalid 'minimum_length' for '{key_path}': Expected a number but got {type(minimum_length)}",
                 info_map,
@@ -2188,7 +2188,7 @@ class InputManager:
                 f"Invalid 'minimum_length' for '{key_path}': " f"Expected a number but got {type(minimum_length)}"
             )
         if maximum_length is not None and not isinstance(maximum_length, (int, float)):
-            om.add_error(
+            self.om.add_error(
                 "Invalid metadata default array maximum length.",
                 f"Invalid 'maximum_length' for '{key_path}': Expected a number but got {type(maximum_length)}",
                 info_map,
@@ -2197,7 +2197,7 @@ class InputManager:
                 f"Invalid 'maximum_length' for '{key_path}': " f"Expected a number but got {type(maximum_length)}"
             )
         if maximum_length is not None and minimum_length is not None and maximum_length < minimum_length:
-            om.add_error(
+            self.om.add_error(
                 "Invalid metadata array length range.",
                 f"Invalid length 'range' for key '{key_path}': 'minimum_length' value {minimum_length} is "
                 f"greater than 'maximum_length' value {maximum_length}",
@@ -2229,7 +2229,7 @@ class InputManager:
             "function": self._validate_metadata_properties_keys.__name__,
         }
         if missing_required_keys := required_properties_keys - properties.keys():
-            om.add_error(
+            self.om.add_error(
                 "Metadata Validation",
                 f"Missing required keys {sorted(missing_required_keys)} for {path}. Required"
                 f" keys are {sorted(required_properties_keys)}.",
@@ -2243,7 +2243,7 @@ class InputManager:
         valid_properties_keys = required_properties_keys.union(optional_properties_keys)
         if property_type == "object":
             if not (set(properties.keys()) - valid_properties_keys):
-                om.add_error(
+                self.om.add_error(
                     "Metadata Validation",
                     f"No unique keys for {path}. At least one unique key is expected.",
                     info_map,
@@ -2251,7 +2251,7 @@ class InputManager:
                 raise ValueError(f"No unique keys for {path}. At least one unique key is expected.")
             return
         if invalid_keys := set(properties.keys()) - valid_properties_keys:
-            om.add_error(
+            self.om.add_error(
                 "Metadata Validation",
                 f"Invalid keys {sorted(invalid_keys)} in {property_type} for {path}. Valid"
                 f" keys are {sorted(valid_properties_keys)}.",
@@ -2286,20 +2286,20 @@ class InputManager:
         }
         records = self._parse_metadata_properties(self.__metadata["properties"])
         df = pd.DataFrame(records)
-        path_to_save = output_dir / om.generate_file_name("InputManager_metadata_properties", extension="csv")
-        om.add_log("CSV save attempt.", f"Attempting to save metadata properties as CSV to {path_to_save}", info_map)
+        path_to_save = output_dir / self.om.generate_file_name("InputManager_metadata_properties", extension="csv")
+        self.om.add_log("CSV save attempt.", f"Attempting to save metadata properties as CSV to {path_to_save}", info_map)
         try:
-            om.create_directory(output_dir)
+            self.om.create_directory(output_dir)
             df.to_csv(path_to_save, index=False)
-            om.add_log("Save CSV success.", f"Successfully saved to {path_to_save}.", info_map)
+            self.om.add_log("Save CSV success.", f"Successfully saved to {path_to_save}.", info_map)
         except FileNotFoundError as fnfe:
-            om.add_error("Save CSV failure.", f"Unable to save to {path_to_save} because of {fnfe}.", info_map)
+            self.om.add_error("Save CSV failure.", f"Unable to save to {path_to_save} because of {fnfe}.", info_map)
             raise fnfe
         except PermissionError as pe:
-            om.add_error("Save CSV failure.", f"Unable to save to {path_to_save} because of {pe}.", info_map)
+            self.om.add_error("Save CSV failure.", f"Unable to save to {path_to_save} because of {pe}.", info_map)
             raise pe
         except OSError as e:
-            om.add_error("Save CSV failure.", f"Unable to save to {path_to_save} because of {e}.", info_map)
+            self.om.add_error("Save CSV failure.", f"Unable to save to {path_to_save} because of {e}.", info_map)
             raise e
 
     def _parse_metadata_properties(
@@ -2406,7 +2406,7 @@ class InputManager:
             "class": self.__class__.__name__,
             "function": self.compare_metadata_properties.__name__,
         }
-        om.create_directory(output_directory)
+        self.om.create_directory(output_directory)
         self._load_metadata(properties_file_path)
         properties1 = deepcopy(self.meta_data)
         self.meta_data = {}
@@ -2420,7 +2420,7 @@ class InputManager:
         file_name = f"diff_results_{first_file_path}_vs_{second_file_path}"
 
         try:
-            om.add_log("Save metadata diff try", f"Attempting to save to {file_name}", info_map)
+            self.om.add_log("Save metadata diff try", f"Attempting to save to {file_name}", info_map)
             with open(f"{str(output_directory)}/{file_name}.txt", "w") as file:
                 file.write(
                     f"Comparing changes going from '{properties_file_path}'"
@@ -2443,17 +2443,17 @@ class InputManager:
                                 file.write(f"{sub_key}: {value}\n")
                             file.write("\n")
 
-            om.add_log("Save metadata diff successful", f"Successfully saved to {file_name}", info_map)
+            self.om.add_log("Save metadata diff successful", f"Successfully saved to {file_name}", info_map)
 
         except PermissionError:
-            om.add_error(
+            self.om.add_error(
                 "Permission error in saving file",
                 f"Permission denied when trying to write to {file_name}.txt.",
                 info_map,
             )
             raise
         except OSError as e:
-            om.add_error(
+            self.om.add_error(
                 "Unexpected error in saving file",
                 f"An unexpected OS error occurred: {e}",
                 info_map,

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -1443,7 +1443,7 @@ class InputManager:
         except KeyError:
             error_name = "Cannot find data"
             error_message = "Could not find input metadata."
-            om.add_error(error_name, error_message, info_map)
+            self.om.add_error(error_name, error_message, info_map)
             return data_keys
 
         data_keys = [key for key, data in input_data.items() if data.get("properties") == target_properties]

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -1668,7 +1668,9 @@ class InputManager:
             self.om.add_error("IM Runtime Modification", f"{variable_name} is not modifiable during runtime.", info_map)
             raise PermissionError(f"IM Runtime Modification Error: {variable_name} is not modifiable during runtime.")
         elif not is_modifiable_during_runtime:
-            self.om.add_warning("IM Runtime Modification", f"{variable_name} is not modifiable during runtime.", info_map)
+            self.om.add_warning(
+                "IM Runtime Modification", f"{variable_name} is not modifiable during runtime.", info_map
+            )
             return False
         return True
 
@@ -1997,7 +1999,9 @@ class InputManager:
                                 )
                                 raise ValueError(f"Properties 'type' value not in {list(type_to_validator_map.keys())}")
 
-        self.om.add_log("Metadata properties depth", f"Max depth of metadata properties is {current_max_depth}", info_map)
+        self.om.add_log(
+            "Metadata properties depth", f"Max depth of metadata properties is {current_max_depth}", info_map
+        )
         self.om.add_log("Metadata properties path", f"Deepest path of metadata properties is {deepest_path}", info_map)
 
     def _metadata_number_validator(self, key_path: list[str], value: dict[str, Any]) -> None:
@@ -2287,7 +2291,9 @@ class InputManager:
         records = self._parse_metadata_properties(self.__metadata["properties"])
         df = pd.DataFrame(records)
         path_to_save = output_dir / self.om.generate_file_name("InputManager_metadata_properties", extension="csv")
-        self.om.add_log("CSV save attempt.", f"Attempting to save metadata properties as CSV to {path_to_save}", info_map)
+        self.om.add_log(
+            "CSV save attempt.", f"Attempting to save metadata properties as CSV to {path_to_save}", info_map
+        )
         try:
             self.om.create_directory(output_dir)
             df.to_csv(path_to_save, index=False)

--- a/RUFAS/routines/feed/feed.py
+++ b/RUFAS/routines/feed/feed.py
@@ -10,8 +10,6 @@ from RUFAS.routines.animal.ration.user_defined_ration import (
 from ...enums import AnimalCombination
 import math
 
-om = OutputManager()
-
 udrm = UserDefinedRationManager()
 
 
@@ -48,6 +46,7 @@ class Feed:
         Args:
             data: the feed information from the input JSON file
         """
+        self.om = OutputManager()
         self.im = InputManager()
         self.nutrient_standard = self.im.get_data("config.nutrient_standard")
         self.nutrient_table = "NASEM_Comp" if self.nutrient_standard == "NASEM" else "NRC_Comp"
@@ -128,7 +127,7 @@ class Feed:
             target_user_defined_ration_percentage_sum,
             abs_tol=user_defined_ration_percentage_sum_tolerance,
         ):
-            om.add_warning(
+            self.om.add_warning(
                 "User defined calf_ration percentages do not sum to 100",
                 f"User defined calf_ration sums to {sum(udrm.calf_ration.values())}",
                 info_map,
@@ -143,7 +142,7 @@ class Feed:
             target_user_defined_ration_percentage_sum,
             abs_tol=user_defined_ration_percentage_sum_tolerance,
         ):
-            om.add_warning(
+            self.om.add_warning(
                 "User defined growing_ration percentages do not sum to 100",
                 f"User defined growing_ration sums to {sum(udrm.growing_ration.values())}",
                 info_map,
@@ -158,7 +157,7 @@ class Feed:
             target_user_defined_ration_percentage_sum,
             abs_tol=user_defined_ration_percentage_sum_tolerance,
         ):
-            om.add_warning(
+            self.om.add_warning(
                 "User defined close_up_ration percentages do not sum to 100",
                 f"User defined close_up_ration sums to {sum(udrm.close_up_ration.values())}",
                 info_map,
@@ -173,7 +172,7 @@ class Feed:
             target_user_defined_ration_percentage_sum,
             abs_tol=user_defined_ration_percentage_sum_tolerance,
         ):
-            om.add_warning(
+            self.om.add_warning(
                 "User defined lactating_cow_ration percentages do not sum to 100",
                 f"User defined lactating_cow_ration sums to {sum(udrm.lactating_cow_ration.values())}",
                 info_map,
@@ -222,7 +221,7 @@ class Feed:
             nutrients_dict["crude_protein"] = self.CP
             nutrients_dict["carbon_loss"] = self.C_loss
             nutrients_dict["crude_protein_loss"] = self.CP_loss
-            om.add_variable("nutrients_summary", nutrients_dict, dict(info_map, **{"units": nutrient_dict_units}))
+            self.om.add_variable("nutrients_summary", nutrients_dict, dict(info_map, **{"units": nutrient_dict_units}))
 
     class Storage:
         def __init__(self, data):
@@ -1219,7 +1218,7 @@ class Feed:
                 values.append(var_values)
                 result_list.append(self._pack_into_dict(var_names, var_values))
             except IndexError as e:
-                om.add_error("Length mismatch", str(e), info_map=info_map)
+                self.om.add_error("Length mismatch", str(e), info_map=info_map)
                 raise e
 
         return result_list

--- a/RUFAS/routines/feed_storage/silage.py
+++ b/RUFAS/routines/feed_storage/silage.py
@@ -9,8 +9,6 @@ from ...units import MeasurementUnits
 from ...output_manager import OutputManager
 
 
-om = OutputManager()
-
 """Fraction of effluent that is dry matter by mass."""
 DRY_MATTER_FRACTION_OF_EFFLUENT = 0.1035
 """Number of days that loss of effluent occurs over after a crop is ensiled."""

--- a/RUFAS/routines/feed_storage/silage.py
+++ b/RUFAS/routines/feed_storage/silage.py
@@ -40,6 +40,7 @@ class Silage(Storage):
             CropCategory.GRASS,
             CropCategory.SMALL_GRAIN,
         ]
+        self.om = OutputManager()
 
     def process_degradations(self, weather: Weather, time: Time) -> None:
         """
@@ -87,8 +88,8 @@ class Silage(Storage):
 
             self.reset_mass_attributes_after_loss(crop, dry_matter_loss, moisture_loss)
 
-        om.add_variable("total_effluent_dry_matter_loss", total_effluent_dry_matter_loss, info_map)
-        om.add_variable("total_effluent_moisture_loss", total_effluent_moisture_loss, info_map)
+        self.om.add_variable("total_effluent_dry_matter_loss", total_effluent_dry_matter_loss, info_map)
+        self.om.add_variable("total_effluent_moisture_loss", total_effluent_moisture_loss, info_map)
 
         super().process_degradations(weather, time)
 

--- a/RUFAS/routines/feed_storage/storage.py
+++ b/RUFAS/routines/feed_storage/storage.py
@@ -32,7 +32,6 @@ NON_ALFALFA_FERMENTATION_CONSTANTS: dict[str, float] = {
     "loss_coefficient": 0.0193,
     "base_loss_fraction": 0.00864,
 }
-om = OutputManager()
 
 
 class Storage:
@@ -92,6 +91,7 @@ class Storage:
         self.adf_loss_coefficient = 0.0
         self.ndf_loss_coefficient = 0.0
         self.sugar_loss_coefficient = 0.0
+        self.om = OutputManager()
 
     @property
     def stored_mass(self) -> float:
@@ -182,7 +182,7 @@ class Storage:
 
             crop.last_time_degraded = copy.deepcopy(time)
             self.reset_mass_attributes_after_loss(crop, gaseous_dry_matter_loss, moisture_loss=0.0)
-        om.add_variable("gaseous_dry_matter_loss", total_gaseous_dry_matter_loss, info_map)
+        self.om.add_variable("gaseous_dry_matter_loss", total_gaseous_dry_matter_loss, info_map)
         self.record_stored_crops()
 
     def give_feed(self, amount: float, crop_type: CropType) -> None:
@@ -233,37 +233,37 @@ class Storage:
         Records the total mass and nutrient amounts held in storage.
         """
         info_map = {"class": self.__class__.__name__, "function": self.record_stored_crops.__name__, "units": "kg"}
-        om.add_variable("total_fresh_mass", self.stored_mass, info_map)
+        self.om.add_variable("total_fresh_mass", self.stored_mass, info_map)
 
         total_dry_matter_mass = sum([crop.dry_matter_mass for crop in self.stored])
-        om.add_variable("total_dry_matter_mass", total_dry_matter_mass, info_map)
+        self.om.add_variable("total_dry_matter_mass", total_dry_matter_mass, info_map)
 
         total_digestible_dry_matter = self._get_total_nutritive_amount("dry_matter_digestibility")
-        om.add_variable("total_digestible_dry_matter", total_digestible_dry_matter, info_map)
+        self.om.add_variable("total_digestible_dry_matter", total_digestible_dry_matter, info_map)
 
         total_crude_protein = self._get_total_nutritive_amount("crude_protein_percent")
-        om.add_variable("total_crude_protein", total_crude_protein, info_map)
+        self.om.add_variable("total_crude_protein", total_crude_protein, info_map)
 
         total_non_protein_nitrogen = self._get_total_nutritive_amount("non_protein_nitrogen")
-        om.add_variable("total_non_protein_nitrogen", total_non_protein_nitrogen, info_map)
+        self.om.add_variable("total_non_protein_nitrogen", total_non_protein_nitrogen, info_map)
 
         total_starch = self._get_total_nutritive_amount("starch")
-        om.add_variable("total_starch", total_starch, info_map)
+        self.om.add_variable("total_starch", total_starch, info_map)
 
         total_adf = self._get_total_nutritive_amount("adf")
-        om.add_variable("total_adf", total_adf, info_map)
+        self.om.add_variable("total_adf", total_adf, info_map)
 
         total_ndf = self._get_total_nutritive_amount("ndf")
-        om.add_variable("total_ndf", total_ndf, info_map)
+        self.om.add_variable("total_ndf", total_ndf, info_map)
 
         total_lignin = self._get_total_nutritive_amount("lignin")
-        om.add_variable("total_lignin", total_lignin, info_map)
+        self.om.add_variable("total_lignin", total_lignin, info_map)
 
         total_sugar = self._get_total_nutritive_amount("sugar")
-        om.add_variable("total_sugar", total_sugar, info_map)
+        self.om.add_variable("total_sugar", total_sugar, info_map)
 
         total_ash = self._get_total_nutritive_amount("ash")
-        om.add_variable("total_ash", total_ash, info_map)
+        self.om.add_variable("total_ash", total_ash, info_map)
 
     def _get_total_nutritive_amount(self, nutrient_name: str) -> float:
         """
@@ -429,7 +429,7 @@ class Storage:
                 + f"{fraction_of_nutrient_in_lost_dry_matter}"
             )
             warning_message = "Calculating updated percentage of nutrient in stored crop dry matter to be 0"
-            om.add_warning(warning_title, warning_message, info_map)
+            self.om.add_warning(warning_title, warning_message, info_map)
             return 0.0
 
         updated_nutrient_fraction = (initial_nutrient_fraction - fraction_of_nutrient_in_lost_dry_matter) / (

--- a/RUFAS/routines/field/soil/snow.py
+++ b/RUFAS/routines/field/soil/snow.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 from RUFAS.routines.field.soil.soil_data import SoilData
 from RUFAS.current_day_conditions import CurrentDayConditions
-from RUFAS.output_manager import OutputManager
 
 
 class Snow:

--- a/RUFAS/routines/field/soil/snow.py
+++ b/RUFAS/routines/field/soil/snow.py
@@ -5,8 +5,6 @@ from RUFAS.routines.field.soil.soil_data import SoilData
 from RUFAS.current_day_conditions import CurrentDayConditions
 from RUFAS.output_manager import OutputManager
 
-om = OutputManager()
-
 
 class Snow:
     """
@@ -43,6 +41,7 @@ class Snow:
     def __init__(self, soil_data: Optional[SoilData] = None, field_size: Optional[float] = None):
         """object that tracks all soil variable throughout the simulation"""
         self.soil_data = soil_data or SoilData(field_size=field_size)
+        self.om = OutputManager
 
     @staticmethod
     def _calc_snow_temp(soil_data: SoilData, current_day_conditions: CurrentDayConditions) -> float:

--- a/RUFAS/routines/field/soil/snow.py
+++ b/RUFAS/routines/field/soil/snow.py
@@ -41,7 +41,6 @@ class Snow:
     def __init__(self, soil_data: Optional[SoilData] = None, field_size: Optional[float] = None):
         """object that tracks all soil variable throughout the simulation"""
         self.soil_data = soil_data or SoilData(field_size=field_size)
-        self.om = OutputManager
 
     @staticmethod
     def _calc_snow_temp(soil_data: SoilData, current_day_conditions: CurrentDayConditions) -> float:

--- a/RUFAS/simulation_engine.py
+++ b/RUFAS/simulation_engine.py
@@ -52,6 +52,7 @@ class SimulationEngine:
         """
         Initializes the simulation engine.
         """
+        self.om = OutputManager()
         self.im = InputManager()
         self.time = Time()
         self._initialize_simulation()
@@ -80,7 +81,7 @@ class SimulationEngine:
             "amount": MeasurementUnits.KILOGRAMS,
         }
         for available_feed in available_feeds_on_final_day:
-            om.add_variable(
+            self.om.add_variable(
                 "available_feeds_on_final_day",
                 available_feed,
                 dict(info_map, **{"units": available_feeds_units}),
@@ -88,10 +89,10 @@ class SimulationEngine:
         EEEManager.estimate_all()
         t_end_sim = timer.time()
 
-        om.add_log("Simulation complete", "Simulation Completed.", info_map)
+        self.om.add_log("Simulation complete", "Simulation Completed.", info_map)
         total_simulation_time = t_end_sim - t_start_sim
         total_simulation_time_log = f"Total simulation time is: {total_simulation_time}"
-        om.add_log("total_simulation_time", total_simulation_time_log, info_map)
+        self.om.add_log("total_simulation_time", total_simulation_time_log, info_map)
 
     def _run_simulation_main_loop(self) -> None:
         """
@@ -160,7 +161,7 @@ class SimulationEngine:
         """
 
         weather_data = self.im.get_data("weather")
-        om.time = self.time
+        self.om.time = self.time
         self.weather = Weather(weather_data, self.time)
         self.feed_manager = FeedManager()
 

--- a/RUFAS/simulation_engine.py
+++ b/RUFAS/simulation_engine.py
@@ -17,8 +17,6 @@ from RUFAS.units import MeasurementUnits
 from RUFAS.weather import Weather
 from .routines.EEE.EEE_manager import EEEManager
 
-om = OutputManager()
-
 
 class SimulationEngine:
     """

--- a/RUFAS/time.py
+++ b/RUFAS/time.py
@@ -92,7 +92,9 @@ class Time:
             "function": self.record_time.__name__,
             "prefix": "Time",
         }
-        self.om.add_variable("day", self.current_julian_day, dict(info_map, **{"units": MeasurementUnits.SIMULATION_DAY}))
+        self.om.add_variable(
+            "day", self.current_julian_day, dict(info_map, **{"units": MeasurementUnits.SIMULATION_DAY})
+        )
         self.om.add_variable(
             "year", self.current_simulation_year, dict(info_map, **{"units": MeasurementUnits.SIMULATION_YEAR})
         )

--- a/RUFAS/time.py
+++ b/RUFAS/time.py
@@ -7,14 +7,13 @@ from RUFAS.output_manager import OutputManager
 from RUFAS.units import MeasurementUnits
 from RUFAS.util import Utility
 
-om = OutputManager()
-
 
 class Time:
     def __init__(self):
         """
         This object is responsible for creating and tracking time in the simulation.
         """
+        self.om = OutputManager()
         self.im = InputManager()
         self.config_data: Dict[str, str | int | bool] = self.im.get_data("config")
         self.start_date: datetime = datetime.datetime.strptime(self.config_data["start_date"], "%Y:%j")
@@ -93,14 +92,14 @@ class Time:
             "function": self.record_time.__name__,
             "prefix": "Time",
         }
-        om.add_variable("day", self.current_julian_day, dict(info_map, **{"units": MeasurementUnits.SIMULATION_DAY}))
-        om.add_variable(
+        self.om.add_variable("day", self.current_julian_day, dict(info_map, **{"units": MeasurementUnits.SIMULATION_DAY}))
+        self.om.add_variable(
             "year", self.current_simulation_year, dict(info_map, **{"units": MeasurementUnits.SIMULATION_YEAR})
         )
-        om.add_variable(
+        self.om.add_variable(
             "calendar_year", self.current_calendar_year, dict(info_map, **{"units": MeasurementUnits.CALENDAR_YEAR})
         )
-        om.add_variable(
+        self.om.add_variable(
             "simulation_day", self.simulation_day, dict(info_map, **{"units": MeasurementUnits.SIMULATION_DAY})
         )
 

--- a/RUFAS/weather.py
+++ b/RUFAS/weather.py
@@ -7,8 +7,6 @@ from RUFAS.current_day_conditions import CurrentDayConditions
 from RUFAS.output_manager import OutputManager
 from RUFAS.time import Time
 
-om = OutputManager()
-
 
 class Weather:
     """
@@ -46,6 +44,7 @@ class Weather:
         time starts at 1).
 
         """
+        self.om = OutputManager()
         self.weather_data = {}
 
         self.check_adequate_weather_data(weather_file, time)
@@ -74,7 +73,7 @@ class Weather:
                         "function": "__init__",
                         "prefix": "Weather",
                     }
-                    om.add_warning(
+                    self.om.add_warning(
                         "Duplicate weather", f"duplicate weather data found for the date {date_key}", info_map
                     )
                 self.weather_data[date_key] = conditions
@@ -86,7 +85,7 @@ class Weather:
             "function": "__init__",
             "prefix": "Weather",
         }
-        om.add_variable(
+        self.om.add_variable(
             "average_annual_temperature",
             self.mean_annual_temperature,
             dict(info_map, **{"units": MeasurementUnits.DEGREES_CELSIUS}),
@@ -186,34 +185,34 @@ class Weather:
             "prefix": "Weather",
         }
         current_weather = self.get_current_day_conditions(time)
-        om.add_variable(
+        self.om.add_variable(
             "precipitation",
             current_weather.precipitation,
             dict(info_map, **{"units": MeasurementUnits.MILLIMETERS}),
         )
-        om.add_variable("rainfall", current_weather.rainfall, dict(info_map, **{"units": MeasurementUnits.MILLIMETERS}))
-        om.add_variable("snowfall", current_weather.snowfall, dict(info_map, **{"units": MeasurementUnits.MILLIMETERS}))
-        om.add_variable(
+        self.om.add_variable("rainfall", current_weather.rainfall, dict(info_map, **{"units": MeasurementUnits.MILLIMETERS}))
+        self.om.add_variable("snowfall", current_weather.snowfall, dict(info_map, **{"units": MeasurementUnits.MILLIMETERS}))
+        self.om.add_variable(
             "maximum_temperature",
             current_weather.max_air_temperature,
             dict(info_map, **{"units": MeasurementUnits.DEGREES_CELSIUS}),
         )
-        om.add_variable(
+        self.om.add_variable(
             "minimum_temperature",
             current_weather.min_air_temperature,
             dict(info_map, **{"units": MeasurementUnits.DEGREES_CELSIUS}),
         )
-        om.add_variable(
+        self.om.add_variable(
             "average_temperature",
             current_weather.mean_air_temperature,
             dict(info_map, **{"units": MeasurementUnits.DEGREES_CELSIUS}),
         )
-        om.add_variable(
+        self.om.add_variable(
             "radiation",
             current_weather.incoming_light,
             dict(info_map, **{"units": MeasurementUnits.MEGAJOULES_PER_SQUARE_METER}),
         )
-        om.add_variable(
+        self.om.add_variable(
             "irrigation", current_weather.irrigation, dict(info_map, **{"units": MeasurementUnits.MILLIMETERS})
         )
 
@@ -266,6 +265,7 @@ class Weather:
         None
 
         """
+        om = OutputManager()
         years_list = weather_file["year"]
         days_list = weather_file["jday"]
         date_range = (time.end_date - time.start_date).days + 1

--- a/RUFAS/weather.py
+++ b/RUFAS/weather.py
@@ -190,8 +190,12 @@ class Weather:
             current_weather.precipitation,
             dict(info_map, **{"units": MeasurementUnits.MILLIMETERS}),
         )
-        self.om.add_variable("rainfall", current_weather.rainfall, dict(info_map, **{"units": MeasurementUnits.MILLIMETERS}))
-        self.om.add_variable("snowfall", current_weather.snowfall, dict(info_map, **{"units": MeasurementUnits.MILLIMETERS}))
+        self.om.add_variable(
+            "rainfall", current_weather.rainfall, dict(info_map, **{"units": MeasurementUnits.MILLIMETERS})
+        )
+        self.om.add_variable(
+            "snowfall", current_weather.snowfall, dict(info_map, **{"units": MeasurementUnits.MILLIMETERS})
+        )
         self.om.add_variable(
             "maximum_temperature",
             current_weather.max_air_temperature,

--- a/tests/test_feed_storage_module/test_silage.py
+++ b/tests/test_feed_storage_module/test_silage.py
@@ -12,9 +12,6 @@ from RUFAS.weather import Weather
 from RUFAS.output_manager import OutputManager
 
 
-om = OutputManager()
-
-
 @pytest.fixture
 def silage() -> Silage:
     return Silage()
@@ -61,7 +58,7 @@ def test_process_degradations(
     )
     cp_coeffient = mocker.patch.object(silage, "calculate_crude_protein_after_effluent_loss", return_value=5.0)
     reset_attributes = mocker.patch.object(silage, "reset_mass_attributes_after_loss")
-    add_variable = mocker.patch.object(om, "add_variable")
+    add_variable = mocker.patch.object(silage.om, "add_variable")
     super_process_degradations = mocker.patch("RUFAS.routines.feed_storage.storage.Storage.process_degradations")
     second_crop = copy.deepcopy(harvested_crop)
     silage.stored = [harvested_crop, second_crop]

--- a/tests/test_feed_storage_module/test_silage.py
+++ b/tests/test_feed_storage_module/test_silage.py
@@ -9,7 +9,6 @@ from RUFAS.routines.feed_storage.enums import CropCategory, CropType
 from RUFAS.units import MeasurementUnits
 from RUFAS.time import Time
 from RUFAS.weather import Weather
-from RUFAS.output_manager import OutputManager
 
 
 @pytest.fixture

--- a/tests/test_feed_storage_module/test_storage.py
+++ b/tests/test_feed_storage_module/test_storage.py
@@ -11,8 +11,6 @@ from RUFAS.units import MeasurementUnits
 from RUFAS.weather import Weather
 from .sample_crop_data import sample_crop_data
 
-#om = OutputManager()
-
 
 @pytest.fixture
 def storage() -> Storage:

--- a/tests/test_feed_storage_module/test_storage.py
+++ b/tests/test_feed_storage_module/test_storage.py
@@ -11,7 +11,7 @@ from RUFAS.units import MeasurementUnits
 from RUFAS.weather import Weather
 from .sample_crop_data import sample_crop_data
 
-#om = OutputManager()
+# om = OutputManager()
 
 
 @pytest.fixture

--- a/tests/test_feed_storage_module/test_storage.py
+++ b/tests/test_feed_storage_module/test_storage.py
@@ -6,7 +6,6 @@ from RUFAS.routines.feed_storage.storage import Storage
 from RUFAS.routines.feed_storage.harvested_crop import HarvestedCrop
 from RUFAS.routines.feed_storage.enums import CropCategory, CropType
 from RUFAS.time import Time
-from RUFAS.output_manager import OutputManager
 from RUFAS.units import MeasurementUnits
 from RUFAS.weather import Weather
 from .sample_crop_data import sample_crop_data

--- a/tests/test_feed_storage_module/test_storage.py
+++ b/tests/test_feed_storage_module/test_storage.py
@@ -11,7 +11,7 @@ from RUFAS.units import MeasurementUnits
 from RUFAS.weather import Weather
 from .sample_crop_data import sample_crop_data
 
-om = OutputManager()
+#om = OutputManager()
 
 
 @pytest.fixture
@@ -112,7 +112,7 @@ def test_process_degradations(
     mock_get_conditions = mocker.patch.object(storage, "_get_conditions", return_value=mock_conditions)
     mock_dry_matter_loss = mocker.patch.object(storage, "calculate_dry_matter_loss_to_gas", return_value=loss)
     mock_recalc_percentage = mocker.patch.object(storage, "recalculate_nutrient_percentage", return_value=percentage)
-    mock_add_var = mocker.patch.object(om, "add_variable")
+    mock_add_var = mocker.patch.object(storage.om, "add_variable")
     mock_deepcopy = mocker.patch("RUFAS.routines.feed_storage.storage.copy.deepcopy", return_value=mock_time)
     mock_reset_mass = mocker.patch.object(storage, "reset_mass_attributes_after_loss")
     mock_record = mocker.patch.object(storage, "record_stored_crops")
@@ -187,7 +187,7 @@ def test_record_stored_crops(storage: Storage, mocker: MockerFixture) -> None:
         "RUFAS.routines.feed_storage.storage.Storage.stored_mass", new_callable=mocker.PropertyMock
     )
     mock_total_amount = mocker.patch.object(storage, "_get_total_nutritive_amount")
-    mock_add_var = mocker.patch.object(om, "add_variable")
+    mock_add_var = mocker.patch.object(storage.om, "add_variable")
     expected_get_total_amount_call_count = 9
     expected_add_var_call_count = 11
 
@@ -328,7 +328,7 @@ def test_recalculate_nutrient_percentage(
     """
     Test the recalculate_nutrient_percentage method of the Storage class.
     """
-    mock_warn = mocker.patch.object(om, "add_warning")
+    mock_warn = mocker.patch.object(storage.om, "add_warning")
     actual = storage.recalculate_nutrient_percentage(nutrients, loss_coefficient, dry_matter_loss, dry_matter)
 
     assert pytest.approx(actual) == expected

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -1066,7 +1066,7 @@ def test_fix_string_type_fixable_data(
     dummy_input_data = mock_input_string_data_for_fix_data()
     dummy_properties_key = "dummy_variable_properties"
 
-    with (patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning, ):
+    with (patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning,):
         result = mock_input_manager._fix_data(
             dummy_variable_properties,
             dummy_element_hierarchy,
@@ -1714,16 +1714,14 @@ def test_get_metadata_raises_exception(
         error_message = key_error.value.__str__().strip("'")
         assert (
             error_message == f'Data not found: Cannot find "{dummy_metadata_path}", '
-                             f'"{expected_error_parent_address}" does not have attribute '
-                             f'"{expected_error_invalid_key}".'
+            f'"{expected_error_parent_address}" does not have attribute '
+            f'"{expected_error_invalid_key}".'
         )
         assert add_error.call_count == expected_warning_call_count
 
 
 def test_get_data_by_properties_no_data(
-    mock_input_manager: InputManager,
-    input_manager_original_method_states: Dict[str, Callable],
-    mocker: MockerFixture
+    mock_input_manager: InputManager, input_manager_original_method_states: Dict[str, Callable], mocker: MockerFixture
 ) -> None:
     """Tests that error is handled properly when get_metadata() raises KeyError."""
     mock_input_manager.get_metadata = MagicMock(side_effect=KeyError)
@@ -3166,10 +3164,9 @@ def test_dump_get_data_logs(
     }
     mock_dir_path = Path("dummy_path")
     mock_generated_file_name = "dummy_file_name.json"
-    patch_for_generate_file_name = mocker.patch.object(mock_input_manager.om,
-                                                       "generate_file_name",
-                                                       return_value=mock_generated_file_name
-                                                       )
+    patch_for_generate_file_name = mocker.patch.object(
+        mock_input_manager.om, "generate_file_name", return_value=mock_generated_file_name
+    )
     patch_create_dir = mocker.patch("RUFAS.output_manager.OutputManager.create_directory")
 
     mock_dict_to_file_json = mocker.patch.object(mock_input_manager.om, "dict_to_file_json")

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -314,8 +314,8 @@ def test_populate_pool_valid(
         input_manager, "_load_data_from_csv", side_effect=lambda _: {"element3": "value3", "element4": "value4"}
     )
     mocker.patch.object(input_manager, "_validate_input_by_type", side_effect=lambda *args, **kwargs: True)
-    mocker.patch("RUFAS.input_manager.om.add_warning")
-    mocker.patch("RUFAS.input_manager.om.add_log")
+    mocker.patch.object(input_manager, "om")
+    mocker.patch.object(input_manager.om, "add_log")
 
     # Act
     result = input_manager._populate_pool(eager_termination=True)
@@ -344,8 +344,8 @@ def test_populate_pool_invalid(
         input_manager, "_load_data_from_csv", side_effect=lambda _: {"element3": "value3", "element4": "value4"}
     )
     mocker.patch.object(input_manager, "_validate_input_by_type", side_effect=lambda *args, **kwargs: False)
-    mocker.patch("RUFAS.input_manager.om.add_warning")
-    mocker.patch("RUFAS.input_manager.om.add_log")
+    mocker.patch.object(input_manager, "om")
+    mocker.patch.object(input_manager.om, "add_log")
     elements_counter = ElementsCounter()
     elements_counter.increment(ElementState.INVALID)
     mocker.patch.object(input_manager, "elements_counter", elements_counter)
@@ -375,8 +375,8 @@ def test_populate_pool_partial_invalid(
         input_manager, "_load_data_from_csv", side_effect=lambda _: {"element3": "value3", "element4": "value4"}
     )
     mocker.patch.object(input_manager, "_validate_input_by_type", side_effect=[True, False, True, False])
-    mocker.patch("RUFAS.input_manager.om.add_warning")
-    mocker.patch("RUFAS.input_manager.om.add_log")
+    mocker.patch.object(input_manager, "om")
+    mocker.patch.object(input_manager.om, "add_log")
 
     # Act
     result = input_manager._populate_pool(eager_termination=False)
@@ -410,8 +410,8 @@ def test_populate_pool_eager_termination(
         input_manager, "_load_data_from_csv", side_effect=lambda _: {"element3": "value3", "element4": "value4"}
     )
     mocker.patch.object(input_manager, "_validate_input_by_type", side_effect=lambda *args, **kwargs: False)
-    mocker.patch("RUFAS.input_manager.om.add_warning")
-    mocker.patch("RUFAS.input_manager.om.add_log")
+    mocker.patch.object(input_manager, "om")
+    mocker.patch.object(input_manager.om, "add_log")
 
     # Act
     result = input_manager._populate_pool(eager_termination=True)
@@ -483,7 +483,7 @@ def test_bool_type_validator(
     unused_bool_input = False
     patch_extract = mocker.patch.object(input_manager, "_extract_input_data_by_key_list", return_value=input_data_value)
     patch_path_to_str = mocker.patch.object(input_manager, "_convert_variable_path_to_str", return_value="dummy_name")
-    patch_for_add_warning = mocker.patch("RUFAS.input_manager.om.add_warning")
+    patch_for_add_warning = mocker.patch.object(input_manager.om, "add_warning")
 
     # Act
     result = input_manager._bool_type_validator(
@@ -539,17 +539,17 @@ def test_number_type_validator(
     dummy_counter = mocker.MagicMock(autospec=ElementsCounter)
     patch_extract = mocker.patch.object(input_manager, "_extract_input_data_by_key_list", return_value=dummy_value)
     patch_path_to_str = mocker.patch.object(input_manager, "_convert_variable_path_to_str", return_value="dummy_name")
+    add_warning = mocker.patch.object(input_manager.om, "add_warning")
 
-    with patch("RUFAS.input_manager.om.add_warning") as add_warning:
-        result = input_manager._number_type_validator(
-            dummy_var_path,
-            dummy_variable_properties,
-            dummy_input_data,
-            unused_bool_input,
-            dummy_properties_key,
-            dummy_counter,
-            unused_bool_input,
-        )
+    result = input_manager._number_type_validator(
+        dummy_var_path,
+        dummy_variable_properties,
+        dummy_input_data,
+        unused_bool_input,
+        dummy_properties_key,
+        dummy_counter,
+        unused_bool_input,
+    )
 
     patch_extract.assert_called_once_with(
         dummy_input_data, dummy_var_path, dummy_variable_properties, unused_bool_input
@@ -597,7 +597,7 @@ def test_string_type_validator(
     patch_path_to_str = mocker.patch.object(
         mock_input_manager, "_convert_variable_path_to_str", return_value="dummy_name"
     )
-    add_warning = mocker.patch("RUFAS.input_manager.om.add_warning")
+    add_warning = mocker.patch.object(mock_input_manager.om, "add_warning")
 
     result = mock_input_manager._string_type_validator(
         var_path,
@@ -1066,7 +1066,7 @@ def test_fix_string_type_fixable_data(
     dummy_input_data = mock_input_string_data_for_fix_data()
     dummy_properties_key = "dummy_variable_properties"
 
-    with (patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning,):
+    with (patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning, ):
         result = mock_input_manager._fix_data(
             dummy_variable_properties,
             dummy_element_hierarchy,
@@ -1438,7 +1438,7 @@ def test_get_data_returns_none(
     # Arrange
     input_manager = InputManager()
     mocker.patch.object(input_manager, "_InputManager__pool", mock_pool_for_get_data)
-    patch_for_add_error = mocker.patch("RUFAS.input_manager.om.add_error")
+    patch_for_add_error = mocker.patch.object(input_manager.om, "add_error")
 
     # Act
     result = input_manager.get_data(dummy_data_path)
@@ -1714,8 +1714,8 @@ def test_get_metadata_raises_exception(
         error_message = key_error.value.__str__().strip("'")
         assert (
             error_message == f'Data not found: Cannot find "{dummy_metadata_path}", '
-            f'"{expected_error_parent_address}" does not have attribute '
-            f'"{expected_error_invalid_key}".'
+                             f'"{expected_error_parent_address}" does not have attribute '
+                             f'"{expected_error_invalid_key}".'
         )
         assert add_error.call_count == expected_warning_call_count
 
@@ -1723,12 +1723,14 @@ def test_get_metadata_raises_exception(
 def test_get_data_by_properties_no_data(
     mock_input_manager: InputManager,
     input_manager_original_method_states: Dict[str, Callable],
+    mocker: MockerFixture
 ) -> None:
     """Tests that error is handled properly when get_metadata() raises KeyError."""
     mock_input_manager.get_metadata = MagicMock(side_effect=KeyError)
 
-    with patch("RUFAS.output_manager.OutputManager.add_error") as add_error:
-        actual = mock_input_manager.get_data_keys_by_properties("dummy_property")
+    add_error = mocker.patch.object(mock_input_manager.om, "add_error")
+
+    actual = mock_input_manager.get_data_keys_by_properties("dummy_property")
 
     assert add_error.call_count == 1
     assert actual == []
@@ -1991,8 +1993,8 @@ def test_add_variable_to_pool_valid(
     patch_prepare = mocker.patch("RUFAS.input_manager.InputManager._prepare_data", wraps=input_manager._prepare_data)
 
     expected_add_warning_count = 1 if starting_im_pool else 0
-    patch_for_add_warning = mocker.patch("RUFAS.input_manager.om.add_warning")
-    patch_for_add_error = mocker.patch("RUFAS.input_manager.om.add_error")
+    patch_for_add_warning = mocker.patch.object(input_manager.om, "add_warning")
+    patch_for_add_error = mocker.patch.object(input_manager.om, "add_error")
 
     # Act
     result = input_manager._add_variable_to_pool(
@@ -2122,8 +2124,8 @@ def test_add_variable_to_pool_invalid(
     mocker.patch.object(input_manager, "_InputManager__metadata", mock_metadata_for_add_variable_to_pool)
     mocker.patch.object(input_manager, "_InputManager__pool", starting_im_pool)
     mocker.patch.object(input_manager, "_validate_input_by_type", return_value=False)
-    patch_for_add_warning = mocker.patch("RUFAS.input_manager.om.add_warning")
-    patch_for_add_error = mocker.patch("RUFAS.input_manager.om.add_error")
+    patch_for_add_warning = mocker.patch.object(input_manager.om, "add_warning")
+    patch_for_add_error = mocker.patch.object(input_manager.om, "add_error")
     mock_elements_counter = mocker.MagicMock()
     mock_elements_counter.invalid_elements = 1
     mocker.patch("RUFAS.input_manager.ElementsCounter", return_value=mock_elements_counter)
@@ -2258,8 +2260,8 @@ def test_add_variable_to_pool_eager_termination(
     mock_elements_counter = mocker.MagicMock()
     mock_elements_counter.invalid_elements = 1
     mocker.patch("RUFAS.input_manager.ElementsCounter", return_value=mock_elements_counter)
-    patch_for_add_warning = mocker.patch("RUFAS.input_manager.om.add_warning")
-    patch_for_add_error = mocker.patch("RUFAS.input_manager.om.add_error")
+    patch_for_add_warning = mocker.patch.object(input_manager.om, "add_warning")
+    patch_for_add_error = mocker.patch.object(input_manager.om, "add_error")
 
     # Act
     with pytest.raises(ValueError):
@@ -3121,9 +3123,9 @@ def test_add_variable_to_pool_nested(
     mocker.patch.object(input_manager, "_InputManager__metadata", mock_metadata_for_add_variable_to_pool_nested)
     mocker.patch.object(input_manager, "_InputManager__pool", mock_pool_for_add_variable_to_pool_nested)
     mocker.patch.object(input_manager, "_validate_input_by_type", return_value=True)
-    mocker.patch("RUFAS.input_manager.om.add_log")
-    patch_for_add_warning = mocker.patch("RUFAS.input_manager.om.add_warning")
-    mocker.patch("RUFAS.input_manager.om.add_error")
+    mocker.patch.object(input_manager.om, "add_log")
+    patch_for_add_warning = mocker.patch.object(input_manager.om, "add_warning")
+    mocker.patch.object(input_manager.om, "add_error")
 
     if (not is_modifiable_during_runtime) and eager_termination:
         with pytest.raises(PermissionError):
@@ -3164,13 +3166,15 @@ def test_dump_get_data_logs(
     }
     mock_dir_path = Path("dummy_path")
     mock_generated_file_name = "dummy_file_name.json"
-    patch_for_generate_file_name = mocker.patch(
-        "RUFAS.input_manager.om.generate_file_name", return_value=mock_generated_file_name
-    )
+    patch_for_generate_file_name = mocker.patch.object(mock_input_manager.om,
+                                                       "generate_file_name",
+                                                       return_value=mock_generated_file_name
+                                                       )
     patch_create_dir = mocker.patch("RUFAS.output_manager.OutputManager.create_directory")
 
-    with patch("RUFAS.output_manager.OutputManager.dict_to_file_json") as mock_dict_to_file_json:
-        mock_input_manager.dump_get_data_logs(path=mock_dir_path)
+    mock_dict_to_file_json = mocker.patch.object(mock_input_manager.om, "dict_to_file_json")
+
+    mock_input_manager.dump_get_data_logs(path=mock_dir_path)
 
     patch_for_generate_file_name.assert_called_once_with(base_name="InputManager_get_data_log", extension="json")
     patch_create_dir.assert_called_once_with(mock_dir_path)
@@ -3363,7 +3367,7 @@ def test_object_type_validator(
     input_manager = InputManager()
     mocker.patch.object(input_manager, "_extract_input_data_by_key_list", return_value=patch_extract_return)
     mocker.patch.object(input_manager, "_validate_input_by_type", return_value=patch_validate_return)
-    mocker.patch("RUFAS.input_manager.om.add_warning", return_value=None)
+    mocker.patch.object(input_manager.om, "add_warning", return_value=None)
     mock_elements_counter = mocker.MagicMock()
 
     # Act
@@ -3397,7 +3401,7 @@ def test_object_type_validator_key_removal(
     mocker.patch.object(input_manager, "_extract_input_data_by_key_list", return_value=data)
     mocker.patch.object(input_manager, "_validate_input_by_type", return_value=True)
     mocker.patch.object(input_manager, "_convert_variable_path_to_str", return_value="dummy path")
-    add_warning = mocker.patch("RUFAS.input_manager.om.add_warning", return_value=None)
+    add_warning = mocker.patch.object(input_manager.om, "add_warning", return_value=None)
     mock_elements_counter = mocker.MagicMock()
     variable_properties: dict[str, Any] = {"key1": {}, "key2": {}}
     violation_msg = "Violates properties defined in metadata properties section 'properties blob'."
@@ -3482,7 +3486,7 @@ def test_validate_array_container_properties(
 
     # Arrange
     input_manager = InputManager()
-    patch_for_add_warning = mocker.patch("RUFAS.input_manager.om.add_warning")
+    patch_for_add_warning = mocker.patch.object(input_manager.om, "add_warning")
 
     # Act
     result = input_manager._validate_array_container_properties(
@@ -3812,8 +3816,8 @@ def test_save_metadata_properties_errors(
     mock_parse = mocker.patch.object(mock_input_manager, "_parse_metadata_properties", return_value=mock_records)
     mocker.patch("RUFAS.output_manager.OutputManager.create_directory")
     mocker.patch("pandas.DataFrame.to_csv", side_effect=exception(error_message))
-    mocker.patch("RUFAS.input_manager.om.generate_file_name", return_value=generated_filename)
-    mock_add_error = mocker.patch("RUFAS.output_manager.OutputManager.add_error")
+    mocker.patch.object(mock_input_manager.om, "generate_file_name", return_value=generated_filename)
+    mock_add_error = mocker.patch.object(mock_input_manager.om, "add_error")
 
     with pytest.raises(exception) as exc_info:
         mock_input_manager.save_metadata_properties(output_dir)
@@ -4972,7 +4976,7 @@ def test_validate_data(
         "_validate_input_by_type",
         # fmt: off
         side_effect=lambda variable_path, variable_properties, input_data, eager_termination, properties_blob_key,
-        elements_counter, called_during_initialization: input_data.get(variable_path[0]) is not None,
+                           elements_counter, called_during_initialization: input_data.get(variable_path[0]) is not None,
         # fmt: on
     )
 

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -4973,7 +4973,7 @@ def test_validate_data(
         "_validate_input_by_type",
         # fmt: off
         side_effect=lambda variable_path, variable_properties, input_data, eager_termination, properties_blob_key,
-                           elements_counter, called_during_initialization: input_data.get(variable_path[0]) is not None,
+        elements_counter, called_during_initialization: input_data.get(variable_path[0]) is not None,
         # fmt: on
     )
 

--- a/tests/test_simulation_engine.py
+++ b/tests/test_simulation_engine.py
@@ -34,11 +34,13 @@ def test_simulate(mocker: MockerFixture, start_time: int, end_time: int) -> None
     """
 
     # Arrange
-    patch_for_output_manager = mocker.patch("RUFAS.simulation_engine.om")
-    patch_for_output_manager.get_error_and_warning_counts.return_value = (1, 2)
+    # patch_for_output_manager = mocker.patch("RUFAS.simulation_engine.om")
+    # patch_for_output_manager.get_error_and_warning_counts.return_value = (1, 2)
     mocker.patch("RUFAS.simulation_engine.timer.time", side_effect=[start_time, end_time])
     mocker.patch.object(SimulationEngine, "__init__", return_value=None)
     simulation_engine = SimulationEngine()
+    patch_for_output_manager = mocker.patch.object(simulation_engine, "get_error_and_warning_counts",
+                                                   return_value = (1, 2))
     simulation_engine.time = mocker.MagicMock()
     simulation_engine.time.simulation_day = 100
     simulation_engine.feed = mocker.MagicMock()

--- a/tests/test_simulation_engine.py
+++ b/tests/test_simulation_engine.py
@@ -2,6 +2,7 @@ import pytest
 from mock.mock import MagicMock
 from pytest_mock import MockerFixture
 
+from RUFAS.output_manager import OutputManager
 from RUFAS.routines import Feed
 from RUFAS.routines.EEE.EEE_manager import EEEManager
 from RUFAS.simulation_engine import SimulationEngine
@@ -34,13 +35,13 @@ def test_simulate(mocker: MockerFixture, start_time: int, end_time: int) -> None
     """
 
     # Arrange
-    # patch_for_output_manager = mocker.patch("RUFAS.simulation_engine.om")
-    # patch_for_output_manager.get_error_and_warning_counts.return_value = (1, 2)
+    patch_for_output_manager = mocker.patch("RUFAS.output_manager.OutputManager")
+    patch_for_output_manager.get_error_and_warning_counts.return_value = (1, 2)
     mocker.patch("RUFAS.simulation_engine.timer.time", side_effect=[start_time, end_time])
+    mocker.patch("RUFAS.time.Time")
     mocker.patch.object(SimulationEngine, "__init__", return_value=None)
     simulation_engine = SimulationEngine()
-    patch_for_output_manager = mocker.patch.object(simulation_engine, "get_error_and_warning_counts",
-                                                   return_value = (1, 2))
+    simulation_engine.om = patch_for_output_manager
     simulation_engine.time = mocker.MagicMock()
     simulation_engine.time.simulation_day = 100
     simulation_engine.feed = mocker.MagicMock()
@@ -170,6 +171,7 @@ def test_initialize_simulation(mocker: MockerFixture) -> None:
 
     mock_feed_manager = mocker.MagicMock()
     patch_for_feed_manager = mocker.patch("RUFAS.simulation_engine.FeedManager", return_value=mock_feed_manager)
+    simulation_engine.om = OutputManager()
 
     # Act
     simulation_engine._initialize_simulation()

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -321,16 +321,14 @@ def test_get_conditions_series(
 
 
 def test_record_weather(
-    mock_weather: Weather,
-    mock_current_day_conditions: CurrentDayConditions,
-    mock_time: Time,
-    mocker: MockerFixture
+    mock_weather: Weather, mock_current_day_conditions: CurrentDayConditions, mock_time: Time, mocker: MockerFixture
 ) -> None:
     """Tests that weather conditions are correctly recorded to the OutputManager."""
 
     add_var = mocker.patch("RUFAS.output_manager.OutputManager.add_variable")
-    mock_current_day_conditions = mocker.patch.object(mock_weather, "get_current_day_conditions",
-                                                      return_value=mock_current_day_conditions)
+    mock_current_day_conditions = mocker.patch.object(
+        mock_weather, "get_current_day_conditions", return_value=mock_current_day_conditions
+    )
 
     mock_weather.record_weather(mock_time)
     assert mock_current_day_conditions.call_count == 1

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -44,6 +44,7 @@ def mock_weather(mocker: MockerFixture) -> Weather:
     """Fixture for Weather object."""
     mocker.patch("RUFAS.weather.Weather.__init__", return_value=None)
     mock_weather = Weather({}, mock_time)
+    mock_weather.om = OutputManager()
     weather_data = {
         datetime(2023, 9, 24): CurrentDayConditions(
             incoming_light=1,
@@ -323,19 +324,17 @@ def test_record_weather(
     mock_weather: Weather,
     mock_current_day_conditions: CurrentDayConditions,
     mock_time: Time,
+    mocker: MockerFixture
 ) -> None:
     """Tests that weather conditions are correctly recorded to the OutputManager."""
-    with (
-        patch("RUFAS.output_manager.OutputManager.add_variable") as add_var,
-        patch.object(
-            mock_weather,
-            "get_current_day_conditions",
-            return_value=mock_current_day_conditions,
-        ) as mock_current_day_conditions,
-    ):
-        mock_weather.record_weather(mock_time)
-        assert mock_current_day_conditions.call_count == 1
-        assert add_var.call_count == 8
+
+    add_var = mocker.patch("RUFAS.output_manager.OutputManager.add_variable")
+    mock_current_day_conditions = mocker.patch.object(mock_weather, "get_current_day_conditions",
+                                                      return_value=mock_current_day_conditions)
+
+    mock_weather.record_weather(mock_time)
+    assert mock_current_day_conditions.call_count == 1
+    assert add_var.call_count == 8
 
 
 @pytest.mark.parametrize("weather_file", [{"year": [2023], "jday": [267, 268, 269, 270, 271]}])


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
This PR removes the global initialization of OM in files outside routines, feed, and soil.
### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1848 

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.
      
How big are the changes in the PR? Would you nominate it for a major version upgrade?
- [ ] Yes
- [x] No

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
- Removes global OM initialization.
- Initiates OM in static methods or constructors
- Update the tests' mockings.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
- We want to avoid global variables and performance won't be much affected since OM is singleton.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
- Removes the global OM.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
- Updates and runs test suites on modified code.
