### PR TITLE
[DCA] Add TaskManager tasks as input that can be collected with Data Collection App.

### DIFF
--- a/DataCollectionApp/index.html
+++ b/DataCollectionApp/index.html
@@ -18,7 +18,6 @@
     <script src="./schema/manure_management_schema.js"></script>
     <script src="./schema/field_schema.js"></script>
     <script src="./schema/tractor_dataset_schema.js"></script>
-    <script src="./schema/tasks_schema.js"></script>
     <link rel='stylesheet' id='theme-link'>
     <link rel='stylesheet' id='iconlib-link'>
     <style>
@@ -107,7 +106,7 @@
             "items": {
                 "type": "object",
                 "title": "Data Entry",
-                "anyOf": [config_schema, animal_schema, crop_schedule_schema, fertilizer_schedule_schema, manure_schedule_schema, tillage_schedule_schema, feed_schema, manure_management_schema, field_schema, tractor_dataset_schema, tasks_schema]
+                "anyOf": [config_schema, animal_schema, crop_schedule_schema, fertilizer_schedule_schema, manure_schedule_schema, tillage_schedule_schema, feed_schema, manure_management_schema, field_schema, tractor_dataset_schema]
             }
         }
         var data = {}

--- a/DataCollectionApp/index.html
+++ b/DataCollectionApp/index.html
@@ -18,6 +18,7 @@
     <script src="./schema/manure_management_schema.js"></script>
     <script src="./schema/field_schema.js"></script>
     <script src="./schema/tractor_dataset_schema.js"></script>
+    <script src="./schema/tasks_schema.js"></script>
     <link rel='stylesheet' id='theme-link'>
     <link rel='stylesheet' id='iconlib-link'>
     <style>
@@ -106,7 +107,7 @@
             "items": {
                 "type": "object",
                 "title": "Data Entry",
-                "anyOf": [config_schema, animal_schema, crop_schedule_schema, fertilizer_schedule_schema, manure_schedule_schema, tillage_schedule_schema, feed_schema, manure_management_schema, field_schema, tractor_dataset_schema]
+                "anyOf": [config_schema, animal_schema, crop_schedule_schema, fertilizer_schedule_schema, manure_schedule_schema, tillage_schedule_schema, feed_schema, manure_management_schema, field_schema, tractor_dataset_schema, tasks_schema]
             }
         }
         var data = {}

--- a/RUFAS/data_collection_app_updater.py
+++ b/RUFAS/data_collection_app_updater.py
@@ -65,12 +65,7 @@ class DataCollectionAppUpdater:
         Parameters
         ----------
         task_manager_metadata_properties : dict[str, Any]
-            Properties Task Manager inputs.        
-
-        Parameters
-        ----------
-        task_metadata_properties : dict[str, Any]
-            Metadata properties of task inputs.
+            Properties Task Manager inputs.
 
         """
         schema_paths = self._rewrite_schemas(task_manager_metadata_properties)

--- a/RUFAS/data_collection_app_updater.py
+++ b/RUFAS/data_collection_app_updater.py
@@ -65,7 +65,7 @@ class DataCollectionAppUpdater:
         Parameters
         ----------
         task_manager_metadata_properties : dict[str, Any]
-            Properties Task Manager inputs.        
+            Properties Task Manager inputs.
 
         Parameters
         ----------

--- a/RUFAS/data_collection_app_updater.py
+++ b/RUFAS/data_collection_app_updater.py
@@ -58,9 +58,14 @@ class DataCollectionAppUpdater:
             "object": self._create_object_schema,
         }
 
-    def update_data_collection_app(self, task_metadata_properties: dict[str, Any]) -> None:
+    def update_data_collection_app(self, task_manager_metadata_properties: dict[str, Any]) -> None:
         """
         Updates schemas for collection of RuFaS inputs in the Data Collection App.
+
+        Parameters
+        ----------
+        task_manager_metadata_properties : dict[str, Any]
+            Properties Task Manager inputs.        
 
         Parameters
         ----------
