### PR TITLE
[Output Manager] Fixes Bug For Reporting CSV Units

### DIFF
--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -1002,6 +1002,9 @@ class OutputManager(object):
         if not isinstance(units, dict):
             return f" ({units})" if units else ""
 
+        if variable_name in units:
+            return f" ({units[variable_name]})"
+
         if subkey is None:
             self.add_error(
                 "units_subkey_missing",

--- a/changelog.md
+++ b/changelog.md
@@ -111,6 +111,7 @@ v0.9.2
 - [2236](https://github.com/RuminantFarmSystems/MASM/pull/2236) - [minor change] [Testing] Changes E2E expected results update task to automatically update all expected results regardless of whether the old and new expected results differ.
 - [2233](https://github.com/RuminantFarmSystems/MASM/pull/2233) - [minor change] [Manure] Adds a base manure Digester class.
 - [2247](https://github.com/RuminantFarmSystems/MASM/pull/2247) - [minor change] [Crop & Soil] Fix the ZeroDivisionError for surface machine manure application.
+- [2255](https://github.com/RuminantFarmSystems/MASM/pull/2255) - [minor change] [OutputManager] Fix the error reporting units properly to CSV OM files.
 
 ### v0.9.2
 

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -178,6 +178,7 @@ def test_dict_to_csv_column_list(
         ("nested_units", {"value": "kg", "error": "kg"}, "value", " (kg)", None),
         ("nested_units", {"value": "kg", "error": "kg"}, "uncertainty", "", "units_key_error"),
         ("coordinates", {"x": "m", "y": "m"}, None, "", "units_subkey_missing"),
+        ("var1", {"var1": "m"}, None, " (m)", None),
     ],
 )
 def test_get_units_substr(


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Accounts for reporting units properly to CSVs generated by OM when units are reported to OM as a dictionary.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2224

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Fixes the error

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
Previously this was causing an error because there was no check within the `_get_units_substr()` method for if the variable name was in the units dictionary prior to checking if the subkey was None.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Adds a check in `OM._get_units_substr()` before error is raised for if there is no `subkey`.
The check is for whether the `variable_name` is in the `units` dict. If it is, it will extract the correct units for that variable and return it.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
This is the example CSV filter from the issue that wasn't properly reporting units:
```
{
    "name": "ManRequest-Farm",
    "filters": [
      "ManureManager._record_manure_request_results.on_farm_manure.*"
    ],
    "variables": [".*"]
}
```
Running a simulation with it now correctly reports the units to the CSV column headers.

I also wanted to make sure this wasn't interfering with the existing other possible calls to this `_get_units_substr()` method. This filter triggers the other pathway in `OM._dict_to_csv_column_list()` that calls it:
```
{
    "name": "sim eng",
    "filters": [
      ".*available_feeds_on_final_day.*"
    ]
  }
```

I would recommend running a simulation with at least both of these csv filters and checking the results. They were both working as expected for me.