### PR TITLE
[Manure] Adds separator configs to refresh manure mgmt json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-96%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-3226%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-96%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-3226%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)

--- a/RUFAS/biophysical/manure/processor.py
+++ b/RUFAS/biophysical/manure/processor.py
@@ -125,7 +125,8 @@ class Processor(ABC):
         if manure_stream_dict.keys() != ManureStream.MANURE_STREAM_UNITS.keys():
             self._om.add_error(
                 "Manure Stream Keys Error",
-                f"Expected keys: {set(ManureStream.MANURE_STREAM_UNITS.keys())}, received: {set(manure_stream_dict.keys())}.",
+                f"Expected keys: {set(ManureStream.MANURE_STREAM_UNITS.keys())}, "
+                f"received: {set(manure_stream_dict.keys())}.",
                 info_map,
             )
             raise ValueError("Manure Stream must contain the same keys as manure_stream_units to properly log it.")

--- a/RUFAS/biophysical/manure/processor.py
+++ b/RUFAS/biophysical/manure/processor.py
@@ -103,7 +103,8 @@ class Processor(ABC):
         """
         pass
 
-    def _log_manure_stream(self, manure_stream: ManureStream | dict[str, float], stream_name: str, time: Time) -> None:
+    def _log_manure_stream(self, manure_stream: ManureStream | dict[str, float | None], stream_name: str, time: Time
+                           ) -> None:
         """
         Logs the manure stream data to Output Manager.
 

--- a/RUFAS/biophysical/manure/processor.py
+++ b/RUFAS/biophysical/manure/processor.py
@@ -6,7 +6,6 @@ from RUFAS.data_structures.animal_to_manure_connection import ManureStream
 from RUFAS.general_constants import GeneralConstants
 from RUFAS.time import Time
 from RUFAS.output_manager import OutputManager
-from RUFAS.units import MeasurementUnits
 from RUFAS.util import Utility
 
 
@@ -40,22 +39,6 @@ class Processor(ABC):
         Handles the daily operations for the processor.
 
     """
-
-    MANURE_STREAM_UNITS = {
-        "water": MeasurementUnits.KILOGRAMS,
-        "ammoniacal_nitrogen": MeasurementUnits.KILOGRAMS,
-        "nitrogen": MeasurementUnits.KILOGRAMS,
-        "phosphorus": MeasurementUnits.KILOGRAMS,
-        "potassium": MeasurementUnits.KILOGRAMS,
-        "ash": MeasurementUnits.KILOGRAMS,
-        "non_degradable_volatile_solids": MeasurementUnits.KILOGRAMS,
-        "degradable_volatile_solids": MeasurementUnits.KILOGRAMS,
-        "total_solids": MeasurementUnits.KILOGRAMS,
-        "volume": MeasurementUnits.CUBIC_METERS,
-        "mass": MeasurementUnits.KILOGRAMS,
-        "total_volatile_solids": MeasurementUnits.KILOGRAMS,
-        "pen_manure_data": None,
-    }
 
     def __init__(self, name: str, is_housing_emissions_calculator: bool) -> None:
         """Initializes a new Processor."""
@@ -139,10 +122,10 @@ class Processor(ABC):
             )
             raise ValueError("Manure stream must be a dictionary or a ManureStream instance to properly log it.")
 
-        if manure_stream_dict.keys() != self.MANURE_STREAM_UNITS.keys():
+        if manure_stream_dict.keys() != ManureStream.MANURE_STREAM_UNITS.keys():
             self._om.add_error(
                 "Manure Stream Keys Error",
-                f"Expected keys: {set(self.MANURE_STREAM_UNITS.keys())}, received: {set(manure_stream_dict.keys())}.",
+                f"Expected keys: {set(ManureStream.MANURE_STREAM_UNITS.keys())}, received: {set(manure_stream_dict.keys())}.",
                 info_map,
             )
             raise ValueError("Manure Stream must contain the same keys as manure_stream_units to properly log it.")
@@ -150,7 +133,7 @@ class Processor(ABC):
         for key, value in manure_stream_dict.items():
             if key != "pen_manure_data":
                 self._om.add_variable(
-                    f"{stream_name}.manure_{key}", value, {**info_map, "units": self.MANURE_STREAM_UNITS[key]}
+                    f"{stream_name}.manure_{key}", value, {**info_map, "units": ManureStream.MANURE_STREAM_UNITS[key]}
                 )
 
     def check_manure_stream_compatibility(self, manure_stream: ManureStream) -> bool:

--- a/RUFAS/biophysical/manure/processor.py
+++ b/RUFAS/biophysical/manure/processor.py
@@ -87,24 +87,24 @@ class Processor(ABC):
         """
         pass
 
-    def _log_manure_stream(
+    def _report_manure_stream(
         self, manure_stream: ManureStream | dict[str, float | None], stream_name: str, time: Time
     ) -> None:
         """
-        Logs the manure stream data to Output Manager.
+        Reports the manure stream data to Output Manager.
 
         Parameters
         ----------
         manure_stream : ManureStream | dict[str, float]
-            The manure stream to log. If a `ManureStream` instance is passed, it will be converted to a dictionary.
+            The manure stream to report. If a `ManureStream` instance is passed, it will be converted to a dictionary.
         stream_name : str
-            The name of the manure stream being logged.
+            The name of the manure stream being reported.
         time : Time
             The simulation time object.
         """
         info_map = {
             "class": self.__class__.__name__,
-            "function": self._log_manure_stream.__name__,
+            "function": self._report_manure_stream.__name__,
             "prefix": self._prefix,
             "simulation_day": time.simulation_day,
         }
@@ -120,7 +120,7 @@ class Processor(ABC):
                 "This function requires either a ManureStream instance or a dictionary.",
                 info_map,
             )
-            raise ValueError("Manure stream must be a dictionary or a ManureStream instance to properly log it.")
+            raise ValueError("Manure stream must be a dictionary or a ManureStream instance to properly report it.")
 
         if manure_stream_dict.keys() != ManureStream.MANURE_STREAM_UNITS.keys():
             self._om.add_error(
@@ -129,7 +129,7 @@ class Processor(ABC):
                 f"received: {set(manure_stream_dict.keys())}.",
                 info_map,
             )
-            raise ValueError("Manure Stream must contain the same keys as manure_stream_units to properly log it.")
+            raise ValueError("Manure Stream must contain the same keys as manure_stream_units to properly report it.")
 
         for key, value in manure_stream_dict.items():
             if key != "pen_manure_data":

--- a/RUFAS/biophysical/manure/processor.py
+++ b/RUFAS/biophysical/manure/processor.py
@@ -40,6 +40,7 @@ class Processor(ABC):
         Handles the daily operations for the processor.
 
     """
+
     MANURE_STREAM_UNITS = {
         "water": MeasurementUnits.KILOGRAMS,
         "ammoniacal_nitrogen": MeasurementUnits.KILOGRAMS,
@@ -103,8 +104,9 @@ class Processor(ABC):
         """
         pass
 