@@ -68,12 +73,17 @@ class DataCollectionAppUpdater:
             Metadata properties of task inputs.
 
         """
-        schema_paths = self._rewrite_schemas(task_metadata_properties)
+        schema_paths = self._rewrite_schemas(task_manager_metadata_properties)
         self._rewrite_index_page(schema_paths)
 
-    def _rewrite_schemas(self) -> list[Path]:
+    def _rewrite_schemas(self, task_manager_metadata_properties: dict[str, Any]) -> list[Path]:
         """
         Rewrites schemas in the Data Collection App using the input properties found in the Input Manager.
+
+        Parameters
+        ----------
+        task_manager_metadata_properties : dict[str, Any]
+            Properties Task Manager inputs.
 
         Returns
         -------
@@ -88,6 +98,7 @@ class DataCollectionAppUpdater:
         Utility.empty_dir(SCHEMA_DIRECTORY_PATH, [".keep"])
 
         properties: dict[str, Any] = self._im.meta_data["properties"]
+        properties = properties | task_manager_metadata_properties
 
         schema_paths = []
 

--- a/RUFAS/data_collection_app_updater.py
+++ b/RUFAS/data_collection_app_updater.py
@@ -58,11 +58,17 @@ class DataCollectionAppUpdater:
             "object": self._create_object_schema,
         }
 
-    def update_data_collection_app(self) -> None:
+    def update_data_collection_app(self, task_metadata_properties: dict[str, Any]) -> None:
         """
         Updates schemas for collection of RuFaS inputs in the Data Collection App.
+
+        Parameters
+        ----------
+        task_metadata_properties : dict[str, Any]
+            Metadata properties of task inputs.
+
         """
-        schema_paths = self._rewrite_schemas()
+        schema_paths = self._rewrite_schemas(task_metadata_properties)
         self._rewrite_index_page(schema_paths)
 
     def _rewrite_schemas(self) -> list[Path]:

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -767,4 +767,5 @@ class TaskManager:
         """Handler for all methods related to updating the Data Collection App."""
         dca_updater = DataCollectionAppUpdater()
 
-        dca_updater.update_data_collection_app()
+        task_metadata_properties = args["task_metadata_properties"]
+        dca_updater.update_data_collection_app(task_metadata_properties)

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -193,6 +193,7 @@ class TaskManager:
         parsed_multi_run_args: List[Dict[str, Any]] = []
         task_config: Dict[str, Any] = self.input_manager.get_data("tasks")
         tasks_from_input: List[Dict[str, Any]] = task_config.get("tasks")
+        task_manager_metadata_properties = self.input_manager.get_metadata("properties")
         export_input_data_to_csv = task_config.get("export_input_data_to_csv")
         input_data_csv_export_path = Path(task_config.get("input_data_csv_export_path"))
         input_data_csv_import_path = Path(task_config.get("input_data_csv_import_path"))
@@ -214,6 +215,7 @@ class TaskManager:
             input_task["export_input_data_to_csv"] = export_input_data_to_csv
             input_task["input_data_csv_export_path"] = input_data_csv_export_path
             input_task["input_data_csv_import_path"] = input_data_csv_import_path
+            input_task["task_manager_metadata_properties"] = task_manager_metadata_properties
             if input_task["task_type"].is_multi_run():
                 parsed_multi_run_args.append(input_task)
             else:
@@ -767,5 +769,5 @@ class TaskManager:
         """Handler for all methods related to updating the Data Collection App."""
         dca_updater = DataCollectionAppUpdater()
 
-        task_metadata_properties = args["task_metadata_properties"]
+        task_metadata_properties = args["task_manager_metadata_properties"]
         dca_updater.update_data_collection_app(task_metadata_properties)

