### PR TITLE
Rename Handler ammonia emission output name

### DIFF
--- a/RUFAS/biophysical/manure/handler/handler.py
+++ b/RUFAS/biophysical/manure/handler/handler.py
@@ -181,7 +181,7 @@ class Handler(Processor):
         }
 
         self.manure_stream = None
-        self._om.add_variable("housing_ammonia_emissions", ammonia_emission, emission_info_map)
+        self._om.add_variable("housing_ammonia_N_emissions", ammonia_emission, emission_info_map)
 
         return {
             "manure": ManureStream(

--- a/changelog.md
+++ b/changelog.md
@@ -123,7 +123,7 @@ v0.9.2
 - [2280](https://github.com/RuminantFarmSystems/MASM/pull/2280) - [minor change] [Manure] Updates input configs for refreshed Separator class.
 - [2235](https://github.com/RuminantFarmSystems/MASM/pull/2235) - [major change] [Animal] Refresh the Animal module.
 - [2297](https://github.com/RuminantFarmSystems/MASM/pull/2297) - [minor change] [Animal] Fix the flake8 errors in the refreshed animal module and modify "HerdManager._gather_pen_history()" to optimize run time.
-
+- [2302](https://github.com/RuminantFarmSystems/MASM/pull/2302) - [minor change] [Manure] Rename the ammonia emission output in Handler from "housing_ammonia_emissions" to "housing_ammonia_N_emissions".
 ### v0.9.2
 
 - [1968](https://github.com/RuminantFarmSystems/MASM/pull/1968) - [minor change] [Changelog] Move the changelog from a Google sheet into a markdown document in the repository.


### PR DESCRIPTION
This PR renames the ammonia emission output from "housing_ammonia_emissions" to "housing_ammonia_N_emissions".

<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2207 

### What
<!-- Add more detail about the changes that are being made in the pull request. -->


### Why
<!-- Discuss why the changes in this pull request are needed or important. -->


### How
<!-- Give an explanation of how this pull request addresses needed changes. -->


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
