### PR TITLE
[GraphGenerator] Add User Option for Setting Time on X-axis for Graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-96%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3449%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3456%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-96%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3456%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3448%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-96%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3455%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3452%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-96%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3452%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3455%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 from matplotlib.figure import Axes, Figure
+import matplotlib.dates as mdates
 
 from RUFAS.util import Utility
 
@@ -553,18 +554,39 @@ class GraphGenerator:
         """
         if graph_type not in MATPLOTLIB_PLOT_FUNCTIONS:
             raise ValueError(f"Unsupported graph type: {graph_type}")
+        simulation_start_date = self.time.start_date
+        # prepare dates for x-axis
+        num_days = max(len(values) for values in data.values())  # Number of days based on data length
+        dates = [simulation_start_date + datetime.timedelta(days=i) for i in range(num_days)]
         plot_function = MATPLOTLIB_PLOT_FUNCTIONS[graph_type]
+        fig, ax = plt.subplots()
         if graph_type in TUPLE_BASED_FUNCTIONS:
             values_tuple = tuple(data[variable] for variable in selected_variables)
-            indices_list = list(range(len(values_tuple[0])))
-            plot_function(indices_list, values_tuple)
+            # indices_list = list(range(len(values_tuple[0])))
+            # plot_function(indices_list, values_tuple)
+            ax.xaxis_date()
+            plot_function(dates, values_tuple)
         else:
             for value in data.values():
                 if not mask_values:
-                    plot_function(value)
+                    # plot_function(value)
+                    plot_function(dates, value)
                 else:
                     indices, masked_values = self._mask_values(value)
-                    plot_function(indices, masked_values)
+                    masked_dates = [dates[i] for i in indices]
+                    # plot_function(indices, masked_values)
+                    plot_function(masked_dates, masked_values)
+        # Customize the x-axis date format
+        ax.xaxis.set_major_formatter(mdates.DateFormatter('%j/%Y'))  # Day of year / Year format
+        plt.xticks(rotation=45)  # Rotate x-axis labels for better readability
+
+        # Add labels and title
+        plt.xlabel("Calendar Day")
+        plt.ylabel("Values")
+        plt.title("Simulation Data Over Time")
+
+        plt.tight_layout()
+        plt.show()
 
     def _mask_values(self, values: list[Any]) -> tuple[npt.NDArray[Any], npt.NDArray[np.float32]]:
         """

--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -225,7 +225,8 @@ class GraphGenerator:
             mask_values = graph_details.get("mask_values", False)
             use_calendar_dates = graph_details.get("use_calendar_dates", False)
             self._draw_graph(
-                graph_details["type"], prepared_data, list(prepared_data.keys()), ax, mask_values, use_calendar_dates
+                graph_details["type"], prepared_data, list(prepared_data.keys()), ax, mask_values, use_calendar_dates,
+                graph_details.get("slice_start", None), graph_details.get("slice_end", None)
             )
             if graph_details.get("title"):
                 corrected_graph_title = Utility.remove_special_chars(graph_details.get("title", "Untitled graph"))
@@ -534,6 +535,8 @@ class GraphGenerator:
         ax: Axes,
         mask_values: bool = False,
         use_calendar_dates: bool = False,
+        slice_start: int | None = None,
+        slice_end: int | None = None,
     ) -> None:
         """
         Draw the graph based on the provided graph type and data.
@@ -549,10 +552,14 @@ class GraphGenerator:
         mask_values : bool, default False
             Whether data that will be plotted with non-tuple based functions should be masked to remove None or NaN
             values.
-        ax : Axes, default None
+        ax : Axes
             The matplotlib Axes object to plot the graph on.
         use_calendar_dates : bool, default False
             Whether to use calendar dates on the x-axis.
+        slice_start : int, default None
+            The starting index of the data to plot.
+        slice_end : int, default None
+            The ending index of the data to plot.
 
         Raises
         ------
@@ -561,14 +568,27 @@ class GraphGenerator:
         """
         if graph_type not in MATPLOTLIB_PLOT_FUNCTIONS:
             raise ValueError(f"Unsupported graph type: {graph_type}")
-        dates_in_data_range = [
-            self.time.start_date + datetime.timedelta(days=i) for i in range(max(len(v) for v in data.values()))
-        ]
+        max_data_length = max(len(v) for v in data.values())
+        if slice_start is not None:
+            if slice_start < 0:
+                slice_start = max(0, self.time.simulation_length_days + slice_start)
+            if slice_end is None or slice_end > self.time.simulation_length_days:
+                slice_end = self.time.simulation_length_days
+            elif slice_end < 0:
+                slice_end = max(0, self.time.simulation_length_days + slice_end)
+            dates_in_data_range = [
+                self.time.convert_simulation_day_to_date(i) for i in range(slice_start, slice_end)
+            ]
+        else:
+            dates_in_data_range = [
+                self.time.start_date + datetime.timedelta(days=i) for i in range(max_data_length)
+            ]
         plot_function = MATPLOTLIB_PLOT_FUNCTIONS[graph_type]
 
-        def get_x_values(values_length: int) -> list[int]:
-            """Get appropriate x-axis values based on user choice."""
-            return dates_in_data_range[:values_length] if use_calendar_dates else list(range(values_length))
+        get_x_values : Callable[[int], list[int]] = (
+            lambda values_length: dates_in_data_range[:values_length] if use_calendar_dates else
+            list(range(values_length))
+        )
 
         if graph_type in TUPLE_BASED_FUNCTIONS:
             values_tuple = tuple(data[variable] for variable in selected_variables)

--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -226,8 +226,9 @@ class GraphGenerator:
 
             mask_values = graph_details.get("mask_values", False)
             use_calendar_dates = graph_details.get("use_calendar_dates", False)
-            self._draw_graph(graph_details["type"], prepared_data, list(prepared_data.keys()), mask_values, ax,
-                             use_calendar_dates)
+            self._draw_graph(
+                graph_details["type"], prepared_data, list(prepared_data.keys()), mask_values, ax, use_calendar_dates
+            )
             if graph_details.get("title"):
                 corrected_graph_title = Utility.remove_special_chars(graph_details.get("title"))
                 graph_details["title"] = corrected_graph_title
