### PR TITLE
Update maximum value for pen stocking density from 3 to 5

### DIFF
--- a/input/metadata/properties/default.json
+++ b/input/metadata/properties/default.json
@@ -836,7 +836,7 @@
           "description": "Maximum Stocking Density -- The maximum ratio of the number of animals in the pen to the number of stalls in the pen",
           "type": "number",
           "minimum": 0.5,
-          "maximum": 3,
+          "maximum": 5,
           "default": 1.2
         },
         "manure_management_scenario_id": {


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Changed metadata properties max value for `maxium_stocking_density` from 3 to 5
### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
The automated creation of new pens challenges the planned application in FARM-ES. To avoid creation of new pens we are increasing the maximum possible stocking density. 

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.
      
How big are the changes in the PR? Would you nominate it for a major version upgrade?
- [ ] Yes
- [x] No

### What
<!-- Add more detail about the changes that are being made in the pull request. -->


### Why
<!-- Discuss why the changes in this pull request are needed or important. -->


### How
<!-- Give an explanation of how this pull request addresses needed changes. -->


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Run a simulation with the value for `maxium_stocking_density` set to something above 3 and check the warnings file to see if the IM accepted this value or fixed it. 