--- a/changelog.md
+++ b/changelog.md
@@ -85,6 +85,7 @@ v0.9.2
 - [2142](https://github.com/RuminantFarmSystems/MASM/pull/2142) - [minor change] [Animal] Refreshes module which calculates the nutrition requirements of an animal with the NRC (2001) methodology.
 - [2144](https://github.com/RuminantFarmSystems/MASM/pull/2144) - [minor change] [Animal] Refreshes module which evaluates if the nutrition supply of a ration satisfies the demand of animal or the average demand of a group of animals.
 - [2161](https://github.com/RuminantFarmSystems/MASM/pull/2161) - [minor change] [Animal] Refreshes calf nutrition intake and requirement routines.
+- [2172](https://github.com/RuminantFarmSystems/MASM/pull/2172) - [minor change] [Data Collection App] Makes TaskManager Tasks a type of input that can be collected with the Data Collection App.
 
 
 ### v0.9.2

--- a/input/metadata/properties/tasks_properties.json
+++ b/input/metadata/properties/tasks_properties.json
@@ -57,13 +57,13 @@
         },
         "log_verbosity": {
           "type": "string",
-          "pattern": "errors|warnings|logs|credits|none",
+          "pattern": "^(errors|warnings|logs|credits|none)$",
           "default": "errors",
           "description": "Specifies the level of log type to be printed on console."
         },
         "variable_name_style": {
           "type": "string",
-          "pattern": "block|inline|verbose|basic",
+          "pattern": "^(block|inline|verbose|basic)$",
           "description": "The formatting option for variable_names.txt file",
           "default": "basic"
         },
@@ -176,7 +176,7 @@
         "sampler": {
           "type": "string",
           "description": "The sampler for Sensitivity Analysis",
-          "pattern": "fractional_factorial|sobol|morris",
+          "pattern": "^(fractional_factorial|sobol|morris)$",
           "default": "fractional_factorial"
         },
         "skip_values": {
@@ -216,7 +216,7 @@
               "type": "string",
               "description": "Specifies the data type of this variable",
               "default": "float",
-              "pattern": "float|int"
+              "pattern": "^(float|int)$"
             }
           }
         },

--- a/input/metadata/properties/tasks_properties.json
+++ b/input/metadata/properties/tasks_properties.json
@@ -1,6 +1,6 @@
 {
   "tasks_properties": {
-    "data_collection_app_compatible": false,
+    "data_collection_app_compatible": true,
     "parallel_workers": {
       "type": "number",
       "description": "How many parallel workers should Task Manager use",
@@ -29,7 +29,7 @@
         "type": "object",
         "task_type": {
           "type": "string",
-          "pattern": "HERD_INITIALIZATION|SIMULATION_SINGLE_RUN|SIMULATION_MULTI_RUN|SENSITIVITY_ANALYSIS|INPUT_DATA_AUDIT|END_TO_END_TESTING|POST_PROCESSING|COMPARE_METADATA_PROPERTIES|DATA_COLLECTION_APP_UPDATE",
+          "pattern": "^(HERD_INITIALIZATION|SIMULATION_SINGLE_RUN|SIMULATION_MULTI_RUN|SENSITIVITY_ANALYSIS|INPUT_DATA_AUDIT|END_TO_END_TESTING|POST_PROCESSING|COMPARE_METADATA_PROPERTIES|DATA_COLLECTION_APP_UPDATE)$",
           "description": "What kind of task is this?"
         },
         "metadata_file_path": {

--- a/tests/test_data_collection_app_updater.py
+++ b/tests/test_data_collection_app_updater.py
@@ -29,8 +29,11 @@ def test_update_data_collection_app(dca_updater: DataCollectionAppUpdater, mocke
     """Tests that DCA Updater subroutines are called correctly."""
     rewrite_schemas = mocker.patch.object(dca_updater, "_rewrite_schemas", return_value=(paths := mocker.MagicMock()))
     rewrite_index = mocker.patch.object(dca_updater, "_rewrite_index_page")
+    task_manager_metadata_properties = {
+        "task_tm_properties": {"data_collection_app_compatible": True, "tasks": "task_properties"}
+    }
 
-    dca_updater.update_data_collection_app()
+    dca_updater.update_data_collection_app(task_manager_metadata_properties)
 
     rewrite_schemas.assert_called_once()
     rewrite_index.assert_called_once_with(paths)
@@ -40,6 +43,10 @@ def test_rewrite_schemas(dca_updater: DataCollectionAppUpdater, mocker: MockerFi
     """Tests that metadata properties are correctly grabbed and have schema written for them."""
     add_log = mocker.patch.object(dca_updater._om, "add_log")
     empty_dir = mocker.patch.object(Utility, "empty_dir")
+    task_manager_metadata_properties = {
+        "task_tm_properties": {"data_collection_app_compatible": True, "tasks": "task_properties"},
+        "other_tm_properties": {"data_collection_app_compatible": False, "dummy": "property"},
+    }
     dca_updater._im.meta_data = {
         "properties": {
             "animal_properties": {"data_collection_app_compatible": True, "dummy_animal_props": "dummy_prop_content"},
@@ -53,6 +60,7 @@ def test_rewrite_schemas(dca_updater: DataCollectionAppUpdater, mocker: MockerFi
     expected_schema_paths = [
         Path("DataCollectionApp/schema/animal_schema.js"),
         Path("DataCollectionApp/schema/config_schema.js"),
+        Path("DataCollectionApp/schema/task_tm_schema.js"),
     ]
     dummy_schema: dict[str, str] = {"test?": "test!"}
     create_object_schema = mocker.patch.object(dca_updater, "_create_object_schema", return_value={"test?": "test!"})
@@ -60,17 +68,18 @@ def test_rewrite_schemas(dca_updater: DataCollectionAppUpdater, mocker: MockerFi
     expected_create_calls = [
         mocker.call("animal_properties", {"dummy_animal_props": "dummy_prop_content"}),
         mocker.call("config_properties", {"dummy_config_props": "dummy_prop_content"}),
+        mocker.call("task_tm_properties", {"tasks": "task_properties"}),
     ]
     mock_open = mocker.patch("RUFAS.data_collection_app_updater.open")
 
-    actual_schemas = dca_updater._rewrite_schemas()
+    actual_schemas = dca_updater._rewrite_schemas(task_manager_metadata_properties)
 
-    assert add_log.call_count == 3
+    assert add_log.call_count == 4
     empty_dir.assert_called_once()
     create_object_schema.assert_has_calls(expected_create_calls)
-    assert add_filename.call_count == 2
+    assert add_filename.call_count == 3
     assert actual_schemas == expected_schema_paths
-    assert mock_open.call_count == 2
+    assert mock_open.call_count == 3
 
 
 def test_rewrite_index_page(dca_updater: DataCollectionAppUpdater, mocker: MockerFixture) -> None:

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -1721,8 +1721,9 @@ def test_handle_data_collection_app_update(mocker: MockerFixture, task_manager: 
     mock_update = mocker.patch(
         "RUFAS.data_collection_app_updater.DataCollectionAppUpdater.update_data_collection_app", return_value=None
     )
+    args = {"task_manager_metadata_properties": {"task_properties": {"dummy": "property"}}}
 
-    task_manager._handle_data_collection_app_update({}, mocker.MagicMock(), mocker.MagicMock(), "test", False, False)
+    task_manager._handle_data_collection_app_update(args, mocker.MagicMock(), mocker.MagicMock(), "test", False, False)
 
     mock_init.assert_called_once()
     mock_update.assert_called_once()


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Makes TaskManager tasks an input that can be collected with the Data Collection App.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2123

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Changes how the `TaskManager` handles the DCA update task, so that the DCA updater can add tasks as a type of input that can be collected with the Data Collection App.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
Tasks are a type of input that many users will need to create that are specific to the simulations they want to run. By making them collectable with the DCA, we make the process of creating these inputs easier.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Modified the `TaskManager` to collect and pass the metadata properties from its `InputManager` as one of the values in the dictionary passed to the workers which actually execute tasks. Also changed the DCA update routines to pass these properties into the DCA Updater class.

Modified the DCA Updater class to parse the properties passed to it in addition to the ones that are pulled from its `InputManager` instance.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Updated and ran the unit test suite to ensure correct behavior.

Also reran the DCA Update task (by changing `default_task.json` to `dca_update_task.json` in `task_manager_metadata.json`). Opened up the DCA and checked that tasks could be collected properly.