### PR TITLE
[Manure] Re-implement Anaerobic Digestion Logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-96%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3230%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3232%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-96%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3232%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3228%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/RUFAS/biophysical/manure/digester/anaerobic_digester.py
+++ b/RUFAS/biophysical/manure/digester/anaerobic_digester.py
@@ -257,6 +257,7 @@ class AnaerobicDigester(Digester):
         )
         self._om.add_variable("manure_nitrogen", self._manure_to_digest.nitrogen, info_map_kg)
         self._om.add_variable("manure_phosphorus", self._manure_to_digest.phosphorus, info_map_kg)
+        self._om.add_variable("manure_potassium", self._manure_to_digest.potassium, info_map_kg)
         self._om.add_variable("manure_ash", self._manure_to_digest.ash, info_map_kg)
         self._om.add_variable(
             "manure_non_degradable_volatile_solids", self._manure_to_digest.non_degradable_volatile_solids, info_map_kg

--- a/RUFAS/biophysical/manure/digester/anaerobic_digester.py
+++ b/RUFAS/biophysical/manure/digester/anaerobic_digester.py
@@ -56,7 +56,7 @@ class AnaerobicDigester(Digester):
 
     Attributes
     ----------
-    _received_manure : ManureStream
+    _manure_to_digest : ManureStream
         The total amount of manure received by an anaerobic digester in a single day.
     _temperature_set_point : float
         Temperature set point for the anaerobic digestion (degrees C).
@@ -82,7 +82,7 @@ class AnaerobicDigester(Digester):
         evaporation_fraction: float,
     ) -> None:
         super().__init__(name=name, is_housing_emissions_calculator=False)
-        self._received_manure: ManureStream = ManureStream.make_empty_manure_stream()
+        self._manure_to_digest: ManureStream = ManureStream.make_empty_manure_stream()
         self._temperature_set_point: float = temperature_set_point
         self._hydraulic_retention_time: int = hydraulic_retention_time
         self._top_cover_volume_fraction: float = top_cover_volume_fraction
@@ -94,11 +94,11 @@ class AnaerobicDigester(Digester):
         is_received_manure_valid = self.check_manure_stream_compatibility(manure)
         if is_received_manure_valid is False:
             raise ValueError(f"Anaerobic digester {self.name} received an invalid manure stream.")
-        self._received_manure += manure
+        self._manure_to_digest += manure
 
     def process_manure(self, conditions: CurrentDayConditions, time: Time) -> dict[str, ManureStream]:
         """Digests manure received on the current day."""
-        if self._received_manure.is_empty is True:
+        if self._manure_to_digest.is_empty is True:
             self._report_anaerobic_digester_outputs(
                 biogas=0.0,
                 biogas_energy_content=0.0,
@@ -112,36 +112,36 @@ class AnaerobicDigester(Digester):
             )
             return {}
 
-        moisture_fraction = self._received_manure.water / self._received_manure.mass
+        moisture_fraction = self._manure_to_digest.water / self._manure_to_digest.mass
         specific_input_energy = self._calculate_specific_input_energy(
             conditions.mean_air_temperature, moisture_fraction, self._temperature_set_point
         )
         heating_input_energy = (  # TODO: wrong unit conversion factor?
-            specific_input_energy * self._received_manure.volume * GeneralConstants.LITERS_TO_CUBIC_METERS
+            specific_input_energy * self._manure_to_digest.volume * GeneralConstants.LITERS_TO_CUBIC_METERS
         )
 
-        minimum_volume = self._received_manure.volume * self._hydraulic_retention_time
-        top_cover_volume = self._received_manure * self._top_cover_volume_fraction
+        minimum_volume = self._manure_to_digest.volume * self._hydraulic_retention_time
+        top_cover_volume = self._manure_to_digest * self._top_cover_volume_fraction
 
