### PR TITLE
Manure Refresh Patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-88%25-yellowgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-88%25-yellowgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
-[![Mypy](https://img.shields.io/badge/Mypy-3300%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3302%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 
 # Vision

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-88%25-yellowgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
-[![Mypy](https://img.shields.io/badge/Mypy-3299%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3300%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-88%25-yellowgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 [![Mypy](https://img.shields.io/badge/Mypy-3300%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-88%25-yellowgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-88%25-yellowgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
-[![Mypy](https://img.shields.io/badge/Mypy-3302%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3297%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 
 # Vision

--- a/RUFAS/biophysical/manure/digester/anaerobic_digester.py
+++ b/RUFAS/biophysical/manure/digester/anaerobic_digester.py
@@ -108,7 +108,7 @@ class AnaerobicDigester(Digester):
                 methane_leakage_mass=0.0,
                 minimum_digester_volume=0.0,
                 top_cover_volume=0.0,
-                time=time,
+                simulation_day=time.simulation_day,
             )
             return {}
 
@@ -152,7 +152,7 @@ class AnaerobicDigester(Digester):
             methane_leakage_mass=methane_leakage,
             minimum_digester_volume=minimum_digester_volume,
             top_cover_volume=top_cover_volume,
-            time=time,
+            simulation_day=time.simulation_day,
         )
 
         digested_manure = replace(self._manure_in_digester)

--- a/RUFAS/biophysical/manure/digester/anaerobic_digester.py
+++ b/RUFAS/biophysical/manure/digester/anaerobic_digester.py
@@ -253,7 +253,7 @@ class AnaerobicDigester(Digester):
         self._report_manure_stream(self._manure_in_digester, "", simulation_day)
 
         self._report_processor_output(
-            "biogas",biogas, data_origin_function, MeasurementUnits.KILOGRAMS, simulation_day
+            "biogas", biogas, data_origin_function, MeasurementUnits.KILOGRAMS, simulation_day
         )
         self._report_processor_output(
             "methane_leakage_mass",

--- a/RUFAS/biophysical/manure/digester/anaerobic_digester.py
+++ b/RUFAS/biophysical/manure/digester/anaerobic_digester.py
@@ -221,7 +221,7 @@ class AnaerobicDigester(Digester):
         methane_leakage_mass: float,
         minimum_digester_volume: float,
         top_cover_volume: float,
-        time: Time,
+        simulation_day: int,
     ) -> None:
         """
         Reports manure that was digested and the amounts of different things that were lost in the anaerobic digestion
@@ -231,7 +231,7 @@ class AnaerobicDigester(Digester):
         ----------
         biogas : float
             Captured biogas (kg).
-        biogass_energy_content : float
+        biogas_energy_content : float
             Energy from captured biogas (MJ).
         evaporated_water : float
             Water that evaporated during anaerobic digestion (m^3)
@@ -245,61 +245,64 @@ class AnaerobicDigester(Digester):
             Minimum volume of manure allowed to be left in the anaerobic digester (m^3).
         top_cover_volume : float
             Headspace volume above manure inside digester where biogas collects (m^3).
+        simulation_day : int
+            The current simulation day.
 
         """
-        self._report_manure_stream(self._manure_in_digester, "", time)
+        data_origin_function = self._report_anaerobic_digester_outputs.__name__
+        self._report_manure_stream(self._manure_in_digester, "", simulation_day)
 
         self._report_processor_output(
-            "biogas", biogas, self._report_anaerobic_digester_outputs.__name__, MeasurementUnits.KILOGRAMS, time
+            "biogas",biogas, data_origin_function, MeasurementUnits.KILOGRAMS, simulation_day
         )
         self._report_processor_output(
             "methane_leakage_mass",
             methane_leakage_mass,
-            self._report_anaerobic_digester_outputs.__name__,
+            data_origin_function,
             MeasurementUnits.KILOGRAMS,
-            time,
+            simulation_day,
         )
         self._report_processor_output(
             "methane_generation_volume",
             methane_generation_volume,
-            self._report_anaerobic_digester_outputs.__name__,
+            data_origin_function,
             MeasurementUnits.CUBIC_METERS,
-            time,
+            simulation_day,
         )
         self._report_processor_output(
             "evaporated_water",
             evaporated_water,
-            self._report_anaerobic_digester_outputs.__name__,
+            data_origin_function,
             MeasurementUnits.CUBIC_METERS,
-            time,
+            simulation_day,
         )
         self._report_processor_output(
             "minimum_digester_volume",
             minimum_digester_volume,
-            self._report_anaerobic_digester_outputs.__name__,
+            data_origin_function,
             MeasurementUnits.CUBIC_METERS,
-            time,
+            simulation_day,
         )
         self._report_processor_output(
             "top_cover_volume",
             top_cover_volume,
-            self._report_anaerobic_digester_outputs.__name__,
+            data_origin_function,
             MeasurementUnits.CUBIC_METERS,
-            time,
+            simulation_day,
         )
         self._report_processor_output(
             "heating_input_energy",
             heating_input_energy,
-            self._report_anaerobic_digester_outputs.__name__,
+            data_origin_function,
             MeasurementUnits.MEGAJOULES,
-            time,
+            simulation_day,
         )
         self._report_processor_output(
             "biogas_energy_content",
             biogas_energy_content,
-            self._report_anaerobic_digester_outputs.__name__,
+            data_origin_function,
             MeasurementUnits.MEGAJOULES,
-            time,
+            simulation_day,
         )
 
     @staticmethod

--- a/RUFAS/biophysical/manure/digester/anaerobic_digester.py
+++ b/RUFAS/biophysical/manure/digester/anaerobic_digester.py
@@ -247,59 +247,75 @@ class AnaerobicDigester(Digester):
             Headspace volume above manure inside digester where biogas collects (m^3).
 
         """
-        info_map = {
-            "class": self.__class__.__name__,
-            "function": self._report_anaerobic_digester_outputs.__name__,
-            "prefix": self._prefix,
-            "simulation_day": time.simulation_day,
-        }
+        self._report_manure_stream(self._manure_in_digester, "", time)
 
-        info_map_kg = info_map | {"units": MeasurementUnits.KILOGRAMS}
-        self._om.add_variable("manure_water", self._manure_in_digester.water, info_map_kg)
-        self._om.add_variable(
-            "manure_total_ammoniacal_nitrogen", self._manure_in_digester.ammoniacal_nitrogen, info_map_kg
+        self._report_processor_output(
+            "biogas",
+            biogas,
+            self._report_anaerobic_digester_outputs.__name__,
+            MeasurementUnits.KILOGRAMS,
+            time
         )
-        self._om.add_variable("manure_nitrogen", self._manure_in_digester.nitrogen, info_map_kg)
-        self._om.add_variable("manure_phosphorus", self._manure_in_digester.phosphorus, info_map_kg)
-        self._om.add_variable("manure_potassium", self._manure_in_digester.potassium, info_map_kg)
-        self._om.add_variable("manure_ash", self._manure_in_digester.ash, info_map_kg)
-        self._om.add_variable(
-            "manure_non_degradable_volatile_solids",
-            self._manure_in_digester.non_degradable_volatile_solids,
-            info_map_kg,
+        self._report_processor_output(
+            "methane_leakage_mass",
+            methane_leakage_mass,
+            self._report_anaerobic_digester_outputs.__name__,
+            MeasurementUnits.KILOGRAMS,
+            time
         )
-        self._om.add_variable(
-            "manure_degradable_volatile_solids", self._manure_in_digester.degradable_volatile_solids, info_map_kg
+        self._report_processor_output(
+            "methane_generation_volume",
+            methane_generation_volume,
+            self._report_anaerobic_digester_outputs.__name__,
+            MeasurementUnits.CUBIC_METERS,
+            time
         )
-        self._om.add_variable(
-            "manure_total_volatile_solids", self._manure_in_digester.total_volatile_solids, info_map_kg
+        self._report_processor_output(
+            "evaporated_water",
+            evaporated_water,
+            self._report_anaerobic_digester_outputs.__name__,
+            MeasurementUnits.CUBIC_METERS,
+            time
         )
-        self._om.add_variable("manure_total_solids", self._manure_in_digester.total_solids, info_map_kg)
-        self._om.add_variable("manure_mass", self._manure_in_digester.mass, info_map_kg)
-        self._om.add_variable("biogas", biogas, info_map_kg)
-        self._om.add_variable("methane_leakage_mass", methane_leakage_mass, info_map_kg)
+        self._report_processor_output(
+            "minimum_digester_volume",
+            minimum_digester_volume,
+            self._report_anaerobic_digester_outputs.__name__,
+            MeasurementUnits.CUBIC_METERS,
+            time
+        )
+        self._report_processor_output(
+            "top_cover_volume",
+            top_cover_volume,
+            self._report_anaerobic_digester_outputs.__name__,
+            MeasurementUnits.CUBIC_METERS,
+            time
+        )
+        self._report_processor_output(
+            "heating_input_energy",
+            heating_input_energy,
+            self._report_anaerobic_digester_outputs.__name__,
+            MeasurementUnits.MEGAJOULES,
+            time
+        )
+        self._report_processor_output(
+            "biogas_energy_content",
+            biogas_energy_content,
+            self._report_anaerobic_digester_outputs.__name__,
+            MeasurementUnits.MEGAJOULES,
+            time
+        )
 
-        info_map_cubic_m = info_map | {"units": MeasurementUnits.CUBIC_METERS}
-        self._om.add_variable("manure_volume", self._manure_in_digester.volume, info_map_cubic_m)
-        self._om.add_variable("methane_generation_volume", methane_generation_volume, info_map_cubic_m)
-        self._om.add_variable("evaporated_water", evaporated_water, info_map_cubic_m)
-        self._om.add_variable("minimum_digester_volume", minimum_digester_volume, info_map_cubic_m)
-        self._om.add_variable("top_cover_volume", top_cover_volume, info_map_cubic_m)
-
-        info_map_megajoules = info_map | {"units": MeasurementUnits.MEGAJOULES}
-        self._om.add_variable("biogas_energy_content", biogas_energy_content, info_map_megajoules)
-        self._om.add_variable("heating_input_energy", heating_input_energy, info_map_megajoules)
-
-    @classmethod
+    @staticmethod
     def _calculate_specific_input_energy(
-        cls, average_temp: float, moisture_fraction: float, temperature_set_point: float
+            average_temperature: float, moisture_fraction: float, temperature_set_point: float
     ) -> float:
         """
         Calculates the energy required to maintain anaerobic digestion temperature at set point.
 
         Parameters
         ----------
-        average_temp : float
+        average_temperature : float
             Average ambient temperature (degrees C).
         moisture_fraction : float
             Fraction of total manure mass that is water (unitless).
@@ -312,22 +328,24 @@ class AnaerobicDigester(Digester):
             Energy required to maintain anaerobic digestion temperature at set point (MJ / m^3).
 
         """
-        effluent_temperature = cls._bind_influent_temperature(average_temp)
-        influent_heat_capacity = cls._calculate_manure_heat_capacity(average_temp, moisture_fraction)
-        anaerobic_digester_heat_capacity = cls._calculate_manure_heat_capacity(temperature_set_point, moisture_fraction)
+        effluent_temperature = AnaerobicDigester._bind_influent_temperature(average_temperature)
+        influent_heat_capacity = AnaerobicDigester._calculate_manure_heat_capacity(
+            average_temperature, moisture_fraction)
+        anaerobic_digester_heat_capacity = AnaerobicDigester._calculate_manure_heat_capacity(
+            temperature_set_point, moisture_fraction)
 
         average_heat_capacity = (influent_heat_capacity + anaerobic_digester_heat_capacity) / 2.0
         heating_input_energy = average_heat_capacity * (temperature_set_point - effluent_temperature)
         return heating_input_energy
 
-    @classmethod
-    def _bind_influent_temperature(cls, average_temp: float) -> float:
+    @staticmethod
+    def _bind_influent_temperature(average_temperature: float) -> float:
         """
         Lower-bounds the influent temperature of manure based on the average ambient temperature.
 
         Parameters
         ----------
-        average_temp : float
+        average_temperature : float
             Average ambient temperature (degrees C).
 
         Returns
@@ -336,10 +354,10 @@ class AnaerobicDigester(Digester):
             The bound temperature of influent manure (degrees C).
 
         """
-        return max(average_temp, MINIMUM_INFLUENT_TEMPERATURE)
+        return max(average_temperature, MINIMUM_INFLUENT_TEMPERATURE)
 
-    @classmethod
-    def _calculate_manure_heat_capacity(cls, temperature: float, moisture_fraction: float) -> float:
+    @staticmethod
+    def _calculate_manure_heat_capacity(temperature: float, moisture_fraction: float) -> float:
         """
         Calculates the heat capacity of manure.
 
@@ -358,8 +376,8 @@ class AnaerobicDigester(Digester):
         """
         return 0.68298 + 0.025662 * temperature + 0.01306 * moisture_fraction * GeneralConstants.FRACTION_TO_PERCENTAGE
 
-    @classmethod
-    def _calculate_CSTR_methane_volume(cls, total_volatile_solids: float) -> float:
+    @staticmethod
+    def _calculate_CSTR_methane_volume(total_volatile_solids: float) -> float:
         """
         Calculates volume of methane generated from a continuously-stirred tank reactor.
 
@@ -384,8 +402,8 @@ class AnaerobicDigester(Digester):
         """
         return ManureConstants.ACHIEVABLE_METHANE_EMISSION * total_volatile_solids
 
-    @classmethod
-    def _calculate_methane_leakage(cls, generated_methane_mass: float, leakage_fraction: float) -> float:
+    @staticmethod
+    def _calculate_methane_leakage(generated_methane_mass: float, leakage_fraction: float) -> float:
         """
         Calculates the mass of methane lost from an anaerobic digester as leakage.
 
@@ -393,7 +411,7 @@ class AnaerobicDigester(Digester):
         ----------
         generated_methane_mass : float
             Amount of methane generated within the digester (kg).
-        digester_methane_leakage_fraction : float
+        leakage_fraction : float
             Fraction of generated methane that escapes as leakage (unitless).
 
         Returns
@@ -404,8 +422,8 @@ class AnaerobicDigester(Digester):
         """
         return generated_methane_mass * leakage_fraction
 
-    @classmethod
-    def _calculate_methane_energy_content(cls, methane_mass: float) -> float:
+    @staticmethod
+    def _calculate_methane_energy_content(methane_mass: float) -> float:
         """
         Calculates energy content of methane generated in an anaerobic digester.
 

--- a/RUFAS/biophysical/manure/digester/anaerobic_digester.py
+++ b/RUFAS/biophysical/manure/digester/anaerobic_digester.py
@@ -250,65 +250,61 @@ class AnaerobicDigester(Digester):
         self._report_manure_stream(self._manure_in_digester, "", time)
 
         self._report_processor_output(
-            "biogas",
-            biogas,
-            self._report_anaerobic_digester_outputs.__name__,
-            MeasurementUnits.KILOGRAMS,
-            time
+            "biogas", biogas, self._report_anaerobic_digester_outputs.__name__, MeasurementUnits.KILOGRAMS, time
         )
         self._report_processor_output(
             "methane_leakage_mass",
             methane_leakage_mass,
             self._report_anaerobic_digester_outputs.__name__,
             MeasurementUnits.KILOGRAMS,
-            time
+            time,
         )
         self._report_processor_output(
             "methane_generation_volume",
             methane_generation_volume,
             self._report_anaerobic_digester_outputs.__name__,
             MeasurementUnits.CUBIC_METERS,
-            time
+            time,
         )
         self._report_processor_output(
             "evaporated_water",
             evaporated_water,
             self._report_anaerobic_digester_outputs.__name__,
             MeasurementUnits.CUBIC_METERS,
-            time
+            time,
         )
         self._report_processor_output(
             "minimum_digester_volume",
             minimum_digester_volume,
             self._report_anaerobic_digester_outputs.__name__,
             MeasurementUnits.CUBIC_METERS,
-            time
+            time,
         )
         self._report_processor_output(
             "top_cover_volume",
             top_cover_volume,
             self._report_anaerobic_digester_outputs.__name__,
             MeasurementUnits.CUBIC_METERS,
-            time
+            time,
         )
         self._report_processor_output(
             "heating_input_energy",
             heating_input_energy,
             self._report_anaerobic_digester_outputs.__name__,
             MeasurementUnits.MEGAJOULES,
-            time
+            time,
         )
         self._report_processor_output(
             "biogas_energy_content",
             biogas_energy_content,
             self._report_anaerobic_digester_outputs.__name__,
             MeasurementUnits.MEGAJOULES,
-            time
+            time,
         )
 
     @staticmethod
     def _calculate_specific_input_energy(
-            average_temperature: float, moisture_fraction: float, temperature_set_point: float
+        average_temperature: float, moisture_fraction: float, temperature_set_point: float
     ) -> float:
         """
         Calculates the energy required to maintain anaerobic digestion temperature at set point.
@@ -330,9 +326,11 @@ class AnaerobicDigester(Digester):
         """
         effluent_temperature = AnaerobicDigester._bind_influent_temperature(average_temperature)
         influent_heat_capacity = AnaerobicDigester._calculate_manure_heat_capacity(
-            average_temperature, moisture_fraction)
+            average_temperature, moisture_fraction
+        )
         anaerobic_digester_heat_capacity = AnaerobicDigester._calculate_manure_heat_capacity(
-            temperature_set_point, moisture_fraction)
+            temperature_set_point, moisture_fraction
+        )
 
         average_heat_capacity = (influent_heat_capacity + anaerobic_digester_heat_capacity) / 2.0
         heating_input_energy = average_heat_capacity * (temperature_set_point - effluent_temperature)

--- a/RUFAS/biophysical/manure/handler/handler.py
+++ b/RUFAS/biophysical/manure/handler/handler.py
@@ -165,7 +165,7 @@ class Handler(Processor):
             barn_temperature,
             self.process_manure.__name__,
             MeasurementUnits.DEGREES_CELSIUS,
-            time.simulation_day
+            time.simulation_day,
         )
 
         manure_water = self.determine_manure_water(self.manure_stream.water, total_cleaning_water_volume)

--- a/RUFAS/biophysical/manure/handler/handler.py
+++ b/RUFAS/biophysical/manure/handler/handler.py
@@ -1,7 +1,5 @@
 from typing import Any
 
-from numpy import clip
-
 from RUFAS.biophysical.manure.manure_constants import ManureConstants
 from RUFAS.biophysical.manure.processor import Processor
 from RUFAS.current_day_conditions import CurrentDayConditions
@@ -71,6 +69,7 @@ class Handler(Processor):
         self.cleaning_water_use_amount = cleaning_water_use_amount
         self.cleaning_water_recycle_fraction = cleaning_water_recycle_fraction
         self.use_parlor_flush = use_parlor_flush
+        self._prefix = f"Manure.{self.__class__.__name__}.{handler_type}.{self.name}"
 
     def receive_manure(self, manure_stream: ManureStream) -> None:
         """
@@ -124,8 +123,6 @@ class Handler(Processor):
             )
             raise TypeError("Handler tries to process 'NoneType' object ManureStream.")
 
-        info_map_c = {"units": MeasurementUnits.DEGREES_CELSIUS, **info_map}
-        info_map_m3 = {"units": MeasurementUnits.CUBIC_METERS, **info_map}
         cleaning_water_volume = self.determine_handler_cleaning_water_volume(
             self.manure_stream.pen_manure_data.num_animals,
             self.cleaning_water_use_amount,
@@ -156,8 +153,20 @@ class Handler(Processor):
             cleaning_water_volume, fresh_water_volume_used_for_milking
         )
 
-        self._om.add_variable("total_cleaning_water_volume", total_cleaning_water_volume, info_map_m3)
-        self._om.add_variable("barn_temperature", barn_temperature, info_map_c)
+        self._report_processor_output(
+            "total_cleaning_water_volume",
+            total_cleaning_water_volume,
+            self.process_manure.__name__,
+            MeasurementUnits.CUBIC_METERS,
+            time
+        )
+        self._report_processor_output(
+            "barn_temperature",
+            barn_temperature,
+            self.process_manure.__name__,
+            MeasurementUnits.DEGREES_CELSIUS,
+            time
+        )
 
         manure_water = self.determine_manure_water(self.manure_stream.water, total_cleaning_water_volume)
 
@@ -171,17 +180,14 @@ class Handler(Processor):
         volume = self.manure_stream.volume + total_cleaning_water_volume
         total_solids = self.manure_stream.total_solids
 
-        emission_info_map: dict[str, Any] = {
-            "class": self.__class__.__name__,
-            "function": self.process_manure.__name__,
-            "prefix": self._prefix,
-            "simulation_day": time.simulation_day,
-            "units": MeasurementUnits.KILOGRAMS,
-            "handler type": self.handler_type,
-        }
-
         self.manure_stream = None
-        self._om.add_variable("housing_ammonia_emissions", ammonia_emission, emission_info_map)
+        self._report_processor_output(
+            "housing_ammonia_emissions",
+            ammonia_emission,
+            self.process_manure.__name__,
+            MeasurementUnits.KILOGRAMS,
+            time
+        )
 
         return {
             "manure": ManureStream(
@@ -230,31 +236,6 @@ class Handler(Processor):
         """
         return num_animals * (cleaning_water_use_amount * (1 - cleaning_water_recycle_fraction))
 
-    @staticmethod
-    def determine_barn_temperature(air_temp: float) -> float:
-        """
-        Calculates the barn temperature.
-
-        Parameters
-        ----------
-        air_temp : float
-            Air temperature (c).
-
-        Returns
-        -------
-        float
-            Adjusted barn temperature (c).
-
-        References
-        ----------
-        Between 5 and 30 C, barn temperature is assumed to be equal to outdoor air temperature.
-        This function assumes that barn temperature does not drop below 5 C or increase above 30 C.
-        These bounds were suggested by manure SMEs and are supported by barn temperature ranges
-        reported in Bucklin et al. (FL, upper limit; https://doi.org/10.13031/2013.28851).
-        The lower bound (5 C) suggested by SMEs was based on general industry standards/conditions.
-
-        """
-        return float(clip(air_temp, 5, 30))
 
     def check_manure_stream_compatibility(self, manure_stream: ManureStream) -> bool:
         """

--- a/RUFAS/biophysical/manure/handler/handler.py
+++ b/RUFAS/biophysical/manure/handler/handler.py
@@ -69,7 +69,7 @@ class Handler(Processor):
         self.cleaning_water_use_amount = cleaning_water_use_amount
         self.cleaning_water_recycle_fraction = cleaning_water_recycle_fraction
         self.use_parlor_flush = use_parlor_flush
-        self._prefix = f"Manure.{self.__class__.__name__}.{handler_type}.{self.name}"
+        self._prefix = f"Manure.{self.__class__.__name__}.{self.handler_type}.{self.name}"
 
     def receive_manure(self, manure_stream: ManureStream) -> None:
         """
@@ -128,7 +128,7 @@ class Handler(Processor):
             self.cleaning_water_use_amount,
             self.cleaning_water_recycle_fraction,
         )
