### PR TITLE
[GraphGenerator] Ensure Custom Graph Legend Matches Graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-96%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3446%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3459%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-96%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3462%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3456%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-96%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3459%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3440%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -228,7 +228,7 @@ class GraphGenerator:
             if graph_details.get("legend", False):
                 sorted_keys = sorted(
                     prepared_data.keys(),
-                    key=lambda k: self._generate_legend_keys(k, omit_legend_prefix=True, omit_legend_suffix=True),
+                    key=lambda k: self._generate_legend_keys(k, omit_legend_prefix=True, omit_legend_suffix=True)
                 )
                 prepared_data = {key: prepared_data[key] for key in sorted_keys}
             else:

--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -242,7 +242,10 @@ class GraphGenerator:
                 graph_details["title"] = corrected_graph_title
 
             if graph_details.get("legend"):
-                sorted_keys = sorted(prepared_data.keys(), key=lambda k: self._generate_legend_keys(k, omit_legend_prefix=True, omit_legend_suffix=True))
+                sorted_keys = sorted(
+                    prepared_data.keys(),
+                    key=lambda k: self._generate_legend_keys(k, omit_legend_prefix=True, omit_legend_suffix=True),
+                )
                 prepared_data = {key: prepared_data[key] for key in sorted_keys}
             else:
                 graph_details = self._set_graph_legend(graph_details, prepared_data)

--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -225,7 +225,14 @@ class GraphGenerator:
             mask_values = graph_details.get("mask_values", False)
             use_calendar_dates = graph_details.get("use_calendar_dates", False)
             date_format = graph_details.get("date_format", None)
-            print(prepared_data.keys())
+            if graph_details.get("legend", False):
+                sorted_keys = sorted(prepared_data.keys(), key=lambda k: self._generate_legend_keys(k, omit_legend_prefix=True, omit_legend_suffix=True))
+                prepared_data = {key: prepared_data[key] for key in sorted_keys}
+            else:
+                graph_details = self._set_graph_legend(graph_details, prepared_data)
+            if graph_details.get("title"):
+                corrected_graph_title = Utility.remove_special_chars(graph_details.get("title", "Untitled graph"))
+                graph_details["title"] = corrected_graph_title
             self._draw_graph(
                 graph_details["type"],
                 prepared_data,
@@ -237,18 +244,6 @@ class GraphGenerator:
                 graph_details.get("slice_start", None),
                 graph_details.get("slice_end", None),
             )
-            if graph_details.get("title"):
-                corrected_graph_title = Utility.remove_special_chars(graph_details.get("title", "Untitled graph"))
-                graph_details["title"] = corrected_graph_title
-
-            if graph_details.get("legend"):
-                sorted_keys = sorted(
-                    prepared_data.keys(),
-                    key=lambda k: self._generate_legend_keys(k, omit_legend_prefix=True, omit_legend_suffix=True),
-                )
-                prepared_data = {key: prepared_data[key] for key in sorted_keys}
-            else:
-                graph_details = self._set_graph_legend(graph_details, prepared_data)
 
             self._customize_graph(fig, graph_details)
             self._save_graph(graph_details, filter_file_name, graphics_dir)

--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -228,7 +228,7 @@ class GraphGenerator:
             if graph_details.get("legend", False):
                 sorted_keys = sorted(
                     prepared_data.keys(),
-                    key=lambda k: self._generate_legend_keys(k, omit_legend_prefix=True, omit_legend_suffix=True)
+                    key=lambda k: self._generate_legend_keys(k, omit_legend_prefix=True, omit_legend_suffix=True),
                 )
                 prepared_data = {key: prepared_data[key] for key in sorted_keys}
             else:

--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -226,7 +226,10 @@ class GraphGenerator:
             use_calendar_dates = graph_details.get("use_calendar_dates", False)
             date_format = graph_details.get("date_format", None)
             if graph_details.get("legend", False):
-                sorted_keys = sorted(prepared_data.keys(), key=lambda k: self._generate_legend_keys(k, omit_legend_prefix=True, omit_legend_suffix=True))
+                sorted_keys = sorted(
+                    prepared_data.keys(),
+                    key=lambda k: self._generate_legend_keys(k, omit_legend_prefix=True, omit_legend_suffix=True)
+                )
                 prepared_data = {key: prepared_data[key] for key in sorted_keys}
             else:
                 graph_details = self._set_graph_legend(graph_details, prepared_data)

