### PR TITLE
Assigning correct ration attribute when non lac cow formulation fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3595%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3593%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/RUFAS/biophysical/animal/ration/ration_driver.py
+++ b/RUFAS/biophysical/animal/ration/ration_driver.py
@@ -143,8 +143,8 @@ class RationManager:
             return ration, ration_vals
         # safeguard if scipy SLSQP bounds error still occurs after many iterations
         # using previous cycles ration for this pen
-        elif pen.ration != {}:
-            return pen.ration, ration_vals
+        elif pen.ration_per_animal != {}:
+            return pen.ration_per_animal, ration_vals
         else:
             om.add_error(
                 "No previous ration available",

--- a/RUFAS/biophysical/animal/ration/ration_driver.py
+++ b/RUFAS/biophysical/animal/ration/ration_driver.py
@@ -66,7 +66,7 @@ class RationManager:
         Returns
         -------
         Dict[str, float]
-            Formulated ration.
+            Formulated ration for a single animal.
         Dict[str, float]
             Summary of ration content.
         """
@@ -80,10 +80,10 @@ class RationManager:
         # Use grouping scenario to find the type of each animal in pen
         req.set_requirements(pen, animal_grouping_scenario, False)
         if udrm.use_user_defined_ration:
-            ration, ration_vals = cls.get_user_defined_ration(
+            ration_per_animal, ration_vals = cls.get_user_defined_ration(
                 req, pen, available_feeds, animal_grouping_scenario, sim_day
             )
-            return ration, ration_vals
+            return ration_per_animal, ration_vals
 
         previous_ration = None
         if hasattr(pen, "ration_per_animal"):
@@ -139,12 +139,12 @@ class RationManager:
                     )
 
         if solution is not None and solution.success:
-            ration = cls.make_ration_from_solution(available_feeds, solution)
-            return ration, ration_vals
+            ration_per_animal = cls.make_ration_from_solution(available_feeds, solution)
+            return ration_per_animal, ration_vals
         # safeguard if scipy SLSQP bounds error still occurs after many iterations
         # using previous cycles ration for this pen
-        elif pen.ration_per_animal != {}:
-            return pen.ration_per_animal, ration_vals
+        elif previous_ration != {}:
+            return previous_ration, ration_vals
         else:
             om.add_error(
                 "No previous ration available",

--- a/RUFAS/routines/animal/ration/ration_driver.py
+++ b/RUFAS/routines/animal/ration/ration_driver.py
@@ -143,8 +143,8 @@ class RationManager:
             return ration, ration_vals
         # safeguard if scipy SLSQP bounds error still occurs after many iterations
         # using previous cycles ration for this pen
-        elif pen.ration != {}:
-            return pen.ration, ration_vals
+        elif pen.ration_per_animal != {}:
+            return pen.ration_per_animal, ration_vals
         else:
             om.add_error(
                 "No previous ration available",

--- a/tests/animal_module_tests/test_animal.py
+++ b/tests/animal_module_tests/test_animal.py
@@ -2888,7 +2888,7 @@ def test_formulate_ration_hasattr(mocker: MockerFixture) -> None:
     mock_solution.success = False
     mock_ration_vals = mocker.MagicMock()
     mock_ration_config = mocker.MagicMock()
-    expected = (mock_pen.ration, mock_ration_vals)
+    expected = (mock_pen.ration_per_animal, mock_ration_vals)
     mock_attempt_optimization = mocker.patch(
         "RUFAS.routines.animal.ration.ration_optimizer.RationOptimizer.attempt_optimization",
         return_value=(mock_solution, mock_ration_vals, mock_ration_config),
@@ -2922,7 +2922,7 @@ def test_formulate_ration_noattr(mocker: MockerFixture) -> None:
     delattr(mock_pen, "ration_per_animal")
     mock_pen.animal_combination = mocker.MagicMock()
     mock_pen.animal_combination = AnimalCombination.LAC_COW
-    mock_pen.ration = None
+    mock_pen.ration_per_animal = None
     mock_animal = mocker.MagicMock()
     mock_body_weight_history = mocker.MagicMock()
     mock_body_weight_history.simulation_day = 100
@@ -2935,7 +2935,7 @@ def test_formulate_ration_noattr(mocker: MockerFixture) -> None:
     mock_solution_exists.success = True
     mock_ration_vals = mocker.MagicMock()
     mock_ration_config = mocker.MagicMock()
-    expected = (mock_pen.ration, mock_ration_vals)
+    expected = (mock_pen.ration_per_animal, mock_ration_vals)
     mock_attempt_optimization = mocker.patch(
         "RUFAS.routines.animal.ration.ration_optimizer.RationOptimizer.attempt_optimization",
         side_effect=[

--- a/tests/animal_module_tests/test_animal_manager.py
+++ b/tests/animal_module_tests/test_animal_manager.py
@@ -1735,7 +1735,7 @@ def setup_dummy_animal_manager_with_pens(
 
         dummy_pen = setup_dummy_pen(pen_dict["pen_id"], pen_dict["num_stalls"], animal_list)
 
-        dummy_pen.ration = pen_dict["ration"]
+        dummy_pen.ration_per_animal = pen_dict["ration_per_animal"]
 
         for animal in animal_list:
             dummy_pen.animals_in_pen[animal.id] = animal


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #

- [x] The [changelog](https://docs.google.com/spreadsheets/d/1U-3igxdstHTFb6k5dVcE5-x9IL0r6q18eUiwwytKZyA/edit#gid=0) has been updated.
      
How big are the changes in the PR? Would you nominate it for a major version upgrade?
- [ ] Yes
- [x] No

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
When ration formulation fails for non lactating cow pens, the previous formulation interval's ration should be used. See the related issue below for other heifer ration formulation improvements that need to be considered in other PRs. rehttps://github.com/RuminantFarmSystems/MASM/issues/577

However: currently the ration selected is one that is summed for the entire pen, not the "per animal" ration.

Also note: 
The attribute `pen.ration` should perhaps be renamed for clarity in the future, but this is outside the scope of this quick fix. Opening #1990 to handle this related concern.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
This error causes a rapid increase in phosphorus requirements, since this massively increases the amount fed to each animal (which is used in the calculation of `p_maint_feces` in the `phosphorus_rqmts` method.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Before/after comparison of growing animal pens captured in pilot test farm c1f3. Used report filter below, provided by @KFosterReed 

```
{
    "multiple": [

        {
            "name": "Phos Diet Amount",
            "filters": ["AnimalModuleReporter.report_ration_interval_data.ration_nutrient_amount_pen_._GROWING"],
          "variables": ["phosphorus"],
            "vertical_aggregation": "average",
            "slice_start": -365
           },
        {
            "name": "Phos Req NASEM",
            "filters": ["AnimalModuleReporter.report_ration_interval_data.avg_rqmts_pen_._GROWING"],
            "variables": ["P_req", "P_req_process", "avg_BW"],
            "vertical_aggregation": "average",
            "slice_start": -365
           },{
            "name": "Phos Diet Amount-Daily",
            "filters": ["AnimalModuleReporter.report_ration_interval_data.ration_nutrient_amount_pen_._GROWING"],
          "variables": ["phosphorus"]
           },
        {
            "name": "Phos Req NASEM-Daily",
            "filters": ["AnimalModuleReporter.report_ration_interval_data.avg_rqmts_pen_._GROWING"],
            "variables": ["P_req", "P_req_process", "avg_BW"]
           },{
            "name": "Avg Bodyweight",
            "filters": ["AnimalModuleReporter.report_ration_interval_data.avg_rqmts_pen_._GROWING"],
            "variables": ["P_req", "P_req_process"]
           }

    ]
}
```