-        barn_temperature = self.determine_barn_temperature(conditions.mean_air_temperature)
+        barn_temperature = self._determine_barn_temperature(conditions.mean_air_temperature)
         surface_area = self.manure_stream.pen_manure_data.manure_deposition_surface_area
 
         ammonia_emission = 0.0

--- a/RUFAS/biophysical/manure/handler/handler.py
+++ b/RUFAS/biophysical/manure/handler/handler.py
@@ -158,10 +158,14 @@ class Handler(Processor):
             total_cleaning_water_volume,
             self.process_manure.__name__,
             MeasurementUnits.CUBIC_METERS,
-            time,
+            time.simulation_day,
         )
         self._report_processor_output(
-            "barn_temperature", barn_temperature, self.process_manure.__name__, MeasurementUnits.DEGREES_CELSIUS, time
+            "barn_temperature",
+            barn_temperature,
+            self.process_manure.__name__,
+            MeasurementUnits.DEGREES_CELSIUS,
+            time.simulation_day
         )
 
         manure_water = self.determine_manure_water(self.manure_stream.water, total_cleaning_water_volume)
@@ -182,7 +186,7 @@ class Handler(Processor):
             ammonia_emission,
             self.process_manure.__name__,
             MeasurementUnits.KILOGRAMS,
