### PR TITLE
[GitHub Actions] Added if statement to missing changelog entry notification comment

### DIFF
--- a/.github/workflows/combined_format_lint_test_mypy.yml
+++ b/.github/workflows/combined_format_lint_test_mypy.yml
@@ -282,10 +282,12 @@ jobs:
         env:
           URL: ${{ github.event.pull_request.comments_url }}
         run: |
-          curl \
-              -X POST \
-              $URL \
-              -H "Content-Type: application/json" \
-              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              --data "{\"body\": \"🚨 Please update the changelog. This PR cannot be merged until \`changelog.md\` is updated to reflect the changes.\"}"
-          exit 1
+          if [ -n "$URL" ]; then
+            curl \
+                -X POST \
+                $URL \
+                -H "Content-Type: application/json" \
+                -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                --data "{\"body\": \"🚨 Please update the changelog. This PR cannot be merged until \`changelog.md\` is updated to reflect the changes.\"}"
+            exit 1
+          fi

--- a/changelog.md
+++ b/changelog.md
@@ -31,3 +31,4 @@ v0.9.1
 - [1986](https://github.com/RuminantFarmSystems/MASM/pull/1986/) - [minor change] [Animal] Creates the biophysical folder, and necessary files with empty class and folders for the redesigned animal module.
 - [1979](https://github.com/RuminantFarmSystems/MASM/pull/1979) - [minor change] [EEE] Updates synthetic fertilizer emissions to be partitioned by crop schedule instead of by dry yield.
 - [1784](https://github.com/RuminantFarmSystems/MASM/pull/1784) - [minor change] [Task Manager][Feed Storage] Adds end-to-end testing routine for the Feed Storage module which can be extended to test other parts of RuFaS.
+- [1998](https://github.com/RuminantFarmSystems/MASM/pull/1998) - [minor change] [GitHub Actions] Adds if statement to make sure there is a PR to comment on before attempting to post a comment.


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
When the linting and testing Action runs on `dev` after a PR gets merged in, the action consistently fails when it reaches the step for posting a comment saying that there has been no update to the changelog. 

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1981

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
An if statement is added to the step "Notify User of Missing Changelog Updates" to ensure that there is a GitHub comments URL before curl'ing a POST request to that URL.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
When an action is running on `dev` after a PR is merged into it, there is no associated PR to post a comment to. Naturally an errors when the action tries to comment on something that is non-existent.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
I copied this logic from the "Comment on Coverage and Mypy Errors" step which makes me very confident that the logic is sound.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
I created this branch initially without a changelog entry, and then verified that the comment with an alert about the unmodified changelog was posted, as expected. Then I made to a changelog entry to ensure that the comment was not posted, also as expected.

To test that this fix works as expected when there is no PR associated with a branch, I created a new branch off of dev and pushed it to GitHub _and did not_ create a PR for it. Then I ran the linting/testing GH action on it to make sure that it fails when trying to post the comment about the unmodified changelog (it does). After verifying the buggy behavior, I applied the fix to the Actions but did not modify the changelog and reran the Action. This time it did not fail when it reached the step to post the comment about the missing changelog entry. To see these results, check out workflow runs #'s [1811](https://github.com/RuminantFarmSystems/MASM/actions/runs/10851115436) and [1812](https://github.com/RuminantFarmSystems/MASM/actions/runs/10851204845)

