### PR TITLE
[E2E Testing] Updates E2ETestResultsComparer so that it works on Windows machines

### DIFF
--- a/RUFAS/e2e_test_results_comparer.py
+++ b/RUFAS/e2e_test_results_comparer.py
@@ -8,7 +8,6 @@ from RUFAS.output_manager import OutputManager
 from RUFAS.units import MeasurementUnits
 
 import json
-import re
 
 
 ResultPathType = namedtuple("ResultPaths", ["domain", "expected_results_path", "actual_results_path"])
@@ -46,8 +45,8 @@ class E2ETestResultsComparer:
             )
             path_to_actual_results = None
             for path in json_output_path.iterdir():
-                escaped_path = re.escape(str(json_output_path / path_set.actual_results_path))
-                is_a_match = re.match(f"{escaped_path}.*", str(path))
+                actual_results_base_path = Path(path_set.actual_results_path)
+                is_a_match = path.name.startswith(actual_results_base_path.name)
                 if is_a_match:
                     path_to_actual_results = path
                     break

--- a/RUFAS/e2e_test_results_comparer.py
+++ b/RUFAS/e2e_test_results_comparer.py
@@ -46,7 +46,8 @@ class E2ETestResultsComparer:
             )
             path_to_actual_results = None
             for path in json_output_path.iterdir():
-                is_a_match = re.match(f"{json_output_path}/{path_set.actual_results_path}.*", str(path))
+                escaped_path = re.escape(str(json_output_path / path_set.actual_results_path))
+                is_a_match = re.match(f"{escaped_path}.*", str(path))
                 if is_a_match:
                     path_to_actual_results = path
                     break

--- a/changelog.md
+++ b/changelog.md
@@ -32,4 +32,4 @@ v0.9.1
 - [1979](https://github.com/RuminantFarmSystems/MASM/pull/1979) - [minor change] [EEE] Updates synthetic fertilizer emissions to be partitioned by crop schedule instead of by dry yield.
 - [1784](https://github.com/RuminantFarmSystems/MASM/pull/1784) - [minor change] [Task Manager][Feed Storage] Adds end-to-end testing routine for the Feed Storage module which can be extended to test other parts of RuFaS.
 - [1998](https://github.com/RuminantFarmSystems/MASM/pull/1998) - [minor change] [GitHub Actions] Adds if statement to make sure there is a PR to comment on before attempting to post a comment.
-- [2001](https://github.com/RuminantFarmSystems/MASM/pull/2001) - [minor change] [E2E Testing] Changes unit test suite for E2ETestResultsComparer so that it passes on Windows machines.
+- [2001](https://github.com/RuminantFarmSystems/MASM/pull/2001) - [minor change] [E2E Testing] Changes E2ETestResultsComparer so that it constructs file paths properly on Windows machines.

--- a/changelog.md
+++ b/changelog.md
@@ -32,4 +32,4 @@ v0.9.1
 - [1979](https://github.com/RuminantFarmSystems/MASM/pull/1979) - [minor change] [EEE] Updates synthetic fertilizer emissions to be partitioned by crop schedule instead of by dry yield.
 - [1784](https://github.com/RuminantFarmSystems/MASM/pull/1784) - [minor change] [Task Manager][Feed Storage] Adds end-to-end testing routine for the Feed Storage module which can be extended to test other parts of RuFaS.
 - [1998](https://github.com/RuminantFarmSystems/MASM/pull/1998) - [minor change] [GitHub Actions] Adds if statement to make sure there is a PR to comment on before attempting to post a comment.
-- [2001](https://github.com/RuminantFarmSystems/MASM/pull/2001) - [minor change] [E2E Testing] Changes unit test suite for E2EResultsComparer so that it passes on Windows machines.
+- [2001](https://github.com/RuminantFarmSystems/MASM/pull/2001) - [minor change] [E2E Testing] Changes unit test suite for E2ETestResultsComparer so that it passes on Windows machines.

--- a/changelog.md
+++ b/changelog.md
@@ -32,3 +32,4 @@ v0.9.1
 - [1979](https://github.com/RuminantFarmSystems/MASM/pull/1979) - [minor change] [EEE] Updates synthetic fertilizer emissions to be partitioned by crop schedule instead of by dry yield.
 - [1784](https://github.com/RuminantFarmSystems/MASM/pull/1784) - [minor change] [Task Manager][Feed Storage] Adds end-to-end testing routine for the Feed Storage module which can be extended to test other parts of RuFaS.
 - [1998](https://github.com/RuminantFarmSystems/MASM/pull/1998) - [minor change] [GitHub Actions] Adds if statement to make sure there is a PR to comment on before attempting to post a comment.
+- [2001](https://github.com/RuminantFarmSystems/MASM/pull/2001) - [minor change] [E2E Testing] Changes unit test suite for E2EResultsComparer so that it passes on Windows machines.


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Fixes the `E2ETestResultsComparer` so it runs on Windows machines.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes # N/A

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
When the E2ETestResultsComparer runs, it tried to construct file paths using "/" as the file path separator. This works on Unix-like systems (Linux and MacOS), but not Windows.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
End-to-end testing needs to run properly on both Windows and Unix-like machines.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
The target file path is sanitized with `re.escape` before looking for matching file paths.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Ran the test suite on both Linux and Windows machines to check that they are running properly. Also ran end to end testing on both Linux and Windows systems to make sure that it was passing (as it was expected to be).

The command to run end-to-end testing currently is `python main.py -p input/metadata/end_to_end_testing_tm_metadata.json`. 