--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -225,6 +225,7 @@ class GraphGenerator:
             mask_values = graph_details.get("mask_values", False)
             use_calendar_dates = graph_details.get("use_calendar_dates", False)
             date_format = graph_details.get("date_format", None)
+            print(prepared_data.keys())
             self._draw_graph(
                 graph_details["type"],
                 prepared_data,
@@ -239,7 +240,11 @@ class GraphGenerator:
             if graph_details.get("title"):
                 corrected_graph_title = Utility.remove_special_chars(graph_details.get("title", "Untitled graph"))
                 graph_details["title"] = corrected_graph_title
-            if not graph_details.get("legend"):
+
+            if graph_details.get("legend"):
+                sorted_keys = sorted(prepared_data.keys(), key=lambda k: self._generate_legend_keys(k, omit_legend_prefix=True, omit_legend_suffix=True))
+                prepared_data = {key: prepared_data[key] for key in sorted_keys}
+            else:
                 graph_details = self._set_graph_legend(graph_details, prepared_data)
 
             self._customize_graph(fig, graph_details)

--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -228,7 +228,7 @@ class GraphGenerator:
             if graph_details.get("legend", False):
                 sorted_keys = sorted(
                     prepared_data.keys(),
-                    key=lambda k: self._generate_legend_keys(k, omit_legend_prefix=True, omit_legend_suffix=True),
+                    key=lambda k: self._generate_legend_keys(k, omit_legend_prefix=True, omit_legend_suffix=False),
                 )
                 prepared_data = {key: prepared_data[key] for key in sorted_keys}
             else:

--- a/changelog.md
+++ b/changelog.md
@@ -78,6 +78,7 @@ v0.9.2
 - [2136](https://github.com/RuminantFarmSystems/MASM/pull/2136) - [minor change] [Animal] Adds data structures to support calculation of animal nutrient requirements and supply.
 - [2138](https://github.com/RuminantFarmSystems/MASM/pull/2138) - [minor change] [Animal] Refreshes module which calculates the nutrients supplied to an animal by a ration.
 - [2128](https://github.com/RuminantFarmSystems/MASM/pull/2128) - [minor change] [Animal] Updates culling-related metadata descriptions
+- [2164](https://github.com/RuminantFarmSystems/MASM/pull/2128) - [minor change] [GraphGenerator] Aligns graphs with alphabetized, user-customized GG legend.
 
 
 ### v0.9.2

--- a/tests/test_graph_generator.py
+++ b/tests/test_graph_generator.py
@@ -218,18 +218,18 @@ def test_generate_graph_error_found(graph_generator: GraphGenerator) -> None:
 
 
 def test_generate_graph_success(graph_generator: GraphGenerator, mocker: MockerFixture) -> None:
-    graph_generator._draw_graph = MagicMock()
-    graph_generator._customize_graph = MagicMock()
-    graph_generator._validate_graph_filter = MagicMock(return_value=[])
-    graph_generator._save_graph = MagicMock(return_value="graph path")
+    mocker.patch.object(graph_generator, "_draw_graph")
+    mocker.patch.object(graph_generator, "_customize_graph")
+    mocker.patch.object(graph_generator, "_validate_graph_filter", return_value=[])
+    mocker.patch.object(graph_generator, "_save_graph", return_value="graph path")
     filtered_pool = {"var1": {"values": [1, 2, 3]}}
     updated_pool = {"var1": {"values": [1, 2, 3], "units": "units"}}
     var_units_logs = []
-    graph_generator._add_var_units = MagicMock(return_value=(updated_pool, var_units_logs))
+    mocker.patch.object(graph_generator, "_add_var_units", return_value=(updated_pool, var_units_logs))
     prepared_data = {"var1": [1, 2, 3]}
     mock_log_pool = [{"log": "mock_log_message"}]
     mock_remove_special_chars = mocker.patch("RUFAS.util.Utility.remove_special_chars")
-    graph_generator._log_non_numerical_data = MagicMock(return_value=[{"log": "mock_log_message"}])
+    mocker.patch.object(graph_generator, "_log_non_numerical_data", return_value=[{"log": "mock_log_message"}])
     graph_details = {"type": "plot", "filters": ["var1", "var2"], "title": "dummy.graph/title", "display_units": True}
     filter_file_name = "filter_file"
     graphics_dir = Path("graphs")
@@ -249,15 +249,23 @@ def test_generate_graph_success(graph_generator: GraphGenerator, mocker: MockerF
 
 
 def test_generate_graph_with_custom_legend(graph_generator: GraphGenerator, mocker: MockerFixture) -> None:
-    graph_generator._draw_graph = MagicMock()
-    graph_generator._customize_graph = MagicMock()
-    graph_generator._validate_graph_filter = MagicMock(return_value=[])
-    graph_generator._save_graph = MagicMock()
-    graph_generator._generate_legend_keys = MagicMock(side_effect=lambda k, **kwargs: f"legend_{k}")
-    graph_generator._add_var_units = MagicMock(
-        return_value=({"var1": {"values": [1, 2, 3]}, "var2": {"values": [4, 5, 6]}}, [])
+    mocker.patch.object(graph_generator, "_draw_graph")
+    mocker.patch.object(graph_generator, "_customize_graph")
+    mocker.patch.object(graph_generator, "_validate_graph_filter", return_value=[])
+    mocker.patch.object(graph_generator, "_save_graph")
+    mock_generate_legend_keys = mocker.patch.object(
+        graph_generator,
+        "_generate_legend_keys",
+        side_effect=lambda k, **kwargs: f"legend_{k}",
     )
-    graph_generator._log_non_numerical_data = MagicMock(return_value=[])
+    mocker.patch.object(
+        graph_generator,
+        "_add_var_units",
+        return_value=({"var1": {"values": [1, 2, 3]}, "var2": {"values": [4, 5, 6]}}, []),
+    )
+    mocker.patch.object(graph_generator, "_log_non_numerical_data", return_value=[])
+    mock_ax = mocker.MagicMock()
+    mocker.patch("matplotlib.pyplot.subplots", return_value=(mocker.MagicMock(), mock_ax))
 
     filtered_pool = {"var1": {"values": [1, 2, 3]}, "var2": {"values": [4, 5, 6]}}
     graph_details = {
@@ -268,13 +276,11 @@ def test_generate_graph_with_custom_legend(graph_generator: GraphGenerator, mock
     }
     filter_file_name = "filter_file"
     graphics_dir = Path("graphs")
-    mock_ax = mocker.MagicMock()
-    mocker.patch("matplotlib.pyplot.subplots", return_value=(mocker.MagicMock(), mock_ax))
 
     graph_generator.generate_graph(filtered_pool, graph_details, filter_file_name, graphics_dir, True)
 
-    graph_generator._generate_legend_keys.assert_any_call("var1", omit_legend_prefix=True, omit_legend_suffix=True)
-    graph_generator._generate_legend_keys.assert_any_call("var2", omit_legend_prefix=True, omit_legend_suffix=True)
+    mock_generate_legend_keys.assert_any_call("var1", omit_legend_prefix=True, omit_legend_suffix=True)
+    mock_generate_legend_keys.assert_any_call("var2", omit_legend_prefix=True, omit_legend_suffix=True)
 
     sorted_keys = ["var1", "var2"]
     expected_prepared_data = {"var1": [1, 2, 3], "var2": [4, 5, 6]}
@@ -286,11 +292,11 @@ def test_generate_graph_with_custom_legend(graph_generator: GraphGenerator, mock
     graph_generator._save_graph.assert_called_once_with(graph_details, filter_file_name, graphics_dir)
 
 
-def test_generate_graph_exception(graph_generator: GraphGenerator) -> None:
-    graph_generator._draw_graph = MagicMock()
-    graph_generator._customize_graph = MagicMock()
-    graph_generator._validate_graph_filter = MagicMock(return_value=[])
-    graph_generator._save_graph = MagicMock(side_effect=Exception)
+def test_generate_graph_exception(graph_generator: GraphGenerator, mocker: MockerFixture) -> None:
+    mocker.patch.object(graph_generator, "_draw_graph")
+    mocker.patch.object(graph_generator, "_customize_graph")
+    mocker.patch.object(graph_generator, "_validate_graph_filter", return_value=[])
+    mocker.patch.object(graph_generator, "_save_graph", side_effect=Exception)
     filtered_pool = {}
     graph_details = {"type": "plot", "variables": ["var1", "var2"]}
     filter_file_name = "filter_file"

--- a/tests/test_graph_generator.py
+++ b/tests/test_graph_generator.py
@@ -254,7 +254,9 @@ def test_generate_graph_with_custom_legend(graph_generator: GraphGenerator, mock
     graph_generator._validate_graph_filter = MagicMock(return_value=[])
     graph_generator._save_graph = MagicMock()
     graph_generator._generate_legend_keys = MagicMock(side_effect=lambda k, **kwargs: f"legend_{k}")
-    graph_generator._add_var_units = MagicMock(return_value=({"var1": {"values": [1, 2, 3]}, "var2": {"values": [4, 5, 6]}}, []))
+    graph_generator._add_var_units = MagicMock(
+        return_value=({"var1": {"values": [1, 2, 3]}, "var2": {"values": [4, 5, 6]}}, [])
+    )
     graph_generator._log_non_numerical_data = MagicMock(return_value=[])
 
     filtered_pool = {"var1": {"values": [1, 2, 3]}, "var2": {"values": [4, 5, 6]}}

--- a/tests/test_graph_generator.py
+++ b/tests/test_graph_generator.py
@@ -279,8 +279,8 @@ def test_generate_graph_with_custom_legend(graph_generator: GraphGenerator, mock
 
     graph_generator.generate_graph(filtered_pool, graph_details, filter_file_name, graphics_dir, True)
 
-    mock_generate_legend_keys.assert_any_call("var1", omit_legend_prefix=True, omit_legend_suffix=True)
-    mock_generate_legend_keys.assert_any_call("var2", omit_legend_prefix=True, omit_legend_suffix=True)
+    mock_generate_legend_keys.assert_any_call("var1", omit_legend_prefix=True, omit_legend_suffix=False)
+    mock_generate_legend_keys.assert_any_call("var2", omit_legend_prefix=True, omit_legend_suffix=False)
 
     sorted_keys = ["var1", "var2"]
     expected_prepared_data = {"var1": [1, 2, 3], "var2": [4, 5, 6]}

--- a/tests/test_graph_generator.py
+++ b/tests/test_graph_generator.py
@@ -248,6 +248,42 @@ def test_generate_graph_success(graph_generator: GraphGenerator, mocker: MockerF
     graph_generator._add_var_units.assert_called_once_with(filtered_pool, "dummy.graph/title")
 
 
+def test_generate_graph_with_custom_legend(graph_generator: GraphGenerator, mocker: MockerFixture) -> None:
+    graph_generator._draw_graph = MagicMock()
+    graph_generator._customize_graph = MagicMock()
+    graph_generator._validate_graph_filter = MagicMock(return_value=[])
+    graph_generator._save_graph = MagicMock()
+    graph_generator._generate_legend_keys = MagicMock(side_effect=lambda k, **kwargs: f"legend_{k}")
+    graph_generator._add_var_units = MagicMock(return_value=({"var1": {"values": [1, 2, 3]}, "var2": {"values": [4, 5, 6]}}, []))
+    graph_generator._log_non_numerical_data = MagicMock(return_value=[])
+
+    filtered_pool = {"var1": {"values": [1, 2, 3]}, "var2": {"values": [4, 5, 6]}}
+    graph_details = {
+        "type": "plot",
+        "filters": ["var1", "var2"],
+        "title": "dummy graph",
+        "legend": True,
+    }
+    filter_file_name = "filter_file"
+    graphics_dir = Path("graphs")
+    mock_ax = mocker.MagicMock()
+    mocker.patch("matplotlib.pyplot.subplots", return_value=(mocker.MagicMock(), mock_ax))
+
+    graph_generator.generate_graph(filtered_pool, graph_details, filter_file_name, graphics_dir, True)
+
+    graph_generator._generate_legend_keys.assert_any_call("var1", omit_legend_prefix=True, omit_legend_suffix=True)
+    graph_generator._generate_legend_keys.assert_any_call("var2", omit_legend_prefix=True, omit_legend_suffix=True)
+
+    sorted_keys = ["var1", "var2"]
+    expected_prepared_data = {"var1": [1, 2, 3], "var2": [4, 5, 6]}
+    graph_generator._draw_graph.assert_called_once_with(
+        "plot", expected_prepared_data, sorted_keys, mock_ax, False, False, None, None, None
+    )
+
+    graph_generator._customize_graph.assert_called_once()
+    graph_generator._save_graph.assert_called_once_with(graph_details, filter_file_name, graphics_dir)
+
+
 def test_generate_graph_exception(graph_generator: GraphGenerator) -> None:
     graph_generator._draw_graph = MagicMock()
     graph_generator._customize_graph = MagicMock()


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Previously there were issues when the user opted to write their own custom legend with the legend matching what is graphed. This PR provides a method by which the user can set their own legend (and write var names however they want them to appear) and it will match the order of what is graphed. The caveat is that they have to organize their legend alphabetically according to the original variable names.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2145

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Sorts the data sent to GG alphabetically by variable name (the name of the variable itself, removed of the class and function context) and graphs it in that order if the user specifies their own custom legend.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
While GG will automatically generate a properly sorted and organized legend if the user doesn't specify a legend on their graph, the option to still write the names of the variables in the legend however the user wants would be helpful.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
- The new functionality first checks if the user has added a legend to their output filter.
- If they have, the data sent to be graphed will be sorted by variable name (e.g. if the filter has "^ManureTreatmentDailyOutput_Pen_3_LAC_COW.storage_methane$" and "ManureHandlerDailyOutput_Pen_3_LAC_COW.air_temperature", GG will sort them based on the variable portion of their filter-names only and therefore graph `air_temperature` first and then `storage_methane`).
**The user will be responsible for knowing this sorting and will have to sort their custom legend accordingly. We can't know what they will call these variables in advance nor tie them to the corresponding variable being graphed so having a sorting mechanism in place would be extremely difficult).**
- So for the above example, the user's custom legend should look like:
`legend`: `["Temperature", "Storage Meth"]`
- If they order it the other way with "Storage Meth" first, it will graph incorrectly.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Unit testing is updated.
Step 1:
- Create a graph filter that has multiple variables and set a custom legend (properly alphabetized based on variable name).

Step 2:
- Add a second version of that same graph filter but move the variable names around in the filter section.

Step 3:
- Compare the two graphs - they should both have the colors in the legend match the graphed data lines.

Optional Step 4:
- Try a 3rd version of the graph where you don't add a legend to the graph filter and see how it aligns with the custom legend version (they should all be the same except the automatic legend version will have the original filter variable names).

Example:
```
{
    "multiple": [
{
    "type": "plot",
    "filters": [
      "^ManureTreatmentDailyOutput_Pen_3_LAC_COW.storage_methane$",
      "ManureHandlerDailyOutput_Pen_3_LAC_COW.air_temperature",
      "ManureHandlerDailyOutput_Pen_3_LAC_COW.housing_methane"
    ],
    "title": "Manure Storage Methane and Air Temp (improperly sorted)",
    "legend": ["Temperature", "Housing Methane", "Manure Storage Methane (kg/d)"]
  },
  {
    "type": "plot",
    "filters": [
        "ManureHandlerDailyOutput_Pen_3_LAC_COW.air_temperature",
      "ManureHandlerDailyOutput_Pen_3_LAC_COW.housing_methane",
     "^ManureTreatmentDailyOutput_Pen_3_LAC_COW.storage_methane$"      
    ],
    "title": "Manure Storage Methane and Air Temp (properly sorted)",
    "legend": ["Temperature", "Housing Methane", "Manure Storage Methane (kg/d)"]
  },
  {
    "type": "plot",
    "filters": [
      "^ManureTreatmentDailyOutput_Pen_3_LAC_COW.storage_methane$",
      "ManureHandlerDailyOutput_Pen_3_LAC_COW.air_temperature",
      "ManureHandlerDailyOutput_Pen_3_LAC_COW.housing_methane"
    ],
    "title": "Manure Storage Methane and Air Temp (No Custom Legend)"
  }
]
}
```
There are 3 variables being graphed here - `storage_methane`, `air_temperature`, and `housing_methane`.
The legend order should match the expected alphabetized version of these variable names e.g. ["Temp", "Methane from Housing", "Alphabetically Last Storage Methane"] but as per the example here, the names you call them in the legend don't need to be alphabetized themselves.

Here is the expected output of the first 2 even thought the filters section is not alphabetized:
<img width="857" alt="Screenshot 2025-01-08 at 3 27 10 PM" src="https://github.com/user-attachments/assets/3498e37f-a286-463a-a78e-e927462902ef" />

You can also look at the third graph `"Manure Storage Methane and Air Temp (No Custom Legend)"` so see how they would be graphed and matched to the legend automatically (which will always be correct).
<img width="1121" alt="Screenshot 2025-01-08 at 3 28 21 PM" src="https://github.com/user-attachments/assets/68daf4e6-f5f2-47ab-a9dc-6ab729e5415c" />