-    def _log_manure_stream(self, manure_stream: ManureStream | dict[str, float | None], stream_name: str, time: Time
-                           ) -> None:
+    def _log_manure_stream(
+        self, manure_stream: ManureStream | dict[str, float | None], stream_name: str, time: Time
+    ) -> None:
         """
         Logs the manure stream data to Output Manager.
 

--- a/RUFAS/biophysical/manure/processor.py
+++ b/RUFAS/biophysical/manure/processor.py
@@ -1,10 +1,12 @@
 from abc import ABC, abstractmethod
+from dataclasses import asdict
 
 from RUFAS.current_day_conditions import CurrentDayConditions
 from RUFAS.data_structures.animal_to_manure_connection import ManureStream
 from RUFAS.general_constants import GeneralConstants
 from RUFAS.time import Time
 from RUFAS.output_manager import OutputManager
+from RUFAS.units import MeasurementUnits
 from RUFAS.util import Utility
 
 
@@ -38,6 +40,21 @@ class Processor(ABC):
         Handles the daily operations for the processor.
 
     """
+    MANURE_STREAM_UNITS = {
+        "water": MeasurementUnits.KILOGRAMS,
+        "ammoniacal_nitrogen": MeasurementUnits.KILOGRAMS,
+        "nitrogen": MeasurementUnits.KILOGRAMS,
+        "phosphorus": MeasurementUnits.KILOGRAMS,
+        "potassium": MeasurementUnits.KILOGRAMS,
+        "ash": MeasurementUnits.KILOGRAMS,
+        "non_degradable_volatile_solids": MeasurementUnits.KILOGRAMS,
+        "degradable_volatile_solids": MeasurementUnits.KILOGRAMS,
+        "total_solids": MeasurementUnits.KILOGRAMS,
+        "volume": MeasurementUnits.CUBIC_METERS,
+        "mass": MeasurementUnits.KILOGRAMS,
+        "total_volatile_solids": MeasurementUnits.KILOGRAMS,
+        "pen_manure_data": None,
+    }
 
     def __init__(self, name: str, is_housing_emissions_calculator: bool) -> None:
         """Initializes a new Processor."""
@@ -85,6 +102,53 @@ class Processor(ABC):
 
         """
         pass
+
+    def _log_manure_stream(self, manure_stream: ManureStream | dict[str, float], stream_name: str, time: Time) -> None:
+        """
+        Logs the manure stream data to Output Manager.
+
+        Parameters
+        ----------
+        manure_stream : ManureStream | dict[str, float]
+            The manure stream to log. If a `ManureStream` instance is passed, it will be converted to a dictionary.
+        stream_name : str
+            The name of the manure stream being logged.
+        time : Time
+            The simulation time object.
+        """
+        info_map = {
+            "class": self.__class__.__name__,
+            "function": self._log_manure_stream.__name__,
+            "prefix": self._prefix,
+            "simulation_day": time.simulation_day,
+        }
+        if isinstance(manure_stream, ManureStream):
+            manure_stream_dict = asdict(manure_stream)
+            manure_stream_dict["total_volatile_solids"] = ManureStream.total_volatile_solids
+            manure_stream_dict["mass"] = ManureStream.mass
+        elif isinstance(manure_stream, dict):
+            manure_stream_dict = manure_stream.copy()
+        else:
+            self._om.add_error(
+                "Manure Stream Type Error",
+                "This function requires either a ManureStream instance or a dictionary.",
+                info_map,
+            )
+            raise ValueError("Manure stream must be a dictionary or a ManureStream instance to properly log it.")
+
+        if manure_stream_dict.keys() != self.MANURE_STREAM_UNITS.keys():
+            self._om.add_error(
+                "Manure Stream Keys Error",
+                f"Expected keys: {set(self.MANURE_STREAM_UNITS.keys())}, received: {set(manure_stream_dict.keys())}.",
+                info_map,
+            )
+            raise ValueError("Manure Stream must contain the same keys as manure_stream_units to properly log it.")
+
+        for key, value in manure_stream_dict.items():
+            if key != "pen_manure_data":
+                self._om.add_variable(
+                    f"{stream_name}.manure_{key}", value, {**info_map, "units": self.MANURE_STREAM_UNITS[key]}
+                )
 
     def check_manure_stream_compatibility(self, manure_stream: ManureStream) -> bool:
         """

--- a/RUFAS/biophysical/manure/separator/separator.py
+++ b/RUFAS/biophysical/manure/separator/separator.py
@@ -152,7 +152,7 @@ class Separator(Processor):
         solid_manure_stream_dict = asdict(solid_manure_stream)
         solid_manure_stream_dict["mass"] = solid_manure_total_mass
         solid_manure_stream_dict["total_volatile_solids"] = solid_manure_stream.total_volatile_solids
-        self._log_manure_stream(solid_manure_stream, solid_stream_name, time)
+        self._report_manure_stream(solid_manure_stream, solid_stream_name, time)
 
         liquid_manure_water = self.held_manure.water - solid_manure_water
         liquid_manure_total_solids = self.held_manure.total_solids * (1 - self.total_solids_efficiency)
@@ -175,7 +175,7 @@ class Separator(Processor):
             pen_manure_data=None,
         )
         liquid_stream_name = "SeparatedLiquid"
-        self._log_manure_stream(liquid_manure_stream, liquid_stream_name, time)
+        self._report_manure_stream(liquid_manure_stream, liquid_stream_name, time)
 
         self.clear_held_manure()
 

--- a/RUFAS/biophysical/manure/separator/separator.py
+++ b/RUFAS/biophysical/manure/separator/separator.py
@@ -15,7 +15,7 @@ class Separator(Processor):
     ----------
     name : str
         The name of the separator.
-    percent_dry_solids : float
+    separated_solids_dry_matter : float
         The dry matter content (percent DM) of separated manure solids.
     ammoniacal_nitrogen_efficiency : float
         The efficiency of the separator in removing ammoniacal nitrogen from the manure.
@@ -40,7 +40,7 @@ class Separator(Processor):
         The name of the separator.
     prefix : str
         The prefix to be used for naming output variables.
-    percent_dry_solids : float
+    separated_solids_dry_matter : float
         The dry matter content (percent DM) of separated manure solids.
     ammoniacal_nitrogen_efficiency : float
         The efficiency of the separator in removing ammoniacal nitrogen from the manure.