-            time,
+            time.simulation_day,
         )
 
         return {

--- a/RUFAS/biophysical/manure/handler/handler.py
+++ b/RUFAS/biophysical/manure/handler/handler.py
@@ -158,14 +158,10 @@ class Handler(Processor):
             total_cleaning_water_volume,
             self.process_manure.__name__,
             MeasurementUnits.CUBIC_METERS,
-            time
+            time,
         )
         self._report_processor_output(
-            "barn_temperature",
-            barn_temperature,
-            self.process_manure.__name__,
-            MeasurementUnits.DEGREES_CELSIUS,
-            time
+            "barn_temperature", barn_temperature, self.process_manure.__name__, MeasurementUnits.DEGREES_CELSIUS, time
         )
 
         manure_water = self.determine_manure_water(self.manure_stream.water, total_cleaning_water_volume)
@@ -186,7 +182,7 @@ class Handler(Processor):
             ammonia_emission,
             self.process_manure.__name__,
             MeasurementUnits.KILOGRAMS,
-            time
+            time,
         )
 
         return {
@@ -235,7 +231,6 @@ class Handler(Processor):
 
         """
         return num_animals * (cleaning_water_use_amount * (1 - cleaning_water_recycle_fraction))
-
 
     def check_manure_stream_compatibility(self, manure_stream: ManureStream) -> bool:
         """

--- a/RUFAS/biophysical/manure/handler/single_stream_handler.py
+++ b/RUFAS/biophysical/manure/handler/single_stream_handler.py
@@ -96,18 +96,23 @@ class SingleStreamHandler(Handler):
             raise TypeError("Handler tries to process 'NoneType' object ManureStream or PenManureData.")
         barn_temperature = self.determine_barn_temperature(conditions.mean_air_temperature)
         surface_area = self.manure_stream.pen_manure_data.manure_deposition_surface_area
-        emission_info_map: dict[str, Any] = {
-            "class": self.__class__.__name__,
-            "function": self.process_manure.__name__,
-            "prefix": self._prefix,
-            "simulation_day": time.simulation_day,
-            "units": MeasurementUnits.KILOGRAMS,
-            "handler type": self.handler_type,
-        }
+
         housing_CO2_emissions = self.determine_housing_carbon_dioxide_emissions(surface_area, barn_temperature)
         housing_methane_emissions = self.determine_housing_methane_emissions(surface_area, barn_temperature)
-        self._om.add_variable("housing_CO2_emissions", housing_CO2_emissions, emission_info_map)
-        self._om.add_variable("housing_methane_emissions", housing_methane_emissions, emission_info_map)
+        self._report_processor_output(
+            "housing_CO2_emissions",
+            housing_CO2_emissions,
+            self.process_manure.__name__,
+            MeasurementUnits.KILOGRAMS,
+            time
+        )
+        self._report_processor_output(
+            "housing_methane_emissions",
+            housing_methane_emissions,
+            self.process_manure.__name__,
+            MeasurementUnits.KILOGRAMS,
+            time
+        )
         return super().process_manure(conditions, time)
 
     @staticmethod

--- a/RUFAS/biophysical/manure/handler/single_stream_handler.py
+++ b/RUFAS/biophysical/manure/handler/single_stream_handler.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from RUFAS.biophysical.manure.handler.handler import Handler
 from RUFAS.current_day_conditions import CurrentDayConditions
 from RUFAS.data_structures.animal_to_manure_connection import ManureStream

--- a/RUFAS/biophysical/manure/handler/single_stream_handler.py
+++ b/RUFAS/biophysical/manure/handler/single_stream_handler.py
@@ -101,14 +101,14 @@ class SingleStreamHandler(Handler):
             housing_CO2_emissions,
             self.process_manure.__name__,
             MeasurementUnits.KILOGRAMS,
-            time,
+            time.simulation_day,
         )
         self._report_processor_output(
             "housing_methane_emissions",
             housing_methane_emissions,
             self.process_manure.__name__,
             MeasurementUnits.KILOGRAMS,
-            time,
+            time.simulation_day,
         )
         return super().process_manure(conditions, time)
 

--- a/RUFAS/biophysical/manure/handler/single_stream_handler.py
+++ b/RUFAS/biophysical/manure/handler/single_stream_handler.py
@@ -35,7 +35,6 @@ class SingleStreamHandler(Handler):
         super().__init__(
             name, handler_type, cleaning_water_use_amount, cleaning_water_recycle_fraction, use_parlor_flush
         )
-        self._prefix = f"{self.__class__.__name__}.{self.handler_type}.{self.name}"
 
     def receive_manure(self, manure_stream: ManureStream) -> None:
         """
@@ -92,7 +91,7 @@ class SingleStreamHandler(Handler):
                 info_map,
             )
             raise TypeError("Handler tries to process 'NoneType' object ManureStream or PenManureData.")
-        barn_temperature = self.determine_barn_temperature(conditions.mean_air_temperature)
+        barn_temperature = self._determine_barn_temperature(conditions.mean_air_temperature)
         surface_area = self.manure_stream.pen_manure_data.manure_deposition_surface_area
 
         housing_CO2_emissions = self.determine_housing_carbon_dioxide_emissions(surface_area, barn_temperature)

--- a/RUFAS/biophysical/manure/handler/single_stream_handler.py
+++ b/RUFAS/biophysical/manure/handler/single_stream_handler.py
@@ -104,14 +104,14 @@ class SingleStreamHandler(Handler):
             housing_CO2_emissions,
             self.process_manure.__name__,
             MeasurementUnits.KILOGRAMS,
-            time
+            time,
         )
         self._report_processor_output(
             "housing_methane_emissions",
             housing_methane_emissions,
             self.process_manure.__name__,
             MeasurementUnits.KILOGRAMS,
-            time
+            time,
         )
         return super().process_manure(conditions, time)
 

--- a/RUFAS/biophysical/manure/processor.py
+++ b/RUFAS/biophysical/manure/processor.py
@@ -1,4 +1,3 @@
-import inspect
 from abc import ABC, abstractmethod
 from dataclasses import asdict
 

--- a/RUFAS/biophysical/manure/processor.py
+++ b/RUFAS/biophysical/manure/processor.py
@@ -353,7 +353,7 @@ class Processor(ABC):
         return float(clip(air_temp, 5.0, 30.0))
 
     def _report_processor_output(
-        self, variable_name: str, variable_value: float, data_origin_function: str, unit: MeasurementUnits, time: Time
+        self, variable_name: str, variable_value: float, data_origin_function: str, units: MeasurementUnits, time: Time
     ) -> None:
         """
         Reports an output variable to the OutputManager.
@@ -377,7 +377,7 @@ class Processor(ABC):
             "function": data_origin_function,
             "prefix": self._prefix,
             "simulation_day": time.simulation_day,
-            "units": unit,
+            "units": units,
         }
 
         self._om.add_variable(variable_name, variable_value, info_map)

--- a/RUFAS/biophysical/manure/processor.py
+++ b/RUFAS/biophysical/manure/processor.py
@@ -367,7 +367,7 @@ class Processor(ABC):
         data_origin_function : str
             The name of the function that reported the variable value.
         units : MeasurementUnits
-            The unit for the reported variable value.
+            The units for the reported variable value.
         time : Time
             Time instance tracking the current time of the simulation.
 

--- a/RUFAS/biophysical/manure/processor.py
+++ b/RUFAS/biophysical/manure/processor.py
@@ -326,13 +326,13 @@ class Processor(ABC):
         return float(clip(air_temperature, 0.0, 35.0))
 
     @staticmethod
-    def _determine_barn_temperature(air_temp: float) -> float:
+    def _determine_barn_temperature(air_temperature: float) -> float:
         """
         Calculates the barn temperature.
 
         Parameters
         ----------
-        air_temp : float
+        air_temperature : float
             Air temperature (c).
 
         Returns
@@ -349,7 +349,7 @@ class Processor(ABC):
         The lower bound (5 C) suggested by SMEs was based on general industry standards/conditions.
 
         """
