### PR TITLE
Again, Rename Handler ammonia emission output name

### DIFF
--- a/RUFAS/biophysical/manure/handler/handler.py
+++ b/RUFAS/biophysical/manure/handler/handler.py
@@ -182,7 +182,7 @@ class Handler(Processor):
 
         self.manure_stream = None
         self._report_processor_output(
-            "housing_ammonia_emissions",
+            "housing_ammonia_N_emissions",
             ammonia_emission,
             self.process_manure.__name__,
             MeasurementUnits.KILOGRAMS,

--- a/changelog.md
+++ b/changelog.md
@@ -128,6 +128,8 @@ v0.9.2
 - [2310](https://github.com/RuminantFarmSystems/MASM/pull/2310) - [minor change] [Bug fix] Quick fix for errors introduced by PR #2194.
 - [2306](https://github.com/RuminantFarmSystems/MASM/pull/2306) - [minor change] [Manure] Implement patches to manure refresh after the dev team discussion.
 - [2302](https://github.com/RuminantFarmSystems/MASM/pull/2302) - [minor change] [Manure] Rename the ammonia emission output in Handler from "housing_ammonia_emissions" to "housing_ammonia_N_emissions".
+- [2311](https://github.com/RuminantFarmSystems/MASM/pull/2311) - [minor change] [Manure] Rename the ammonia emission output in Handler from "housing_ammonia_emissions" to "housing_ammonia_N_emissions".
+
 
 ### v0.9.2
 


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
This PR renames the ammonia emission output in `Handler` from "housing_ammonia_emissions" to "housing_ammonia_N_emissions".
The previous attempt in PR #2302 was accidentally overwritten when resolving merge conflicts.
### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #

### What
<!-- Add more detail about the changes that are being made in the pull request. -->


### Why
<!-- Discuss why the changes in this pull request are needed or important. -->


### How
<!-- Give an explanation of how this pull request addresses needed changes. -->


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
