### PR TITLE
Update default parity fraction

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -56,7 +56,7 @@ v0.9.2
 - [2069](https://github.com/RuminantFarmSystems/MASM/pull/2069) - [minor change] [Crop & Soil] Flatten the units in SC module.
 - [2076](https://github.com/RuminantFarmSystems/MASM/pull/2076) - [minor change] [Crop & Soil] Removes TODOs from the Crop & Soil module.
 - [1785](https://github.com/RuminantFarmSystems/MASM/pull/1785) - [minor change] [TaskManager] Adds sobol and morris samplers, updates argument names.
-
+- [2086](https://github.com/RuminantFarmSystems/MASM/pull/2086) - [minor change] [Animal] Updates default parity fraction. 
 
 ### v0.9.2
 

--- a/input/data/animal/default_animal.json
+++ b/input/data/animal/default_animal.json
@@ -9,9 +9,9 @@
     "herd_num": 100,
     "breed": "HO",
     "parity_fractions": {
-      "1": 0.386,
-      "2": 0.281,
-      "3": 0.333
+      "1": 0.346,
+      "2": 0.272,
+      "3": 0.379
     },
     "annual_milk_yield": null
   },

--- a/input/metadata/properties/default.json
+++ b/input/metadata/properties/default.json
@@ -93,17 +93,20 @@
         "1": {
           "type": "number",
           "minimum": 0.0,
-          "maximum": 1.0
+          "maximum": 1.0,
+          "default": 0.346
         },
         "2": {
           "type": "number",
           "minimum": 0.0,
-          "maximum": 1.0
+          "maximum": 1.0,
+          "default": 0.272
         },
         "3": {
           "type": "number",
           "minimum": 0.0,
-          "maximum": 1.0
+          "maximum": 1.0,
+          "default": 0.379
         }
       },
       "annual_milk_yield": {

--- a/tests/animal_module_tests/life_cycle/test_lactation_curve.py
+++ b/tests/animal_module_tests/life_cycle/test_lactation_curve.py
@@ -22,7 +22,7 @@ def animal_inputs() -> dict[str, Any]:
     return {
         "herd_information": {
             "cow_num": 100,
-            "parity_fractions": {"1": 38.6, "2": 28.1, "3": 33.3},
+            "parity_fractions": {"1": 34.6, "2": 27.2, "3": 37.9},
             "annual_milk_yield": 10_000_000,
         },
         "animal_config": {"management_decisions": {"cow_times_milked_per_day": 2.7}},

--- a/tests/animal_module_tests/milk_tests/test_lactation_curve.py
+++ b/tests/animal_module_tests/milk_tests/test_lactation_curve.py
@@ -15,7 +15,7 @@ def animal_inputs() -> dict[str, Any]:
     return {
         "herd_information": {
             "cow_num": 100,
-            "parity_fractions": {"1": 38.6, "2": 28.1, "3": 33.3},
+            "parity_fractions": {"1": 34.6, "2": 27.2, "3": 37.9},
             "annual_milk_yield": 10_000_000,
         },
         "animal_config": {"management_decisions": {"cow_times_milked_per_day": 2.7}},


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2085 

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Updated default parity_fractions values to align with the latest research findings.
Old values:
```
{
  "1": 0.386,
  "2": 0.281,
  "3": 0.333
}
```
New values:
```
{
  "1": 0.346,
  "2": 0.272,
  "3": 0.379
}
```


### Why
<!-- Discuss why the changes in this pull request are needed or important. -->

- The current values are outdated and do not reflect the latest data from recent studies.
- This update improves the accuracy and reliability of the model predictions.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->

- Modified the default `parity_fractions` values in the configuration file.
- Updated relevant the metadata file to reflect these changes.


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->

- Verify that the updated parity_fractions are correctly loaded by the system.
- Run test simulations with the new values and validate output consistency.
