### PR TITLE
[OutputManager] Hot Fix for Variables Not Properly Reported to OM

### DIFF
--- a/RUFAS/biophysical/animal/milk/lactation_curve.py
+++ b/RUFAS/biophysical/animal/milk/lactation_curve.py
@@ -123,7 +123,7 @@ class LactationCurve:
             3: lactation_inputs["parameter_standard_deviations"]["3"],
         }
 
-        info_map: dict[str, Any] = {"class": cls.__class__.__name__, "function": "__init__"}
+        info_map: dict[str, Any] = {"class": cls.__name__, "function": "__init__"}
         annual_milk_yield: float = animal_inputs["herd_information"]["annual_milk_yield"]
         if annual_milk_yield is not None:
             cls._om.add_log(
@@ -152,7 +152,7 @@ class LactationCurve:
         """Retrieves the appropriate adjustment values based on the end year of the simulation."""
         end_year = time.end_date.year
 
-        info_map = {"class": cls.__class__.__name__, "function": cls._get_year_adjustments.__name__}
+        info_map = {"class": cls.__name__, "function": cls._get_year_adjustments.__name__}
         if not 2006 <= end_year <= 2016:
             bounded_end_year = min(2016, max(2006, end_year))
             cls._om.add_warning(
@@ -333,7 +333,7 @@ class LactationCurve:
                 f"Using {PARITY_1_DEFAULT_FRACTION_OF_MILKING_COWS}, {PARITY_2_DEFAULT_FRACTION_OF_MILKING_COWS} and "
                 f"{PARITY_3_DEFAULT_FRACTION_OF_MILKING_COWS} as the fractions of parity 1, 2 and 3+ cows in the "
                 "milking herd, respectively",
-                {"class": cls.__class__.__name__, "function": cls._estimate_305_day_milk_yield_by_parity.__name__},
+                {"class": cls.__name__, "function": cls._estimate_305_day_milk_yield_by_parity.__name__},
             )
             parity_1_frac = PARITY_1_DEFAULT_FRACTION_OF_MILKING_COWS
             parity_2_frac = PARITY_2_DEFAULT_FRACTION_OF_MILKING_COWS
@@ -344,7 +344,7 @@ class LactationCurve:
                 f" difference is within the accepted tolerance of {ACCEPTABLE_PARITY_FRACTION_ERROR}",
                 f"Will use {parity_1_frac}, {parity_2_frac} and {parity_3_frac} as the fractions of parity 1, 2, and 3+"
                 " cows in the milking herd, respectively.",
-                {"class": cls.__class__.__name__, "function": cls._estimate_305_day_milk_yield_by_parity.__name__},
+                {"class": cls.__name__, "function": cls._estimate_305_day_milk_yield_by_parity.__name__},
             )
 
         parity_1_305_day_milk_yield = milk_yield_305_day / (
@@ -402,7 +402,7 @@ class LactationCurve:
                     f"Captured warning during optimization of type {warning.category.__name__}",
                     f"{warning.message}. Warning generated in {warning.filename}",
                     {
-                        "class": cls.__class__.__name__,
+                        "class": cls.__name__,
                         "function": cls._fit_wood_l_param_to_milk_yield.__name__,
                         "full_warning": warning,
                     },

--- a/RUFAS/biophysical/animal/ration/user_defined_ration_manager.py
+++ b/RUFAS/biophysical/animal/ration/user_defined_ration_manager.py
@@ -37,7 +37,7 @@ class UserDefinedRationManager:
             List of dictionaries containing the user-defined rations for each animal combination.
 
         """
-        info_map = {"class": cls.__class__.__name__, "function": cls.set_user_defined_rations.__name__}
+        info_map = {"class": cls.__name__, "function": cls.set_user_defined_rations.__name__}
 
         cls.user_defined_rations = {animal_combination: {} for animal_combination in AnimalCombination}
 

--- a/RUFAS/routines/field/crop/crop_data_factory.py
+++ b/RUFAS/routines/field/crop/crop_data_factory.py
@@ -96,7 +96,7 @@ class CropDataFactory:
             crop_config = cls._manufacture_crop_configuration(config)
             if (name := crop_config["name"]) in cls._crop_configurations.keys():
                 info_map = {
-                    "class": cls.__class__.__name__,
+                    "class": cls.__name__,
                     "function": cls.setup_crop_configurations.__name__,
                     "name": name,
                 }
@@ -133,7 +133,7 @@ class CropDataFactory:
 
         if crop_type not in CROP_CATEGORY_TO_CROP_TYPE_MAPPING[crop_category]:
             info_map = {
-                "class": cls.__class__.__name__,
+                "class": cls.__name__,
                 "function": cls._manufacture_crop_configuration.__name__,
                 "crop_type": crop_type,
                 "crop_category": crop_category,
@@ -196,7 +196,7 @@ class CropDataFactory:
         """
         if crop_type not in cls._crop_configurations.keys():
             info_map = {
-                "class": cls.__class__.__name__,
+                "class": cls.__name__,
                 "function": cls.create_crop_data.__name__,
                 "crop_type": crop_type,
             }

--- a/RUFAS/routines/field/crop/non_water_uptake.py
+++ b/RUFAS/routines/field/crop/non_water_uptake.py
@@ -329,7 +329,7 @@ class NonWaterUptake(NutrientUptake):
         """
         if root_depth < 0.0:
             info_map = {
-                "class": cls.__class__.__name__,
+                "class": cls.__name__,
                 "function": cls._determine_deepest_accessible_layer.__name__,
             }
             om = OutputManager()
@@ -408,7 +408,7 @@ class NonWaterUptake(NutrientUptake):
 
         """
         info_map = {
-            "class": cls.__class__.__name__,
+            "class": cls.__name__,
             "function": cls.determine_layer_nutrient_uptake_potential.__name__,
         }
         om = OutputManager()
@@ -473,7 +473,7 @@ class NonWaterUptake(NutrientUptake):
 
         """
         info_map = {
-            "class": cls.__class__.__name__,
+            "class": cls.__name__,
             "function": cls._determine_nutrient_uptake_to_depth.__name__,
         }
         om = OutputManager()
@@ -580,7 +580,7 @@ class NonWaterUptake(NutrientUptake):
         """
         if mature_heat_fraction == half_mature_heat_fraction:
             info_map = {
-                "class": cls.__class__.__name__,
+                "class": cls.__name__,
                 "function": cls.determine_nutrient_shape_parameters.__name__,
             }
             om = OutputManager()
@@ -664,7 +664,7 @@ class NonWaterUptake(NutrientUptake):
 
         """
         info_map = {
-            "class": cls.__class__.__name__,
+            "class": cls.__name__,
             "function": cls._determine_shape_log.__name__,
         }
         om = OutputManager()
@@ -868,7 +868,7 @@ class NonWaterUptake(NutrientUptake):
 
         """
         info_map = {
-            "class": cls.__class__.__name__,
+            "class": cls.__name__,
             "function": cls.determine_layer_nutrient_uptake.__name__,
         }
         om = OutputManager()

--- a/RUFAS/routines/manure/IO_helpers/manure_manager_config_handler.py
+++ b/RUFAS/routines/manure/IO_helpers/manure_manager_config_handler.py
@@ -173,7 +173,7 @@ class ManureManagerConfigHandler:
             A dictionary of bedding config objects, with the key being the bedding name.
 
         """
-        info_map = {"class": cls.__class__.__name__, "function": cls._process_bedding_configs.__name__}
+        info_map = {"class": cls.__name__, "function": cls._process_bedding_configs.__name__}
         available_bedding_configs: Dict[str, BeddingConfig] = {}
         om = OutputManager()
         for config in bedding_configs:

--- a/changelog.md
+++ b/changelog.md
@@ -135,7 +135,8 @@ v0.9.2
 - [2316](https://github.com/RuminantFarmSystems/MASM/pull/2316) - [minor change] [Animal][HerdFactory] Create User-defined directory for saving generated herd if not already exists.
 - [2311](https://github.com/RuminantFarmSystems/MASM/pull/2311) - [minor change] [Project Build][Dependencies] Set the minimum required versions for all RuFaS dependencies specified in requirements.txt.
 - [2315](https://github.com/RuminantFarmSystems/MASM/pull/2315) - [minor change] [Time] Rename `Time` to `RufasTime`.
-- [2321](https://github.com/RuminantFarmSystems/MASM/pull/2321) - [minor change] [Animal] Fix ZeroDivision Error when No Calf in Pen .
+- [2321](https://github.com/RuminantFarmSystems/MASM/pull/2321) - [minor change] [Animal] Fix ZeroDivision Error when No Calf in Pen.
+- [2325](https://github.com/RuminantFarmSystems/MASM/pull/2325) - [minor change] [OutputManager] Fix class-name-reporting to Output Manager for a handful of variables.
 
 
 ### v0.9.2


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
This provides a quick and easy fix for some variables I came across that were not reported properly to OM.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes # n/a

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
There were a handful of variables from classmethods that were not properly reporting the class name in the info map so it looked like this in the OM list of variable names:
<img width="671" alt="Screenshot 2025-04-04 at 4 54 11 PM" src="https://github.com/user-attachments/assets/f3f3915a-3194-4efd-8461-da0e3eb368c3" />


### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
We need the class name to be properly reported to OM.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Very straightforward fix:
The class name was reported as `cls.__class__.__name__` which was reporting the name `type` because I think it was reporting the name of the class of class which is the metaclass `type`.
So that was changed to `cls.__name__` and that reported the actual class name.
Did a quick findall and replace for that here.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Did not affect unit testing (checked and made sure).
Reran a simulation and looked at the variable names and the classes were being properly reported:
<img width="777" alt="Screenshot 2025-04-04 at 5 02 20 PM" src="https://github.com/user-attachments/assets/781d86fb-f0f1-4426-a8ec-60eeaea9d52b" />
