### PR TITLE
Reduce Number of Warnings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -139,6 +139,7 @@ v0.9.2
 - [2321](https://github.com/RuminantFarmSystems/MASM/pull/2321) - [minor change] [Animal] Fix ZeroDivision Error when No Calf in Pen .
 - [2183](https://github.com/RuminantFarmSystems/MASM/pull/2183) - [minor change] [helpful_scripts] Removes now-deprecated files used to help develop sensitivity analysis methodology. Files archived and relevant info/graphics moved to scientific documentation. 
 - [2322](https://github.com/RuminantFarmSystems/MASM/pull/2322) - [minor change] [Github action] Make unauthorized files change check to log and trigger exit at the end of the second step.
+- [2327](https://github.com/RuminantFarmSystems/MASM/pull/2327) - [minor change] [Animal] Reduces the number of warnings during a default simulation run.
 
 
 ### v0.9.2


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
This PR reduces the number of warnings during a default simulation run. 

The warning number went up significantly due to some modifications to the `animal_population.json` during the animal refresh. This PR uses the following script to reduce the warning number back to reasonable range (~46,000 to ~400) by deleting the extra variables saved in the `animal_population.json` but not required in the metadata.
```python
import json

animal_population_file = "input/data/animal/animal_population.json"
output_animal_population_file = "input/data/animal/animal_population.json"

variables_to_remove: list[str] = [
    "heifer_tai_program_start_day", "heifer_synch_ed_program_start_day", "heifer_synch_ed_estrus_day",
    "heifer_synch_ed_stop_day", "cow_reproduction_sub_protocol"
]

with open(animal_population_file, "r") as f:
    animal_population = json.load(f)

for animal in (animal_population["calves"] + animal_population["heiferIs"] + animal_population["heiferIIs"]
               + animal_population["heiferIIIs"] + animal_population["cows"] + animal_population["replacement"]):
    for variable in variables_to_remove:
        if variable in animal.keys():
            del animal[variable]

with open(output_animal_population_file, "w") as f:
    json.dump(
        animal_population,
        f,
        separators=(",", ":"),
        ensure_ascii=False,
    )
```

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Compare the warning number on a default simulation run on dev and this branch.