-        return float(clip(air_temp, 5.0, 30.0))
+        return float(clip(air_temperature, 5.0, 30.0))
 
     def _report_processor_output(
         self, variable_name: str, variable_value: float, data_origin_function: str, units: MeasurementUnits, time: Time

--- a/RUFAS/biophysical/manure/processor.py
+++ b/RUFAS/biophysical/manure/processor.py
@@ -354,12 +354,7 @@ class Processor(ABC):
         return float(clip(air_temp, 5, 30))
 
     def _report_processor_output(
-            self,
-            variable_name: str,
-            variable_value: float,
-            data_origin_function: str,
-            unit: MeasurementUnits,
-            time: Time
+        self, variable_name: str, variable_value: float, data_origin_function: str, unit: MeasurementUnits, time: Time
     ) -> None:
         """
         Reports a gas emission output to the OutputManager.

--- a/RUFAS/biophysical/manure/processor.py
+++ b/RUFAS/biophysical/manure/processor.py
@@ -135,7 +135,6 @@ class Processor(ABC):
             )
             raise ValueError("Manure Stream must contain the same keys as manure_stream_units to properly report it.")
 
-        # TODO: Also report the properties (mass and total_volatile_solids)
         for key, value in manure_stream_dict.items():
             if key != "pen_manure_data":
                 self._om.add_variable(

--- a/RUFAS/biophysical/manure/processor.py
+++ b/RUFAS/biophysical/manure/processor.py
@@ -1,11 +1,15 @@
+import inspect
 from abc import ABC, abstractmethod
 from dataclasses import asdict
+
+from numpy import clip
 
 from RUFAS.current_day_conditions import CurrentDayConditions
 from RUFAS.data_structures.animal_to_manure_connection import ManureStream
 from RUFAS.general_constants import GeneralConstants
 from RUFAS.time import Time
 from RUFAS.output_manager import OutputManager
+from RUFAS.units import MeasurementUnits
 from RUFAS.util import Utility
 
 
@@ -45,7 +49,8 @@ class Processor(ABC):
         self.name = name
         self.is_housing_emissions_calculator = is_housing_emissions_calculator
         self._om = OutputManager()
-        self._prefix = f"{self.__class__.__name__}.{self.name}"
+        base_class_name = self.__class__.__bases__[0].__name__
+        self._prefix = f"Manure.{base_class_name}.{self.__class__.__name__}.{self.name}"
 
     @abstractmethod
     def receive_manure(self, manure: ManureStream) -> None:
@@ -131,10 +136,11 @@ class Processor(ABC):
             )
             raise ValueError("Manure Stream must contain the same keys as manure_stream_units to properly report it.")
 
+        # TODO: Also report the properties (mass and total_volatile_solids)
         for key, value in manure_stream_dict.items():
             if key != "pen_manure_data":
                 self._om.add_variable(
-                    f"{stream_name}.manure_{key}", value, {**info_map, "units": ManureStream.MANURE_STREAM_UNITS[key]}
+                    f"{stream_name}_manure_{key}", value, {**info_map, "units": ManureStream.MANURE_STREAM_UNITS[key]}
                 )
 
     def check_manure_stream_compatibility(self, manure_stream: ManureStream) -> bool:
@@ -161,9 +167,8 @@ class Processor(ABC):
 
         return is_valid_housing_emissions_calculator ^ is_valid_non_housing_emissions_calculator
 
-    @classmethod
+    @staticmethod
     def _calculate_ammonia_emissions(
-        cls,
         total_ammoniacal_nitrogen: float,
         volume: float,
         density: float,
@@ -224,22 +229,22 @@ class Processor(ABC):
         temp_kelvin = Utility.convert_celsius_to_kelvin(temperature)
         manure_kilograms_per_square_meter = (volume * density) / surface_area
         total_ammoniacal_nitrogen_per_meter = total_ammoniacal_nitrogen / surface_area
-        equilibrium_coefficient = cls._calculate_ammonia_equilibrium_coefficient(temp_kelvin, pH)
+        equilibrium_coefficient = Processor._calculate_ammonia_equilibrium_coefficient(temp_kelvin, pH)
         ammonia_loss_per_meter = (total_ammoniacal_nitrogen_per_meter * GeneralConstants.SECONDS_PER_DAY * density) / (
             ammonia_resistance * manure_kilograms_per_square_meter * equilibrium_coefficient
         )
         total_ammonia_loss = min(ammonia_loss_per_meter * surface_area, total_ammoniacal_nitrogen)
         return max(0.0, total_ammonia_loss)
 
-    @classmethod
-    def _calculate_ammonia_equilibrium_coefficient(cls, temp: float, pH: float) -> float:
+    @staticmethod
+    def _calculate_ammonia_equilibrium_coefficient(temperature: float, pH: float) -> float:
         """
         Calculates the equilibrium coefficient for the ammonia gas in the air for a given concentration of total
         ammoniacal nitrogen in the solution.
 
         Parameters
         ----------
-        temp : float
+        temperature : float
             Manure solution temperature in Kelvin (K).
         pH : float
             Manure solution pH (unitless).
@@ -250,18 +255,18 @@ class Processor(ABC):
             Equilibrium coefficient for the ammonia gas in the air (unitless).
 
         """
-        henrys_ammonia_coefficient = cls._calculate_henry_law_coefficient_of_ammonia(temp)
-        ammonium_dissociation_coefficient = cls._calculate_dissociation_coefficient_of_ammonium(temp, pH)
+        henrys_ammonia_coefficient = Processor._calculate_henry_law_coefficient_of_ammonia(temperature)
+        ammonium_dissociation_coefficient = Processor._calculate_dissociation_coefficient_of_ammonium(temperature, pH)
         return henrys_ammonia_coefficient * ammonium_dissociation_coefficient
 
-    @classmethod
-    def _calculate_henry_law_coefficient_of_ammonia(cls, temp: float) -> float:
+    @staticmethod
+    def _calculate_henry_law_coefficient_of_ammonia(temperature: float) -> float:
         """
         Calculate Henry's Law coefficient of ammonia.
 
         Parameters
         ----------
-        temp : float
+        temperature : float
             Temperature in Kelvin (K).
 
         Returns
@@ -270,16 +275,16 @@ class Processor(ABC):
             Henry's law coefficient of ammonia (unitless).
 
         """
-        return 10 ** (1478 / temp - 1.69)
+        return 10 ** (1478 / temperature - 1.69)
 
-    @classmethod
-    def _calculate_dissociation_coefficient_of_ammonium(cls, temp: float, pH: float) -> float:
+    @staticmethod
+    def _calculate_dissociation_coefficient_of_ammonium(temperature: float, pH: float) -> float:
         """
         Calculate dissociation coefficient of ammonium.
 
         Parameters
         ----------
-        temp : float
+        temperature : float
             Temperature in Kelvin (K).
         pH : float
             Manure solution acidity (unitless).
@@ -290,4 +295,95 @@ class Processor(ABC):
             Dissociation coefficient of ammonium (unitless).
 
         """
-        return 1 + 10 ** (0.09018 + 2729.9 / temp - pH)
+        return 1 + 10 ** (0.09018 + 2729.9 / temperature - pH)
+
+    @staticmethod
+    def _determine_outdoor_storage_temperature(air_temperature: float) -> float:
+        """
+        Determines the temperature of the manure in outdoor liquid and slurry storages.
+
+        Parameters
+        ----------
+        air_temperature : float
+            The current day's ambient air temperature (°C).
+
+        Returns
+        -------
+        float
+            The estimated temperature of the manure storage (°C).
+
+        References
+        ----------
+        The temperature bounds of this method were based on personal communication and recommendations from A. Leytem
+        (april.leytem@usda.gov) and A. VanderZaag (andrew.vanderzaag@AGR.GC.CA). These bounds are also support by work
+        from Genedy and Ogejo, 2021 (https://doi.org/10.1016/j.compag.2021.106234) who observed similar minimum and
+        maximum liquid manure temperatures in outdoor clay pit and concrete tank manure storages.
+
+        Notes
+        -----
+        This function clamps stored manure temperature to between 0 and 35 °C. Between 0 and 35 °C, outdoor stored
+        liquid manure temperature is assumed to be equal to ambient air temperature.
+
+        """
+        return float(clip(air_temperature, 0.0, 35.0))
+
+    @staticmethod
+    def determine_barn_temperature(air_temp: float) -> float:
+        """
+        Calculates the barn temperature.
+
+        Parameters
+        ----------
+        air_temp : float
+            Air temperature (c).
+
+        Returns
+        -------
+        float
+            Adjusted barn temperature (c).
+
+        References
+        ----------
+        Between 5 and 30 C, barn temperature is assumed to be equal to outdoor air temperature.
+        This function assumes that barn temperature does not drop below 5 C or increase above 30 C.
+        These bounds were suggested by manure SMEs and are supported by barn temperature ranges
+        reported in Bucklin et al. (FL, upper limit; https://doi.org/10.13031/2013.28851).
+        The lower bound (5 C) suggested by SMEs was based on general industry standards/conditions.
+
+        """
+        return float(clip(air_temp, 5, 30))
+
+    def _report_processor_output(
+            self,
+            variable_name: str,
+            variable_value: float,
+            data_origin_function: str,
+            unit: MeasurementUnits,
+            time: Time
+    ) -> None:
+        """
+        Reports a gas emission output to the OutputManager.
+
+        Parameters
+        ----------
+        variable_name : str
+            The name of the reported variable.
+        variable_value : str
+            The value of the reported gas emission value.
+        data_origin_function : str
+            The name of the function that reported the gas emission value.
+        unit : MeasurementUnits
+            The unit for the reported gas emission value.
+        time : Time
+            Time instance tracking the current time of the simulation.
+
+        """
+        info_map = {
+            "class": self.__class__.__name__,
+            "function": data_origin_function,
+            "prefix": self._prefix,
+            "simulation_day": time.simulation_day,
+            "units": unit,
+        }
+
+        self._om.add_variable(variable_name, variable_value, info_map)

--- a/RUFAS/biophysical/manure/processor.py
+++ b/RUFAS/biophysical/manure/processor.py
@@ -366,7 +366,7 @@ class Processor(ABC):
             The value of the reported variable value.
         data_origin_function : str
             The name of the function that reported the variable value.
-        unit : MeasurementUnits
+        units : MeasurementUnits
             The unit for the reported variable value.
         time : Time
             Time instance tracking the current time of the simulation.

--- a/RUFAS/biophysical/manure/processor.py
+++ b/RUFAS/biophysical/manure/processor.py
@@ -327,7 +327,7 @@ class Processor(ABC):
         return float(clip(air_temperature, 0.0, 35.0))
 
     @staticmethod
-    def determine_barn_temperature(air_temp: float) -> float:
+    def _determine_barn_temperature(air_temp: float) -> float:
         """
         Calculates the barn temperature.
 
@@ -356,18 +356,18 @@ class Processor(ABC):
         self, variable_name: str, variable_value: float, data_origin_function: str, unit: MeasurementUnits, time: Time
     ) -> None:
         """
-        Reports a gas emission output to the OutputManager.
+        Reports an output variable to the OutputManager.
 
         Parameters
         ----------
         variable_name : str
             The name of the reported variable.
         variable_value : str
-            The value of the reported gas emission value.
+            The value of the reported variable value.
         data_origin_function : str
-            The name of the function that reported the gas emission value.
+            The name of the function that reported the variable value.
         unit : MeasurementUnits
-            The unit for the reported gas emission value.
+            The unit for the reported variable value.
         time : Time
             Time instance tracking the current time of the simulation.
 

--- a/RUFAS/biophysical/manure/processor.py
+++ b/RUFAS/biophysical/manure/processor.py
@@ -357,7 +357,7 @@ class Processor(ABC):
         variable_value: float,
         data_origin_function: str,
         units: MeasurementUnits,
-        simulation_day: int
+        simulation_day: int,
     ) -> None:
         """
         Reports an output variable to the OutputManager.

--- a/RUFAS/biophysical/manure/processor.py
+++ b/RUFAS/biophysical/manure/processor.py
@@ -350,7 +350,7 @@ class Processor(ABC):
         The lower bound (5 C) suggested by SMEs was based on general industry standards/conditions.
 
         """
-        return float(clip(air_temp, 5, 30))
+        return float(clip(air_temp, 5.0, 30.0))
 
     def _report_processor_output(
         self, variable_name: str, variable_value: float, data_origin_function: str, unit: MeasurementUnits, time: Time

--- a/RUFAS/biophysical/manure/processor.py
+++ b/RUFAS/biophysical/manure/processor.py
@@ -92,7 +92,7 @@ class Processor(ABC):
         pass
 
     def _report_manure_stream(
-        self, manure_stream: ManureStream | dict[str, float | None], stream_name: str, time: Time
+        self, manure_stream: ManureStream | dict[str, float | None], stream_name: str, simulation_day: int
     ) -> None:
         """
         Reports the manure stream data to Output Manager.
@@ -103,14 +103,14 @@ class Processor(ABC):
             The manure stream to report. If a `ManureStream` instance is passed, it will be converted to a dictionary.
         stream_name : str
             The name of the manure stream being reported.
-        time : Time
-            The simulation time object.
+        simulation_day : int
+            The current simulation day.
         """
         info_map = {
             "class": self.__class__.__name__,
             "function": self._report_manure_stream.__name__,
             "prefix": self._prefix,
-            "simulation_day": time.simulation_day,
+            "simulation_day": simulation_day,
         }
         if isinstance(manure_stream, ManureStream):
             manure_stream_dict = asdict(manure_stream)
@@ -352,7 +352,12 @@ class Processor(ABC):
         return float(clip(air_temperature, 5.0, 30.0))
 
     def _report_processor_output(
-        self, variable_name: str, variable_value: float, data_origin_function: str, units: MeasurementUnits, time: Time
+        self,
+        variable_name: str,
+        variable_value: float,
+        data_origin_function: str,
+        units: MeasurementUnits,
+        simulation_day: int
     ) -> None:
         """
         Reports an output variable to the OutputManager.
@@ -367,15 +372,15 @@ class Processor(ABC):
             The name of the function that reported the variable value.
         units : MeasurementUnits
             The units for the reported variable value.
-        time : Time
-            Time instance tracking the current time of the simulation.
+        simulation_day : int
+            The current simulation day.
 
         """
         info_map = {
             "class": self.__class__.__name__,
             "function": data_origin_function,
             "prefix": self._prefix,
-            "simulation_day": time.simulation_day,
+            "simulation_day": simulation_day,
             "units": units,
         }
 

--- a/RUFAS/biophysical/manure/separator/separator.py
+++ b/RUFAS/biophysical/manure/separator/separator.py
@@ -84,7 +84,7 @@ class Separator(Processor):
         self.ash_efficiency: float = ash_efficiency
         self.volatile_solids_efficiency: float = volatile_solids_efficiency
         self.total_solids_efficiency: float = total_solids_efficiency
-        # TODO: replace '{"separator_type"}' with '{self.type.value}' once we implement the processor type enum.
+        # TODO: replace '{"separator_type"}' with '{self.type.value}' once we implement the processor type enum. Issue #2281
         self._prefix = f"Manure.{self.__class__.__name__}.{"separator_type"}.{self.name}"
 
     def receive_manure(self, manure: ManureStream) -> None:

--- a/RUFAS/biophysical/manure/separator/separator.py
+++ b/RUFAS/biophysical/manure/separator/separator.py
@@ -84,7 +84,8 @@ class Separator(Processor):
         self.ash_efficiency: float = ash_efficiency
         self.volatile_solids_efficiency: float = volatile_solids_efficiency
         self.total_solids_efficiency: float = total_solids_efficiency
-        # TODO: replace '{"separator_type"}' with '{self.type.value}' once we implement the processor type enum. Issue #2281
+        # TODO: replace '{"separator_type"}' with '{self.type.value}' once we implement the processor type enum.
+        #  Issue #2281
         self._prefix = f"Manure.{self.__class__.__name__}.{"separator_type"}.{self.name}"
 
     def receive_manure(self, manure: ManureStream) -> None:

--- a/RUFAS/biophysical/manure/separator/separator.py
+++ b/RUFAS/biophysical/manure/separator/separator.py
@@ -155,7 +155,7 @@ class Separator(Processor):
         solid_manure_stream_dict = asdict(solid_manure_stream)
         solid_manure_stream_dict["mass"] = solid_manure_total_mass
         solid_manure_stream_dict["total_volatile_solids"] = solid_manure_stream.total_volatile_solids
-        self._report_manure_stream(solid_manure_stream, solid_stream_name, time)
+        self._report_manure_stream(solid_manure_stream, solid_stream_name, time.simulation_day)
 
         liquid_manure_water = self.held_manure.water - solid_manure_water
         liquid_manure_total_solids = self.held_manure.total_solids * (1 - self.total_solids_efficiency)
@@ -178,7 +178,7 @@ class Separator(Processor):
             pen_manure_data=None,
         )
         liquid_stream_name = "SeparatedLiquid"
-        self._report_manure_stream(liquid_manure_stream, liquid_stream_name, time)
+        self._report_manure_stream(liquid_manure_stream, liquid_stream_name, time.simulation_day)
 
         self.clear_held_manure()
 

--- a/RUFAS/biophysical/manure/separator/separator.py
+++ b/RUFAS/biophysical/manure/separator/separator.py
@@ -84,6 +84,8 @@ class Separator(Processor):
         self.ash_efficiency: float = ash_efficiency
         self.volatile_solids_efficiency: float = volatile_solids_efficiency
         self.total_solids_efficiency: float = total_solids_efficiency
+        # TODO: replace '{"separator_type"}' with '{self.type.value}' once we implement the processor type enum.
+        self._prefix = f"Manure.{self.__class__.__name__}.{"separator_type"}.{self.name}"
 
     def receive_manure(self, manure: ManureStream) -> None:
         """

--- a/RUFAS/biophysical/manure/storage/storage.py
+++ b/RUFAS/biophysical/manure/storage/storage.py
@@ -50,7 +50,6 @@ METHANE_DESTRUCTION_EFFICIENCY = 81.0
 """Natural log of the Arrhenius constant (g methane / kg manure Volatile Solids / hour)."""
 NATURAL_LOG_ARRHENIUS_CONSTANT: float = 31.2
 
-
 """
 Mapping of storage cover types to the nitrous oxide emissions factor associated with that cover type (kg nitrous oxide N
 / kg manure N).
@@ -75,7 +74,7 @@ class Storage(Processor):
         How long manure is stored for before emptying the storage (days). None if the storage is never emptied.
     surface_area : float
         The surface area of the manure storage (m^2).
-    nitrous_oxide_emission_factor : float
+    nitrous_oxide_emissions_factor : float
         Factor governing the nitrous oxide emissions from storage (kg nitrous oxide N / kg manure N).
     capacity : float, default math.inf
         Volumetric capacity of the storage (m^3).

--- a/RUFAS/biophysical/manure/storage/storage.py
+++ b/RUFAS/biophysical/manure/storage/storage.py
@@ -1,4 +1,3 @@
-import inspect
 from dataclasses import replace
 from math import inf
 from numpy import exp
@@ -8,7 +7,6 @@ from RUFAS.current_day_conditions import CurrentDayConditions
 from RUFAS.data_structures.animal_to_manure_connection import ManureStream
 from RUFAS.general_constants import GeneralConstants
 from RUFAS.time import Time
-from RUFAS.units import MeasurementUnits
 from RUFAS.util import Utility
 
 from .storage_cover import StorageCover

--- a/RUFAS/biophysical/manure/storage/storage.py
+++ b/RUFAS/biophysical/manure/storage/storage.py
@@ -151,7 +151,7 @@ class Storage(Processor):
 
         is_emptying_day = self._storage_time_period is not None and time.simulation_day % self._storage_time_period == 0
         if is_emptying_day:
-            self._report_manure_stream(self._stored_manure, "emptied", time)
+            self._report_manure_stream(self._stored_manure, "emptied", time.simulation_day)
             manure_to_be_returned = {"manure": replace(self._stored_manure)}
             self._stored_manure = ManureStream.make_empty_manure_stream()
         else:

--- a/RUFAS/biophysical/manure/storage/storage.py
+++ b/RUFAS/biophysical/manure/storage/storage.py
@@ -244,7 +244,8 @@ class Storage(Processor):
         is_temp_invalid: bool = not (GENERAL_LOWER_BOUND_TEMPERATURE <= temperature <= GENERAL_UPPER_BOUND_TEMPERATURE)
         if is_temp_invalid:
             raise ValueError(
-                f"Temperature must be between -40 and 60 degrees Celsius. Temperature provided: {temperature}")
+                f"Temperature must be between -40 and 60 degrees Celsius. Temperature provided: {temperature}"
+            )
 
         temp_kelvin = Utility.convert_celsius_to_kelvin(temperature)
         return float(exp(NATURAL_LOG_ARRHENIUS_CONSTANT - (ACTIVATION_ENERGY / (GAS_CONSTANT * temp_kelvin))))

--- a/RUFAS/biophysical/manure/storage/storage.py
+++ b/RUFAS/biophysical/manure/storage/storage.py
@@ -1,6 +1,7 @@
+import inspect
 from dataclasses import replace
 from math import inf
-from numpy import clip, exp
+from numpy import exp
 
 from RUFAS.biophysical.manure.processor import Processor
 from RUFAS.current_day_conditions import CurrentDayConditions
@@ -119,7 +120,7 @@ class Storage(Processor):
         self._storage_time_period = storage_time_period
         self._surface_area = surface_area
         self._nitrous_oxide_emissions_factor = nitrous_oxide_emissions_factor
-        self._accumulated_output_prefix = f"Accumulated{self._prefix}"
+        self._manure_to_process = ManureStream.make_empty_manure_stream()
 
     @property
     def is_overflowing(self) -> bool:
@@ -151,7 +152,7 @@ class Storage(Processor):
 
         is_emptying_day = self._storage_time_period is not None and time.simulation_day % self._storage_time_period == 0
         if is_emptying_day:
-            self._report_storage_outputs(self._prefix, "emptied", self._stored_manure, time)
+            self._report_manure_stream(self._stored_manure, "emptied", time)
             manure_to_be_returned = {"manure": replace(self._stored_manure)}
             self._stored_manure = ManureStream.make_empty_manure_stream()
         else:
@@ -160,59 +161,7 @@ class Storage(Processor):
         if self.is_overflowing is True:
             self.handle_overflowing_manure(time)
 
-        self._report_storage_outputs(self._accumulated_output_prefix, "accumulated", self._stored_manure, time)
-
         return manure_to_be_returned
-
-    def _report_storage_outputs(
-        self, info_map_prefix: str, variable_name_prefix: str, manure: ManureStream, time: Time
-    ) -> None:
-        """
-        Reports attributes of a manure stream instance as directed from a manure storage.
-
-        Parameters
-        ----------
-        info_map_prefix : str
-            Prefix for the info map.
-        variable_name_prefix : str
-            Prefix for the variable name.
-        manure : ManureStream
-            The manure stream instance to report.
-        time : Time
-            Time instance tracking the current time of the simulation.
-
-        """
-        info_map = {
-            "class": self.__class__.__name__,
-            "function": self._report_storage_outputs.__name__,
-            "prefix": info_map_prefix,
-            "simulation_day": time.simulation_day,
-        }
-        info_map_kg = info_map | {"units": MeasurementUnits.KILOGRAMS}
-        info_map_m3 = info_map | {"units": MeasurementUnits.CUBIC_METERS}
-
-        self._om.add_variable(f"{variable_name_prefix}_manure_water", manure.water, info_map_kg)
-        self._om.add_variable(
-            f"{variable_name_prefix}_manure_total_ammoniacal_nitrogen", manure.ammoniacal_nitrogen, info_map_kg
-        )
-        self._om.add_variable(f"{variable_name_prefix}_manure_nitrogen", manure.nitrogen, info_map_kg)
-        self._om.add_variable(f"{variable_name_prefix}_manure_phosphorus", manure.phosphorus, info_map_kg)
-        self._om.add_variable(f"{variable_name_prefix}_manure_potassium", manure.potassium, info_map_kg)
-        self._om.add_variable(f"{variable_name_prefix}_manure_ash", manure.ash, info_map_kg)
-        self._om.add_variable(
-            f"{variable_name_prefix}_manure_non_degradable_volatile_solids",
-            manure.non_degradable_volatile_solids,
-            info_map_kg,
-        )
-        self._om.add_variable(
-            f"{variable_name_prefix}_manure_degradable_volatile_solids", manure.degradable_volatile_solids, info_map_kg
-        )
-        self._om.add_variable(
-            f"{variable_name_prefix}_manure_total_volatile_solids", manure.total_volatile_solids, info_map_kg
-        )
-        self._om.add_variable(f"{variable_name_prefix}_manure_total_solids", manure.total_solids, info_map_kg)
-        self._om.add_variable(f"{variable_name_prefix}_manure_mass", manure.mass, info_map_kg)
-        self._om.add_variable(f"{variable_name_prefix}_manure_volume", manure.volume, info_map_m3)
 
     def handle_overflowing_manure(self, time: Time) -> None:
         """
@@ -232,10 +181,8 @@ class Storage(Processor):
         }
         self._om.add_warning(f"Manure storage '{self.name}' is overflowing!", "Handling excess manure", info_map)
 
-    @classmethod
-    def _calculate_methane_emissions(
-        cls, volatile_solids: float, manure_temperature: float, is_degradable: bool
-    ) -> float:
+    @staticmethod
+    def _calculate_methane_emissions(volatile_solids: float, manure_temperature: float, is_degradable: bool) -> float:
         """
         Calculates methane that is emitted from liquid manure storages by calculating emissions from the degradable and
         non-degradable volatile solids fractions.
@@ -256,7 +203,7 @@ class Storage(Processor):
 
         """
 
-        arrhenius_exponent = cls._calculate_arrhenius_exponent(manure_temperature)
+        arrhenius_exponent = Storage._calculate_arrhenius_exponent(manure_temperature)
 
         if is_degradable:
             rate_correcting_factor = DEGRADABLE_VOLATILE_SOLIDS_RATE_CORRECTING_FACTOR
@@ -273,14 +220,14 @@ class Storage(Processor):
 
         return methane_emissions
 
-    @classmethod
-    def _calculate_arrhenius_exponent(cls, temp: float) -> float:
+    @staticmethod
+    def _calculate_arrhenius_exponent(temperature: float) -> float:
         """
         Calculate the Arrhenius exponent.
 
         Parameters
         ----------
-        temp : float
+        temperature : float
             Temperature in Celsius (degrees C).
 
         Returns
@@ -294,15 +241,16 @@ class Storage(Processor):
             If the temperature is not between -40 and 60 degrees Celsius.
 
         """
-        is_temp_invalid: bool = not (GENERAL_LOWER_BOUND_TEMPERATURE <= temp <= GENERAL_UPPER_BOUND_TEMPERATURE)
+        is_temp_invalid: bool = not (GENERAL_LOWER_BOUND_TEMPERATURE <= temperature <= GENERAL_UPPER_BOUND_TEMPERATURE)
         if is_temp_invalid:
-            raise ValueError(f"Temperature must be between -40 and 60 degrees Celsius. Temperature provided: {temp}")
+            raise ValueError(
+                f"Temperature must be between -40 and 60 degrees Celsius. Temperature provided: {temperature}")
 
-        temp_kelvin = Utility.convert_celsius_to_kelvin(temp)
+        temp_kelvin = Utility.convert_celsius_to_kelvin(temperature)
         return float(exp(NATURAL_LOG_ARRHENIUS_CONSTANT - (ACTIVATION_ENERGY / (GAS_CONSTANT * temp_kelvin))))
 
-    @classmethod
-    def _calculate_cover_and_flare_methane(cls, methane_loss: float) -> tuple[float, float]:
+    @staticmethod
+    def _calculate_cover_and_flare_methane(methane_loss: float) -> tuple[float, float]:
         """
         Adjust the methane burned and lost when using cover and flare cover type.
 
@@ -321,42 +269,8 @@ class Storage(Processor):
         adjusted_methane_loss = methane_loss - storage_methane_burned
         return storage_methane_burned, adjusted_methane_loss
 
-    @classmethod
-    def _determine_outdoor_storage_temperature(cls, air_temperature: float) -> float:
-        """
-        Determines the temperature of the manure in outdoor liquid and slurry storages.
-
-        Parameters
-        ----------
-        air_temperature : float
-            The current day's ambient air temperature (°C).
-
-        Returns
-        -------
-        float
-            The estimated temperature of the manure storage (°C).
-
-        References
-        ----------
-        The temperature bounds of this method were based on personal communication and recommendations from A. Leytem
-        (april.leytem@usda.gov) and A. VanderZaag (andrew.vanderzaag@AGR.GC.CA). These bounds are also support by work
-        from Genedy and Ogejo, 2021 (https://doi.org/10.1016/j.compag.2021.106234) who observed similar minimum and
-        maximum liquid manure temperatures in outdoor clay pit and concrete tank manure storages.
-
-        Notes
-        -----
-        This function clamps stored manure temperature to between 0 and 35 °C. Between 0 and 35 °C, outdoor stored
-        liquid manure temperature is assumed to be equal to ambient air temperature.
-
-        """
-        return float(clip(air_temperature, 0.0, 35.0))
-
-    @classmethod
-    def _calculate_nitrous_oxide_emissions(
-        cls,
-        nitrous_oxide_emissions_factor: float,
-        nitrogen_added: float,
-    ) -> float:
+    @staticmethod
+    def _calculate_nitrous_oxide_emissions(nitrous_oxide_emissions_factor: float, nitrogen_added: float) -> float:
         """
         Calculates amount of nitrous oxide nitrogen emitted from a storage on a single day.
 

--- a/RUFAS/biophysical/manure/storage/storage.py
+++ b/RUFAS/biophysical/manure/storage/storage.py
@@ -94,8 +94,10 @@ class Storage(Processor):
         Interval between emptyings of the storage (days). If the storage is never emptied, this is None.
     _surface_area : float
         Surface area of the manure storage (m^2).
-    _nitrous_oxide_emission_factor : float
+    _nitrous_oxide_emissions_factor : float
         Factor governing the nitrous oxide emissions from storage (kg nitrous oxide N / kg manure N).
+    _manure_to_process : ManureStream
+        The manure that to be processed during the `process_manure()` method call.
 
     """
 

--- a/changelog.md
+++ b/changelog.md
@@ -124,6 +124,7 @@ v0.9.2
 - [2298](https://github.com/RuminantFarmSystems/MASM/pull/2298) - [minor change] [Manure] Fixed failing tests in handler.
 - [2235](https://github.com/RuminantFarmSystems/MASM/pull/2235) - [major change] [Animal] Refresh the Animal module.
 - [2297](https://github.com/RuminantFarmSystems/MASM/pull/2297) - [minor change] [Animal] Fix the flake8 errors in the refreshed animal module and modify "HerdManager._gather_pen_history()" to optimize run time.
+- [2306](https://github.com/RuminantFarmSystems/MASM/pull/2306) - [minor change] [Manure] Implement patches to manure refresh after the dev team discussion.
 
 ### v0.9.2
 

--- a/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
+++ b/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
@@ -188,7 +188,7 @@ def test_report_anaerobic_digester_outputs(digester: AnaerobicDigester, time: Ti
         methane_leakage_mass=0.0,
         minimum_digester_volume=0.0,
         top_cover_volume=0.0,
-        time=time,
+        simulation_day=time.simulation_day,
     )
 
     assert add_var.call_count == 20

--- a/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
+++ b/tests/test_biophysical/test_manure/test_digester/test_anaerobic_digester.py
@@ -173,7 +173,7 @@ def test_report_anaerobic_digester_outputs(digester: AnaerobicDigester, time: Ti
     expected_info_map = {
         "class": "AnaerobicDigester",
         "function": "_report_anaerobic_digester_outputs",
-        "prefix": "AnaerobicDigester.test",
+        "prefix": "Manure.Digester.AnaerobicDigester.test",
         "simulation_day": time.simulation_day,
         "units": MeasurementUnits.CUBIC_METERS,
     }

--- a/tests/test_biophysical/test_manure/test_digester/test_digester.py
+++ b/tests/test_biophysical/test_manure/test_digester/test_digester.py
@@ -5,4 +5,4 @@ from RUFAS.biophysical.manure.digester.digester import Digester
 def test_processor_init_error() -> None:
     """Test that base Digester class throws appropriate error when initialized."""
     with pytest.raises(TypeError):
-        Digester(name="test digester", is_housing_emissions_calculator=False)       # type: ignore[abstract]
+        Digester(name="test digester", is_housing_emissions_calculator=False)  # type: ignore[abstract]

--- a/tests/test_biophysical/test_manure/test_digester/test_digester.py
+++ b/tests/test_biophysical/test_manure/test_digester/test_digester.py
@@ -5,4 +5,4 @@ from RUFAS.biophysical.manure.digester.digester import Digester
 def test_processor_init_error() -> None:
     """Test that base Digester class throws appropriate error when initialized."""
     with pytest.raises(TypeError):
-        Digester(name="test digester", is_housing_emissions_calculator=False)
+        Digester(name="test digester", is_housing_emissions_calculator=False)       # type: ignore[abstract]

--- a/tests/test_biophysical/test_manure/test_handler/test_handler.py
+++ b/tests/test_biophysical/test_manure/test_handler/test_handler.py
@@ -46,7 +46,7 @@ def test_process_manure_parlor_cleaning(handler: Handler, mocker: MockerFixture)
     cleaning_patch = mocker.patch.object(
         handler, "determine_handler_cleaning_water_volume", return_value=cleaning_water_return
     )
-    temp_patch = mocker.patch.object(handler, "determine_barn_temperature", return_value=barn_temperature_return)
+    temp_patch = mocker.patch.object(handler, "_determine_barn_temperature", return_value=barn_temperature_return)
     conditions = CurrentDayConditions(
         mean_air_temperature=20.0, incoming_light=15, min_air_temperature=0, max_air_temperature=30
     )
@@ -107,7 +107,7 @@ def test_process_manure(handler: Handler, mocker: MockerFixture) -> None:
     cleaning_patch = mocker.patch.object(
         handler, "determine_handler_cleaning_water_volume", return_value=cleaning_water_return
     )
-    temp_patch = mocker.patch.object(handler, "determine_barn_temperature", return_value=barn_temperature_return)
+    temp_patch = mocker.patch.object(handler, "_determine_barn_temperature", return_value=barn_temperature_return)
     conditions = CurrentDayConditions(
         mean_air_temperature=20.0, incoming_light=15, min_air_temperature=0, max_air_temperature=30
     )

--- a/tests/test_biophysical/test_manure/test_handler/test_handler.py
+++ b/tests/test_biophysical/test_manure/test_handler/test_handler.py
@@ -201,12 +201,6 @@ def test_receive_manure(compatible: bool, handler: Handler, mocker: MockerFixtur
             mock_add_error.assert_called_once()
 
 
-@pytest.mark.parametrize("air_temp, expected", [(-5, 5), (15, 15), (45, 30)])
-def test_determine_barn_temperature(air_temp: float, expected: float, handler: Handler) -> None:
-    """Tests the adjustment of barn temperature."""
-    assert handler.determine_barn_temperature(air_temp) == expected
-
-
 @pytest.mark.parametrize(
     "num_animals, cleaning_water_use_rate, cleaning_water_recycle_fraction,expected ",
     [(15, 0.7, 0.4, 6.3), (15, 0.5, 0.2, 6.0)],

--- a/tests/test_biophysical/test_manure/test_handler/test_single_stream_handler.py
+++ b/tests/test_biophysical/test_manure/test_handler/test_single_stream_handler.py
@@ -79,7 +79,7 @@ def test_process_manure(handler: SingleStreamHandler, mocker: MockerFixture) -> 
         volume=0.0,
         pen_manure_data=pen,
     )
-    mock_barn_temp = mocker.patch.object(handler, "determine_barn_temperature", return_value=16)
+    mock_barn_temp = mocker.patch.object(handler, "_determine_barn_temperature", return_value=16)
     mock_process = mocker.patch.object(Handler, "process_manure", return_value={"manure": stream})
     conditions = CurrentDayConditions(
         mean_air_temperature=20.0, incoming_light=15, min_air_temperature=0, max_air_temperature=30

--- a/tests/test_biophysical/test_manure/test_processor.py
+++ b/tests/test_biophysical/test_manure/test_processor.py
@@ -172,7 +172,7 @@ def test_report_manure_stream_valid_dict(mock_separator: Separator, time: Time, 
         "pen_manure_data": None,
     }
     mock_om = mocker.patch.object(mock_separator, "_om", autospec=True)
-    mock_separator._report_manure_stream(manure_dict, "test_stream", time)
+    mock_separator._report_manure_stream(manure_dict, "test_stream", time.simulation_day)
 
     mock_om.add_variable.assert_any_call(
         "test_stream_manure_water",
@@ -192,7 +192,7 @@ def test_report_manure_stream_invalid_type(mock_separator: Separator, time: Time
     invalid_input = cast("ManureStream | dict[str, float | None]", "invalid_string")
     mock_om = mocker.patch.object(mock_separator, "_om", autospec=True)
     with pytest.raises(ValueError, match="Manure stream must be a dictionary or a ManureStream instance"):
-        mock_separator._report_manure_stream(invalid_input, "error_stream", time)
+        mock_separator._report_manure_stream(invalid_input, "error_stream", time.simulation_day)
 
     mock_om.add_error.assert_called_once_with(
         "Manure Stream Type Error",
@@ -211,7 +211,7 @@ def test_report_manure_stream_mismatched_keys(mock_separator: Separator, time: T
     invalid_manure_dict: dict[str, float | None] = {"wrong_key": 42.0}
     mock_om = mocker.patch.object(mock_separator, "_om", autospec=True)
     with pytest.raises(ValueError, match="Manure Stream must contain the same keys as manure_stream_units"):
-        mock_separator._report_manure_stream(invalid_manure_dict, "mismatch_stream", time)
+        mock_separator._report_manure_stream(invalid_manure_dict, "mismatch_stream", time.simulation_day)
 
     mock_om.add_error.assert_called_once_with(
         "Manure Stream Keys Error",
@@ -265,6 +265,7 @@ def test_report_processor_output(
         "simulation_day": time.simulation_day,
         "units": variable_units,
     }
-    mock_separator._report_processor_output(variable_name, variable_value, data_origin_function, variable_units, time)
+    mock_separator._report_processor_output(
+        variable_name, variable_value, data_origin_function, variable_units, time.simulation_day)
 
     mock_om_add_variable.assert_called_once_with(variable_name, variable_value, expected_info_map)

--- a/tests/test_biophysical/test_manure/test_processor.py
+++ b/tests/test_biophysical/test_manure/test_processor.py
@@ -12,7 +12,7 @@ from RUFAS.units import MeasurementUnits
 def test_processor_init_error() -> None:
     """Test that base Processor class throws appropriate error when initialized."""
     with pytest.raises(TypeError):
-        Processor(name="test processor", is_housing_emissions_calculator=True)
+        Processor(name="test processor", is_housing_emissions_calculator=True)      # type: ignore[abstract]
 
 
 # TODO: test with a grandchild of Processor in #2102, #2103, #2104, or #2105

--- a/tests/test_biophysical/test_manure/test_processor.py
+++ b/tests/test_biophysical/test_manure/test_processor.py
@@ -142,7 +142,7 @@ def test_report_manure_stream_via_process_manure(
     assert mock_om.add_variable.call_count > 0
 
     mock_om.add_variable.assert_any_call(
-        "SeparatedSolids.manure_total_solids",
+        "SeparatedSolids_manure_total_solids",
         pytest.approx(manure_stream.total_solids * mock_separator.total_solids_efficiency),
         {
             "class": "Separator",
@@ -175,7 +175,7 @@ def test_report_manure_stream_valid_dict(mock_separator: Separator, time: Time, 
     mock_separator._report_manure_stream(manure_dict, "test_stream", time)
 
     mock_om.add_variable.assert_any_call(
-        "test_stream.manure_water",
+        "test_stream_manure_water",
         1000.0,
         {
             "class": "Separator",
@@ -237,3 +237,34 @@ def test_determine_outdoor_storage_temperature(temp: float, expected: float) -> 
 def test_determine_barn_temperature(air_temp: float, expected: float) -> None:
     """Tests the adjustment of barn temperature."""
     assert Processor.determine_barn_temperature(air_temp) == expected
+
+
+@pytest.mark.parametrize(
+    "variable_name, variable_value, data_origin_function, variable_units",
+    [
+        ("test_variable", 1.0, "test_function", MeasurementUnits.KILOGRAMS),
+        ("test_variable_2", 2.0, "test_function_2", MeasurementUnits.GRAMS),
+    ]
+)
+def test_report_processor_output(
+        variable_name: str,
+        variable_value: float,
+        data_origin_function: str,
+        variable_units: MeasurementUnits,
+        mock_separator: Separator,
+        time: Time,
+        mocker: MockerFixture
+) -> None:
+    """Tests that the Processor output is reported correctly."""
+    mock_om_add_variable = mocker.patch.object(mock_separator._om, "add_variable")
+
+    expected_info_map = {
+        "class": mock_separator.__class__.__name__,
+        "function": data_origin_function,
+        "prefix": mock_separator._prefix,
+        "simulation_day": time.simulation_day,
+        "units": variable_units,
+    }
+    mock_separator._report_processor_output(variable_name, variable_value, data_origin_function, variable_units, time)
+
+    mock_om_add_variable.assert_called_once_with(variable_name, variable_value, expected_info_map)

--- a/tests/test_biophysical/test_manure/test_processor.py
+++ b/tests/test_biophysical/test_manure/test_processor.py
@@ -12,7 +12,7 @@ from RUFAS.units import MeasurementUnits
 def test_processor_init_error() -> None:
     """Test that base Processor class throws appropriate error when initialized."""
     with pytest.raises(TypeError):
-        Processor(name="test processor", is_housing_emissions_calculator=True)      # type: ignore[abstract]
+        Processor(name="test processor", is_housing_emissions_calculator=True)  # type: ignore[abstract]
 
 
 # TODO: test with a grandchild of Processor in #2102, #2103, #2104, or #2105

--- a/tests/test_biophysical/test_manure/test_processor.py
+++ b/tests/test_biophysical/test_manure/test_processor.py
@@ -236,7 +236,7 @@ def test_determine_outdoor_storage_temperature(temp: float, expected: float) -> 
 @pytest.mark.parametrize("air_temp, expected", [(-5, 5), (15, 15), (45, 30)])
 def test_determine_barn_temperature(air_temp: float, expected: float) -> None:
     """Tests the adjustment of barn temperature."""
-    assert Processor.determine_barn_temperature(air_temp) == expected
+    assert Processor._determine_barn_temperature(air_temp) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_biophysical/test_manure/test_processor.py
+++ b/tests/test_biophysical/test_manure/test_processor.py
@@ -244,16 +244,16 @@ def test_determine_barn_temperature(air_temp: float, expected: float) -> None:
     [
         ("test_variable", 1.0, "test_function", MeasurementUnits.KILOGRAMS),
         ("test_variable_2", 2.0, "test_function_2", MeasurementUnits.GRAMS),
-    ]
+    ],
 )
 def test_report_processor_output(
-        variable_name: str,
-        variable_value: float,
-        data_origin_function: str,
-        variable_units: MeasurementUnits,
-        mock_separator: Separator,
-        time: Time,
-        mocker: MockerFixture
+    variable_name: str,
+    variable_value: float,
+    data_origin_function: str,
+    variable_units: MeasurementUnits,
+    mock_separator: Separator,
+    time: Time,
+    mocker: MockerFixture,
 ) -> None:
     """Tests that the Processor output is reported correctly."""
     mock_om_add_variable = mocker.patch.object(mock_separator._om, "add_variable")

--- a/tests/test_biophysical/test_manure/test_processor.py
+++ b/tests/test_biophysical/test_manure/test_processor.py
@@ -266,6 +266,7 @@ def test_report_processor_output(
         "units": variable_units,
     }
     mock_separator._report_processor_output(
-        variable_name, variable_value, data_origin_function, variable_units, time.simulation_day)
+        variable_name, variable_value, data_origin_function, variable_units, time.simulation_day
+    )
 
     mock_om_add_variable.assert_called_once_with(variable_name, variable_value, expected_info_map)

--- a/tests/test_biophysical/test_manure/test_processor.py
+++ b/tests/test_biophysical/test_manure/test_processor.py
@@ -147,7 +147,7 @@ def test_report_manure_stream_via_process_manure(
         {
             "class": "Separator",
             "function": "_report_manure_stream",
-            "prefix": "Separator.TestSeparator",
+            "prefix": "Manure.Separator.separator_type.TestSeparator",
             "simulation_day": 42,
             "units": MeasurementUnits.KILOGRAMS,
         },
@@ -223,3 +223,17 @@ def test_report_manure_stream_mismatched_keys(mock_separator: Separator, time: T
             "simulation_day": 42,
         },
     )
+
+
+@pytest.mark.parametrize("temp, expected", [(-10.0, 0.0), (0.0, 0.0), (15.0, 15.0), (35.0, 35.0), (45.0, 35.0)])
+def test_determine_outdoor_storage_temperature(temp: float, expected: float) -> None:
+    """Test that the temperature of manure in outdoor storages is calculated correctly."""
+    actual = Processor._determine_outdoor_storage_temperature(temp)
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize("air_temp, expected", [(-5, 5), (15, 15), (45, 30)])
+def test_determine_barn_temperature(air_temp: float, expected: float) -> None:
+    """Tests the adjustment of barn temperature."""
+    assert Processor.determine_barn_temperature(air_temp) == expected

--- a/tests/test_biophysical/test_manure/test_separator/test_separator.py
+++ b/tests/test_biophysical/test_manure/test_separator/test_separator.py
@@ -29,7 +29,7 @@ def mock_separator() -> Separator:
 def test_separator_init_with_params(mock_separator: Separator) -> None:
     """Test the initialization of the Separator class with parameters."""
     assert mock_separator.name == "TestSeparator"
-    assert mock_separator._prefix == "Separator.TestSeparator"
+    assert mock_separator._prefix == "Manure.Separator.separator_type.TestSeparator"
     assert mock_separator.held_manure is None
     assert mock_separator.separated_solids_dry_matter == 0.8
     assert mock_separator.ammoniacal_nitrogen_efficiency == 0.7
@@ -158,7 +158,7 @@ def test_process_manure_empty_held_manure(mocker: MockerFixture, mock_separator:
         {
             "class": "Separator",
             "function": "process_manure",
-            "prefix": "Separator.TestSeparator",
+            "prefix": "Manure.Separator.separator_type.TestSeparator",
             "simulation_day": mock_time.simulation_day,
             "units": MeasurementUnits.UNITLESS,
         },

--- a/tests/test_biophysical/test_manure/test_storage/test_storage.py
+++ b/tests/test_biophysical/test_manure/test_storage/test_storage.py
@@ -10,7 +10,6 @@ from RUFAS.data_structures.animal_to_manure_connection import ManureStream, PenM
 from RUFAS.enums import AnimalCombination
 from RUFAS.time import Time
 from RUFAS.output_manager import OutputManager
-from RUFAS.units import MeasurementUnits
 
 
 @pytest.fixture

--- a/tests/test_biophysical/test_manure/test_storage/test_storage.py
+++ b/tests/test_biophysical/test_manure/test_storage/test_storage.py
@@ -83,8 +83,7 @@ def test_storage_init() -> None:
     assert actual._storage_time_period == 100
     assert actual._surface_area == 300.0
     assert actual._nitrous_oxide_emissions_factor == 0.0
-    assert actual._prefix == "Storage.test"
-    assert actual._accumulated_output_prefix == "AccumulatedStorage.test"
+    assert actual._prefix == "Manure.Processor.Storage.test"
 
 
 @pytest.mark.parametrize(
@@ -194,7 +193,7 @@ def test_process_manure(
     storage._storage_time_period = storage_period
     mocker.patch.object(Time, "simulation_day", new_callable=mocker.PropertyMock, return_value=day)
     handle_overflow = mocker.patch.object(storage, "handle_overflowing_manure", return_value=None)
-    add_var = mocker.patch.object(storage._om, "add_variable", return_value=None)
+    mock_report_manure_stream = mocker.patch.object(storage, "_report_manure_stream", return_value=None)
     if expected_emptied_volume is not None:
         manure_stream = ManureStream.make_empty_manure_stream()
         manure_stream.volume = expected_emptied_volume
@@ -205,31 +204,13 @@ def test_process_manure(
     actual = storage.process_manure(current_conditions, time)
 
     assert actual == expected_returned_manure
-    expected_info_map = {
-        "class": "Storage",
-        "function": "_report_storage_outputs",
-        "prefix": "Storage.fixture",
-        "simulation_day": day,
-        "units": MeasurementUnits.CUBIC_METERS,
-    }
     assert storage._stored_manure.volume == expected_stored_volume
     if expected_emptied_volume is not None:
-        add_var.assert_any_call("emptied_manure_volume", expected_emptied_volume, expected_info_map)
+        mock_report_manure_stream.assert_called_once_with(expected_returned_manure["manure"], "emptied", time)
+    else:
+        mock_report_manure_stream.assert_not_called()
     if expected_overflow:
         handle_overflow.assert_called_once_with(time)
-    expected_info_map["prefix"] = "AccumulatedStorage.fixture"
-    add_var.assert_any_call("accumulated_manure_volume", expected_stored_volume, expected_info_map)
-
-
-def test_report_storage_outputs(storage: Storage, time: Time, mocker: MockerFixture) -> None:
-    """Test that the _report_storage_outputs method in Storage works correctly."""
-    add_var = mocker.patch.object(storage._om, "add_variable", return_value=None)
-    mocker.patch.object(Time, "simulation_day", new_callable=mocker.PropertyMock, return_value=1)
-    manure = ManureStream.make_empty_manure_stream()
-
-    storage._report_storage_outputs("test_info_map_prefix", "test_var_name_prefix", manure, time)
-
-    assert add_var.call_count == 12
 
 
 def test_handle_overflowing_manure(storage: Storage, mocker: MockerFixture, time: Time) -> None:
@@ -286,14 +267,6 @@ def test_calculate_cover_and_flare_methane(loss: float, expected_burned: float, 
 
     assert actual_burned == expected_burned
     assert actual_loss == expected_loss
-
-
-@pytest.mark.parametrize("temp, expected", [(-10.0, 0.0), (0.0, 0.0), (15.0, 15.0), (35.0, 35.0), (45.0, 35.0)])
-def test_determine_outdoor_storage_temperature(temp: float, expected: float) -> None:
-    """Test that the temperature of manure in outdoor storages is calculated correctly."""
-    actual = Storage._determine_outdoor_storage_temperature(temp)
-
-    assert actual == expected
 
 
 @pytest.mark.parametrize("factor, nitrogen, expected", [(0.1, 100.0, 10.0), (0.0, 20.0, 0.0), (1.0, 40.0, 40.0)])

--- a/tests/test_biophysical/test_manure/test_storage/test_storage.py
+++ b/tests/test_biophysical/test_manure/test_storage/test_storage.py
@@ -36,7 +36,6 @@ def storage(mocker: MockerFixture) -> Storage:
     storage._received_manure = ManureStream.make_empty_manure_stream()
     storage._stored_manure = ManureStream.make_empty_manure_stream()
     storage._prefix = "Storage.fixture"
-    storage._accumulated_output_prefix = "AccumulatedStorage.fixture"
     return storage
 
 

--- a/tests/test_biophysical/test_manure/test_storage/test_storage.py
+++ b/tests/test_biophysical/test_manure/test_storage/test_storage.py
@@ -212,7 +212,7 @@ def test_process_manure(is_emptying_day: bool, is_overflowing: bool, storage: St
     if is_emptying_day:
         assert result["manure"] == dummy_total_manure
         assert storage._stored_manure == ManureStream.make_empty_manure_stream()
-        mock_report_manure_stream.assert_called_once_with(dummy_total_manure, "emptied", mock_time)
+        mock_report_manure_stream.assert_called_once_with(dummy_total_manure, "emptied", mock_time.simulation_day)
     else:
         assert result == {}
         assert storage._stored_manure == dummy_total_manure

--- a/tests/test_biophysical/test_manure/test_storage/test_storage.py
+++ b/tests/test_biophysical/test_manure/test_storage/test_storage.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import pytest
 from datetime import datetime
 from pytest_mock import MockerFixture
@@ -162,54 +164,63 @@ def test_receive_manure_error(
 
 
 @pytest.mark.parametrize(
-    "received_volume, stored_volume, capacity, storage_period, day, expected_stored_volume, expected_emptied_volume,"
-    "expected_overflow",
-    [
-        (1000.0, 2000.0, 4000.0, 30, 20, 3000.0, None, False),
-        (1000.0, 2000.0, 2500.0, 30, 20, 3000.0, None, True),
-        (1000.0, 2000.0, 2500.0, None, 20, 3000.0, None, True),
-        (1000.0, 2000.0, 2500.0, 30, 30, 0.0, 3000.0, False),
-    ],
+    "is_emptying_day, is_overflowing", [(True, False), (False, False), (False, True), (True, True)]
 )
-def test_process_manure(
-    storage: Storage,
-    current_conditions: CurrentDayConditions,
-    time: Time,
-    mocker: MockerFixture,
-    received_volume: float,
-    stored_volume: float,
-    capacity: float,
-    storage_period: int | None,
-    day: int,
-    expected_stored_volume: float,
-    expected_emptied_volume: float | None,
-    expected_overflow: bool,
-) -> None:
-    """Test that Storage processes manure correctly."""
-    storage._received_manure.volume = received_volume
-    storage._stored_manure.volume = stored_volume
-    storage._capacity = capacity
-    storage._storage_time_period = storage_period
-    mocker.patch.object(Time, "simulation_day", new_callable=mocker.PropertyMock, return_value=day)
-    handle_overflow = mocker.patch.object(storage, "handle_overflowing_manure", return_value=None)
+def test_process_manure(is_emptying_day: bool, is_overflowing: bool, storage: Storage, mocker: MockerFixture) -> None:
+    """Test that the process_manure method in Storage works correctly."""
     mock_report_manure_stream = mocker.patch.object(storage, "_report_manure_stream", return_value=None)
-    if expected_emptied_volume is not None:
-        manure_stream = ManureStream.make_empty_manure_stream()
-        manure_stream.volume = expected_emptied_volume
-        expected_returned_manure = {"manure": manure_stream}
-    else:
-        expected_returned_manure = {}
+    mock_handle_overflowing_manure = mocker.patch.object(storage, "handle_overflowing_manure", return_value=None)
+    mock_time = MagicMock(spec=Time)
+    mock_time.simulation_day = storage._storage_time_period if is_emptying_day else 1
+    mocker.patch.object(Storage, "is_overflowing", new_callable=mocker.PropertyMock, return_value=is_overflowing)
 
-    actual = storage.process_manure(current_conditions, time)
+    storage._received_manure = (
+        dummy_received_manure := ManureStream(
+            water=1.23,
+            ammoniacal_nitrogen=2.34,
+            nitrogen=3.45,
+            phosphorus=4.56,
+            potassium=5.67,
+            ash=6.78,
+            non_degradable_volatile_solids=7.89,
+            degradable_volatile_solids=8.90,
+            total_solids=29.01,
+            volume=10.12,
+            pen_manure_data=None,
+        )
+    )
+    storage._stored_manure = (
+        dummy_stored_manure := ManureStream(
+            water=10.11,
+            ammoniacal_nitrogen=20.22,
+            nitrogen=30.33,
+            phosphorus=40.44,
+            potassium=50.55,
+            ash=60.66,
+            non_degradable_volatile_solids=70.77,
+            degradable_volatile_solids=80.88,
+            total_solids=290.01,
+            volume=100.12,
+            pen_manure_data=None,
+        )
+    )
+    dummy_total_manure = dummy_received_manure + dummy_stored_manure
 
-    assert actual == expected_returned_manure
-    assert storage._stored_manure.volume == expected_stored_volume
-    if expected_emptied_volume is not None:
-        mock_report_manure_stream.assert_called_once_with(expected_returned_manure["manure"], "emptied", time)
+    result = storage.process_manure(MagicMock(auto_spec=CurrentDayConditions), mock_time)
+
+    assert storage._received_manure == ManureStream.make_empty_manure_stream()
+    if is_emptying_day:
+        assert result["manure"] == dummy_total_manure
+        assert storage._stored_manure == ManureStream.make_empty_manure_stream()
+        mock_report_manure_stream.assert_called_once_with(dummy_total_manure, "emptied", mock_time)
     else:
+        assert result == {}
+        assert storage._stored_manure == dummy_total_manure
         mock_report_manure_stream.assert_not_called()
-    if expected_overflow:
-        handle_overflow.assert_called_once_with(time)
+    if is_overflowing:
+        mock_handle_overflowing_manure.assert_called_once_with(mock_time)
+    else:
+        mock_handle_overflowing_manure.assert_not_called()
 
 
 def test_handle_overflowing_manure(storage: Storage, mocker: MockerFixture, time: Time) -> None:


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
This PR implements the changes requested per the dev team meeting on 3/26/2025. Specifically:
## New `Processor._report_processor_output()` function
This is a wrapper function for `self._om.add_variable()` and the necessary `info_map` in the base `Processor` class.
All of the children and grandchildren class can call this method to add a variable to the `OutputManager` by providing:
- variable_name : str
- variable_value : float
Currently, we are expecting the added variable to be a float, we can easily update this to accept `Any` value if needed.
- data_origin_funcion : str
The name of the function that reported the variable value.
- unit : MeasurementUnits
The unit for the reported variable.
- time : Time

All direct calls to `om.add_variable()` are updated to use this new method.

## New `Storage._manure_to_process` attribute
Create a new `_manure_to_process` attribute of type `ManureStream` in the base `Storage` class.
This property represents the manure that will be processed during the `process_manure()` method call. We introduce this variable to track that manure as emissions are being calculated and removed.


## Relocate `Handler. determine_barn_temperature()` and `Storage._determine_outdoor_storage_temperature()`
Both `Handler. determine_barn_temperature()` and `Storage._determine_outdoor_storage_temperature()` are relocated into the base `Processor` class.
`determine_barn_temperature()` is renamed to `_determine_barn_temperature` for consistency.


## Change all class methods into static methods
After discussion and careful evaluation, we have decided to change all class methods in the refreshed manure module into static methods, by changing the function decoration from `@classmethod` to `@staticmethod` and make any other necessary updates to all the references to those methods.

## new prefix format
### Generic prefix
The base prefix is configured to be
```python
self._prefix = f"Manure.{base_class_name}.{self.__class__.__name__}.{self.name}"
```
where the `base_class_name` is defined as 
```python
base_class_name = self.__class__.__bases__[0].__name__
```
This format should apply to all the `Storage` and `Digester` classes. (there is only one `AnaerobicDigester` class under `Digester`).
Here is a full list of the resulting prefixes for all members in the `Storage` and `Digester` class.
- `AnaerobicDigester`: "Manure.Digester.AnaerobicDigester.my_anaerobic_digester"
- `AnaerobicLagoon`: "Manure.Storage.AnaerobicLagoon.my_anaerobic_lagoon"
- `SlurryStorageOutdoor`: "Manure.Storage.SlurryStorageOutdoor.my_slurry_storage_outdoor"
- `SlurryStorageUnderFloor`: "Manure.Storage.SlurryStorageOutdoor.my_slurry_storage_underfloor"
- `OpenLots`: "Manure.Storage.OpenLots.my_open_lots"
- `Composting`: "Manure.Storage.Composting.my_composting"
- `CompostBeddedPackBarn`: "Manure.Storage.CompostBeddedPackBarn.my_compos_bedded_pack_barn"

### Handler
The prefixes for all `Handler` classes are configured in the base `Handler` class as
```python
self._prefix = f"Manure.{self.__class__.__name__}.{self.handler_type}.{self.name}"
```
The `f"{self.handler_type}"` portion will be replaced with `f"{self.type.value}"` once the processor type enum is implemented in issue #2281.
Here is a full list of the resulting prefixes for all members of the `Handler` class (using "MANUAL_SCRAPER" as handler type for example):
- `Handler`: "Manure.Handler.MANUAL_SCRAPER.my_manual_scraper_handler"
- `SingleStreamHandler`: "Manure. SingleStreamHandler.MANUAL_SCRAPER.my_manual_scraper_handler"

### Separator
The prefix for the `Separator ` class is configured as
```python
self._prefix = f"Manure.{self.__class__.__name__}.{"separator_type"}.{self.name}"
```
where `"separator_type"` is a placeholder for the actual type of separator. This will be updated after the implementation of the processor type enum in issues #2281.
Here is the an example for resulting prefix:
- `Separator`: "Manure.Separator.separator_type.my_separator"

## Other Changes
- Updated `AnaerobicDigester._report_anaerobic_digester_outputs()` function to use `Processor._report_manure_stream()` to handle the reporting of `self._manure_in_digester` properties.
- Changed all variables with name `temp` or `average_temp` to `temperature` and `average_temperature`

## TODO
- Update the prefix for `Handler` and `Separator` after completing issue #2281.

## Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
All affected unit tests have been updated.