@@ -562,8 +563,9 @@ class GraphGenerator:
         """
         if graph_type not in MATPLOTLIB_PLOT_FUNCTIONS:
             raise ValueError(f"Unsupported graph type: {graph_type}")
-        dates_in_data_range = [self.time.start_date + datetime.timedelta(days=i)
-                               for i in range(max(len(v) for v in data.values()))]
+        dates_in_data_range = [
+            self.time.start_date + datetime.timedelta(days=i) for i in range(max(len(v) for v in data.values()))
+        ]
         plot_function = MATPLOTLIB_PLOT_FUNCTIONS[graph_type]
 
         def get_x_values(values_length):
@@ -584,7 +586,7 @@ class GraphGenerator:
                     x_values = get_x_values(len(value))
                     plot_function(x_values, value)
         if use_calendar_dates:
-            ax.xaxis.set_major_formatter(mdates.DateFormatter('%j/%Y'))
+            ax.xaxis.set_major_formatter(mdates.DateFormatter("%j/%Y"))
             plt.xlabel("Calendar Day")
             plt.xticks(rotation=45)
 

--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -92,7 +92,6 @@ UNSUPPORTED_GRAPH_FUNCTIONS: List[str] = [
 FIGURE_SETTERS: Dict[str, FUNCTION_TYPE] = {
     "align_labels": Figure.align_labels,
     "canvas": Figure.set_canvas,
-    "constrained_layout": Figure.set_constrained_layout,
     "dpi": Figure.set_dpi,
     "edgecolor": Figure.set_edgecolor,
     "figheight": Figure.set_figheight,
@@ -102,7 +101,6 @@ FIGURE_SETTERS: Dict[str, FUNCTION_TYPE] = {
     "frameon": Figure.set_frameon,
     "snap": Figure.set_snap,
     "subplot_adjust": Figure.subplots_adjust,
-    "tight_layout": Figure.set_tight_layout,
     "zorder": Figure.set_zorder,
 }
 
@@ -227,10 +225,10 @@ class GraphGenerator:
             mask_values = graph_details.get("mask_values", False)
             use_calendar_dates = graph_details.get("use_calendar_dates", False)
             self._draw_graph(
-                graph_details["type"], prepared_data, list(prepared_data.keys()), mask_values, ax, use_calendar_dates
+                graph_details["type"], prepared_data, list(prepared_data.keys()), ax, mask_values, use_calendar_dates
             )
             if graph_details.get("title"):
-                corrected_graph_title = Utility.remove_special_chars(graph_details.get("title"))
+                corrected_graph_title = Utility.remove_special_chars(graph_details.get("title", "Untitled graph"))
                 graph_details["title"] = corrected_graph_title
             if not graph_details.get("legend"):
                 graph_details = self._set_graph_legend(graph_details, prepared_data)
@@ -530,11 +528,11 @@ class GraphGenerator:
 
     def _draw_graph(
         self,
-        graph_type: str | list[str],
+        graph_type: str,
         data: dict[str, list[int | float]],
         selected_variables: list[str],
+        ax: Axes,
         mask_values: bool = False,
-        ax: Axes = None,
         use_calendar_dates: bool = False,
     ) -> None:
         """
@@ -568,7 +566,7 @@ class GraphGenerator:
         ]
         plot_function = MATPLOTLIB_PLOT_FUNCTIONS[graph_type]
 
-        def get_x_values(values_length):
+        def get_x_values(values_length: int) -> list[int]:
             """Get appropriate x-axis values based on user choice."""
             return dates_in_data_range[:values_length] if use_calendar_dates else list(range(values_length))
 

--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -589,6 +589,8 @@ class GraphGenerator:
             ax.xaxis.set_major_formatter(mdates.DateFormatter("%j/%Y"))
             plt.xlabel("Calendar Day")
             plt.xticks(rotation=45)
+        else:
+            plt.xlabel("Simulation Day")
 
     def _mask_values(self, values: list[Any]) -> tuple[npt.NDArray[Any], npt.NDArray[np.float32]]:
         """

--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -220,12 +220,14 @@ class GraphGenerator:
 
             figure_width = 10
             figure_height = 6
-            fig, _ = plt.subplots(figsize=(figure_width, figure_height))
+            fig, ax = plt.subplots(figsize=(figure_width, figure_height))
             ratio_of_graph_to_legend = 0.65
             plt.subplots_adjust(right=ratio_of_graph_to_legend)
 
             mask_values = graph_details.get("mask_values", False)
-            self._draw_graph(graph_details["type"], prepared_data, list(prepared_data.keys()), mask_values)
+            use_calendar_dates = graph_details.get("use_calendar_dates", False)
+            self._draw_graph(graph_details["type"], prepared_data, list(prepared_data.keys()), mask_values, ax,
+                             use_calendar_dates)
             if graph_details.get("title"):
                 corrected_graph_title = Utility.remove_special_chars(graph_details.get("title"))
                 graph_details["title"] = corrected_graph_title
@@ -527,9 +529,11 @@ class GraphGenerator:
     def _draw_graph(
         self,
         graph_type: str | list[str],
-        data: Dict[str, List[int | float]],
-        selected_variables: Optional[List[str]] = None,
+        data: dict[str, list[int | float]],
+        selected_variables: Optional[list[str]] = None,
         mask_values: bool = False,
+        ax: Axes = None,
+        use_calendar_dates: bool = False,
     ) -> None:
         """
         Draw the graph based on the provided graph type and data.
@@ -538,9 +542,9 @@ class GraphGenerator:
         ----------
         graph_type : str
             The type of graph to draw.
-        data : Dict[str, List[int | float]]
+        data : dict[str, list[int | float]]
             The data to use for plotting.
-        selected_variables : Optional[List[str]]
+        selected_variables : Optional[list[str]]
             If it is present and the data is a list of dicts,
             it selects the variables to be plotted.
         mask_values : bool, default False
@@ -554,39 +558,31 @@ class GraphGenerator:
         """
         if graph_type not in MATPLOTLIB_PLOT_FUNCTIONS:
             raise ValueError(f"Unsupported graph type: {graph_type}")
-        simulation_start_date = self.time.start_date
-        # prepare dates for x-axis
-        num_days = max(len(values) for values in data.values())  # Number of days based on data length
-        dates = [simulation_start_date + datetime.timedelta(days=i) for i in range(num_days)]
+        dates_in_data_range = [self.time.start_date + datetime.timedelta(days=i)
+                               for i in range(max(len(v) for v in data.values()))]
         plot_function = MATPLOTLIB_PLOT_FUNCTIONS[graph_type]
-        fig, ax = plt.subplots()
         if graph_type in TUPLE_BASED_FUNCTIONS:
             values_tuple = tuple(data[variable] for variable in selected_variables)
             # indices_list = list(range(len(values_tuple[0])))
             # plot_function(indices_list, values_tuple)
             ax.xaxis_date()
-            plot_function(dates, values_tuple)
+            plot_function(dates_in_data_range[:len(values_tuple[0])], values_tuple)
         else:
             for value in data.values():
                 if not mask_values:
                     # plot_function(value)
-                    plot_function(dates, value)
+
+                    plot_function(dates_in_data_range[:len(value)], value)
                 else:
-                    indices, masked_values = self._mask_values(value)
-                    masked_dates = [dates[i] for i in indices]
+                    indices, masked_values = self._mask_values(data.values())
+                    masked_dates = [dates_in_data_range[i] for i in indices]
                     # plot_function(indices, masked_values)
                     plot_function(masked_dates, masked_values)
-        # Customize the x-axis date format
+
         ax.xaxis.set_major_formatter(mdates.DateFormatter('%j/%Y'))  # Day of year / Year format
         plt.xticks(rotation=45)  # Rotate x-axis labels for better readability
-
-        # Add labels and title
         plt.xlabel("Calendar Day")
         plt.ylabel("Values")
-        plt.title("Simulation Data Over Time")
-
-        plt.tight_layout()
-        plt.show()
 
     def _mask_values(self, values: list[Any]) -> tuple[npt.NDArray[Any], npt.NDArray[np.float32]]:
         """

--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -439,9 +439,10 @@ class GraphGenerator:
                 "use_fill_value_at_end",
                 "mask_values",
                 "is_aggregated_report_data",
+                "use_calendar_dates",
             ]
         )
