### PR TITLE
Preventing `dump_all_nondata_pools` crash in except block of `task()`

### DIFF
--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -1539,6 +1539,7 @@ class OutputManager(object):
         """
         Dumps all non-data pools into the given path to a directory.
         """
+        self.create_directory(path)
         self.dump_variable_names_and_contexts(path, exclude_info_maps, format_option)
         self.dump_logs(path)
         self.dump_warnings(path)

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -887,6 +887,7 @@ def test_dump_all_nondata_pools(mocker: MockerFixture) -> None:
     # Arrange
     output_manager = OutputManager()
     path = "dummy_path"
+    patch_create_dir = mocker.patch.object(output_manager, "create_directory")
     patch_for_dump_errors = mocker.patch.object(output_manager, "dump_errors")
     patch_for_dump_warnings = mocker.patch.object(output_manager, "dump_warnings")
     patch_for_dump_logs = mocker.patch.object(output_manager, "dump_logs")
@@ -897,6 +898,7 @@ def test_dump_all_nondata_pools(mocker: MockerFixture) -> None:
     output_manager.dump_all_nondata_pools(path, False, "verbose")
 
     # Assert
+    patch_create_dir.assert_called_once_with(path)
     patch_for_dump_variable_names_and_contexts.assert_called_once_with(path, False, "verbose")
     patch_for_dump_errors.assert_called_once_with(path)
     patch_for_dump_warnings.assert_called_once_with(path)
@@ -907,6 +909,7 @@ def test_dump_all_nondata_pools(mocker: MockerFixture) -> None:
     output_manager.dump_all_nondata_pools(path, True, "verbose")
 
     # Assert
+    assert patch_create_dir.call_count == 2
     assert patch_for_dump_variable_names_and_contexts.call_count == 2
     assert patch_for_dump_errors.call_count == 2
     assert patch_for_dump_warnings.call_count == 2


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Prevents crash from occurring by ensuring directory is created before trying to create a file in said directory.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1923 

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.
      
How big are the changes in the PR? Would you nominate it for a major version upgrade?
- [ ] Yes
- [x] No

### What & Why & How
<!-- Add more detail about the changes that are being made in the pull request. -->
The crash described in the issue occurred because the `logs` directory in the `output` directory is not always present before the OutputManager's `dump_all_nondata_pools` method is called. When this is the case, the OutputManager attempts to write log files to a directory that doesn't exist and this is a big no-no. The solution is pretty simple, add a call to `create_directory` in `dump_all_nondata_pools`. This method is idempotent, so it runs gracefully whether or not the logs directory has already been created.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Raised `ValueError`s at different points within the `try` block of `task` in `TaskManager`, and ran the simulation with the `-c` flag. Checked the simulation crashed gracefully with all logs, warnings, and errors being dumped into the `logs` directory.