### PR TITLE
[Crop and Soil] Relocate TillageImplements Enum from EEE to data_structures dir

### DIFF
--- a/RUFAS/data_structures/events.py
+++ b/RUFAS/data_structures/events.py
@@ -8,9 +8,9 @@ specific harvest method will be used when harvesting a crop, and a `crop_referen
 crop that is presently growing in a field will be harvested.
 """
 
-from RUFAS.routines.EEE.enums import TillageImplement
-from RUFAS.routines.field.crop.harvest_operations import HarvestOperation
 from RUFAS.data_structures.manure_types import ManureType
+from RUFAS.data_structures.tillage_implements import TillageImplement
+from RUFAS.routines.field.crop.harvest_operations import HarvestOperation
 from RUFAS.time import Time
 
 

--- a/RUFAS/data_structures/tillage_implements.py
+++ b/RUFAS/data_structures/tillage_implements.py
@@ -4,6 +4,7 @@ from enum import Enum
 class TillageImplement(Enum):
     """
     Defines the supported tillage implements for RuFaS.
+
     Attributes
     ----------
     SUBSOILER : str

--- a/RUFAS/routines/field/field/tillage_application.py
+++ b/RUFAS/routines/field/field/tillage_application.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
+from RUFAS.data_structures.tillage_implements import TillageImplement
 from RUFAS.output_manager import OutputManager
-from RUFAS.routines.EEE.enums import TillageImplement
 from RUFAS.routines.field.field.field_data import FieldData
 from RUFAS.routines.field.soil.manure_pool import ManurePool
 from RUFAS.routines.field.soil.soil_data import SoilData

--- a/RUFAS/routines/field/manager/tillage_schedule.py
+++ b/RUFAS/routines/field/manager/tillage_schedule.py
@@ -1,7 +1,7 @@
 from typing import List, Any
 
-from RUFAS.routines.EEE.enums import TillageImplement
 from RUFAS.data_structures.events import TillageEvent
+from RUFAS.data_structures.tillage_implements import TillageImplement
 from RUFAS.routines.field.manager.schedule import Schedule
 from RUFAS.util import Utility
 

--- a/changelog.md
+++ b/changelog.md
@@ -70,6 +70,7 @@ v0.9.2
 - [2067](https://github.com/RuminantFarmSystems/MASM/pull/2067) - [minor change] [EEE] Adds updated feeds emissions sheets, which replaces 0s with the average of neighboring FIPS codes.
 - [2120](https://github.com/RuminantFarmSystems/MASM/pull/2120) - [minor change] [Crop and Soil] Log errors to OM before throwing errors in NitrogenIncorporation.
 - [2133](https://github.com/RuminantFarmSystems/MASM/pull/2133) - [minor change] [Animal] Use closest available genetic data for animals entering the herd or being initialized as calves. 
+- [2149](https://github.com/RuminantFarmSystems/MASM/pull/2149) - [minor change] [Crop and Soil] Relocates TillageImplements to data structures dir.
 
 
 ### v0.9.2

--- a/tests/soil_crop_tests/field_tests/test_field.py
+++ b/tests/soil_crop_tests/field_tests/test_field.py
@@ -11,8 +11,8 @@ from RUFAS.data_structures.manure_to_crop_soil_connection import (
     ManureEventNutrientRequestResults,
 )
 from RUFAS.data_structures.crop_soil_to_feed_storage_connection import HarvestedCropStorageType, StorageType
+from RUFAS.data_structures.tillage_implements import TillageImplement
 from RUFAS.output_manager import OutputManager
-from RUFAS.routines.EEE.enums import TillageImplement
 from RUFAS.routines.field.crop.crop import Crop
 from RUFAS.routines.field.crop.crop_data import CropData
 from RUFAS.routines.field.crop.crop_enum import CropSpecies

--- a/tests/soil_crop_tests/field_tests/test_tillage_application.py
+++ b/tests/soil_crop_tests/field_tests/test_tillage_application.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, PropertyMock, call
 import pytest
 from pytest_mock import MockerFixture
 
-from RUFAS.routines.EEE.enums import TillageImplement
+from RUFAS.data_structures.tillage_implements import TillageImplement
 from RUFAS.routines.field.field.field import Field
 from RUFAS.routines.field.field.field_data import FieldData
 from RUFAS.routines.field.field.tillage_application import TillageApplication

--- a/tests/soil_crop_tests/manager_tests/test_events.py
+++ b/tests/soil_crop_tests/manager_tests/test_events.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from RUFAS.routines.EEE.enums import TillageImplement
+from RUFAS.data_structures.tillage_implements import TillageImplement
 from RUFAS.routines.field.crop.harvest_operations import HarvestOperation
 from RUFAS.data_structures.events import (
     BaseFieldManagementEvent,

--- a/tests/soil_crop_tests/manager_tests/test_tillage_schedule.py
+++ b/tests/soil_crop_tests/manager_tests/test_tillage_schedule.py
@@ -2,7 +2,7 @@ from typing import List
 
 import pytest
 
-from RUFAS.routines.EEE.enums import TillageImplement
+from RUFAS.data_structures.tillage_implements import TillageImplement
 from RUFAS.data_structures.events import TillageEvent
 from RUFAS.routines.field.manager.tillage_schedule import TillageSchedule
 


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Moves the `TillageImplements` enum out of EEE to data_structures dir.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2077

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Pretty simple moving the `TillageImplements` enum to the data_structures dir and updating the references to the class across the codebase.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
This structure was residing in the EEE module but was used exclusively in the C&S module. It will be used by EEE in the future so the best location for it to match what we're doing with other similarly-used data structures is the move it to the data_structures dir.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Relocated the class and updated the references.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Not much beyond running the simulation and the test suite.