-        graph_filter_validation_logs: List[Dict[str, str | Dict[str, str]]] = []
+        graph_filter_validation_logs: list[dict[str, str | dict[str, str]]] = []
         info_map = {
             "class": self.__class__.__name__,
             "function": self._validate_graph_filter.__name__,

--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -224,6 +224,7 @@ class GraphGenerator:
 
             mask_values = graph_details.get("mask_values", False)
             use_calendar_dates = graph_details.get("use_calendar_dates", False)
+            date_format = graph_details.get("date_format", None)
             self._draw_graph(
                 graph_details["type"],
                 prepared_data,
@@ -231,6 +232,7 @@ class GraphGenerator:
                 ax,
                 mask_values,
                 use_calendar_dates,
+                date_format,
                 graph_details.get("slice_start", None),
                 graph_details.get("slice_end", None),
             )
@@ -446,6 +448,7 @@ class GraphGenerator:
                 "mask_values",
                 "is_aggregated_report_data",
                 "use_calendar_dates",
+                "date_format",
             ]
         )
         graph_filter_validation_logs: list[dict[str, str | dict[str, str]]] = []
@@ -541,6 +544,7 @@ class GraphGenerator:
         ax: Axes,
         mask_values: bool = False,
         use_calendar_dates: bool = False,
+        date_format: str = None,
         slice_start: int | None = None,
         slice_end: int | None = None,
     ) -> None:
@@ -562,6 +566,8 @@ class GraphGenerator:
             The matplotlib Axes object to plot the graph on.
         use_calendar_dates : bool, default False
             Whether to use calendar dates on the x-axis.
+        date_format : str, default None
+            The user-requested format to use for the date on the x-axis.
         slice_start : int, default None
             The starting index of the data to plot.
         slice_end : int, default None
@@ -603,11 +609,40 @@ class GraphGenerator:
                     x_values = get_x_values(len(value))
                     plot_function(x_values, value)
         if use_calendar_dates:
-            ax.xaxis.set_major_formatter(mdates.DateFormatter("%j/%Y"))
-            plt.xlabel("Calendar Day")
+            ax.xaxis.set_major_formatter(self.get_date_formatter(date_format))
+            plt.xlabel("Calendar Date")
             plt.xticks(rotation=45)
         else:
             plt.xlabel("Simulation Day")
+
+    @staticmethod
+    def get_date_formatter(date_format: str | None) -> mdates.DateFormatter:
+        """
+        Get a `matplotlib.dates.DateFormatter` instance for the requested date format.
+
+        Parameters
+        ----------
+        date_format : str
+            The format requested by the user. Supported values are:
+            - "day_of_year": Formats dates as day of year / year (e.g., "123/2024").
+            - "day_month_year": Formats dates as day / month / year (e.g., "23/12/2024").
+
+        Returns
+        -------
+        matplotlib.dates.DateFormatter
+            A `DateFormatter` instance for the specified format.
+
+        """
+        format_mapping = {
+            "day_of_year": "%j/%Y",
+            "day_month_year": "%d/%m/%Y",
+        }
+
+        date_format = format_mapping.get(date_format, None)
+        if date_format is None:
+            return mdates.DateFormatter("%d/%m/%Y")
+
+        return mdates.DateFormatter(date_format)
 
     def _mask_values(self, values: list[Any]) -> tuple[npt.NDArray[Any], npt.NDArray[np.float32]]:
         """

--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -2,7 +2,7 @@ import datetime
 import os
 import re
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Tuple
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -210,7 +210,7 @@ class GraphGenerator:
                     filtered_pool, graph_details.get("title", "Untitled graph")
                 )
                 graph_details["variables"] = list(updated_pool.keys())
-            prepared_data: Dict[str, List[Any]] = {key: updated_pool[key]["values"] for key in updated_pool.keys()}
+            prepared_data: dict[str, list[Any]] = {key: updated_pool[key]["values"] for key in updated_pool.keys()}
             non_numeric_data_logs = self._log_non_numerical_data(updated_pool, graph_details)
             all_logs = non_numeric_data_logs + graph_filter_validation_logs + var_units_logs
 
@@ -530,7 +530,7 @@ class GraphGenerator:
         self,
         graph_type: str | list[str],
         data: dict[str, list[int | float]],
-        selected_variables: Optional[list[str]] = None,
+        selected_variables: list[str],
         mask_values: bool = False,
         ax: Axes = None,
         use_calendar_dates: bool = False,
@@ -544,12 +544,15 @@ class GraphGenerator:
             The type of graph to draw.
         data : dict[str, list[int | float]]
             The data to use for plotting.
-        selected_variables : Optional[list[str]]
-            If it is present and the data is a list of dicts,
-            it selects the variables to be plotted.
+        selected_variables : list[str]
+            The variables selected to be plotted.
         mask_values : bool, default False
             Whether data that will be plotted with non-tuple based functions should be masked to remove None or NaN
             values.
+        ax : Axes, default None
+            The matplotlib Axes object to plot the graph on.
+        use_calendar_dates : bool, default False
+            Whether to use calendar dates on the x-axis.
 
         Raises
         ------
@@ -561,28 +564,28 @@ class GraphGenerator:
         dates_in_data_range = [self.time.start_date + datetime.timedelta(days=i)
                                for i in range(max(len(v) for v in data.values()))]
         plot_function = MATPLOTLIB_PLOT_FUNCTIONS[graph_type]
+
+        def get_x_values(values_length):
+            """Get appropriate x-axis values based on user choice."""
+            return dates_in_data_range[:values_length] if use_calendar_dates else list(range(values_length))
+
         if graph_type in TUPLE_BASED_FUNCTIONS:
             values_tuple = tuple(data[variable] for variable in selected_variables)
-            # indices_list = list(range(len(values_tuple[0])))
-            # plot_function(indices_list, values_tuple)
-            ax.xaxis_date()
-            plot_function(dates_in_data_range[:len(values_tuple[0])], values_tuple)
+            x_values = get_x_values(len(values_tuple[0]))
+            plot_function(x_values, values_tuple)
         else:
             for value in data.values():
-                if not mask_values:
-                    # plot_function(value)
-
-                    plot_function(dates_in_data_range[:len(value)], value)
+                if mask_values:
+                    indices, masked_values = self._mask_values(value)
+                    x_values = get_x_values(len(indices))
+                    plot_function(x_values, masked_values)
                 else:
-                    indices, masked_values = self._mask_values(data.values())
-                    masked_dates = [dates_in_data_range[i] for i in indices]
-                    # plot_function(indices, masked_values)
-                    plot_function(masked_dates, masked_values)
-
-        ax.xaxis.set_major_formatter(mdates.DateFormatter('%j/%Y'))  # Day of year / Year format
-        plt.xticks(rotation=45)  # Rotate x-axis labels for better readability
-        plt.xlabel("Calendar Day")
-        plt.ylabel("Values")
+                    x_values = get_x_values(len(value))
+                    plot_function(x_values, value)
+        if use_calendar_dates:
+            ax.xaxis.set_major_formatter(mdates.DateFormatter('%j/%Y'))
+            plt.xlabel("Calendar Day")
+            plt.xticks(rotation=45)
 
     def _mask_values(self, values: list[Any]) -> tuple[npt.NDArray[Any], npt.NDArray[np.float32]]:
         """