-        self._received_manure.ammoniacal_nitrogen = min(
-            self._received_manure.ammoniacal_nitrogen * TAN_INCREASE_FACTOR, self._received_manure.nitrogen
+        self._manure_to_digest.ammoniacal_nitrogen = min(
+            self._manure_to_digest.ammoniacal_nitrogen * TAN_INCREASE_FACTOR, self._manure_to_digest.nitrogen
         )
 
-        generated_methane_volume = self._calculate_CSTR_methane_volume(self._received_manure.total_volatile_solids)
+        generated_methane_volume = self._calculate_CSTR_methane_volume(self._manure_to_digest.total_volatile_solids)
         generated_methane_mass = generated_methane_volume * METHANE_DENSITY
         generated_carbon_dioxide_mass = (
             generated_methane_volume * CARBON_DIOXIDE_TO_METHANE_RATIO * CARBON_DIOXIDE_DENSITY
         )
         total_volatile_solids_destruction = generated_methane_mass + generated_carbon_dioxide_mass
-        self._received_manure = self._destroy_volatile_solids(total_volatile_solids_destruction)
+        self._manure_to_digest = self._destroy_volatile_solids(total_volatile_solids_destruction)
 
-        self._received_manure.volume -= total_volatile_solids_destruction / ManureConstants.SLURRY_MANURE_DENSITY
+        self._manure_to_digest.volume -= total_volatile_solids_destruction / ManureConstants.SLURRY_MANURE_DENSITY
 
         methane_leakage = self._calculate_methane_leakage(generated_methane_mass, self._methane_leakage_fraction)
         captured_methane_mass = generated_methane_mass - methane_leakage
         captured_methane_energy_content = self._calculate_methane_energy_content(captured_methane_mass)
 
-        evaporated_water = self._received_manure.volume * self._evaporation_fraction
+        evaporated_water = self._manure_to_digest.volume * self._evaporation_fraction
 
         self._report_anaerobic_digester_outputs(
             biogas=captured_methane_mass,
@@ -155,8 +155,8 @@ class AnaerobicDigester(Digester):
             time=time,
         )
 
-        manure_to_pass = replace(self._received_manure)
-        self._received_manure = ManureStream.make_empty_manure_stream()
+        manure_to_pass = replace(self._manure_to_digest)
+        self._manure_to_digest = ManureStream.make_empty_manure_stream()
         return {"manure": manure_to_pass}
 
     def _destroy_volatile_solids(self, total_volatile_solids_destruction: float, time: Time) -> ManureStream:
@@ -174,14 +174,14 @@ class AnaerobicDigester(Digester):
             Manure being processed by the anaerobic digester after volatile solids are removed.
 
         """
-        if self._received_manure.total_volatile_solids < total_volatile_solids_destruction:
+        if self._manure_to_digest.total_volatile_solids < total_volatile_solids_destruction:
             info_map = {
                 "class": self.__class__.__name__,
                 "function": self._destroy_volatile_solids.__name__,
                 "name": self.name,
                 "date": time.current_date.date(),
                 "simulation_day": time.simulation_day,
-                "total_volatile_solids": self._received_manure.total_volatile_solids,
+                "total_volatile_solids": self._manure_to_digest.total_volatile_solids,
                 "total_volatile_solids_destruction": total_volatile_solids_destruction,
             }
             err_name = f"Anerobic digester '{self.name}' attempted to destroy more volatile solids than available"
@@ -192,17 +192,17 @@ class AnaerobicDigester(Digester):
             non_degradable_volatile_solids = 0.0
         else:
             degradable_volatile_solids_frac = (
-                self._received_manure.degradable_volatile_solids / self._received_manure.total_volatile_solids
+                self._manure_to_digest.degradable_volatile_solids / self._manure_to_digest.total_volatile_solids
             )
 
-            degradable_volatile_solids = self._received_manure.degradable_volatile_solids - (
+            degradable_volatile_solids = self._manure_to_digest.degradable_volatile_solids - (
                 total_volatile_solids_destruction * degradable_volatile_solids_frac
             )
-            non_degradable_volatile_solids = self._received_manure.non_degradable_volatile_solids - (
+            non_degradable_volatile_solids = self._manure_to_digest.non_degradable_volatile_solids - (
                 total_volatile_solids_destruction * (1.0 - degradable_volatile_solids_frac)
             )
         return replace(
-            self._received_manure,
+            self._manure_to_digest,
             degradable_volatile_solids=degradable_volatile_solids,
             non_degradable_volatile_solids=non_degradable_volatile_solids,
         )
@@ -251,27 +251,27 @@ class AnaerobicDigester(Digester):
         }
 
         info_map_kg = info_map | {"units": MeasurementUnits.KILOGRAMS}
-        self._om.add_variable("manure_water", self._received_manure.water, info_map_kg)
+        self._om.add_variable("manure_water", self._manure_to_digest.water, info_map_kg)
         self._om.add_variable(
-            "manure_total_ammoniacal_nitrogen", self._received_manure.ammoniacal_nitrogen, info_map_kg
+            "manure_total_ammoniacal_nitrogen", self._manure_to_digest.ammoniacal_nitrogen, info_map_kg
         )
-        self._om.add_variable("manure_nitrogen", self._received_manure.nitrogen, info_map_kg)
-        self._om.add_variable("manure_phosphorus", self._received_manure.phosphorus, info_map_kg)
-        self._om.add_variable("manure_ash", self._received_manure.ash, info_map_kg)
+        self._om.add_variable("manure_nitrogen", self._manure_to_digest.nitrogen, info_map_kg)
+        self._om.add_variable("manure_phosphorus", self._manure_to_digest.phosphorus, info_map_kg)
+        self._om.add_variable("manure_ash", self._manure_to_digest.ash, info_map_kg)
         self._om.add_variable(
-            "manure_non_degradable_volatile_solids", self._received_manure.non_degradable_volatile_solids, info_map_kg
+            "manure_non_degradable_volatile_solids", self._manure_to_digest.non_degradable_volatile_solids, info_map_kg
         )
         self._om.add_variable(
-            "manure_degradable_volatile_solids", self._received_manure.degradable_volatile_solids, info_map_kg
+            "manure_degradable_volatile_solids", self._manure_to_digest.degradable_volatile_solids, info_map_kg
         )
-        self._om.add_variable("manure_total_volatile_solids", self._received_manure.total_volatile_solids, info_map_kg)
-        self._om.add_variable("manure_total_solids", self._received_manure.total_solids, info_map_kg)
-        self._om.add_variable("manure_mass", self._received_manure.mass, info_map_kg)
+        self._om.add_variable("manure_total_volatile_solids", self._manure_to_digest.total_volatile_solids, info_map_kg)
+        self._om.add_variable("manure_total_solids", self._manure_to_digest.total_solids, info_map_kg)
+        self._om.add_variable("manure_mass", self._manure_to_digest.mass, info_map_kg)
         self._om.add_variable("biogas", biogas, info_map_kg)
         self._om.add_variable("methane_leakage_mass", methane_leakage_mass, info_map_kg)
 
         info_map_cubic_m = info_map | {"units": MeasurementUnits.CUBIC_METERS}
-        self._om.add_variable("manure_volume", self._received_manure.volume, info_map_cubic_m)
+        self._om.add_variable("manure_volume", self._manure_to_digest.volume, info_map_cubic_m)
         self._om.add_variable("methane_generation_volume", methane_generation_volume, info_map_cubic_m)
         self._om.add_variable("evaporated_water", evaporated_water, info_map_cubic_m)
         self._om.add_variable("minimum_digester_volume", minimum_digester_volume, info_map_cubic_m)

--- a/RUFAS/biophysical/manure/digester/anaerobic_digester.py
+++ b/RUFAS/biophysical/manure/digester/anaerobic_digester.py
@@ -1,0 +1,118 @@
+from RUFAS.biophysical.manure.digester.digester import Digester
+from RUFAS.current_day_conditions import CurrentDayConditions
+from RUFAS.data_structures.animal_to_manure_connection import ManureStream
+from RUFAS.general_constants import GeneralConstants
+from RUFAS.time import Time
+
+
+"""The lower temperature bound for manure flowing into an anaerobic digester (degrees C)."""
+MINIMUM_INFLUENT_TEMPERATURE = 4.0
+
+
+class AnaerobicDigester(Digester):
+    """
+    Defines the behaviors and attributes of an anaerobic digester.
+
+    Parameters
+    ----------
+    name : str
+        Unique identifier of the processor.
+
+    Attributes
+    ----------
+    _received_manure : ManureStream
+        The total amount of manure received by an anaerobic digester in a single day.
+    _temperature_set_point : float
+        Temperature set point for the anaerobic digestion (degrees C).
+
+    """
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name=name, is_housing_emissions_calculator=False)
+        self._received_manure: ManureStream = ManureStream.make_empty_manure_stream()
+        self._temperature_set_point: float = 20.0
+
+    def receive_manure(self, manure: ManureStream) -> None:
+        """Receives and stores manure to digested."""
+        is_received_manure_valid = self.check_manure_stream_compatibility(manure)
+        if is_received_manure_valid is False:
+            raise ValueError(f"Anaerobic digester {self.name} received an invalid manure stream.")
+        self._received_manure += manure
+
+    def process_manure(self, conditions: CurrentDayConditions, time: Time) -> dict[str, ManureStream]:
+        """Digests manure received on the current day."""
+        if self._received_manure.is_empty is True:
+            pass  # TODO: implement me
+
+        moisture_fraction = self._received_manure.water / self._received_manure.mass
+        _heating_input_energy = self._calculate_specific_input_energy(
+            conditions.mean_air_temperature, moisture_fraction, self._temperature_set_point
+        )
+
+    @classmethod
+    def _calculate_specific_input_energy(
+        cls, average_temp: float, moisture_fraction: float, temperature_set_point: float
+    ) -> float:
+        """
+        Calculates the energy required to maintain anaerobic digestion temperature at set point.
+
+        Parameters
+        ----------
+        average_temp : float
+            Average ambient temperature (degrees C).
+        moisture_fraction : float
+            Fraction of total manure mass that is water (unitless).
+        temperature_set_point : float
+            Temperature set point for anaerobic digestion.
+
+        Returns
+        -------
+        float
+            Energy required to maintain anaerobic digestion temperature at set point (MJ / m^3).
+
+        """
+        effluent_temperature = cls._bind_influent_temperature(average_temp)
+        influent_heat_capacity = cls._calculate_manure_heat_capacity(average_temp, moisture_fraction)
+        anaerobic_digester_heat_capacity = cls._calculate_manure_heat_capacity(temperature_set_point, moisture_fraction)
+
+        average_heat_capacity = (influent_heat_capacity + anaerobic_digester_heat_capacity) / 2.0
+        heating_input_energy = average_heat_capacity * (temperature_set_point - effluent_temperature)
+        return heating_input_energy
+
+    @classmethod
+    def _bind_influent_temperature(cls, average_temp: float) -> float:
+        """
+        Lower-bounds the influent temperature of manure based on the average ambient temperature.
+
+        Parameters
+        ----------
+        average_temp : float
+            Average ambient temperature (degrees C).
+
+        Returns
+        -------
+        float
+            The bound temperature of influent manure (degrees C).
+
+        """
+        return max(average_temp, MINIMUM_INFLUENT_TEMPERATURE)
+
+    @classmethod
+    def _calculate_manure_heat_capacity(cls, temperature: float, moisture_fraction: float) -> float:
+        """
+        Calculates the heat capacity of manure.
+
+        Parameters
+        ----------
+        temperature : float
+            Temperature at which manure heat capacity is being calculated for (degrees C).
+        moisture_fraction : float
+            Fraction of manure mass that is water (unitless).
+
+        Returns
+        -------
+        float
+            Heat capacity of manure in an anaerobic digester (kJ / kg / degrees C).
+
+        """
+        return 0.68298 + 0.025662 * temperature + 0.01306 * moisture_fraction * GeneralConstants.FRACTION_TO_PERCENTAGE

--- a/RUFAS/biophysical/manure/digester/anaerobic_digester.py
+++ b/RUFAS/biophysical/manure/digester/anaerobic_digester.py
@@ -155,9 +155,9 @@ class AnaerobicDigester(Digester):
             time=time,
         )
 
-        manure_to_pass = replace(self._manure_to_digest)
+        digested_manure = replace(self._manure_to_digest)
         self._manure_to_digest = ManureStream.make_empty_manure_stream()
-        return {"manure": manure_to_pass}
+        return {"manure": digested_manure}
 
     def _destroy_volatile_solids(self, total_volatile_solids_destruction: float, time: Time) -> ManureStream:
         """

--- a/RUFAS/biophysical/manure/digester/anaerobic_digester.py
+++ b/RUFAS/biophysical/manure/digester/anaerobic_digester.py
@@ -244,7 +244,7 @@ class AnaerobicDigester(Digester):
         minimum_digester_volume : float
             Minimum volume of manure allowed to be left in the anaerobic digester (m^3).
         top_cover_volume : float
-            Volume of manure that is contained in the cover of the anaerobic digester (m^3).
+            Headspace volume above manure inside digester where biogas collects (m^3).
 
         """
         info_map = {
@@ -383,7 +383,7 @@ class AnaerobicDigester(Digester):
     @classmethod
     def _calculate_methane_leakage(cls, generated_methane_mass: float, leakage_fraction: float) -> float:
         """
-        Calculates the mass of methane lost from an anaerobic digester.
+        Calculates the mass of methane lost from an anaerobic digester as leakage.
 
         Parameters
         ----------

--- a/RUFAS/biophysical/manure/digester/anaerobic_digester.py
+++ b/RUFAS/biophysical/manure/digester/anaerobic_digester.py
@@ -42,6 +42,10 @@ class AnaerobicDigester(Digester):
         The total amount of manure received by an anaerobic digester in a single day.
     _temperature_set_point : float
         Temperature set point for the anaerobic digestion (degrees C).
+    _hydraulic_retention_time : int
+        Number of days manure spends in the anaerobic digester (days).
+    _top_cover_volume_fraction : float
+        Fraction of the total volume of the anaerobic digester that is assumed to be the top cover volume (unitless).
 
     """
 
@@ -49,6 +53,8 @@ class AnaerobicDigester(Digester):
         super().__init__(name=name, is_housing_emissions_calculator=False)
         self._received_manure: ManureStream = ManureStream.make_empty_manure_stream()
         self._temperature_set_point: float = 20.0
+        self._hydraulic_retention_time: int = 25
+        self._top_cover_volume_fraction: float = 0.1
 
     def receive_manure(self, manure: ManureStream) -> None:
         """Receives and stores manure to digested."""
@@ -69,6 +75,9 @@ class AnaerobicDigester(Digester):
         heating_input_energy = (  # TODO: wrong unit conversion factor?
             specific_input_energy * self._received_manure.volume * GeneralConstants.LITERS_TO_CUBIC_METERS
         )
+
+        minimum_volume = self._received_manure.volume * self._hydraulic_retention_time
+        top_cover_volume = self._received_manure * self._top_cover_volume_fraction
 
         generated_methane_volume = self._calculate_CSTR_methane_volume(self._received_manure.total_volatile_solids)
         generated_methane_mass = generated_methane_volume * METHANE_DENSITY

--- a/RUFAS/biophysical/manure/digester/anaerobic_digester.py
+++ b/RUFAS/biophysical/manure/digester/anaerobic_digester.py
@@ -56,7 +56,7 @@ class AnaerobicDigester(Digester):
 
     Attributes
     ----------
-    _manure_to_digest : ManureStream
+    _manure_in_digester : ManureStream
         The total amount of manure received by an anaerobic digester in a single day.
     _temperature_set_point : float
         Temperature set point for the anaerobic digestion (degrees C).
@@ -82,7 +82,7 @@ class AnaerobicDigester(Digester):
         evaporation_fraction: float,
     ) -> None:
         super().__init__(name=name, is_housing_emissions_calculator=False)
-        self._manure_to_digest: ManureStream = ManureStream.make_empty_manure_stream()
+        self._manure_in_digester: ManureStream = ManureStream.make_empty_manure_stream()
         self._temperature_set_point: float = temperature_set_point
         self._hydraulic_retention_time: int = hydraulic_retention_time
         self._top_cover_volume_fraction: float = top_cover_volume_fraction
@@ -94,11 +94,11 @@ class AnaerobicDigester(Digester):
         is_received_manure_valid = self.check_manure_stream_compatibility(manure)
         if is_received_manure_valid is False:
             raise ValueError(f"Anaerobic digester {self.name} received an invalid manure stream.")
-        self._manure_to_digest += manure
+        self._manure_in_digester += manure
 
     def process_manure(self, conditions: CurrentDayConditions, time: Time) -> dict[str, ManureStream]:
         """Digests manure received on the current day."""
-        if self._manure_to_digest.is_empty is True:
+        if self._manure_in_digester.is_empty is True:
             self._report_anaerobic_digester_outputs(
                 biogas=0.0,
                 biogas_energy_content=0.0,
@@ -112,36 +112,36 @@ class AnaerobicDigester(Digester):
             )
             return {}
 
-        moisture_fraction = self._manure_to_digest.water / self._manure_to_digest.mass
+        moisture_fraction = self._manure_in_digester.water / self._manure_in_digester.mass
         specific_input_energy = self._calculate_specific_input_energy(
             conditions.mean_air_temperature, moisture_fraction, self._temperature_set_point
         )
         heating_input_energy = (
-            specific_input_energy * self._manure_to_digest.volume * GeneralConstants.LITERS_TO_CUBIC_METERS
+            specific_input_energy * self._manure_in_digester.volume * GeneralConstants.LITERS_TO_CUBIC_METERS
         )
 
-        minimum_digester_volume = self._manure_to_digest.volume * self._hydraulic_retention_time
+        minimum_digester_volume = self._manure_in_digester.volume * self._hydraulic_retention_time
         top_cover_volume = minimum_digester_volume * self._top_cover_volume_fraction
 
-        self._manure_to_digest.ammoniacal_nitrogen = min(
-            self._manure_to_digest.ammoniacal_nitrogen * TAN_INCREASE_FACTOR, self._manure_to_digest.nitrogen
+        self._manure_in_digester.ammoniacal_nitrogen = min(
+            self._manure_in_digester.ammoniacal_nitrogen * TAN_INCREASE_FACTOR, self._manure_in_digester.nitrogen
         )
 
-        generated_methane_volume = self._calculate_CSTR_methane_volume(self._manure_to_digest.total_volatile_solids)
+        generated_methane_volume = self._calculate_CSTR_methane_volume(self._manure_in_digester.total_volatile_solids)
         generated_methane_mass = generated_methane_volume * METHANE_DENSITY
         generated_carbon_dioxide_mass = (
             generated_methane_volume * CARBON_DIOXIDE_TO_METHANE_RATIO * CARBON_DIOXIDE_DENSITY
         )
         total_volatile_solids_destruction = generated_methane_mass + generated_carbon_dioxide_mass
-        self._manure_to_digest = self._destroy_volatile_solids(total_volatile_solids_destruction, time)
+        self._manure_in_digester = self._destroy_volatile_solids(total_volatile_solids_destruction, time)
 
-        self._manure_to_digest.volume -= total_volatile_solids_destruction / ManureConstants.SLURRY_MANURE_DENSITY
+        self._manure_in_digester.volume -= total_volatile_solids_destruction / ManureConstants.SLURRY_MANURE_DENSITY
 
         methane_leakage = self._calculate_methane_leakage(generated_methane_mass, self._methane_leakage_fraction)
         captured_methane_mass = generated_methane_mass - methane_leakage
         captured_methane_energy_content = self._calculate_methane_energy_content(captured_methane_mass)
 
-        evaporated_water = self._manure_to_digest.volume * self._evaporation_fraction
+        evaporated_water = self._manure_in_digester.volume * self._evaporation_fraction
 
         self._report_anaerobic_digester_outputs(
             biogas=captured_methane_mass,
@@ -155,8 +155,8 @@ class AnaerobicDigester(Digester):
             time=time,
         )
 
-        digested_manure = replace(self._manure_to_digest)
-        self._manure_to_digest = ManureStream.make_empty_manure_stream()
+        digested_manure = replace(self._manure_in_digester)
+        self._manure_in_digester = ManureStream.make_empty_manure_stream()
         return {"manure": digested_manure}
 
     def _destroy_volatile_solids(self, total_volatile_solids_destruction: float, time: Time) -> ManureStream:
@@ -176,16 +176,16 @@ class AnaerobicDigester(Digester):
             Manure being processed by the anaerobic digester after volatile solids are removed.
 
         """
-        if self._manure_to_digest.total_volatile_solids < total_volatile_solids_destruction:
+        if self._manure_in_digester.total_volatile_solids < total_volatile_solids_destruction:
             info_map = {
                 "class": self.__class__.__name__,
                 "function": self._destroy_volatile_solids.__name__,
                 "name": self.name,
                 "date": time.current_date.date(),
                 "simulation_day": time.simulation_day,
-                "degradable_volatile_solids": self._manure_to_digest.degradable_volatile_solids,
-                "non_degradable_volatile_solids": self._manure_to_digest.non_degradable_volatile_solids,
-                "total_volatile_solids": self._manure_to_digest.total_volatile_solids,
+                "degradable_volatile_solids": self._manure_in_digester.degradable_volatile_solids,
+                "non_degradable_volatile_solids": self._manure_in_digester.non_degradable_volatile_solids,
+                "total_volatile_solids": self._manure_in_digester.total_volatile_solids,
                 "total_volatile_solids_destruction": total_volatile_solids_destruction,
             }
             err_name = f"Anerobic digester '{self.name}' attempted to destroy more volatile solids than available"
@@ -196,17 +196,17 @@ class AnaerobicDigester(Digester):
             non_degradable_volatile_solids = 0.0
         else:
             degradable_volatile_solids_frac = (
-                self._manure_to_digest.degradable_volatile_solids / self._manure_to_digest.total_volatile_solids
+                self._manure_in_digester.degradable_volatile_solids / self._manure_in_digester.total_volatile_solids
             )
 
-            degradable_volatile_solids = self._manure_to_digest.degradable_volatile_solids - (
+            degradable_volatile_solids = self._manure_in_digester.degradable_volatile_solids - (
                 total_volatile_solids_destruction * degradable_volatile_solids_frac
             )
-            non_degradable_volatile_solids = self._manure_to_digest.non_degradable_volatile_solids - (
+            non_degradable_volatile_solids = self._manure_in_digester.non_degradable_volatile_solids - (
                 total_volatile_solids_destruction * (1.0 - degradable_volatile_solids_frac)
             )
         return replace(
-            self._manure_to_digest,
+            self._manure_in_digester,
             degradable_volatile_solids=degradable_volatile_solids,
             non_degradable_volatile_solids=non_degradable_volatile_solids,
         )
@@ -255,28 +255,32 @@ class AnaerobicDigester(Digester):
         }
 
         info_map_kg = info_map | {"units": MeasurementUnits.KILOGRAMS}
-        self._om.add_variable("manure_water", self._manure_to_digest.water, info_map_kg)
+        self._om.add_variable("manure_water", self._manure_in_digester.water, info_map_kg)
         self._om.add_variable(
-            "manure_total_ammoniacal_nitrogen", self._manure_to_digest.ammoniacal_nitrogen, info_map_kg
+            "manure_total_ammoniacal_nitrogen", self._manure_in_digester.ammoniacal_nitrogen, info_map_kg
         )
-        self._om.add_variable("manure_nitrogen", self._manure_to_digest.nitrogen, info_map_kg)
-        self._om.add_variable("manure_phosphorus", self._manure_to_digest.phosphorus, info_map_kg)
-        self._om.add_variable("manure_potassium", self._manure_to_digest.potassium, info_map_kg)
-        self._om.add_variable("manure_ash", self._manure_to_digest.ash, info_map_kg)
+        self._om.add_variable("manure_nitrogen", self._manure_in_digester.nitrogen, info_map_kg)
+        self._om.add_variable("manure_phosphorus", self._manure_in_digester.phosphorus, info_map_kg)
+        self._om.add_variable("manure_potassium", self._manure_in_digester.potassium, info_map_kg)
+        self._om.add_variable("manure_ash", self._manure_in_digester.ash, info_map_kg)
         self._om.add_variable(
-            "manure_non_degradable_volatile_solids", self._manure_to_digest.non_degradable_volatile_solids, info_map_kg
+            "manure_non_degradable_volatile_solids",
+            self._manure_in_digester.non_degradable_volatile_solids,
+            info_map_kg,
         )
         self._om.add_variable(
-            "manure_degradable_volatile_solids", self._manure_to_digest.degradable_volatile_solids, info_map_kg
+            "manure_degradable_volatile_solids", self._manure_in_digester.degradable_volatile_solids, info_map_kg
         )
-        self._om.add_variable("manure_total_volatile_solids", self._manure_to_digest.total_volatile_solids, info_map_kg)
-        self._om.add_variable("manure_total_solids", self._manure_to_digest.total_solids, info_map_kg)
-        self._om.add_variable("manure_mass", self._manure_to_digest.mass, info_map_kg)
+        self._om.add_variable(
+            "manure_total_volatile_solids", self._manure_in_digester.total_volatile_solids, info_map_kg
+        )
+        self._om.add_variable("manure_total_solids", self._manure_in_digester.total_solids, info_map_kg)
+        self._om.add_variable("manure_mass", self._manure_in_digester.mass, info_map_kg)
         self._om.add_variable("biogas", biogas, info_map_kg)
         self._om.add_variable("methane_leakage_mass", methane_leakage_mass, info_map_kg)
 
         info_map_cubic_m = info_map | {"units": MeasurementUnits.CUBIC_METERS}
-        self._om.add_variable("manure_volume", self._manure_to_digest.volume, info_map_cubic_m)
+        self._om.add_variable("manure_volume", self._manure_in_digester.volume, info_map_cubic_m)
         self._om.add_variable("methane_generation_volume", methane_generation_volume, info_map_cubic_m)
         self._om.add_variable("evaporated_water", evaporated_water, info_map_cubic_m)
         self._om.add_variable("minimum_digester_volume", minimum_digester_volume, info_map_cubic_m)

--- a/RUFAS/biophysical/manure/digester/anaerobic_digester.py
+++ b/RUFAS/biophysical/manure/digester/anaerobic_digester.py
@@ -23,8 +23,14 @@ Unit conversion factor for methane generated from an anaerobic digester at 1 atm
 """
 METHANE_DENSITY: float = 0.629
 
+"""Methane energy density (MJ / kg)."""
+METHANE_ENERGY_DENSITY: float = 55.0
+
 """The lower temperature bound for manure flowing into an anaerobic digester (degrees C)."""
 MINIMUM_INFLUENT_TEMPERATURE = 4.0
+
+"""Factor by which total ammoniacal nitrogen content is increased by the anaerobic digestion process (unitless)."""
+TAN_INCREASE_FACTOR = 1.60
 
 
 class AnaerobicDigester(Digester):
@@ -46,6 +52,9 @@ class AnaerobicDigester(Digester):
         Number of days manure spends in the anaerobic digester (days).
     _top_cover_volume_fraction : float
         Fraction of the total volume of the anaerobic digester that is assumed to be the top cover volume (unitless).
+    _methane_leakage_fraction : float
+        Fraction of methane generated in the anaerobic digester that escapes to the atmosphere through unintended
+        leakage and is not collected by the gas capture system.
 
     """
 
@@ -55,6 +64,7 @@ class AnaerobicDigester(Digester):
         self._temperature_set_point: float = 20.0
         self._hydraulic_retention_time: int = 25
         self._top_cover_volume_fraction: float = 0.1
+        self._methane_leakage_fraction: float = 0.01
 
     def receive_manure(self, manure: ManureStream) -> None:
         """Receives and stores manure to digested."""
@@ -79,6 +89,10 @@ class AnaerobicDigester(Digester):
         minimum_volume = self._received_manure.volume * self._hydraulic_retention_time
         top_cover_volume = self._received_manure * self._top_cover_volume_fraction
 
+        self._received_manure.ammoniacal_nitrogen = min(
+            self._received_manure.ammoniacal_nitrogen * TAN_INCREASE_FACTOR, self._received_manure.nitrogen
+        )
+
         generated_methane_volume = self._calculate_CSTR_methane_volume(self._received_manure.total_volatile_solids)
         generated_methane_mass = generated_methane_volume * METHANE_DENSITY
         generated_carbon_dioxide_mass = (
@@ -86,6 +100,19 @@ class AnaerobicDigester(Digester):
         )
         total_volatile_solids_destruction = generated_methane_mass + generated_carbon_dioxide_mass
         self._received_manure = self._destroy_volatile_solids(total_volatile_solids_destruction)
+
+        self._received_manure.volume -= total_volatile_solids_destruction / ManureConstants.SLURRY_MANURE_DENSITY
+
+        methane_leakage = self._calculate_methane_leakage(generated_methane_mass, self._methane_leakage_fraction)
+        captured_methane_volume = generated_methane_volume - (methane_leakage / METHANE_DENSITY)
+        captured_methane_mass = generated_methane_mass - methane_leakage
+        captured_methane_energy_content = self._calculate_methane_energy_content(captured_methane_mass)
+
+        self._report_anaerobic_digester_outputs()
+
+        manure_to_pass = replace(self._received_manure)
+        self._received_manure = ManureStream.make_empty_manure_stream()
+        return {"manure": manure_to_pass}
 
     def _destroy_volatile_solids(self, total_volatile_solids_destruction: float, time: Time) -> ManureStream:
         """
@@ -228,3 +255,41 @@ class AnaerobicDigester(Digester):
 
         """
         return ManureConstants.ACHIEVABLE_METHANE_EMISSION * total_volatile_solids
+
+    @classmethod
+    def _calculate_methane_leakage(cls, generated_methane_mass: float, leakage_fraction: float) -> float:
+        """
+        Calculates the mass of methane lost from an anaerobic digester.
+
+        Parameters
+        ----------
+        generated_methane_mass : float
+            Amount of methane generated within the digester (kg).
+        digester_methane_leakage_fraction : float
+            Fraction of generated methane that escapes as leakage (unitless).
+
+        Returns
+        -------
+        float
+            Mass of methane lost as leakage (kg).
+
+        """
+        return generated_methane_mass * leakage_fraction
+
+    @classmethod
+    def _calculate_methane_energy_content(cls, methane_mass: float) -> float:
+        """
+        Calculates energy content of methane generated in an anaerobic digester.
+
+        Parameters
+        ----------
+        methane_mass : float
+            Methane generation mass (kg).
+
+        Returns
+        -------
+        float
+            Methane energy content (MJ).
+
+        """
+        return methane_mass * METHANE_ENERGY_DENSITY

--- a/RUFAS/biophysical/manure/digester/anaerobic_digester.py
+++ b/RUFAS/biophysical/manure/digester/anaerobic_digester.py
@@ -6,6 +6,7 @@ from RUFAS.current_day_conditions import CurrentDayConditions
 from RUFAS.data_structures.animal_to_manure_connection import ManureStream
 from RUFAS.general_constants import GeneralConstants
 from RUFAS.time import Time
+from RUFAS.units import MeasurementUnits
 
 
 """
@@ -40,7 +41,18 @@ class AnaerobicDigester(Digester):
     Parameters
     ----------
     name : str
-        Unique identifier of the processor.
+        Unique identifier of the anaerobic digester.
+    temperature_set_point : float
+        Temperature set point for the anaerobic digestion (degrees C).
+    hydraulic_retention_time : int
+        Number of days manure spends in the anaerobic digester (days).
+    top_cover_volume_fraction : float
+        Fraction of the total volume of the anaerobic digester that is assumed to be the top cover volume (unitless).
+    methane_leakage_fraction : float
+        Fraction of methane generated in the anaerobic digester that escapes to the atmosphere through unintended
+        leakage and is not collected by the gas capture system (unitless).
+    evaporation_fraction : float
+        Fraction of the liquid portion evaporated from the treatment system (unitless).
 
     Attributes
     ----------
@@ -54,17 +66,28 @@ class AnaerobicDigester(Digester):
         Fraction of the total volume of the anaerobic digester that is assumed to be the top cover volume (unitless).
     _methane_leakage_fraction : float
         Fraction of methane generated in the anaerobic digester that escapes to the atmosphere through unintended
-        leakage and is not collected by the gas capture system.
+        leakage and is not collected by the gas capture system (unitless).
+    _evaporation_fraction : float
+        Fraction of the liquid portion evaporated from the treatment system (unitless).
 
     """
 
-    def __init__(self, name: str) -> None:
+    def __init__(
+        self,
+        name: str,
+        temperature_set_point: float,
+        hydraulic_retention_time: int,
+        top_cover_volume_fraction: float,
+        methane_leakage_fraction: float,
+        evaporation_fraction: float,
+    ) -> None:
         super().__init__(name=name, is_housing_emissions_calculator=False)
         self._received_manure: ManureStream = ManureStream.make_empty_manure_stream()
-        self._temperature_set_point: float = 20.0
-        self._hydraulic_retention_time: int = 25
-        self._top_cover_volume_fraction: float = 0.1
-        self._methane_leakage_fraction: float = 0.01
+        self._temperature_set_point: float = temperature_set_point
+        self._hydraulic_retention_time: int = hydraulic_retention_time
+        self._top_cover_volume_fraction: float = top_cover_volume_fraction
+        self._methane_leakage_fraction: float = methane_leakage_fraction
+        self._evaporation_fraction: float = evaporation_fraction
 
     def receive_manure(self, manure: ManureStream) -> None:
         """Receives and stores manure to digested."""
@@ -76,7 +99,18 @@ class AnaerobicDigester(Digester):
     def process_manure(self, conditions: CurrentDayConditions, time: Time) -> dict[str, ManureStream]:
         """Digests manure received on the current day."""
         if self._received_manure.is_empty is True:
-            pass  # TODO: implement me
+            self._report_anaerobic_digester_outputs(
+                biogas=0.0,
+                biogas_energy_content=0.0,
+                evaporated_water=0.0,
+                heating_input_energy=0.0,
+                methane_generation_volume=0.0,
+                methane_leakage_mass=0.0,
+                minimum_digester_volume=0.0,
+                top_cover_volume=0.0,
+                time=time,
+            )
+            return {}
 
         moisture_fraction = self._received_manure.water / self._received_manure.mass
         specific_input_energy = self._calculate_specific_input_energy(
@@ -104,11 +138,22 @@ class AnaerobicDigester(Digester):
         self._received_manure.volume -= total_volatile_solids_destruction / ManureConstants.SLURRY_MANURE_DENSITY
 
         methane_leakage = self._calculate_methane_leakage(generated_methane_mass, self._methane_leakage_fraction)
-        captured_methane_volume = generated_methane_volume - (methane_leakage / METHANE_DENSITY)
         captured_methane_mass = generated_methane_mass - methane_leakage
         captured_methane_energy_content = self._calculate_methane_energy_content(captured_methane_mass)
 
-        self._report_anaerobic_digester_outputs()
+        evaporated_water = self._received_manure.volume * self._evaporation_fraction
+
+        self._report_anaerobic_digester_outputs(
+            biogas=captured_methane_mass,
+            biogas_energy_content=captured_methane_energy_content,
+            evaporated_water=evaporated_water,
+            heating_input_energy=heating_input_energy,
+            methane_generation_volume=generated_methane_volume,
+            methane_leakage_mass=methane_leakage,
+            minimum_digester_volume=minimum_volume,
+            top_cover_volume=top_cover_volume,
+            time=time,
+        )
 
         manure_to_pass = replace(self._received_manure)
         self._received_manure = ManureStream.make_empty_manure_stream()
@@ -161,6 +206,80 @@ class AnaerobicDigester(Digester):
             degradable_volatile_solids=degradable_volatile_solids,
             non_degradable_volatile_solids=non_degradable_volatile_solids,
         )
+
+    def _report_anaerobic_digester_outputs(
+        self,
+        biogas: float,
+        biogas_energy_content: float,
+        evaporated_water: float,
+        heating_input_energy: float,
+        methane_generation_volume: float,
+        methane_leakage_mass: float,
+        minimum_digester_volume: float,
+        top_cover_volume: float,
+        time: Time,
+    ) -> None:
+        """
+        Reports manure that was digested and the amounts of different things that were lost in the anaerobic digestion
+        process.
+
+        Parameters
+        ----------
+        biogas : float
+            Captured biogas (kg).
+        biogass_energy_content : float
+            Energy from captured biogas (MJ).
+        evaporated_water : float
+            Water that evaporated during anaerobic digestion (m^3)
+        heating_input_energy : float
+            Energy required to maintain the anaerobic digester's temperature (MJ).
+        methane_generation_volume : float
+            Volume of all methane generated during anaerobic digestion (m^3).
+        methane_leakage_mass : float
+            Mass of all methane generated during anaerobic digestion (m^3).
+        minimum_digester_volume : float
+            Minimum volume of manure allowed to be left in the anaerobic digester (m^3). TODO: correct me!
+        top_cover_volume : float
+            Volume of manure that is contained in the cover of the anaerobic digester (m^3). TODO: correct me!
+
+        """
+        info_map = {
+            "class": self.__class__.__name__,
+            "function": self._report_anaerobic_digester_outputs.__name__,
+            "prefix": self._prefix,
+            "simulation_day": time.simulation_day,
+        }
+
+        info_map_kg = info_map | {"units": MeasurementUnits.KILOGRAMS}
+        self._om.add_variable("manure_water", self._received_manure.water, info_map_kg)
+        self._om.add_variable(
+            "manure_total_ammoniacal_nitrogen", self._received_manure.ammoniacal_nitrogen, info_map_kg
+        )
+        self._om.add_variable("manure_nitrogen", self._received_manure.nitrogen, info_map_kg)
+        self._om.add_variable("manure_phosphorus", self._received_manure.phosphorus, info_map_kg)
+        self._om.add_variable("manure_ash", self._received_manure.ash, info_map_kg)
+        self._om.add_variable(
+            "manure_non_degradable_volatile_solids", self._received_manure.non_degradable_volatile_solids, info_map_kg
+        )
+        self._om.add_variable(
+            "manure_degradable_volatile_solids", self._received_manure.degradable_volatile_solids, info_map_kg
+        )
+        self._om.add_variable("manure_total_volatile_solids", self._received_manure.total_volatile_solids, info_map_kg)
+        self._om.add_variable("manure_total_solids", self._received_manure.total_solids, info_map_kg)
+        self._om.add_variable("manure_mass", self._received_manure.mass, info_map_kg)
+        self._om.add_variable("biogas", biogas, info_map_kg)
+        self._om.add_variable("methane_leakage_mass", methane_leakage_mass, info_map_kg)
+
+        info_map_cubic_m = info_map | {"units": MeasurementUnits.CUBIC_METERS}
+        self._om.add_variable("manure_volume", self._received_manure.volume, info_map_cubic_m)
+        self._om.add_variable("methane_generation_volume", methane_generation_volume, info_map_cubic_m)
+        self._om.add_variable("evaporated_water", evaporated_water, info_map_cubic_m)
+        self._om.add_variable("minimum_digester_volume", minimum_digester_volume, info_map_cubic_m)
+        self._om.add_variable("top_cover_volume", top_cover_volume, info_map_cubic_m)
+
+        info_map_megajoules = info_map | {"units": MeasurementUnits.MEGAJOULES}
+        self._om.add_variable("biogas_energy_content", biogas_energy_content, info_map_megajoules)
+        self._om.add_variable("heating_input_energy", heating_input_energy, info_map_megajoules)
 
     @classmethod
     def _calculate_specific_input_energy(

--- a/RUFAS/biophysical/manure/digester/anaerobic_digester.py
+++ b/RUFAS/biophysical/manure/digester/anaerobic_digester.py
@@ -116,7 +116,7 @@ class AnaerobicDigester(Digester):
         specific_input_energy = self._calculate_specific_input_energy(
             conditions.mean_air_temperature, moisture_fraction, self._temperature_set_point
         )
-        heating_input_energy = (  # TODO: wrong unit conversion factor?
+        heating_input_energy = (
             specific_input_energy * self._manure_to_digest.volume * GeneralConstants.LITERS_TO_CUBIC_METERS
         )
 
@@ -238,9 +238,9 @@ class AnaerobicDigester(Digester):
         methane_leakage_mass : float
             Mass of all methane generated during anaerobic digestion (m^3).
         minimum_digester_volume : float
-            Minimum volume of manure allowed to be left in the anaerobic digester (m^3). TODO: correct me!
+            Minimum volume of manure allowed to be left in the anaerobic digester (m^3).
         top_cover_volume : float
-            Volume of manure that is contained in the cover of the anaerobic digester (m^3). TODO: correct me!
+            Volume of manure that is contained in the cover of the anaerobic digester (m^3).
 
         """
         info_map = {

--- a/RUFAS/biophysical/manure/digester/anaerobic_digester.py
+++ b/RUFAS/biophysical/manure/digester/anaerobic_digester.py
@@ -133,7 +133,7 @@ class AnaerobicDigester(Digester):
             generated_methane_volume * CARBON_DIOXIDE_TO_METHANE_RATIO * CARBON_DIOXIDE_DENSITY
         )
         total_volatile_solids_destruction = generated_methane_mass + generated_carbon_dioxide_mass
-        self._manure_to_digest = self._destroy_volatile_solids(total_volatile_solids_destruction)
+        self._manure_to_digest = self._destroy_volatile_solids(total_volatile_solids_destruction, time)
 
         self._manure_to_digest.volume -= total_volatile_solids_destruction / ManureConstants.SLURRY_MANURE_DENSITY
 

--- a/RUFAS/biophysical/manure/digester/anaerobic_digester.py
+++ b/RUFAS/biophysical/manure/digester/anaerobic_digester.py
@@ -52,7 +52,7 @@ class AnaerobicDigester(Digester):
         Fraction of methane generated in the anaerobic digester that escapes to the atmosphere through unintended
         leakage and is not collected by the gas capture system (unitless).
     evaporation_fraction : float
-        Fraction of the liquid portion evaporated from the treatment system (unitless).
+        Fraction of the liquid portion evaporated from the anaerobic digester (unitless).
 
     Attributes
     ----------
@@ -68,7 +68,7 @@ class AnaerobicDigester(Digester):
         Fraction of methane generated in the anaerobic digester that escapes to the atmosphere through unintended
         leakage and is not collected by the gas capture system (unitless).
     _evaporation_fraction : float
-        Fraction of the liquid portion evaporated from the treatment system (unitless).
+        Fraction of the liquid portion evaporated from the anaerobic digester (unitless).
 
     """
 
@@ -90,7 +90,7 @@ class AnaerobicDigester(Digester):
         self._evaporation_fraction: float = evaporation_fraction
 
     def receive_manure(self, manure: ManureStream) -> None:
-        """Receives and stores manure to digested."""
+        """Receives and stores manure to be digested."""
         is_received_manure_valid = self.check_manure_stream_compatibility(manure)
         if is_received_manure_valid is False:
             raise ValueError(f"Anaerobic digester {self.name} received an invalid manure stream.")
@@ -167,6 +167,8 @@ class AnaerobicDigester(Digester):
         ----------
         total_volatile_solids_destruction : float
             Amount of volatile solids removed from the manure (kg).
+        time : Time
+            Time instance tracking time of the simulation.
 
         Returns
         -------
@@ -181,6 +183,8 @@ class AnaerobicDigester(Digester):
                 "name": self.name,
                 "date": time.current_date.date(),
                 "simulation_day": time.simulation_day,
+                "degradable_volatile_solids": self._manure_to_digest.degradable_volatile_solids,
+                "non_degradable_volatile_solids": self._manure_to_digest.non_degradable_volatile_solids,
                 "total_volatile_solids": self._manure_to_digest.total_volatile_solids,
                 "total_volatile_solids_destruction": total_volatile_solids_destruction,
             }

--- a/RUFAS/biophysical/manure/digester/anaerobic_digester.py
+++ b/RUFAS/biophysical/manure/digester/anaerobic_digester.py
@@ -1,9 +1,27 @@
+from dataclasses import replace
+
 from RUFAS.biophysical.manure.digester.digester import Digester
+from RUFAS.biophysical.manure.manure_constants import ManureConstants
 from RUFAS.current_day_conditions import CurrentDayConditions
 from RUFAS.data_structures.animal_to_manure_connection import ManureStream
 from RUFAS.general_constants import GeneralConstants
 from RUFAS.time import Time
 
+
+"""
+Unit conversion factor for carbon dioxide generated from anaerobic digestion at 1 atm of pressure and 37.5C (kg / m^3).
+"""
+CARBON_DIOXIDE_DENSITY: float = 1.716
+
+"""
+Volumetric ratio of carbon dioxide to methane generated during anaerobic digestion (m^3 carbon dioxide / m^3 methane).
+"""
+CARBON_DIOXIDE_TO_METHANE_RATIO: float = 4 / 6
+
+"""
+Unit conversion factor for methane generated from an anaerobic digester at 1 atm of pressure and 37.5 C (kg / m^3).
+"""
+METHANE_DENSITY: float = 0.629
 
 """The lower temperature bound for manure flowing into an anaerobic digester (degrees C)."""
 MINIMUM_INFLUENT_TEMPERATURE = 4.0
@@ -45,8 +63,67 @@ class AnaerobicDigester(Digester):
             pass  # TODO: implement me
 
         moisture_fraction = self._received_manure.water / self._received_manure.mass
-        _heating_input_energy = self._calculate_specific_input_energy(
+        specific_input_energy = self._calculate_specific_input_energy(
             conditions.mean_air_temperature, moisture_fraction, self._temperature_set_point
+        )
+        heating_input_energy = (  # TODO: wrong unit conversion factor?
+            specific_input_energy * self._received_manure.volume * GeneralConstants.LITERS_TO_CUBIC_METERS
+        )
+
+        generated_methane_volume = self._calculate_CSTR_methane_volume(self._received_manure.total_volatile_solids)
+        generated_methane_mass = generated_methane_volume * METHANE_DENSITY
+        generated_carbon_dioxide_mass = (
+            generated_methane_volume * CARBON_DIOXIDE_TO_METHANE_RATIO * CARBON_DIOXIDE_DENSITY
+        )
+        total_volatile_solids_destruction = generated_methane_mass + generated_carbon_dioxide_mass
+        self._received_manure = self._destroy_volatile_solids(total_volatile_solids_destruction)
+
+    def _destroy_volatile_solids(self, total_volatile_solids_destruction: float, time: Time) -> ManureStream:
+        """
+        Adjusts the pools of solids in the manure after volatile solids are destroyed.
+
+        Parameters
+        ----------
+        total_volatile_solids_destruction : float
+            Amount of volatile solids removed from the manure (kg).
+
+        Returns
+        -------
+        ManureStream
+            Manure being processed by the anaerobic digester after volatile solids are removed.
+
+        """
+        if self._received_manure.total_volatile_solids < total_volatile_solids_destruction:
+            info_map = {
+                "class": self.__class__.__name__,
+                "function": self._destroy_volatile_solids.__name__,
+                "name": self.name,
+                "date": time.current_date.date(),
+                "simulation_day": time.simulation_day,
+                "total_volatile_solids": self._received_manure.total_volatile_solids,
+                "total_volatile_solids_destruction": total_volatile_solids_destruction,
+            }
+            err_name = f"Anerobic digester '{self.name}' attempted to destroy more volatile solids than available"
+            err_msg = "Setting degradable volatile solids, non-degradable volatile solids, and total volatile solids "
+            "pools to be 0.0."
+            self._om.add_error(err_name, err_msg, info_map)
+            degradable_volatile_solids = 0.0
+            non_degradable_volatile_solids = 0.0
+        else:
+            degradable_volatile_solids_frac = (
+                self._received_manure.degradable_volatile_solids / self._received_manure.total_volatile_solids
+            )
+
+            degradable_volatile_solids = self._received_manure.degradable_volatile_solids - (
+                total_volatile_solids_destruction * degradable_volatile_solids_frac
+            )
+            non_degradable_volatile_solids = self._received_manure.non_degradable_volatile_solids - (
+                total_volatile_solids_destruction * (1.0 - degradable_volatile_solids_frac)
+            )
+        return replace(
+            self._received_manure,
+            degradable_volatile_solids=degradable_volatile_solids,
+            non_degradable_volatile_solids=non_degradable_volatile_solids,
         )
 
     @classmethod
@@ -116,3 +193,29 @@ class AnaerobicDigester(Digester):
 
         """
         return 0.68298 + 0.025662 * temperature + 0.01306 * moisture_fraction * GeneralConstants.FRACTION_TO_PERCENTAGE
+
+    @classmethod
+    def _calculate_CSTR_methane_volume(cls, total_volatile_solids: float) -> float:
+        """
+        Calculates volume of methane generated from a continuously-stirred tank reactor.
+
+        Parameters
+        ----------
+        total_volatile_solids : float
+            Total volatile solids contained in manure (kg).
+
+        Returns
+        -------
+        float
+            Methane generation volume (m^3).
+
+        Notes
+        -----
+        This function originates from personal communications with subject matter experts Wei Liao (liaow@msu.edu) and
+        April Leytem (april.leytem@usda.gov). The equation is a simplification of the IPCC Tier II estimate of CH4
+        emissions from anaerobic digesters, where CH4 generated in the digester is assumed to be equivalent to the
+        amount of manure volatile solids loaded per day, multiplied by the generally-accepted methane potential value
+        for dairy manure (240 L CH4 per kg of manure volatile solids).
+
+        """
+        return ManureConstants.ACHIEVABLE_METHANE_EMISSION * total_volatile_solids

--- a/RUFAS/biophysical/manure/digester/anaerobic_digester.py
+++ b/RUFAS/biophysical/manure/digester/anaerobic_digester.py
@@ -120,8 +120,8 @@ class AnaerobicDigester(Digester):
             specific_input_energy * self._manure_to_digest.volume * GeneralConstants.LITERS_TO_CUBIC_METERS
         )
 
-        minimum_volume = self._manure_to_digest.volume * self._hydraulic_retention_time
-        top_cover_volume = self._manure_to_digest * self._top_cover_volume_fraction
+        minimum_digester_volume = self._manure_to_digest.volume * self._hydraulic_retention_time
+        top_cover_volume = minimum_digester_volume * self._top_cover_volume_fraction
 
         self._manure_to_digest.ammoniacal_nitrogen = min(
             self._manure_to_digest.ammoniacal_nitrogen * TAN_INCREASE_FACTOR, self._manure_to_digest.nitrogen
@@ -150,7 +150,7 @@ class AnaerobicDigester(Digester):
             heating_input_energy=heating_input_energy,
             methane_generation_volume=generated_methane_volume,
             methane_leakage_mass=methane_leakage,
-            minimum_digester_volume=minimum_volume,
+            minimum_digester_volume=minimum_digester_volume,
             top_cover_volume=top_cover_volume,
             time=time,
         )

--- a/RUFAS/biophysical/manure/manure_constants.py
+++ b/RUFAS/biophysical/manure/manure_constants.py
@@ -3,6 +3,9 @@ class ManureConstants:
     A class to store constants for manure management.
     """
 
+    """Achievable emission of methane from dairy manure (m^3 methane / kg volatile solids)."""
+    ACHIEVABLE_METHANE_EMISSION = 0.24
+
     MANURE_DENSITY = 990.0
     """The density of manure (kg/:math:`m^3`)."""
 

--- a/RUFAS/biophysical/manure/manure_constants.py
+++ b/RUFAS/biophysical/manure/manure_constants.py
@@ -3,8 +3,8 @@ class ManureConstants:
     A class to store constants for manure management.
     """
 
-    """Achievable emission of methane from dairy manure (m^3 methane / kg volatile solids)."""
     ACHIEVABLE_METHANE_EMISSION = 0.24
+    """Achievable emission of methane from dairy manure (m^3 methane / kg volatile solids)."""
 
     MANURE_DENSITY = 990.0
     """The density of manure (kg/:math:`m^3`)."""

--- a/changelog.md
+++ b/changelog.md
@@ -114,6 +114,7 @@ v0.9.2
 - [2247](https://github.com/RuminantFarmSystems/MASM/pull/2247) - [minor change] [Crop & Soil] Fix the ZeroDivisionError for surface machine manure application.
 - [2255](https://github.com/RuminantFarmSystems/MASM/pull/2255) - [minor change] [OutputManager] Fix the error reporting units properly to CSV OM files.
 - [2214](https://github.com/RuminantFarmSystems/MASM/pull/2214) - [minor change] [Manure] Adds a base manure Storage class.
+- [2273](https://github.com/RuminantFarmSystems/MASM/pull/2273) - [minor change] [Manure] Re-implements the logic for Anaerobic Digestion.
 
 ### v0.9.2
 

--- a/input/data/manure/refreshed_manure_management.json
+++ b/input/data/manure/refreshed_manure_management.json
@@ -1,0 +1,15 @@
+{
+    "anaerobic_digesters":[
+        {
+            "name": "anaerobic_digester",
+            "hydraulic_retention_time": 25,
+            "top_cover_volume_fraction": 0.2,
+            "evaporation_fraction": 0.02,
+            "anaerobic_digestion_temperature_set_point": 37.5,
+            "methane_leakage_fraction": 0.01,
+            "next_steps": {
+                "storage": 1.0
+            }
+        }
+    ]
+}

--- a/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
+++ b/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
@@ -73,7 +73,7 @@ def test_anaerobic_digester_init() -> None:
     )
 
     assert actual.is_housing_emissions_calculator is False
-    assert actual._manure_to_digest.is_empty is True
+    assert actual._manure_in_digester.is_empty is True
     assert actual._temperature_set_point == 10.0
     assert actual._hydraulic_retention_time == 25
     assert actual._top_cover_volume_fraction == 0.02
@@ -85,7 +85,7 @@ def test_receive_manure(digester: AnaerobicDigester, manure_stream: ManureStream
     """Test that manure is received correctly."""
     digester.receive_manure(manure_stream)
 
-    assert digester._manure_to_digest == manure_stream
+    assert digester._manure_in_digester == manure_stream
 
 
 def test_receive_manure_error(digester: AnaerobicDigester, manure_stream: ManureStream) -> None:
@@ -105,7 +105,7 @@ def test_process_manure(
     mocker: MockerFixture,
 ) -> None:
     """Test that manure is digested correctly."""
-    digester._manure_to_digest = replace(manure_stream)
+    digester._manure_in_digester = replace(manure_stream)
     manure_stream.degradable_volatile_solids, manure_stream.non_degradable_volatile_solids = 12.0, 11.0
     specific_energy_input = mocker.patch.object(digester, "_calculate_specific_input_energy", return_value=3.0)
     methane_volume = mocker.patch.object(digester, "_calculate_CSTR_methane_volume", return_value=10.0)
@@ -131,7 +131,7 @@ def test_process_manure_empty_stream(
     digester: AnaerobicDigester, time: Time, conditions: CurrentDayConditions, mocker: MockerFixture
 ) -> None:
     """Test that process_manure handles no manure to be processed correctly."""
-    digester._manure_to_digest = ManureStream.make_empty_manure_stream()
+    digester._manure_in_digester = ManureStream.make_empty_manure_stream()
     report_outputs = mocker.patch.object(digester, "_report_anaerobic_digester_outputs")
 
     actual = digester.process_manure(conditions, time)
@@ -156,8 +156,8 @@ def test_destroy_volatile_solids(
     expected_error_count: int,
 ) -> None:
     """Test that volatile solids are destroyed correctly."""
-    digester._manure_to_digest.degradable_volatile_solids = degradable
-    digester._manure_to_digest.non_degradable_volatile_solids = non_degradable
+    digester._manure_in_digester.degradable_volatile_solids = degradable
+    digester._manure_in_digester.non_degradable_volatile_solids = non_degradable
     add_error = mocker.patch.object(digester._om, "add_error")
 
     actual = digester._destroy_volatile_solids(destroyed, time)

--- a/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
+++ b/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
@@ -26,6 +26,25 @@ def time() -> Time:
     return Time(datetime(2023, 12, 20), datetime(2025, 3, 7), datetime(2025, 3, 5))
 
 
+def test_anaerobic_digester_init() -> None:
+    """Test that an Anaerobic Digester is initialized correctly."""
+    actual = AnaerobicDigester(
+        name="actual",
+        temperature_set_point=10.0,
+        hydraulic_retention_time=25,
+        top_cover_volume_fraction=0.02,
+        methane_leakage_fraction=0.01,
+        evaporation_fraction=0.001,
+    )
+
+    assert actual._manure_to_digest.is_empty is True
+    assert actual._temperature_set_point == 10.0
+    assert actual._hydraulic_retention_time == 25
+    assert actual._top_cover_volume_fraction == 0.02
+    assert actual._methane_leakage_fraction == 0.01
+    assert actual._evaporation_fraction == 0.001
+
+
 @pytest.mark.parametrize(
     "degradable, non_degradable, destroyed, expected_degradable, expected_non_degradable, expected_error_count",
     [(100.0, 100.0, 50.0, 75.0, 75.0, 0), (900.0, 100.0, 100.0, 810.0, 90.0, 0), (50.0, 20.0, 75.0, 0.0, 0.0, 1)],

--- a/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
+++ b/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from pytest_mock import MockerFixture
 
 from RUFAS.biophysical.manure.digester.anaerobic_digester import AnaerobicDigester
+from RUFAS.data_structures.animal_to_manure_connection import ManureStream, PenManureData
 from RUFAS.time import Time
 from RUFAS.units import MeasurementUnits
 
@@ -17,6 +18,24 @@ def digester() -> AnaerobicDigester:
         top_cover_volume_fraction=0.1,
         methane_leakage_fraction=0.02,
         evaporation_fraction=0.01,
+    )
+
+
+@pytest.fixture
+def manure_stream() -> ManureStream:
+    """Manure Stream fixture for testing."""
+    return ManureStream(
+        water=100.0,
+        ammoniacal_nitrogen=10.0,
+        nitrogen=20.0,
+        phosphorus=3.0,
+        potassium=2.0,
+        ash=15.0,
+        non_degradable_volatile_solids=20.0,
+        degradable_volatile_solids=12.0,
+        total_solids=50.0,
+        volume=500.0,
+        pen_manure_data=None
     )
 
 
@@ -43,6 +62,13 @@ def test_anaerobic_digester_init() -> None:
     assert actual._top_cover_volume_fraction == 0.02
     assert actual._methane_leakage_fraction == 0.01
     assert actual._evaporation_fraction == 0.001
+
+
+def test_receive_manure(digester: AnaerobicDigester, manure_stream: ManureStream) -> None:
+    """Test that manure is received correctly."""
+    digester.receive_manure(manure_stream)
+
+    assert digester._manure_to_digest == manure_stream
 
 
 @pytest.mark.parametrize(

--- a/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
+++ b/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
@@ -1,17 +1,76 @@
 import pytest
+from datetime import datetime
 from pytest_mock import MockerFixture
 
 from RUFAS.biophysical.manure.digester.anaerobic_digester import AnaerobicDigester
+from RUFAS.time import Time
+from RUFAS.units import MeasurementUnits
+
+
+@pytest.fixture
+def digester() -> AnaerobicDigester:
+    """Anaerobic Digester fixture for testing."""
+    return AnaerobicDigester(
+        name="test",
+        temperature_set_point=20.0,
+        hydraulic_retention_time=25.0,
+        top_cover_volume_fraction=0.1,
+        methane_leakage_fraction=0.02,
+        evaporation_fraction=0.01,
+    )
+
+
+@pytest.fixture
+def time() -> Time:
+    """Time fixture for testing."""
+    return Time(datetime(2023, 12, 20), datetime(2025, 3, 7), datetime(2025, 3, 5))
+
+
+def test_report_anaerobic_digester_outputs(digester: AnaerobicDigester, time: Time, mocker: MockerFixture) -> None:
+    """Tests that output variables from an anaerobic digester are calculated correctly."""
+    add_var = mocker.patch.object(digester._om, "add_variable")
+    expected_info_map = {
+        "class": "AnaerobicDigester",
+        "function": "_report_anaerobic_digester_outputs",
+        "prefix": "AnaerobicDigester.test",
+        "simulation_day": time.simulation_day,
+        "units": MeasurementUnits.CUBIC_METERS,
+    }
+    methane = 20.0
+
+    digester._report_anaerobic_digester_outputs(
+        biogas=0.0,
+        biogas_energy_content=0.0,
+        evaporated_water=0.0,
+        heating_input_energy=0.0,
+        methane_generation_volume=methane,
+        methane_leakage_mass=0.0,
+        minimum_digester_volume=0.0,
+        top_cover_volume=0.0,
+        time=time,
+    )
+
+    assert add_var.call_count == 20
+    add_var.assert_any_call("methane_generation_volume", methane, expected_info_map)
 
 
 @pytest.mark.parametrize(
     "set_point, effluent_temp, influent_heat, heat_capacity, expected",
-    [(20.0, 15.0, 1.8, 1.9, 9.25), (17.0, 22.0, 1.2, 1.8, -7.5)]
+    [(20.0, 15.0, 1.8, 1.9, 9.25), (17.0, 22.0, 1.2, 1.8, -7.5)],
 )
-def test_calculate_specific_input_energy(mocker: MockerFixture, set_point: float, effluent_temp: float, influent_heat: float, heat_capacity: float, expected: float) -> None:
+def test_calculate_specific_input_energy(
+    mocker: MockerFixture,
+    set_point: float,
+    effluent_temp: float,
+    influent_heat: float,
+    heat_capacity: float,
+    expected: float,
+) -> None:
     """Test that the specific input energy of an Anaerobic Digester is calculated correctly."""
     mocker.patch.object(AnaerobicDigester, "_bind_influent_temperature", return_value=effluent_temp)
-    mocker.patch.object(AnaerobicDigester, "_calculate_manure_heat_capacity", side_effect=[influent_heat, heat_capacity])
+    mocker.patch.object(
+        AnaerobicDigester, "_calculate_manure_heat_capacity", side_effect=[influent_heat, heat_capacity]
+    )
 
     actual = AnaerobicDigester._calculate_specific_input_energy(17.0, 0.93, set_point)
 

--- a/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
+++ b/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
@@ -26,6 +26,33 @@ def time() -> Time:
     return Time(datetime(2023, 12, 20), datetime(2025, 3, 7), datetime(2025, 3, 5))
 
 
+@pytest.mark.parametrize(
+    "degradable, non_degradable, destroyed, expected_degradable, expected_non_degradable, expected_error_count",
+    [(100.0, 100.0, 50.0, 75.0, 75.0, 0), (900.0, 100.0, 100.0, 810.0, 90.0, 0), (50.0, 20.0, 75.0, 0.0, 0.0, 1)],
+)
+def test_destroy_volatile_solids(
+    digester: AnaerobicDigester,
+    time: Time,
+    mocker: MockerFixture,
+    degradable: float,
+    non_degradable: float,
+    destroyed: float,
+    expected_degradable: float,
+    expected_non_degradable: float,
+    expected_error_count: int,
+) -> None:
+    """Test that volatile solids are destroyed correctly."""
+    digester._manure_to_digest.degradable_volatile_solids = degradable
+    digester._manure_to_digest.non_degradable_volatile_solids = non_degradable
+    add_error = mocker.patch.object(digester._om, "add_error")
+
+    actual = digester._destroy_volatile_solids(destroyed, time)
+
+    assert actual.degradable_volatile_solids == expected_degradable
+    assert actual.non_degradable_volatile_solids == expected_non_degradable
+    assert add_error.call_count == expected_error_count
+
+
 def test_report_anaerobic_digester_outputs(digester: AnaerobicDigester, time: Time, mocker: MockerFixture) -> None:
     """Tests that output variables from an anaerobic digester are calculated correctly."""
     add_var = mocker.patch.object(digester._om, "add_variable")

--- a/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
+++ b/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
@@ -1,19 +1,21 @@
 import pytest
+from pytest_mock import MockerFixture
 
 from RUFAS.biophysical.manure.digester.anaerobic_digester import AnaerobicDigester
 
 
-# @pytest.mark.parametrize(
-#     "temp, moisture_frac, set_point, expected",
-#     [
-#         (),
-#     ]
-# )
-# def test_calculate_specific_input_energy(temp: float, moisture_frac: float, set_point: float, expected: float) -> None:
-#     """Test that the specific input energy of an Anaerobic Digester is calculated correctly."""
-#     actual = AnaerobicDigester._calculate_specific_input_energy(temp, moisture_frac, set_point)
+@pytest.mark.parametrize(
+    "set_point, effluent_temp, influent_heat, heat_capacity, expected",
+    [(20.0, 15.0, 1.8, 1.9, 9.25), (17.0, 22.0, 1.2, 1.8, -7.5)]
+)
+def test_calculate_specific_input_energy(mocker: MockerFixture, set_point: float, effluent_temp: float, influent_heat: float, heat_capacity: float, expected: float) -> None:
+    """Test that the specific input energy of an Anaerobic Digester is calculated correctly."""
+    mocker.patch.object(AnaerobicDigester, "_bind_influent_temperature", return_value=effluent_temp)
+    mocker.patch.object(AnaerobicDigester, "_calculate_manure_heat_capacity", side_effect=[influent_heat, heat_capacity])
 
-#     assert actual == expected
+    actual = AnaerobicDigester._calculate_specific_input_energy(17.0, 0.93, set_point)
+
+    assert actual == expected
 
 
 @pytest.mark.parametrize("temp, expected", [(30.0, 30.0), (10.0, 10.0), (0.0, 4.0)])

--- a/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
+++ b/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
@@ -30,7 +30,7 @@ def digester() -> AnaerobicDigester:
     return AnaerobicDigester(
         name="test",
         temperature_set_point=20.0,
-        hydraulic_retention_time=25.0,
+        hydraulic_retention_time=25,
         top_cover_volume_fraction=0.1,
         methane_leakage_fraction=0.02,
         evaporation_fraction=0.01,

--- a/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
+++ b/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
@@ -72,6 +72,7 @@ def test_anaerobic_digester_init() -> None:
         evaporation_fraction=0.001,
     )
 
+    assert actual.is_housing_emissions_calculator is False
     assert actual._manure_to_digest.is_empty is True
     assert actual._temperature_set_point == 10.0
     assert actual._hydraulic_retention_time == 25
@@ -88,7 +89,7 @@ def test_receive_manure(digester: AnaerobicDigester, manure_stream: ManureStream
 
 
 def test_receive_manure_error(digester: AnaerobicDigester, manure_stream: ManureStream) -> None:
-    """Test that Anaerobic Digester when incompatible manure stream is passed."""
+    """Test that Anaerobic Digester raises an error when incompatible manure is passed."""
     manure_stream.pen_manure_data = PenManureData(
         100, 500.0, AnimalCombination.LAC_COW, "open lot", 1000.0, 50.0, StreamType.GENERAL
     )

--- a/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
+++ b/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
@@ -3,7 +3,8 @@ from datetime import datetime
 from pytest_mock import MockerFixture
 
 from RUFAS.biophysical.manure.digester.anaerobic_digester import AnaerobicDigester
-from RUFAS.data_structures.animal_to_manure_connection import ManureStream, PenManureData
+from RUFAS.data_structures.animal_to_manure_connection import ManureStream, PenManureData, StreamType
+from RUFAS.enums import AnimalCombination
 from RUFAS.time import Time
 from RUFAS.units import MeasurementUnits
 
@@ -70,6 +71,14 @@ def test_receive_manure(digester: AnaerobicDigester, manure_stream: ManureStream
 
     assert digester._manure_to_digest == manure_stream
 
+
+def test_receive_manure_error(digester: AnaerobicDigester, manure_stream: ManureStream) -> None:
+    """Test that Anaerobic Digester when incompatible manure stream is passed."""
+    manure_stream.pen_manure_data = PenManureData(
+        100, 500.0, AnimalCombination.LAC_COW, "open lot", 1000.0, 50.0, StreamType.GENERAL
+    )
+    with pytest.raises(ValueError):
+        digester.receive_manure(manure_stream)
 
 @pytest.mark.parametrize(
     "degradable, non_degradable, destroyed, expected_degradable, expected_non_degradable, expected_error_count",

--- a/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
+++ b/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
@@ -30,3 +30,11 @@ def test_calculate_manure_heat_capacity(temp: float, moisture_frac: float, expec
     actual = AnaerobicDigester._calculate_manure_heat_capacity(temp, moisture_frac)
 
     assert actual == expected
+
+
+@pytest.mark.parametrize("total_vol_sols, expected", [(100.0, 24.0), (0.0, 0.0)])
+def test_calculate_CSTR_methane_volume(total_vol_sols: float, expected: float) -> None:
+    """Test that the generated methane volume is calculated correctly."""
+    actual = AnaerobicDigester._calculate_CSTR_methane_volume(total_vol_sols)
+
+    assert actual == expected

--- a/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
+++ b/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
@@ -1,0 +1,24 @@
+import pytest
+
+from RUFAS.biophysical.manure.digester.anaerobic_digester import AnaerobicDigester
+
+
+# @pytest.mark.parametrize(
+#     "temp, moisture_frac, set_point, expected",
+#     [
+#         (),
+#     ]
+# )
+# def test_calculate_specific_input_energy(temp: float, moisture_frac: float, set_point: float, expected: float) -> None:
+#     """Test that the specific input energy of an Anaerobic Digester is calculated correctly."""
+#     actual = AnaerobicDigester._calculate_specific_input_energy(temp, moisture_frac, set_point)
+
+#     assert actual == expected
+
+
+@pytest.mark.parametrize("temp, expected", [(30.0, 30.0), (10.0, 10.0), (0.0, 4.0)])
+def test_bind_influent_temperature(temp: float, expected: float) -> None:
+    """Test that the influent temperature is bounded correctly."""
+    actual = AnaerobicDigester._bind_influent_temperature(temp)
+
+    assert actual == expected

--- a/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
+++ b/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
@@ -22,3 +22,11 @@ def test_bind_influent_temperature(temp: float, expected: float) -> None:
     actual = AnaerobicDigester._bind_influent_temperature(temp)
 
     assert actual == expected
+
+
+@pytest.mark.parametrize("temp, moisture_frac, expected", [(20.0, 0.5, 1.84922), (5.0, 0.9, 1.98669)])
+def test_calculate_manure_heat_capacity(temp: float, moisture_frac: float, expected: float) -> None:
+    """Test that the heat capacity of manure is calculated correctly."""
+    actual = AnaerobicDigester._calculate_manure_heat_capacity(temp, moisture_frac)
+
+    assert actual == expected

--- a/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
+++ b/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
@@ -38,3 +38,21 @@ def test_calculate_CSTR_methane_volume(total_vol_sols: float, expected: float) -
     actual = AnaerobicDigester._calculate_CSTR_methane_volume(total_vol_sols)
 
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "methane, leakage, expected", [(0.0, 0.0, 0.0), (0.0, 0.2, 0.0), (100.0, 0.0, 0.0), (100.0, 0.25, 25.0)]
+)
+def test_calculate_methane_leakage(methane: float, leakage: float, expected: float) -> None:
+    """Test that methane leakage is calculated correctly."""
+    actual = AnaerobicDigester._calculate_methane_leakage(methane, leakage)
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize("methane, expected", [(100.0, 5500.0), (0.0, 0.0)])
+def test_calculate_methane_energy_content(methane: float, expected: float) -> None:
+    """Test that the energy content of methane is calculated correctly."""
+    actual = AnaerobicDigester._calculate_methane_energy_content(methane)
+
+    assert actual == expected

--- a/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
+++ b/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
@@ -1,12 +1,27 @@
 import pytest
+from dataclasses import replace
 from datetime import datetime
 from pytest_mock import MockerFixture
 
 from RUFAS.biophysical.manure.digester.anaerobic_digester import AnaerobicDigester
+from RUFAS.current_day_conditions import CurrentDayConditions
 from RUFAS.data_structures.animal_to_manure_connection import ManureStream, PenManureData, StreamType
 from RUFAS.enums import AnimalCombination
 from RUFAS.time import Time
 from RUFAS.units import MeasurementUnits
+
+
+@pytest.fixture
+def conditions() -> CurrentDayConditions:
+    """Current day conditions fixture for testing."""
+    return CurrentDayConditions(
+        incoming_light=10.0,
+        min_air_temperature=12.0,
+        mean_air_temperature=18.0,
+        max_air_temperature=24.0,
+        daylength=14.0,
+        annual_mean_air_temperature=14.5,
+    )
 
 
 @pytest.fixture
@@ -36,7 +51,7 @@ def manure_stream() -> ManureStream:
         degradable_volatile_solids=12.0,
         total_solids=50.0,
         volume=500.0,
-        pen_manure_data=None
+        pen_manure_data=None,
     )
 
 
@@ -79,6 +94,50 @@ def test_receive_manure_error(digester: AnaerobicDigester, manure_stream: Manure
     )
     with pytest.raises(ValueError):
         digester.receive_manure(manure_stream)
+
+
+def test_process_manure(
+    digester: AnaerobicDigester,
+    manure_stream: ManureStream,
+    conditions: CurrentDayConditions,
+    time: Time,
+    mocker: MockerFixture,
+) -> None:
+    """Test that manure is digested correctly."""
+    digester._manure_to_digest = replace(manure_stream)
+    manure_stream.degradable_volatile_solids, manure_stream.non_degradable_volatile_solids = 12.0, 11.0
+    specific_energy_input = mocker.patch.object(digester, "_calculate_specific_input_energy", return_value=3.0)
+    methane_volume = mocker.patch.object(digester, "_calculate_CSTR_methane_volume", return_value=10.0)
+    destroy_vol_sols = mocker.patch.object(digester, "_destroy_volatile_solids", return_value=manure_stream)
+    methane_leakage = mocker.patch.object(digester, "_calculate_methane_leakage", return_value=9.0)
+    methane_energy = mocker.patch.object(digester, "_calculate_methane_energy_content", return_value=8.0)
+    report_outputs = mocker.patch.object(digester, "_report_anaerobic_digester_outputs")
+    expected_volume = manure_stream.volume - 0.01790909090909  # Expected reduction in volume calculated manually.
+    expected_manure_stream = replace(manure_stream, volume=expected_volume)
+
+    actual = digester.process_manure(conditions, time)
+
+    assert actual["manure"] == expected_manure_stream
+    specific_energy_input.assert_called_once()
+    methane_volume.assert_called_once()
+    destroy_vol_sols.assert_called_once()
+    methane_leakage.assert_called_once()
+    methane_energy.assert_called_once()
+    report_outputs.assert_called_once()
+
+
+def test_process_manure_empty_stream(
+    digester: AnaerobicDigester, time: Time, conditions: CurrentDayConditions, mocker: MockerFixture
+) -> None:
+    """Test that process_manure handles no manure to be processed correctly."""
+    digester._manure_to_digest = ManureStream.make_empty_manure_stream()
+    report_outputs = mocker.patch.object(digester, "_report_anaerobic_digester_outputs")
+
+    actual = digester.process_manure(conditions, time)
+
+    assert actual == {}
+    report_outputs.assert_called_once()
+
 
 @pytest.mark.parametrize(
     "degradable, non_degradable, destroyed, expected_degradable, expected_non_degradable, expected_error_count",

--- a/tests/test_biophysical/test_manure/test_manure_constants.py
+++ b/tests/test_biophysical/test_manure/test_manure_constants.py
@@ -12,6 +12,7 @@ def test_manure_constants() -> None:
     """
 
     # Assert
+    assert ManureConstants.ACHIEVABLE_METHANE_EMISSION == approx(0.24)
     assert ManureConstants.MANURE_DENSITY == approx(990.0)
     assert ManureConstants.MANURE_SOLIDS_BEDDING_DENSITY == approx(400.0)
     assert ManureConstants.LIQUID_MANURE_DENSITY == approx(1000)


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Re-implements the logic for modeling anaerobic digestion.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2102, closes #1120

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Re-implements the logic for anaerobic digestion in the new `AnaerobicDigester` class, which is a child of the base `Digester` class.

Also adds in the previous defaults for an anaerobic digester into a new manure management configuration file, which will be used to track refreshed manure inputs.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
This logic needs to be reimplemented in order for RuFaS to be able to simulate anaerobic digesters with the refreshed manure module.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Fills in the logic for the `AnaerobicDigester` class, including `receive_manure` and `process_manure`.

`receive_manure` is extremely simple, it checks if manure received is compatible and if so, adds it to the manure that needs to be digested on the current day.

`process_manure` is a re-implementation of the daily logic from the pre-refresh `AnaerobicDigestion`. It takes all the manure that was received on the current day, processes all the physical and chemical changes to the held manure, records the changes and the changed manure, then passes all the manure on.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Wrote a complete unit test suite for `AnaerobicDigester`, which covers 100% of code added in this PR.