@@ -64,7 +64,7 @@ class Separator(Processor):
     def __init__(
         self,
         name: str,
-        percent_dry_solids: float,
+        separated_solids_dry_matter: float,
         ammoniacal_nitrogen_efficiency: float,
         nitrogen_efficiency: float,
         phosphorus_efficiency: float,
@@ -76,7 +76,7 @@ class Separator(Processor):
         """Initializes a new Separator."""
         super().__init__(name=name, is_housing_emissions_calculator=False)
         self.held_manure: ManureStream | None = None
-        self.percent_dry_solids: float = percent_dry_solids
+        self.separated_solids_dry_matter: float = separated_solids_dry_matter
         self.ammoniacal_nitrogen_efficiency: float = ammoniacal_nitrogen_efficiency
         self.nitrogen_efficiency: float = nitrogen_efficiency
         self.phosphorus_efficiency: float = phosphorus_efficiency
@@ -131,7 +131,7 @@ class Separator(Processor):
             self._om.add_variable("empty_separator_output", {}, {**info_map, "units": MeasurementUnits.UNITLESS})
             return {}
         solid_manure_total_solids = self.held_manure.total_solids * self.total_solids_efficiency
-        solid_manure_total_mass = solid_manure_total_solids / self.percent_dry_solids
+        solid_manure_total_mass = solid_manure_total_solids / self.separated_solids_dry_matter
         solid_manure_water = solid_manure_total_mass - solid_manure_total_solids
         solid_manure_volume = (solid_manure_water + solid_manure_total_solids) / ManureConstants.SOLID_MANURE_DENSITY
         solid_manure_stream = ManureStream(
@@ -149,6 +149,9 @@ class Separator(Processor):
             pen_manure_data=None,
         )
         solid_stream_name = "SeparatedSolids"
+        solid_manure_stream_dict = asdict(solid_manure_stream)
+        solid_manure_stream_dict["mass"] = solid_manure_total_mass
+        solid_manure_stream_dict["total_volatile_solids"] = solid_manure_stream.total_volatile_solids
         self._log_manure_stream(solid_manure_stream, solid_stream_name, time)
 
         liquid_manure_water = self.held_manure.water - solid_manure_water
@@ -181,41 +184,3 @@ class Separator(Processor):
     def clear_held_manure(self) -> None:
         """Clears the held manure stream."""
         self.held_manure = None
-
-    def _log_manure_stream(self, manure_stream: ManureStream, stream_name: str, time: Time) -> None:
-        """
-        Logs the manure stream data to Output Manager.
-
-        Parameters
-        ----------
-        manure_stream : ManureStream
-            The manure stream to log.
-        stream_name : str
-            The name of the manure stream being logged.
-
-        """
-        info_map = {
-            "class": self.__class__.__name__,
-            "function": self._log_manure_stream.__name__,
-            "prefix": self._prefix,
-            "simulation_day": time.simulation_day,
-        }
-        manure_stream_units = {
-            "water": MeasurementUnits.KILOGRAMS,
-            "ammoniacal_nitrogen": MeasurementUnits.KILOGRAMS,
-            "nitrogen": MeasurementUnits.KILOGRAMS,
-            "phosphorus": MeasurementUnits.KILOGRAMS,
-            "potassium": MeasurementUnits.KILOGRAMS,
-            "ash": MeasurementUnits.KILOGRAMS,
-            "non_degradable_volatile_solids": MeasurementUnits.KILOGRAMS,
-            "degradable_volatile_solids": MeasurementUnits.KILOGRAMS,
-            "total_solids": MeasurementUnits.KILOGRAMS,
-            "volume": MeasurementUnits.CUBIC_METERS,
-            "mass": MeasurementUnits.KILOGRAMS,
-        }
-        manure_stream_dict = asdict(manure_stream)
-        for key, value in manure_stream_dict.items():
-            if key != "pen_manure_data":
-                self._om.add_variable(
-                    f"{stream_name}.manure_{key}", value, {**info_map, "units": manure_stream_units[key]}
-                )

--- a/RUFAS/data_structures/animal_to_manure_connection.py
+++ b/RUFAS/data_structures/animal_to_manure_connection.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from RUFAS.enums import AnimalCombination
+from RUFAS.units import MeasurementUnits
 
 
 class StreamType(Enum):
@@ -121,6 +122,10 @@ class ManureStream:
     pen_manure_data : PenManureData | None
        Optional, more specific information about the manure and the pen or pens that produced it.
 
+    Class Attributes
+    ----------------
+    MANURE_STREAM_UNITS : dict[str, MeasurementUnits | None]
+        A dictionary mapping manure stream attributes and properties to their respective measurement units.
     """
 
     water: float
@@ -134,6 +139,22 @@ class ManureStream:
     total_solids: float
     volume: float
     pen_manure_data: PenManureData | None
+
+    MANURE_STREAM_UNITS = {
+        "water": MeasurementUnits.KILOGRAMS,
+        "ammoniacal_nitrogen": MeasurementUnits.KILOGRAMS,
+        "nitrogen": MeasurementUnits.KILOGRAMS,
+        "phosphorus": MeasurementUnits.KILOGRAMS,
+        "potassium": MeasurementUnits.KILOGRAMS,
+        "ash": MeasurementUnits.KILOGRAMS,
+        "non_degradable_volatile_solids": MeasurementUnits.KILOGRAMS,
+        "degradable_volatile_solids": MeasurementUnits.KILOGRAMS,
+        "total_solids": MeasurementUnits.KILOGRAMS,
+        "volume": MeasurementUnits.CUBIC_METERS,
+        "mass": MeasurementUnits.KILOGRAMS,
+        "total_volatile_solids": MeasurementUnits.KILOGRAMS,
+        "pen_manure_data": None,
+    }
 
     def __add__(self, other: "ManureStream") -> "ManureStream":
         """

--- a/changelog.md
+++ b/changelog.md
@@ -116,6 +116,7 @@ v0.9.2
 - [2214](https://github.com/RuminantFarmSystems/MASM/pull/2214) - [minor change] [Manure] Adds a base manure Storage class.
 - [2273](https://github.com/RuminantFarmSystems/MASM/pull/2273) - [minor change] [Manure] Re-implements the logic for Anaerobic Digestion.
 - [2278](https://github.com/RuminantFarmSystems/MASM/pull/2278) - [minor change] [GraphGenerator] Adds Graph Generator logs mapping original variable name to how it appears in the graph legend
+- [2280](https://github.com/RuminantFarmSystems/MASM/pull/2280) - [minor change] [Manure] Updates input configs for refreshed Separator class.
 
 ### v0.9.2
 

--- a/input/data/manure/refreshed_manure_management.json
+++ b/input/data/manure/refreshed_manure_management.json
@@ -18,25 +18,25 @@
             "name": "rotary screen",
             "type": "rotary screen",
             "percent_dry_solids": 0.20,
-            "total_solids_removal_efficiency": 0.35,
-            "volatile_solids_removal_efficiency": 0.40,
-            "nitrogen_removal_efficiency": 0.30,
-            "total_ammoniacal_nitrogen_removal_efficiency": 0.15,
-            "phosphorus_removal_efficiency": 0.40,
-            "potassium_removal_efficiency": 0.15,
-            "ash_removal_efficiency": 0.10
+            "total_solids_efficiency": 0.35,
+            "volatile_solids_efficiency": 0.40,
+            "nitrogen_efficiency": 0.30,
+            "ammoniacal_nitrogen_efficiency": 0.15,
+            "phosphorus_efficiency": 0.40,
+            "potassium_efficiency": 0.15,
+            "ash_efficiency": 0.10
           },
           {
             "name": "screw press",
             "type": "screw press",
             "percent_dry_solids": 0.35,
-            "total_solids_removal_efficiency": 0.25,
-            "volatile_solids_removal_efficiency": 0.30,
-            "nitrogen_removal_efficiency": 0.30,
-            "total_ammoniacal_nitrogen_removal_efficiency": 0.10,
-            "phosphorus_removal_efficiency": 0.20,
-            "potassium_removal_efficiency": 0.23,
-            "ash_removal_efficiency": 0.10
+            "total_solids_efficiency": 0.25,
+            "volatile_solids_efficiency": 0.30,
+            "nitrogen_efficiency": 0.30,
+            "ammoniacal_nitrogen_efficiency": 0.10,
+            "phosphorus_efficiency": 0.20,
+            "potassium_efficiency": 0.23,
+            "ash_efficiency": 0.10
           }
     ]
 }

--- a/input/data/manure/refreshed_manure_management.json
+++ b/input/data/manure/refreshed_manure_management.json
@@ -1,25 +1,20 @@
 {
-    "anaerobic_digester_configs":[
+    "anaerobic_digester":[
         {
-            "name": "anaerobic_digester",
-            "processor_type": "anaerobic digester",
+            "name": "anaerobic_digester1",
             "digester_type": "anaerobic digester",
             "hydraulic_retention_time": 25,
             "top_cover_volume_fraction": 0.2,
             "evaporation_fraction": 0.02,
             "anaerobic_digestion_temperature_set_point": 37.5,
-            "methane_leakage_fraction": 0.01,
-            "next_steps": {
-                "storage": 1.0
-            }
+            "methane_leakage_fraction": 0.01
         }
     ],
-    "separator_configs":[
+    "separator":[
         {
-            "name": "rotary_screen",
-            "processor_type": "separator",
+            "name": "separator1",
             "separator_type": "rotary screen",
-            "percent_dry_solids": 0.20,
+            "separated_solids_dry_matter": 0.20,
             "total_solids_efficiency": 0.35,
             "volatile_solids_efficiency": 0.40,
             "nitrogen_efficiency": 0.30,
@@ -29,10 +24,9 @@
             "ash_efficiency": 0.10
           },
           {
-            "name": "screw_press",
-            "processor_type": "separator",
+            "name": "separator2",
             "separator_type": "screw press",
-            "percent_dry_solids": 0.35,
+            "separated_solids_dry_matter": 0.35,
             "total_solids_efficiency": 0.25,
             "volatile_solids_efficiency": 0.30,
             "nitrogen_efficiency": 0.30,

--- a/input/data/manure/refreshed_manure_management.json
+++ b/input/data/manure/refreshed_manure_management.json
@@ -2,7 +2,7 @@
     "anaerobic_digester":[
         {
             "name": "anaerobic_digester1",
-            "digester_type": "continuous_mix",
+            "type": "continuous_mix",
             "hydraulic_retention_time": 25,
             "top_cover_volume_fraction": 0.2,
             "evaporation_fraction": 0.02,
@@ -13,7 +13,7 @@
     "separator":[
         {
             "name": "separator1",
-            "separator_type": "rotary screen",
+            "type": "rotary screen",
             "separated_solids_dry_matter": 0.20,
             "total_solids_efficiency": 0.35,
             "volatile_solids_efficiency": 0.40,
@@ -25,7 +25,7 @@
           },
           {
             "name": "separator2",
-            "separator_type": "screw press",
+            "type": "screw press",
             "separated_solids_dry_matter": 0.35,
             "total_solids_efficiency": 0.25,
             "volatile_solids_efficiency": 0.30,

--- a/input/data/manure/refreshed_manure_management.json
+++ b/input/data/manure/refreshed_manure_management.json
@@ -1,7 +1,8 @@
 {
-    "anaerobic_digesters":[
+    "anaerobic_digester_configs":[
         {
             "name": "anaerobic_digester",
+            "type": "anaerobic_digester",
             "hydraulic_retention_time": 25,
             "top_cover_volume_fraction": 0.2,
             "evaporation_fraction": 0.02,
@@ -11,5 +12,31 @@
                 "storage": 1.0
             }
         }
+    ],
+    "separator_configs":[
+        {
+            "name": "rotary screen",
+            "type": "rotary screen",
+            "percent_dry_solids": 0.20,
+            "total_solids_removal_efficiency": 0.35,
+            "volatile_solids_removal_efficiency": 0.40,
+            "nitrogen_removal_efficiency": 0.30,
+            "total_ammoniacal_nitrogen_removal_efficiency": 0.15,
+            "phosphorus_removal_efficiency": 0.40,
+            "potassium_removal_efficiency": 0.15,
+            "ash_removal_efficiency": 0.10
+          },
+          {
+            "name": "screw press",
+            "type": "screw press",
+            "percent_dry_solids": 0.35,
+            "total_solids_removal_efficiency": 0.25,
+            "volatile_solids_removal_efficiency": 0.30,
+            "nitrogen_removal_efficiency": 0.30,
+            "total_ammoniacal_nitrogen_removal_efficiency": 0.10,
+            "phosphorus_removal_efficiency": 0.20,
+            "potassium_removal_efficiency": 0.23,
+            "ash_removal_efficiency": 0.10
+          }
     ]
 }

--- a/input/data/manure/refreshed_manure_management.json
+++ b/input/data/manure/refreshed_manure_management.json
@@ -2,7 +2,7 @@
     "anaerobic_digester":[
         {
             "name": "anaerobic_digester1",
-            "digester_type": "anaerobic digester",
+            "digester_type": "continuous_mix",
             "hydraulic_retention_time": 25,
             "top_cover_volume_fraction": 0.2,
             "evaporation_fraction": 0.02,
@@ -21,7 +21,7 @@
             "ammoniacal_nitrogen_efficiency": 0.15,
             "phosphorus_efficiency": 0.40,
             "potassium_efficiency": 0.15,
-            "ash_efficiency": 0.10
+            "ash_efficiency": 0.20
           },
           {
             "name": "separator2",
@@ -33,7 +33,7 @@
             "ammoniacal_nitrogen_efficiency": 0.10,
             "phosphorus_efficiency": 0.20,
             "potassium_efficiency": 0.23,
-            "ash_efficiency": 0.10
+            "ash_efficiency": 0.20
           }
     ]
 }

--- a/input/data/manure/refreshed_manure_management.json
+++ b/input/data/manure/refreshed_manure_management.json
@@ -2,7 +2,8 @@
     "anaerobic_digester_configs":[
         {
             "name": "anaerobic_digester",
-            "type": "anaerobic_digester",
+            "processor_type": "anaerobic digester",
+            "digester_type": "anaerobic digester",
             "hydraulic_retention_time": 25,
             "top_cover_volume_fraction": 0.2,
             "evaporation_fraction": 0.02,
@@ -15,8 +16,9 @@
     ],
     "separator_configs":[
         {
-            "name": "rotary screen",
-            "type": "rotary screen",
+            "name": "rotary_screen",
+            "processor_type": "separator",
+            "separator_type": "rotary screen",
             "percent_dry_solids": 0.20,
             "total_solids_efficiency": 0.35,
             "volatile_solids_efficiency": 0.40,
@@ -27,8 +29,9 @@
             "ash_efficiency": 0.10
           },
           {
-            "name": "screw press",
-            "type": "screw press",
+            "name": "screw_press",
+            "processor_type": "separator",
+            "separator_type": "screw press",
             "percent_dry_solids": 0.35,
             "total_solids_efficiency": 0.25,
             "volatile_solids_efficiency": 0.30,

--- a/tests/test_biophysical/test_manure/test_processor.py
+++ b/tests/test_biophysical/test_manure/test_processor.py
@@ -118,7 +118,7 @@ def manure_stream() -> ManureStream:
         degradable_volatile_solids=25.0,
         total_solids=50.0,
         volume=1.5,
-        pen_manure_data=None
+        pen_manure_data=None,
     )
 
 
@@ -130,8 +130,9 @@ def time(mocker: MockerFixture) -> Any:
     return time
 
 
-def test_log_manure_stream_via_process_manure(mock_separator: Separator, manure_stream: ManureStream,
-                                              time: Time, mocker: MockerFixture) -> None:
+def test_log_manure_stream_via_process_manure(
+    mock_separator: Separator, manure_stream: ManureStream, time: Time, mocker: MockerFixture
+) -> None:
     """Test that _log_manure_stream is called correctly from process_manure."""
     mock_om = mocker.patch.object(mock_separator, "_om", autospec=True)
     mock_current_day_conditions = mocker.MagicMock()
@@ -143,8 +144,13 @@ def test_log_manure_stream_via_process_manure(mock_separator: Separator, manure_
     mock_om.add_variable.assert_any_call(
         "SeparatedSolids.manure_total_solids",
         pytest.approx(manure_stream.total_solids * mock_separator.total_solids_efficiency),
-        {"class": "Separator", "function": "_log_manure_stream", "prefix": "Separator.TestSeparator",
-         "simulation_day": 42, "units": MeasurementUnits.KILOGRAMS}
+        {
+            "class": "Separator",
+            "function": "_log_manure_stream",
+            "prefix": "Separator.TestSeparator",
+            "simulation_day": 42,
+            "units": MeasurementUnits.KILOGRAMS,
+        },
     )
 
 
@@ -169,9 +175,15 @@ def test_log_manure_stream_valid_dict(mock_separator: Separator, time: Time, moc
     mock_separator._log_manure_stream(manure_dict, "test_stream", time)
 
     mock_om.add_variable.assert_any_call(
-        "test_stream.manure_water", 1000.0,
-        {"class": "Separator", "function": "_log_manure_stream", "prefix": mock_separator._prefix,
-         "simulation_day": 42, "units": MeasurementUnits.KILOGRAMS}
+        "test_stream.manure_water",
+        1000.0,
+        {
+            "class": "Separator",
+            "function": "_log_manure_stream",
+            "prefix": mock_separator._prefix,
+            "simulation_day": 42,
+            "units": MeasurementUnits.KILOGRAMS,
+        },
     )
 
 
@@ -185,7 +197,12 @@ def test_log_manure_stream_invalid_type(mock_separator: Separator, time: Time, m
     mock_om.add_error.assert_called_once_with(
         "Manure Stream Type Error",
         "This function requires either a ManureStream instance or a dictionary.",
-        {"class": "Separator", "function": "_log_manure_stream", "prefix": mock_separator._prefix, "simulation_day": 42}
+        {
+            "class": "Separator",
+            "function": "_log_manure_stream",
+            "prefix": mock_separator._prefix,
+            "simulation_day": 42,
+        },
     )
 
 
@@ -199,5 +216,10 @@ def test_log_manure_stream_mismatched_keys(mock_separator: Separator, time: Time
     mock_om.add_error.assert_called_once_with(
         "Manure Stream Keys Error",
         f"Expected keys: {set(mock_separator.MANURE_STREAM_UNITS.keys())}, received: {{'wrong_key'}}.",
-        {"class": "Separator", "function": "_log_manure_stream", "prefix": mock_separator._prefix, "simulation_day": 42}
+        {
+            "class": "Separator",
+            "function": "_log_manure_stream",
+            "prefix": mock_separator._prefix,
+            "simulation_day": 42,
+        },
     )

--- a/tests/test_biophysical/test_manure/test_processor.py
+++ b/tests/test_biophysical/test_manure/test_processor.py
@@ -216,5 +216,10 @@ def test_log_manure_stream_mismatched_keys(mock_separator: Separator, time: Time
     mock_om.add_error.assert_called_once_with(
         "Manure Stream Keys Error",
         f"Expected keys: {set(ManureStream.MANURE_STREAM_UNITS.keys())}, received: {{'wrong_key'}}.",
-        {"class": "Separator", "function": "_log_manure_stream", "prefix": mock_separator._prefix, "simulation_day": 42}
+        {
+            "class": "Separator",
+            "function": "_log_manure_stream",
+            "prefix": mock_separator._prefix,
+            "simulation_day": 42,
+        },
     )

--- a/tests/test_biophysical/test_manure/test_processor.py
+++ b/tests/test_biophysical/test_manure/test_processor.py
@@ -130,10 +130,10 @@ def time(mocker: MockerFixture) -> Any:
     return time
 
 
-def test_log_manure_stream_via_process_manure(
+def test_report_manure_stream_via_process_manure(
     mock_separator: Separator, manure_stream: ManureStream, time: Time, mocker: MockerFixture
 ) -> None:
-    """Test that _log_manure_stream is called correctly from process_manure."""
+    """Test that _report_manure_stream is called correctly from process_manure."""
     mock_om = mocker.patch.object(mock_separator, "_om", autospec=True)
     mock_current_day_conditions = mocker.MagicMock()
     mock_separator.receive_manure(manure_stream)
@@ -146,7 +146,7 @@ def test_log_manure_stream_via_process_manure(
         pytest.approx(manure_stream.total_solids * mock_separator.total_solids_efficiency),
         {
             "class": "Separator",
-            "function": "_log_manure_stream",
+            "function": "_report_manure_stream",
             "prefix": "Separator.TestSeparator",
             "simulation_day": 42,
             "units": MeasurementUnits.KILOGRAMS,
@@ -154,7 +154,7 @@ def test_log_manure_stream_via_process_manure(
     )
 
 
-def test_log_manure_stream_valid_dict(mock_separator: Separator, time: Time, mocker: MockerFixture) -> None:
+def test_report_manure_stream_valid_dict(mock_separator: Separator, time: Time, mocker: MockerFixture) -> None:
     """Test logging when manure_stream is a valid dictionary."""
     manure_dict: dict[str, float | None] = {
         "water": 1000.0,
@@ -172,14 +172,14 @@ def test_log_manure_stream_valid_dict(mock_separator: Separator, time: Time, moc
         "pen_manure_data": None,
     }
     mock_om = mocker.patch.object(mock_separator, "_om", autospec=True)
-    mock_separator._log_manure_stream(manure_dict, "test_stream", time)
+    mock_separator._report_manure_stream(manure_dict, "test_stream", time)
 
     mock_om.add_variable.assert_any_call(
         "test_stream.manure_water",
         1000.0,
         {
             "class": "Separator",
-            "function": "_log_manure_stream",
+            "function": "_report_manure_stream",
             "prefix": mock_separator._prefix,
             "simulation_day": 42,
             "units": MeasurementUnits.KILOGRAMS,
@@ -187,38 +187,38 @@ def test_log_manure_stream_valid_dict(mock_separator: Separator, time: Time, moc
     )
 
 
-def test_log_manure_stream_invalid_type(mock_separator: Separator, time: Time, mocker: MockerFixture) -> None:
+def test_report_manure_stream_invalid_type(mock_separator: Separator, time: Time, mocker: MockerFixture) -> None:
     """Test error logging and ValueError when manure_stream is an invalid type."""
     invalid_input = cast("ManureStream | dict[str, float | None]", "invalid_string")
     mock_om = mocker.patch.object(mock_separator, "_om", autospec=True)
     with pytest.raises(ValueError, match="Manure stream must be a dictionary or a ManureStream instance"):
-        mock_separator._log_manure_stream(invalid_input, "error_stream", time)
+        mock_separator._report_manure_stream(invalid_input, "error_stream", time)
 
     mock_om.add_error.assert_called_once_with(
         "Manure Stream Type Error",
         "This function requires either a ManureStream instance or a dictionary.",
         {
             "class": "Separator",
-            "function": "_log_manure_stream",
+            "function": "_report_manure_stream",
             "prefix": mock_separator._prefix,
             "simulation_day": 42,
         },
     )
 
 
-def test_log_manure_stream_mismatched_keys(mock_separator: Separator, time: Time, mocker: MockerFixture) -> None:
+def test_report_manure_stream_mismatched_keys(mock_separator: Separator, time: Time, mocker: MockerFixture) -> None:
     """Test error logging and ValueError when manure_stream_dict keys do not match MANURE_STREAM_UNITS."""
     invalid_manure_dict: dict[str, float | None] = {"wrong_key": 42.0}
     mock_om = mocker.patch.object(mock_separator, "_om", autospec=True)
     with pytest.raises(ValueError, match="Manure Stream must contain the same keys as manure_stream_units"):
-        mock_separator._log_manure_stream(invalid_manure_dict, "mismatch_stream", time)
+        mock_separator._report_manure_stream(invalid_manure_dict, "mismatch_stream", time)
 
     mock_om.add_error.assert_called_once_with(
         "Manure Stream Keys Error",
         f"Expected keys: {set(ManureStream.MANURE_STREAM_UNITS.keys())}, received: {{'wrong_key'}}.",
         {
             "class": "Separator",
-            "function": "_log_manure_stream",
+            "function": "_report_manure_stream",
             "prefix": mock_separator._prefix,
             "simulation_day": 42,
         },

--- a/tests/test_biophysical/test_manure/test_processor.py
+++ b/tests/test_biophysical/test_manure/test_processor.py
@@ -1,3 +1,4 @@
+from typing import Any, cast
 import pytest
 from pytest_mock import MockerFixture
 
@@ -122,7 +123,7 @@ def manure_stream() -> ManureStream:
 
 
 @pytest.fixture
-def time(mocker: MockerFixture) -> Time:
+def time(mocker: MockerFixture) -> Any:
     """Creates a mocked Time object with a simulation day."""
     time = mocker.MagicMock()
     time.simulation_day = 42
@@ -133,12 +134,13 @@ def test_log_manure_stream_via_process_manure(mock_separator: Separator, manure_
                                               time: Time, mocker: MockerFixture) -> None:
     """Test that _log_manure_stream is called correctly from process_manure."""
     mock_om = mocker.patch.object(mock_separator, "_om", autospec=True)
+    mock_current_day_conditions = mocker.MagicMock()
     mock_separator.receive_manure(manure_stream)
-    mock_separator.process_manure(None, time)
+    mock_separator.process_manure(mock_current_day_conditions, time)
 
     assert mock_om.add_variable.call_count > 0
 
-    mock_separator._om.add_variable.assert_any_call(
+    mock_om.add_variable.assert_any_call(
         "SeparatedSolids.manure_total_solids",
         pytest.approx(manure_stream.total_solids * mock_separator.total_solids_efficiency),
         {"class": "Separator", "function": "_log_manure_stream", "prefix": "Separator.TestSeparator",
@@ -148,7 +150,7 @@ def test_log_manure_stream_via_process_manure(mock_separator: Separator, manure_
 
 def test_log_manure_stream_valid_dict(mock_separator: Separator, time: Time, mocker: MockerFixture) -> None:
     """Test logging when manure_stream is a valid dictionary."""
-    manure_dict = {
+    manure_dict: dict[str, float | None] = {
         "water": 1000.0,
         "ammoniacal_nitrogen": 10.0,
         "nitrogen": 20.0,
@@ -175,7 +177,7 @@ def test_log_manure_stream_valid_dict(mock_separator: Separator, time: Time, moc
 
 def test_log_manure_stream_invalid_type(mock_separator: Separator, time: Time, mocker: MockerFixture) -> None:
     """Test error logging and ValueError when manure_stream is an invalid type."""
-    invalid_input = "invalid_string"
+    invalid_input = cast("ManureStream | dict[str, float | None]", "invalid_string")
     mock_om = mocker.patch.object(mock_separator, "_om", autospec=True)
     with pytest.raises(ValueError, match="Manure stream must be a dictionary or a ManureStream instance"):
         mock_separator._log_manure_stream(invalid_input, "error_stream", time)
@@ -189,7 +191,7 @@ def test_log_manure_stream_invalid_type(mock_separator: Separator, time: Time, m
 
 def test_log_manure_stream_mismatched_keys(mock_separator: Separator, time: Time, mocker: MockerFixture) -> None:
     """Test error logging and ValueError when manure_stream_dict keys do not match MANURE_STREAM_UNITS."""
-    invalid_manure_dict = {"wrong_key": 42.0}
+    invalid_manure_dict: dict[str, float | None] = {"wrong_key": 42.0}
     mock_om = mocker.patch.object(mock_separator, "_om", autospec=True)
     with pytest.raises(ValueError, match="Manure Stream must contain the same keys as manure_stream_units"):
         mock_separator._log_manure_stream(invalid_manure_dict, "mismatch_stream", time)

--- a/tests/test_biophysical/test_manure/test_processor.py
+++ b/tests/test_biophysical/test_manure/test_processor.py
@@ -215,11 +215,6 @@ def test_log_manure_stream_mismatched_keys(mock_separator: Separator, time: Time
 
     mock_om.add_error.assert_called_once_with(
         "Manure Stream Keys Error",
-        f"Expected keys: {set(mock_separator.MANURE_STREAM_UNITS.keys())}, received: {{'wrong_key'}}.",
-        {
-            "class": "Separator",
-            "function": "_log_manure_stream",
-            "prefix": mock_separator._prefix,
-            "simulation_day": 42,
-        },
+        f"Expected keys: {set(ManureStream.MANURE_STREAM_UNITS.keys())}, received: {{'wrong_key'}}.",
+        {"class": "Separator", "function": "_log_manure_stream", "prefix": mock_separator._prefix, "simulation_day": 42}
     )

--- a/tests/test_biophysical/test_manure/test_processor.py
+++ b/tests/test_biophysical/test_manure/test_processor.py
@@ -2,6 +2,10 @@ import pytest
 from pytest_mock import MockerFixture
 
 from RUFAS.biophysical.manure.processor import Processor
+from RUFAS.biophysical.manure.separator.separator import Separator
+from RUFAS.data_structures.animal_to_manure_connection import ManureStream
+from RUFAS.time import Time
+from RUFAS.units import MeasurementUnits
 
 
 def test_processor_init_error() -> None:
@@ -80,3 +84,118 @@ def test_calculate_dissociation_coefficient_of_ammonium(temp: float, pH: float, 
     actual = Processor._calculate_dissociation_coefficient_of_ammonium(temp, pH)
 
     assert pytest.approx(actual) == expected
+
+
+@pytest.fixture
+def mock_separator() -> Separator:
+    """Mock the Separator class."""
+    separator = Separator(
+        name="TestSeparator",
+        separated_solids_dry_matter=0.8,
+        ammoniacal_nitrogen_efficiency=0.7,
+        nitrogen_efficiency=0.6,
+        phosphorus_efficiency=0.5,
+        potassium_efficiency=0.4,
+        ash_efficiency=0.3,
+        volatile_solids_efficiency=0.2,
+        total_solids_efficiency=0.1,
+    )
+    return separator
+
+
+@pytest.fixture
+def manure_stream() -> ManureStream:
+    """Creates a test manure stream."""
+    return ManureStream(
+        water=1000.0,
+        ammoniacal_nitrogen=10.0,
+        nitrogen=20.0,
+        phosphorus=5.0,
+        potassium=8.0,
+        ash=2.0,
+        non_degradable_volatile_solids=15.0,
+        degradable_volatile_solids=25.0,
+        total_solids=50.0,
+        volume=1.5,
+        pen_manure_data=None
+    )
+
+
+@pytest.fixture
+def time(mocker: MockerFixture) -> Time:
+    """Creates a mocked Time object with a simulation day."""
+    time = mocker.MagicMock()
+    time.simulation_day = 42
+    return time
+
+
+def test_log_manure_stream_via_process_manure(mock_separator: Separator, manure_stream: ManureStream,
+                                              time: Time, mocker: MockerFixture) -> None:
+    """Test that _log_manure_stream is called correctly from process_manure."""
+    mock_om = mocker.patch.object(mock_separator, "_om", autospec=True)
+    mock_separator.receive_manure(manure_stream)
+    mock_separator.process_manure(None, time)
+
+    assert mock_om.add_variable.call_count > 0
+
+    mock_separator._om.add_variable.assert_any_call(
+        "SeparatedSolids.manure_total_solids",
+        pytest.approx(manure_stream.total_solids * mock_separator.total_solids_efficiency),
+        {"class": "Separator", "function": "_log_manure_stream", "prefix": "Separator.TestSeparator",
+         "simulation_day": 42, "units": MeasurementUnits.KILOGRAMS}
+    )
+
+
+def test_log_manure_stream_valid_dict(mock_separator: Separator, time: Time, mocker: MockerFixture) -> None:
+    """Test logging when manure_stream is a valid dictionary."""
+    manure_dict = {
+        "water": 1000.0,
+        "ammoniacal_nitrogen": 10.0,
+        "nitrogen": 20.0,
+        "phosphorus": 5.0,
+        "potassium": 8.0,
+        "ash": 2.0,
+        "non_degradable_volatile_solids": 15.0,
+        "degradable_volatile_solids": 25.0,
+        "total_solids": 50.0,
+        "volume": 1.5,
+        "mass": 1050.0,
+        "total_volatile_solids": 40.0,
+        "pen_manure_data": None,
+    }
+    mock_om = mocker.patch.object(mock_separator, "_om", autospec=True)
+    mock_separator._log_manure_stream(manure_dict, "test_stream", time)
+
+    mock_om.add_variable.assert_any_call(
+        "test_stream.manure_water", 1000.0,
+        {"class": "Separator", "function": "_log_manure_stream", "prefix": mock_separator._prefix,
+         "simulation_day": 42, "units": MeasurementUnits.KILOGRAMS}
+    )
+
+
+def test_log_manure_stream_invalid_type(mock_separator: Separator, time: Time, mocker: MockerFixture) -> None:
+    """Test error logging and ValueError when manure_stream is an invalid type."""
+    invalid_input = "invalid_string"
+    mock_om = mocker.patch.object(mock_separator, "_om", autospec=True)
+    with pytest.raises(ValueError, match="Manure stream must be a dictionary or a ManureStream instance"):
+        mock_separator._log_manure_stream(invalid_input, "error_stream", time)
+
+    mock_om.add_error.assert_called_once_with(
+        "Manure Stream Type Error",
+        "This function requires either a ManureStream instance or a dictionary.",
+        {"class": "Separator", "function": "_log_manure_stream", "prefix": mock_separator._prefix, "simulation_day": 42}
+    )
+
+
+def test_log_manure_stream_mismatched_keys(mock_separator: Separator, time: Time, mocker: MockerFixture) -> None:
+    """Test error logging and ValueError when manure_stream_dict keys do not match MANURE_STREAM_UNITS."""
+    invalid_manure_dict = {"wrong_key": 42.0}
+    mock_om = mocker.patch.object(mock_separator, "_om", autospec=True)
+    with pytest.raises(ValueError, match="Manure Stream must contain the same keys as manure_stream_units"):
+        mock_separator._log_manure_stream(invalid_manure_dict, "mismatch_stream", time)
+
+    mock_om.add_error.assert_called_once_with(
+        "Manure Stream Keys Error",
+        f"Expected keys: {set(mock_separator.MANURE_STREAM_UNITS.keys())}, received: {{'wrong_key'}}.",
+        {"class": "Separator", "function": "_log_manure_stream", "prefix": mock_separator._prefix, "simulation_day": 42}
+    )

--- a/tests/test_biophysical/test_manure/test_separator/test_separator.py
+++ b/tests/test_biophysical/test_manure/test_separator/test_separator.py
@@ -1,4 +1,3 @@
-from dataclasses import asdict
 import pytest
 from typing import Any
 

--- a/tests/test_biophysical/test_manure/test_separator/test_separator.py
+++ b/tests/test_biophysical/test_manure/test_separator/test_separator.py
@@ -15,7 +15,7 @@ def mock_separator() -> Separator:
     """Mock the Separator class."""
     separator = Separator(
         name="TestSeparator",
-        percent_dry_solids=0.8,
+        separated_solids_dry_matter=0.8,
         ammoniacal_nitrogen_efficiency=0.7,
         nitrogen_efficiency=0.6,
         phosphorus_efficiency=0.5,
@@ -32,7 +32,7 @@ def test_separator_init_with_params(mock_separator: Separator) -> None:
     assert mock_separator.name == "TestSeparator"
     assert mock_separator._prefix == "Separator.TestSeparator"
     assert mock_separator.held_manure is None
-    assert mock_separator.percent_dry_solids == 0.8
+    assert mock_separator.separated_solids_dry_matter == 0.8
     assert mock_separator.ammoniacal_nitrogen_efficiency == 0.7
     assert mock_separator.nitrogen_efficiency == 0.6
     assert mock_separator.phosphorus_efficiency == 0.5
@@ -173,60 +173,3 @@ def test_clear_held_manure(mock_separator: Separator) -> None:
     mock_separator.clear_held_manure()
 
     assert mock_separator.held_manure is None
-
-
-def test_log_manure_stream(mocker: MockerFixture, mock_separator: Separator) -> None:
-    """Test that _log_manure_stream correctly logs manure stream data."""
-    # Arrange
-    mock_om = mocker.patch.object(mock_separator, "_om", autospec=True)
-    mock_time = mocker.MagicMock()
-    mock_time.simulation_day = 42
-    manure_stream = ManureStream(
-        water=100.0,
-        ammoniacal_nitrogen=10.0,
-        nitrogen=15.0,
-        phosphorus=5.0,
-        potassium=3.0,
-        ash=7.0,
-        non_degradable_volatile_solids=4.0,
-        degradable_volatile_solids=6.0,
-        total_solids=20.0,
-        volume=1.5,
-        pen_manure_data=None,
-    )
-
-    stream_name = "TestSeparator.Solid"
-    expected_info_map = {
-        "class": "Separator",
-        "function": "_log_manure_stream",
-        "prefix": "Separator.TestSeparator",
-        "simulation_day": mock_time.simulation_day,
-    }
-    expected_units = {
-        "water": MeasurementUnits.KILOGRAMS,
-        "ammoniacal_nitrogen": MeasurementUnits.KILOGRAMS,
-        "nitrogen": MeasurementUnits.KILOGRAMS,
-        "phosphorus": MeasurementUnits.KILOGRAMS,
-        "potassium": MeasurementUnits.KILOGRAMS,
-        "ash": MeasurementUnits.KILOGRAMS,
-        "non_degradable_volatile_solids": MeasurementUnits.KILOGRAMS,
-        "degradable_volatile_solids": MeasurementUnits.KILOGRAMS,
-        "total_solids": MeasurementUnits.KILOGRAMS,
-        "volume": MeasurementUnits.CUBIC_METERS,
-        "mass": MeasurementUnits.KILOGRAMS,
-    }
-
-    # Act
-    mock_separator._log_manure_stream(manure_stream, stream_name, mock_time)
-
-    # Assert
-    manure_dict = asdict(manure_stream)
-    for key, value in manure_dict.items():
-        if key != "pen_manure_data":
-            mock_om.add_variable.assert_any_call(
-                f"{stream_name}.manure_{key}",
-                value,
-                {**expected_info_map, "units": expected_units[key]},
-            )
-
-    assert mock_om.add_variable.call_count == len(manure_dict) - 1

--- a/tests/test_biophysical/test_manure/test_separator/test_separator.py
+++ b/tests/test_biophysical/test_manure/test_separator/test_separator.py
@@ -99,7 +99,7 @@ def test_process_manure(mock_separator: Separator, mocker: MockerFixture, mock_m
     mock_separator.held_manure = mock_manure_stream
     mock_conditions = mocker.MagicMock()
     mock_time = mocker.MagicMock()
-    mock_log_manure_stream = mocker.patch.object(mock_separator, "_log_manure_stream", autospec=True)
+    mock_report_manure_stream = mocker.patch.object(mock_separator, "_report_manure_stream", autospec=True)
 
     # Act
     result: dict[str, ManureStream] = mock_separator.process_manure(mock_conditions, mock_time)
@@ -136,7 +136,7 @@ def test_process_manure(mock_separator: Separator, mocker: MockerFixture, mock_m
     assert liquid.volume == (liquid.water + liquid.total_solids) / ManureConstants.LIQUID_MANURE_DENSITY
 
     assert mock_separator.held_manure is None
-    assert mock_log_manure_stream.call_count == 2
+    assert mock_report_manure_stream.call_count == 2
 
 
 def test_process_manure_empty_held_manure(mocker: MockerFixture, mock_separator: Separator) -> None:


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Builds off existing `refreshed_manure_management.json` starter input file and incorporates elements from discussion at 3/12/25 manure module meeting.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2109

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Creates a `separator_configs` section of the `refreshed_manure_management.json` input file.
To match the new naming structure:
- Adds `digester_type` for `anaerobic_digester_configs` entry. 
- Adds `separator_type` for `separator_configs` entries.
- We could alternatively just have this field be `type`. Thoughts?

To help facilitate initialization of the proper processor:
- Adds `processor_type` for both to help with initialization.

To match the separator input json attributes with the refreshed separator attributes:
- Adds `ash_removal_efficiency` for both separator types.
- Adjusts efficiency names in json file to match refreshed efficiency names in Separator class for clarity.

**Moves `_log_manure_stream()` method into Processor base class as it will be implemented by multiple child and grandchild classes.**

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
Setting up initialization of the newly refreshed Separator class.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Copy-pasted the separator configs from the current `manure_management.json` file and implemented the above changes.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
No real test plan at this point as it's just adding configs that are not yet used.


### Notes
- At some point we will need to adjust the init methods to handle `processor_type` and each child class's `type`.