--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -225,8 +225,14 @@ class GraphGenerator:
             mask_values = graph_details.get("mask_values", False)
             use_calendar_dates = graph_details.get("use_calendar_dates", False)
             self._draw_graph(
-                graph_details["type"], prepared_data, list(prepared_data.keys()), ax, mask_values, use_calendar_dates,
-                graph_details.get("slice_start", None), graph_details.get("slice_end", None)
+                graph_details["type"],
+                prepared_data,
+                list(prepared_data.keys()),
+                ax,
+                mask_values,
+                use_calendar_dates,
+                graph_details.get("slice_start", None),
+                graph_details.get("slice_end", None),
             )
             if graph_details.get("title"):
                 corrected_graph_title = Utility.remove_special_chars(graph_details.get("title", "Untitled graph"))
@@ -577,13 +583,10 @@ class GraphGenerator:
                 self.time.convert_simulation_day_to_date(i) for i in range(slice_start_sim_day, slice_end_sim_day)
             ]
         else:
-            dates_in_data_range = [
-                self.time.start_date + datetime.timedelta(days=i) for i in range(max_data_length)
-            ]
+            dates_in_data_range = [self.time.start_date + datetime.timedelta(days=i) for i in range(max_data_length)]
 
-        get_x_values : Callable[[int], list[int]] = (
-            lambda values_length: dates_in_data_range[:values_length] if use_calendar_dates else
-            list(range(values_length))
+        get_x_values: Callable[[int], list[int]] = lambda values_length: (
+            dates_in_data_range[:values_length] if use_calendar_dates else list(range(values_length))
         )
 
         if graph_type in TUPLE_BASED_FUNCTIONS:

--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -544,7 +544,7 @@ class GraphGenerator:
         ax: Axes,
         mask_values: bool = False,
         use_calendar_dates: bool = False,
-        date_format: str = None,
+        date_format: str | None = None,
         slice_start: int | None = None,
         slice_end: int | None = None,
     ) -> None:

--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -568,22 +568,18 @@ class GraphGenerator:
         """
         if graph_type not in MATPLOTLIB_PLOT_FUNCTIONS:
             raise ValueError(f"Unsupported graph type: {graph_type}")
+        plot_function = MATPLOTLIB_PLOT_FUNCTIONS[graph_type]
         max_data_length = max(len(v) for v in data.values())
         if slice_start is not None:
-            if slice_start < 0:
-                slice_start = max(0, self.time.simulation_length_days + slice_start)
-            if slice_end is None or slice_end > self.time.simulation_length_days:
-                slice_end = self.time.simulation_length_days
-            elif slice_end < 0:
-                slice_end = max(0, self.time.simulation_length_days + slice_end)
+            slice_start_sim_day = self.time.convert_slice_to_simulation_day(slice_start)
+            slice_end_sim_day = self.time.convert_slice_to_simulation_day(slice_end)
             dates_in_data_range = [
-                self.time.convert_simulation_day_to_date(i) for i in range(slice_start, slice_end)
+                self.time.convert_simulation_day_to_date(i) for i in range(slice_start_sim_day, slice_end_sim_day)
             ]
         else:
             dates_in_data_range = [
                 self.time.start_date + datetime.timedelta(days=i) for i in range(max_data_length)
             ]
-        plot_function = MATPLOTLIB_PLOT_FUNCTIONS[graph_type]
 
         get_x_values : Callable[[int], list[int]] = (
             lambda values_length: dates_in_data_range[:values_length] if use_calendar_dates else

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -1296,7 +1296,7 @@ class OutputManager(object):
                 self.add_error(error_title, error_msg, info_map)
 
         slice_start: int = filter_content.get("slice_start", 0)
-        slice_end: int | None = filter_content.get("slice_end")
+        slice_end: int | None = filter_content.get("slice_end", None)
         for key in results.keys():
             if "info_maps" in results[key].keys():
                 results[key]["info_maps"] = results[key]["info_maps"][slice_start:slice_end]

--- a/RUFAS/time.py
+++ b/RUFAS/time.py
@@ -147,6 +147,26 @@ class Time:
         first_day_of_year = datetime(year, 1, 1)
         return first_day_of_year + timedelta(days=day - 1)
 
+    def convert_slice_to_simulation_day(self, slice_day: int) -> int:
+        """
+        Converts the slice day to a simulation day.
+
+        Parameters
+        ----------
+        slice_day: int
+            The slice day to convert to a simulation day.
+
+        Returns
+        -------
+        int
+            The simulation day that corresponds to the slice day.
+        """
+        if slice_day == 0:
+            return 1
+        if slice_day < 0:
+            return self.simulation_length_days + slice_day + 1
+        return slice_day
+
     def __str__(self) -> str:
         return (
             f"Year: {self.current_simulation_year}, Day: {self.current_julian_day}. "

--- a/changelog.md
+++ b/changelog.md
@@ -66,7 +66,8 @@ v0.9.2
 - [2046](https://github.com/RuminantFarmSystems/MASM/pull/2046) - [major change] [Data Collection App] Integrates the Data Collection App into the RuFaS repository and adds a RuFaS task type to update it.
 - [2075](https://github.com/RuminantFarmSystems/MASM/pull/2075) - [minor change] [Readme] Adds project goals for RuFaS year 2024 - 2025
 - [2067](https://github.com/RuminantFarmSystems/MASM/pull/2067) - [minor change] [EEE] Adds updated feeds emissions sheets, which replaces 0s with the average of neighboring FIPS codes.
-- [2120](https://github.com/RuminantFarmSystems/MASM/pull/2067) - [minor change] [Crop and Soil] Log errors to OM before throwing errors in NitrogenIncorporation.
+- [2120](https://github.com/RuminantFarmSystems/MASM/pull/2120) - [minor change] [Crop and Soil] Log errors to OM before throwing errors in NitrogenIncorporation.
+- [2143](https://github.com/RuminantFarmSystems/MASM/pull/2143) - [minor change] [GraphGenerator] Add user option to set time on x-axis for graphs.
 
 ### v0.9.2
 

--- a/tests/test_graph_generator.py
+++ b/tests/test_graph_generator.py
@@ -239,7 +239,7 @@ def test_generate_graph_success(graph_generator: GraphGenerator, mocker: MockerF
         filtered_pool, graph_details, filter_file_name, graphics_dir, True
     )
     graph_generator._draw_graph.assert_called_once_with(
-        "plot", prepared_data, list(prepared_data.keys()), False, mock_ax, False
+        "plot", prepared_data, list(prepared_data.keys()), mock_ax, False, False
     )
     graph_generator._customize_graph.assert_called_once()
     graph_generator._save_graph.assert_called_once_with(graph_details, filter_file_name, graphics_dir)
@@ -422,7 +422,7 @@ def test_draw_graph_success_tuple_plot(graph_generator: GraphGenerator, mocker: 
     with patch.dict(
         "RUFAS.graph_generator.MATPLOTLIB_PLOT_FUNCTIONS", {"stackplot": MagicMock()}
     ) as mock_plot_functions_dict:
-        graph_generator._draw_graph("stackplot", data, selected_variables, False, mock_ax, False)
+        graph_generator._draw_graph("stackplot", data, selected_variables, mock_ax, False, False)
 
         mock_plot_functions_dict["stackplot"].assert_called_once_with(
             list(range(len(data["key1"]))), (data["key1"], data["key2"])

--- a/tests/test_graph_generator.py
+++ b/tests/test_graph_generator.py
@@ -238,8 +238,9 @@ def test_generate_graph_success(graph_generator: GraphGenerator, mocker: MockerF
     assert mock_log_pool == graph_generator.generate_graph(
         filtered_pool, graph_details, filter_file_name, graphics_dir, True
     )
-    graph_generator._draw_graph.assert_called_once_with("plot", prepared_data, list(prepared_data.keys()), False,
-                                                        mock_ax, False)
+    graph_generator._draw_graph.assert_called_once_with(
+        "plot", prepared_data, list(prepared_data.keys()), False, mock_ax, False
+    )
     graph_generator._customize_graph.assert_called_once()
     graph_generator._save_graph.assert_called_once_with(graph_details, filter_file_name, graphics_dir)
     mock_remove_special_chars.assert_called_once()
@@ -438,17 +439,23 @@ def test_draw_graph_success_plot(graph_generator: GraphGenerator, mocker: Mocker
     graph_generator.time = mock_time
     mock_ax = mocker.MagicMock()
     mocker.patch("matplotlib.pyplot.subplots", return_value=(mocker.MagicMock(), mock_ax))
-    masker = mocker.patch("RUFAS.graph_generator.GraphGenerator._mask_values", return_value=(masked_indices, masked_values))
+    masker = mocker.patch(
+        "RUFAS.graph_generator.GraphGenerator._mask_values", return_value=(masked_indices, masked_values)
+    )
 
     with patch.dict(
         "RUFAS.graph_generator.MATPLOTLIB_PLOT_FUNCTIONS", {"plot": MagicMock()}
     ) as mock_plot_functions_dict:
-        graph_generator._draw_graph("plot", data, list(data.keys()), mask_values=False, ax=mock_ax, use_calendar_dates=False)
+        graph_generator._draw_graph(
+            "plot", data, list(data.keys()), mask_values=False, ax=mock_ax, use_calendar_dates=False
+        )
 
         for key, value in data.items():
             mock_plot_functions_dict["plot"].assert_any_call(indices, value)
 
-        graph_generator._draw_graph("plot", data, list(data.keys()), mask_values=True, ax=mock_ax, use_calendar_dates=False)
+        graph_generator._draw_graph(
+            "plot", data, list(data.keys()), mask_values=True, ax=mock_ax, use_calendar_dates=False
+        )
 
         for key, value in data.items():
             mock_plot_functions_dict["plot"].assert_any_call(masked_indices, masked_values)

--- a/tests/test_graph_generator.py
+++ b/tests/test_graph_generator.py
@@ -1,3 +1,4 @@
+import datetime
 from pathlib import Path
 from typing import Any, Dict, List
 from unittest.mock import patch
@@ -231,10 +232,14 @@ def test_generate_graph_success(graph_generator: GraphGenerator, mocker: MockerF
     graph_details = {"type": "plot", "filters": ["var1", "var2"], "title": "dummy.graph/title", "display_units": True}
     filter_file_name = "filter_file"
     graphics_dir = Path("graphs")
+    mock_ax = mocker.MagicMock()
+    mocker.patch("matplotlib.pyplot.subplots", return_value=(mocker.MagicMock(), mock_ax))
+
     assert mock_log_pool == graph_generator.generate_graph(
         filtered_pool, graph_details, filter_file_name, graphics_dir, True
     )
-    graph_generator._draw_graph.assert_called_once_with("plot", prepared_data, list(prepared_data.keys()), False)
+    graph_generator._draw_graph.assert_called_once_with("plot", prepared_data, list(prepared_data.keys()), False,
+                                                        mock_ax, False)
     graph_generator._customize_graph.assert_called_once()
     graph_generator._save_graph.assert_called_once_with(graph_details, filter_file_name, graphics_dir)
     mock_remove_special_chars.assert_called_once()
@@ -376,12 +381,20 @@ def test_set_graph_legend(graph_generator: GraphGenerator, graph_details, prepar
     assert result["legend"] == expected_legend
 
 
-def test_draw_graph_exception(graph_generator: GraphGenerator) -> None:
+def test_draw_graph_exception(graph_generator: GraphGenerator, mocker: MockerFixture) -> None:
+    mock_ax = mocker.MagicMock()
+    mocker.patch("matplotlib.pyplot.subplots", return_value=(mocker.MagicMock(), mock_ax))
+    mock_time = MagicMock()
+    mock_time.start_date = datetime.datetime(2020, 1, 1)
+    graph_generator.time = mock_time
     with pytest.raises(ValueError):
         graph_generator._draw_graph(
             graph_type="invalid graph type",
             data={},
             selected_variables=["var1", "var2"],
+            mask_values=False,
+            ax=mock_ax,
+            use_calendar_dates=False,
         )
     with pytest.raises(TypeError):
         graph_generator._draw_graph(
@@ -391,16 +404,24 @@ def test_draw_graph_exception(graph_generator: GraphGenerator) -> None:
                 "key2": {"values": [{"a": 5, "b": 6}, {"a": 7, "b": 8}]},
             },
             selected_variables=None,
+            mask_values=False,
+            ax=mock_ax,
+            use_calendar_dates=False,
         )
 
 
-def test_draw_graph_success_tuple_plot(graph_generator: GraphGenerator) -> None:
+def test_draw_graph_success_tuple_plot(graph_generator: GraphGenerator, mocker: MockerFixture) -> None:
     data = {"key1": [1, 2, 3, 4], "key2": [5, 6, 7, 8]}
     selected_variables = ["key1", "key2"]
+    mock_ax = mocker.MagicMock()
+    mocker.patch("matplotlib.pyplot.subplots", return_value=(mocker.MagicMock(), mock_ax))
+    mock_time = MagicMock()
+    mock_time.start_date = datetime.datetime(2020, 1, 1)
+    graph_generator.time = mock_time
     with patch.dict(
         "RUFAS.graph_generator.MATPLOTLIB_PLOT_FUNCTIONS", {"stackplot": MagicMock()}
     ) as mock_plot_functions_dict:
-        graph_generator._draw_graph("stackplot", data, selected_variables)
+        graph_generator._draw_graph("stackplot", data, selected_variables, False, mock_ax, False)
 
         mock_plot_functions_dict["stackplot"].assert_called_once_with(
             list(range(len(data["key1"]))), (data["key1"], data["key2"])
@@ -409,23 +430,29 @@ def test_draw_graph_success_tuple_plot(graph_generator: GraphGenerator) -> None:
 
 def test_draw_graph_success_plot(graph_generator: GraphGenerator, mocker: MockerFixture) -> None:
     data = {"key1": [1, 2, 3, 4], "key2": [5, 6, 7, 8]}
+    indices = [0, 1, 2, 3]
+    masked_indices = indices
+    masked_values = [1, 2, 3, 4]
+    mock_time = MagicMock()
+    mock_time.start_date = datetime.datetime(2020, 1, 1)
+    graph_generator.time = mock_time
+    mock_ax = mocker.MagicMock()
+    mocker.patch("matplotlib.pyplot.subplots", return_value=(mocker.MagicMock(), mock_ax))
+    masker = mocker.patch("RUFAS.graph_generator.GraphGenerator._mask_values", return_value=(masked_indices, masked_values))
+
     with patch.dict(
         "RUFAS.graph_generator.MATPLOTLIB_PLOT_FUNCTIONS", {"plot": MagicMock()}
     ) as mock_plot_functions_dict:
-        graph_generator._draw_graph("plot", data)
+        graph_generator._draw_graph("plot", data, list(data.keys()), mask_values=False, ax=mock_ax, use_calendar_dates=False)
 
-        for value in data.values():
-            mock_plot_functions_dict["plot"].assert_any_call(value)
+        for key, value in data.items():
+            mock_plot_functions_dict["plot"].assert_any_call(indices, value)
 
-    indices, masked_values = [0, 1, 2, 3], [1, 2, 3, 4]
-    masker = mocker.patch("RUFAS.graph_generator.GraphGenerator._mask_values", return_value=(indices, masked_values))
-    with patch.dict(
-        "RUFAS.graph_generator.MATPLOTLIB_PLOT_FUNCTIONS", {"plot": MagicMock()}
-    ) as mock_plot_functions_dict:
-        graph_generator._draw_graph("plot", data, mask_values=True)
+        graph_generator._draw_graph("plot", data, list(data.keys()), mask_values=True, ax=mock_ax, use_calendar_dates=False)
 
-        for value in data.values():
-            mock_plot_functions_dict["plot"].assert_any_call(indices, masked_values)
+        for key, value in data.items():
+            mock_plot_functions_dict["plot"].assert_any_call(masked_indices, masked_values)
+
     assert masker.call_count == 2
 
 

--- a/tests/test_graph_generator.py
+++ b/tests/test_graph_generator.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 from freezegun import freeze_time
 from matplotlib import pyplot as plt
+import matplotlib.dates as mdates
 from mock.mock import MagicMock
 from pytest_mock import MockerFixture
 
@@ -239,7 +240,7 @@ def test_generate_graph_success(graph_generator: GraphGenerator, mocker: MockerF
         filtered_pool, graph_details, filter_file_name, graphics_dir, True
     )
     graph_generator._draw_graph.assert_called_once_with(
-        "plot", prepared_data, list(prepared_data.keys()), mock_ax, False, False, None, None
+        "plot", prepared_data, list(prepared_data.keys()), mock_ax, False, False, None, None, None
     )
     graph_generator._customize_graph.assert_called_once()
     graph_generator._save_graph.assert_called_once_with(graph_details, filter_file_name, graphics_dir)
@@ -522,6 +523,29 @@ def test_draw_graph_sliced_data(graph_generator: GraphGenerator, mocker: MockerF
         mock_plot_functions_dict["plot"].assert_any_call(expected_indices, data["key2"])
 
     assert masker.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "user_input, expected_format",
+    [
+        ("day_of_year", "%j/%Y"),    # Valid input: Day of Year / Year
+        ("day_month_year", "%d/%m/%Y"),  # Valid input: Day / Month / Year
+        ("unknown_format", "%d/%m/%Y"),  # Invalid input: Default fallback
+        ("", "%d/%m/%Y"),           # Edge case: Empty string
+        (None, "%d/%m/%Y"),         # Edge case: None input
+        (12345, "%d/%m/%Y"),        # Edge case: Non-string input
+    ],
+)
+def test_get_date_formatter(user_input: str | None, expected_format: str) -> None:
+    """Test the `get_date_formatter` function with various inputs."""
+    graph_generator = GraphGenerator()
+    formatter = graph_generator.get_date_formatter(user_input)
+    assert isinstance(formatter, mdates.DateFormatter)
+    sample_date = datetime.datetime(2024, 1, 1)
+    numerical_date = mdates.date2num(sample_date)
+    formatted_date = formatter(numerical_date)
+    expected_date = sample_date.strftime(expected_format)
+    assert formatted_date == expected_date
 
 
 def test_mask_values(graph_generator: GraphGenerator) -> None:

--- a/tests/test_graph_generator.py
+++ b/tests/test_graph_generator.py
@@ -239,7 +239,7 @@ def test_generate_graph_success(graph_generator: GraphGenerator, mocker: MockerF
         filtered_pool, graph_details, filter_file_name, graphics_dir, True
     )
     graph_generator._draw_graph.assert_called_once_with(
-        "plot", prepared_data, list(prepared_data.keys()), mock_ax, False, False
+        "plot", prepared_data, list(prepared_data.keys()), mock_ax, False, False, None, None
     )
     graph_generator._customize_graph.assert_called_once()
     graph_generator._save_graph.assert_called_once_with(graph_details, filter_file_name, graphics_dir)
@@ -461,6 +461,62 @@ def test_draw_graph_success_plot(graph_generator: GraphGenerator, mocker: Mocker
             mock_plot_functions_dict["plot"].assert_any_call(masked_indices, masked_values)
 
     assert masker.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "slice_start, slice_end, use_calendar_dates, expected_calls",
+    [
+        # Case 1: No slicing
+        (None, None, False, [
+            ([0, 1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6, 7]),
+            ([0, 1, 2, 3, 4, 5, 6], [8, 7, 6, 5, 4, 3, 2]),
+        ]),
+        # Case 2: slice_start=2, slice_end=5
+        (2, 5, True, [
+            ([datetime.datetime(2020, 1, 3), datetime.datetime(2020, 1, 4), datetime.datetime(2020, 1, 5)], [3, 4, 5]),
+            ([datetime.datetime(2020, 1, 3), datetime.datetime(2020, 1, 4), datetime.datetime(2020, 1, 5)], [6, 5, 4]),
+        ]),
+        # # Case 3: slice_start=-3, slice_end=None
+        # (-3, None, False, [4, 5, 6], [5, 6, 7]),
+        # # Case 4: slice_start=-10, slice_end=-7 (negative indices beyond range)
+        # (-10, -7, False, [], []),
+    ],
+)
+def test_draw_graph_with_slicing_parametrized(
+    graph_generator: GraphGenerator,
+    mocker: MockerFixture,
+    slice_start,
+    slice_end,
+    use_calendar_dates,
+    expected_calls
+) -> None:
+    """Tests _draw_graph with slicing."""
+    data = {"key1": [1, 2, 3, 4, 5, 6, 7], "key2": [8, 7, 6, 5, 4, 3, 2]}
+
+    mock_time = MagicMock()
+    mock_time.start_date = datetime.datetime(2020, 1, 1)
+    mock_time.simulation_length_days = 7
+    mock_time.convert_simulation_day_to_date.side_effect = lambda x: mock_time.start_date + datetime.timedelta(days=x)
+    graph_generator.time = mock_time
+
+    mock_ax = mocker.MagicMock()
+    mocker.patch("matplotlib.pyplot.subplots", return_value=(mocker.MagicMock(), mock_ax))
+    with patch.dict(
+        "RUFAS.graph_generator.MATPLOTLIB_PLOT_FUNCTIONS", {"plot": MagicMock()}
+    ) as mock_plot_functions_dict:
+        graph_generator._draw_graph(
+            "plot",
+            data,
+            list(data.keys()),
+            ax=mock_ax,
+            mask_values=False,
+            use_calendar_dates=use_calendar_dates,
+            slice_start=slice_start,
+            slice_end=slice_end,
+        )
+        print("Actual calls:", mock_plot_functions_dict["plot"].call_args_list)
+        for expected_x, expected_y in expected_calls:
+            mock_plot_functions_dict["plot"].assert_any_call(expected_x, expected_y)
 
 
 def test_mask_values(graph_generator: GraphGenerator) -> None:

--- a/tests/test_graph_generator.py
+++ b/tests/test_graph_generator.py
@@ -463,6 +463,67 @@ def test_draw_graph_success_plot(graph_generator: GraphGenerator, mocker: Mocker
     assert masker.call_count == 2
 
 
+def test_draw_graph_sliced_data(graph_generator: GraphGenerator, mocker: MockerFixture) -> None:
+    """Tests _draw_graph with in the GraphGenerator with sliced data."""
+    data = {
+        "key1": [2, 3, 4],
+        "key2": [8, 9, 10],
+    }
+    slice_start = 1
+    slice_end = 4
+    expected_indices = [
+        datetime.datetime(2020, 1, 2),
+        datetime.datetime(2020, 1, 3),
+        datetime.datetime(2020, 1, 4),
+    ]
+
+    mock_time = MagicMock()
+    mock_time.start_date = datetime.datetime(2020, 1, 1)
+    mock_time.convert_slice_to_simulation_day.side_effect = lambda x: x
+    mock_time.convert_simulation_day_to_date.side_effect = lambda x: mock_time.start_date + datetime.timedelta(days=x)
+    graph_generator.time = mock_time
+
+    mock_ax = mocker.MagicMock()
+    mocker.patch("matplotlib.pyplot.subplots", return_value=(mocker.MagicMock(), mock_ax))
+    masker = mocker.patch(
+        "RUFAS.graph_generator.GraphGenerator._mask_values",
+        side_effect=lambda values: (expected_indices, values),
+    )
+
+    with patch.dict(
+        "RUFAS.graph_generator.MATPLOTLIB_PLOT_FUNCTIONS", {"plot": MagicMock()}
+    ) as mock_plot_functions_dict:
+        graph_generator._draw_graph(
+            "plot",
+            data,
+            list(data.keys()),
+            mask_values=False,
+            ax=mock_ax,
+            use_calendar_dates=True,
+            slice_start=slice_start,
+            slice_end=slice_end,
+        )
+
+        mock_plot_functions_dict["plot"].assert_any_call(expected_indices, data["key1"])
+        mock_plot_functions_dict["plot"].assert_any_call(expected_indices, data["key2"])
+
+        graph_generator._draw_graph(
+            "plot",
+            data,
+            list(data.keys()),
+            mask_values=True,
+            ax=mock_ax,
+            use_calendar_dates=True,
+            slice_start=slice_start,
+            slice_end=slice_end,
+        )
+
+        mock_plot_functions_dict["plot"].assert_any_call(expected_indices, data["key1"])
+        mock_plot_functions_dict["plot"].assert_any_call(expected_indices, data["key2"])
+
+    assert masker.call_count == 2
+
+
 def test_mask_values(graph_generator: GraphGenerator) -> None:
     """Tests _mask_values in the GraphGenerator."""
     values_one = [1, 2, 3, 4]

--- a/tests/test_graph_generator.py
+++ b/tests/test_graph_generator.py
@@ -378,8 +378,7 @@ def test_generate_legend_keys(
         ({}, {}, []),
     ],
 )
-def test_set_graph_legend(graph_generator: GraphGenerator, graph_details, prepared_data, expected_legend
-                          ) -> None:
+def test_set_graph_legend(graph_generator: GraphGenerator, graph_details, prepared_data, expected_legend) -> None:
     result = graph_generator._set_graph_legend(graph_details, prepared_data)
     assert result["legend"] == expected_legend
 

--- a/tests/test_graph_generator.py
+++ b/tests/test_graph_generator.py
@@ -528,12 +528,12 @@ def test_draw_graph_sliced_data(graph_generator: GraphGenerator, mocker: MockerF
 @pytest.mark.parametrize(
     "user_input, expected_format",
     [
-        ("day_of_year", "%j/%Y"),    # Valid input: Day of Year / Year
+        ("day_of_year", "%j/%Y"),  # Valid input: Day of Year / Year
         ("day_month_year", "%d/%m/%Y"),  # Valid input: Day / Month / Year
         ("unknown_format", "%d/%m/%Y"),  # Invalid input: Default fallback
-        ("", "%d/%m/%Y"),           # Edge case: Empty string
-        (None, "%d/%m/%Y"),         # Edge case: None input
-        (12345, "%d/%m/%Y"),        # Edge case: Non-string input
+        ("", "%d/%m/%Y"),  # Edge case: Empty string
+        (None, "%d/%m/%Y"),  # Edge case: None input
+        (12345, "%d/%m/%Y"),  # Edge case: Non-string input
     ],
 )
 def test_get_date_formatter(user_input: str | None, expected_format: str) -> None:

--- a/tests/test_graph_generator.py
+++ b/tests/test_graph_generator.py
@@ -412,7 +412,7 @@ def test_draw_graph_exception(graph_generator: GraphGenerator, mocker: MockerFix
 
 
 def test_draw_graph_success_tuple_plot(graph_generator: GraphGenerator, mocker: MockerFixture) -> None:
-    data = {"key1": [1, 2, 3, 4], "key2": [5, 6, 7, 8]}
+    data: dict[str, list[int | float]] = {"key1": [1, 2, 3, 4], "key2": [5, 6, 7, 8]}
     selected_variables = ["key1", "key2"]
     mock_ax = mocker.MagicMock()
     mocker.patch("matplotlib.pyplot.subplots", return_value=(mocker.MagicMock(), mock_ax))
@@ -430,7 +430,7 @@ def test_draw_graph_success_tuple_plot(graph_generator: GraphGenerator, mocker: 
 
 
 def test_draw_graph_success_plot(graph_generator: GraphGenerator, mocker: MockerFixture) -> None:
-    data = {"key1": [1, 2, 3, 4], "key2": [5, 6, 7, 8]}
+    data: dict[str, list[int | float]] = {"key1": [1, 2, 3, 4], "key2": [5, 6, 7, 8]}
     indices = [0, 1, 2, 3]
     masked_indices = indices
     masked_values = [1, 2, 3, 4]
@@ -465,7 +465,7 @@ def test_draw_graph_success_plot(graph_generator: GraphGenerator, mocker: Mocker
 
 def test_draw_graph_sliced_data(graph_generator: GraphGenerator, mocker: MockerFixture) -> None:
     """Tests _draw_graph with in the GraphGenerator with sliced data."""
-    data = {
+    data: dict[str, list[int | float]] = {
         "key1": [2, 3, 4],
         "key2": [8, 9, 10],
     }

--- a/tests/test_graph_generator.py
+++ b/tests/test_graph_generator.py
@@ -378,7 +378,8 @@ def test_generate_legend_keys(
         ({}, {}, []),
     ],
 )
-def test_set_graph_legend(graph_generator: GraphGenerator, graph_details, prepared_data, expected_legend):
+def test_set_graph_legend(graph_generator: GraphGenerator, graph_details, prepared_data, expected_legend
+                          ) -> None:
     result = graph_generator._set_graph_legend(graph_details, prepared_data)
     assert result["legend"] == expected_legend
 
@@ -667,7 +668,7 @@ def test_log_non_numerical_data(
 )
 def test_validate_graph_filter(
     graph_generator: GraphGenerator,
-    graph_details: Dict[str, str],
+    graph_details: dict[str, str],
     expected_length: int,
     expected_message: str,
 ) -> None:
@@ -726,7 +727,7 @@ def test_add_var_units(
     graph_title: str,
     expected_output: dict[str, dict[str, list[Any]]],
     expected_logs: list[dict[str, str | dict[str, str]]],
-):
+) -> None:
     """Test for the _add_var_units() method in graph_generator.py"""
     updated_pool, logs = graph_generator._add_var_units(filtered_pool, graph_title)
     assert updated_pool == expected_output

--- a/tests/test_graph_generator.py
+++ b/tests/test_graph_generator.py
@@ -463,62 +463,6 @@ def test_draw_graph_success_plot(graph_generator: GraphGenerator, mocker: Mocker
     assert masker.call_count == 2
 
 
-@pytest.mark.parametrize(
-    "slice_start, slice_end, use_calendar_dates, expected_calls",
-    [
-        # Case 1: No slicing
-        (None, None, False, [
-            ([0, 1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6, 7]),
-            ([0, 1, 2, 3, 4, 5, 6], [8, 7, 6, 5, 4, 3, 2]),
-        ]),
-        # Case 2: slice_start=2, slice_end=5
-        (2, 5, True, [
-            ([datetime.datetime(2020, 1, 3), datetime.datetime(2020, 1, 4), datetime.datetime(2020, 1, 5)], [3, 4, 5]),
-            ([datetime.datetime(2020, 1, 3), datetime.datetime(2020, 1, 4), datetime.datetime(2020, 1, 5)], [6, 5, 4]),
-        ]),
-        # # Case 3: slice_start=-3, slice_end=None
-        # (-3, None, False, [4, 5, 6], [5, 6, 7]),
-        # # Case 4: slice_start=-10, slice_end=-7 (negative indices beyond range)
-        # (-10, -7, False, [], []),
-    ],
-)
-def test_draw_graph_with_slicing_parametrized(
-    graph_generator: GraphGenerator,
-    mocker: MockerFixture,
-    slice_start,
-    slice_end,
-    use_calendar_dates,
-    expected_calls
-) -> None:
-    """Tests _draw_graph with slicing."""
-    data = {"key1": [1, 2, 3, 4, 5, 6, 7], "key2": [8, 7, 6, 5, 4, 3, 2]}
-
-    mock_time = MagicMock()
-    mock_time.start_date = datetime.datetime(2020, 1, 1)
-    mock_time.simulation_length_days = 7
-    mock_time.convert_simulation_day_to_date.side_effect = lambda x: mock_time.start_date + datetime.timedelta(days=x)
-    graph_generator.time = mock_time
-
-    mock_ax = mocker.MagicMock()
-    mocker.patch("matplotlib.pyplot.subplots", return_value=(mocker.MagicMock(), mock_ax))
-    with patch.dict(
-        "RUFAS.graph_generator.MATPLOTLIB_PLOT_FUNCTIONS", {"plot": MagicMock()}
-    ) as mock_plot_functions_dict:
-        graph_generator._draw_graph(
-            "plot",
-            data,
-            list(data.keys()),
-            ax=mock_ax,
-            mask_values=False,
-            use_calendar_dates=use_calendar_dates,
-            slice_start=slice_start,
-            slice_end=slice_end,
-        )
-        print("Actual calls:", mock_plot_functions_dict["plot"].call_args_list)
-        for expected_x, expected_y in expected_calls:
-            mock_plot_functions_dict["plot"].assert_any_call(expected_x, expected_y)
-
-
 def test_mask_values(graph_generator: GraphGenerator) -> None:
     """Tests _mask_values in the GraphGenerator."""
     values_one = [1, 2, 3, 4]

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -204,3 +204,27 @@ def test_convert_year_jday_to_date(
 
     actual = time.convert_year_jday_to_date(year, jday)
     assert expected == actual
+
+
+@pytest.mark.parametrize(
+    "slice_day, simulation_length_days, expected_sim_day",
+    [
+        (0, 100, 1),
+        (5, 100, 5),
+        (-1, 100, 100),
+        (-100, 100, 1),
+        (100, 100, 100),
+        (150, 100, 150),
+    ],
+)
+def test_convert_slice_to_simulation_day(slice_day: int, simulation_length_days: int, expected_sim_day: int,
+                                         mocker: MockerFixture) -> None:
+    """Test convert_slice_to_simulation_day for various slice_day inputs."""
+    mocker.patch("RUFAS.input_manager.InputManager.get_data",
+                 return_value={"start_date": "2023:1", "end_date": "2023:100"})
+    mock_time = Time()
+
+    mock_time.simulation_length_days = simulation_length_days
+
+    result = mock_time.convert_slice_to_simulation_day(slice_day)
+    assert result == expected_sim_day, f"Expected {expected_sim_day} but got {result} for slice_day={slice_day}"

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -217,11 +217,13 @@ def test_convert_year_jday_to_date(
         (150, 100, 150),
     ],
 )
-def test_convert_slice_to_simulation_day(slice_day: int, simulation_length_days: int, expected_sim_day: int,
-                                         mocker: MockerFixture) -> None:
+def test_convert_slice_to_simulation_day(
+    slice_day: int, simulation_length_days: int, expected_sim_day: int, mocker: MockerFixture
+) -> None:
     """Test convert_slice_to_simulation_day for various slice_day inputs."""
-    mocker.patch("RUFAS.input_manager.InputManager.get_data",
-                 return_value={"start_date": "2023:1", "end_date": "2023:100"})
+    mocker.patch(
+        "RUFAS.input_manager.InputManager.get_data", return_value={"start_date": "2023:1", "end_date": "2023:100"}
+    )
     mock_time = Time()
 
     mock_time.simulation_length_days = simulation_length_days


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Adds an user option to set the x-axis in graphs to use calendar dates instead of a simulation day counter.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #912

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Adds an optional boolean flag in graph filters `use_calendar_dates` to set whether they want the x-axis of their graphs to be calendar dates in the format of ordinal date (e.g. 001/2015, 229/2019). The default setting is `False` which will default the graph to plot using simulation day counter (i.e. what it currently does on dev).

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
This feature was requested from SMEs to have an option to see the data presented in a different manner which they said would be more helpful for results analysis.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
The `use_calendar_dates` flag is checked for and then sent to the GG's `_draw_graph()` method.
Within `draw_graph()`, the date range of the data to graph is determined based on the start date of the simulation from the Time class instance sent to GG.
A new helper function (`get_x_values()`) is set up within `_draw_graph()` which returns the x-axis values to match whether the user wants calendar dates or not.
Data is then plotted much the same way it was before and the only other difference is if the user does want calendar dates on the x-axis, some additional graph formatting is done to make the graph more readable.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Create a graph filter and try a version with `use_calendar_dates` set to `True` and then try it without that flag in the filter file.
The `True` version should have calendar dates across the x-axis.
Every other version should have the simulation day counter as before.

my example filter file:
`graph_tester.json`

```
{
    "type": "plot",
    "filters": [
      ".*ammonia_emissions.*"
    ],
    "title": "Ammonia Emissions",
    "use_calendar_dates": true
}
```
<img width="1257" alt="Screenshot 2024-12-18 at 12 06 47 PM" src="https://github.com/user-attachments/assets/20f2ed87-8e19-4777-b73c-eeb3824bc003" />

And then the default version without specifying the `use_calendar_dates` flag or setting it to `False`:
<img width="1257" alt="Screenshot 2024-12-18 at 12 10 37 PM" src="https://github.com/user-attachments/assets/cd00b388-961a-48e1-a712-2d8203d47749" />

