### PR TITLE
[Manure] Fix to how organic bedding dry solids are calculated in manure handlers

### DIFF
--- a/RUFAS/routines/manure/manure_handlers/manure_handler_classes.py
+++ b/RUFAS/routines/manure/manure_handlers/manure_handler_classes.py
@@ -159,11 +159,12 @@ class BaseManureHandler:
         if bedding:
             total_bedding_mass = bedding.calc_total_bedding_mass(pen.num_animals)
             total_organic_bedding_mass_added = bedding.calc_organic_bedding_mass_added_to_manure(total_bedding_mass)
+            organic_bedding_dry_solids = total_organic_bedding_mass_added * bedding.bedding_dry_matter_content
         else:
             total_bedding_mass = 0.0
-            total_organic_bedding_mass_added = 0.0
+            organic_bedding_dry_solids = 0.0
 
-        non_degradable_volatile_solids = pen.manure.non_degradable_volatile_solids + total_organic_bedding_mass_added
+        non_degradable_volatile_solids = pen.manure.non_degradable_volatile_solids + organic_bedding_dry_solids
 
         daily_output = ManureHandlerDailyOutput(
             simulation_day=sim_day,
@@ -188,7 +189,7 @@ class BaseManureHandler:
             cleaning_water_volume=self.calc_cleaning_water_volume_in_main_barn(pen.num_animals),
             total_bedding_volume=bedding.calc_total_bedding_volume(pen.num_animals) if bedding is not None else 0.0,
             total_bedding_mass=total_bedding_mass,
-            organic_bedding_added_to_manure=total_organic_bedding_mass_added,
+            organic_bedding_added_to_manure=organic_bedding_dry_solids,
             total_water_volume_in_milking_parlor=(
                 self.milking_parlor.calc_total_water_volume_used_in_milking_parlor(pen.num_lactating_cows)
             ),

--- a/RUFAS/routines/manure/manure_handlers/manure_handler_classes.py
+++ b/RUFAS/routines/manure/manure_handlers/manure_handler_classes.py
@@ -157,6 +157,7 @@ class BaseManureHandler:
             organic_bedding_dry_solids = total_organic_bedding_mass_added * bedding.bedding_dry_matter_content
         else:
             total_bedding_mass = 0.0
+            total_organic_bedding_mass_added = 0.0
             organic_bedding_dry_solids = 0.0
 
         non_degradable_volatile_solids = pen.manure.non_degradable_volatile_solids + organic_bedding_dry_solids
@@ -184,7 +185,7 @@ class BaseManureHandler:
             cleaning_water_volume=self.calc_cleaning_water_volume_in_main_barn(pen.num_animals),
             total_bedding_volume=bedding.calc_total_bedding_volume(pen.num_animals) if bedding is not None else 0.0,
             total_bedding_mass=total_bedding_mass,
-            organic_bedding_added_to_manure=organic_bedding_dry_solids,
+            organic_bedding_added_to_manure=total_organic_bedding_mass_added,
             total_water_volume_in_milking_parlor=(
                 self.milking_parlor.calc_total_water_volume_used_in_milking_parlor(pen.num_lactating_cows)
             ),

--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@ v0.9.2
 
 - [2021](https://github.com/RuminantFarmSystems/MASM/pull/2021) - [minor change] [Animal] **Adds dependency**. Creates a new `MilkProduction` submodule and several support submodules to calculate milk production.
 - [2022](https://github.com/RuminantFarmSystems/MASM/pull/2022) - [minor change] [Manure] Removes DefaultEnum class and all references to it in the Manure module.
+- [2023](https://github.com/RuminantFarmSystems/MASM/pull/2023) - [minor change] [Manure] Fixes calculation of organic bedding dry solids for manure handlers.
 
 ### v0.9.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -27,7 +27,7 @@ v0.9.2
 
 - [2021](https://github.com/RuminantFarmSystems/MASM/pull/2021) - [minor change] [Animal] **Adds dependency**. Creates a new `MilkProduction` submodule and several support submodules to calculate milk production.
 - [2022](https://github.com/RuminantFarmSystems/MASM/pull/2022) - [minor change] [Manure] Removes DefaultEnum class and all references to it in the Manure module.
-- [2023](https://github.com/RuminantFarmSystems/MASM/pull/2023) - [minor change] [Manure] Fixes calculation of organic bedding dry solids for manure handlers.
+- [2023](https://github.com/RuminantFarmSystems/MASM/pull/2023) - [minor change] [Manure] Fixes calculation of organic bedding dry solids added to manure in manure handler.
 - [2025](https://github.com/RuminantFarmSystems/MASM/pull/2025) - [minor change] [Formatting] Sorts import statements in codebase.
 - [2017](https://github.com/RuminantFarmSystems/MASM/pull/2017) - [minor change] [Animal] Deduplicates references to lactation parameters in the `LactationCurve` submodule and reorganizes structure to be consistent with other animal submodules.
 - [1985](https://github.com/RuminantFarmSystems/MASM/pull/1985) - [minor change] [TaskManager] extracts all the input data values (for all input variables from JSON input files) for each task and combines them into a single CSV file for side-by-side comparison.

--- a/input/data/animal/default_animal.json
+++ b/input/data/animal/default_animal.json
@@ -196,7 +196,7 @@
 			"housing_type": "open air barn",
 			"pen_type": "freestall",
 			"max_stocking_density": 1.2,
-			"manure_management_scenario_id": 5
+			"manure_management_scenario_id": 4
 		}
 	]
 }

--- a/input/data/animal/default_animal.json
+++ b/input/data/animal/default_animal.json
@@ -196,7 +196,7 @@
 			"housing_type": "open air barn",
 			"pen_type": "freestall",
 			"max_stocking_density": 1.2,
-			"manure_management_scenario_id": 4
+			"manure_management_scenario_id": 5
 		}
 	]
 }

--- a/tests/test_manure_module/test_manure_handlers.py
+++ b/tests/test_manure_module/test_manure_handlers.py
@@ -326,8 +326,10 @@ def test_manure_handler_daily_update(mocker: MockerFixture) -> None:
     mock_bedding.calc_total_bedding_volume.return_value = total_bedding_volume = 30.0
     mock_bedding.calc_total_bedding_mass.return_value = total_bedding_mass = 31.0
     mock_bedding.calc_organic_bedding_mass_added_to_manure.return_value = organic_bedding_added = 32.0
+    mock_bedding.bedding_dry_matter_content = bedding_dry_matter_content = 0.8
 
-    expected_total_non_degradable_volatile_solids = VSnd + organic_bedding_added
+    expected_organic_bedding_dry_solids = organic_bedding_added * bedding_dry_matter_content
+    expected_total_non_degradable_volatile_solids = VSnd + expected_organic_bedding_dry_solids
 
     sim_day = 10
     housing_ammonia_emission = 1.0


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Small fix to how organic bedding dry solids are calculated in manure handlers.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1975

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Adjusts the `total_organic_bedding_mass_added` obtained from calculating the organic bedding mass added to manure by the bedding dry matter content fraction. This better represents that only dry-solids should be added to the total of `non_degradable_volatile_solids` reported in the ManureHandlerDailyOutput.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
The quantity of mass added from bedding should be the dry solids in the bedding (e.g. total mass * bedding DM fraxction), not the entire bedding mass.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Once the `total_organic_bedding_mass` is calculated, it's now multiplied by the bedding's `bedding_dry_matter_content` to better approximate the dry solids portion.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Unit testing is updated. Exact amounts and whether the change reflects expected results needs to be confirmed by SME.