### PR TITLE
[Crop & Soil] Refactor `Field.execute_manure_application()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-88%25-yellowgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3262%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3280%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 
 # Vision

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-89%25-yellowgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3267%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3256%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3280%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-88%25-yellowgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3256%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 
 # Vision

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-89%25-yellowgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3264%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3267%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/RUFAS/routines/field/field/field.py
+++ b/RUFAS/routines/field/field/field.py
@@ -675,30 +675,40 @@ class Field:
             warning_msg = f"Manure nitrogen deficient by {unmet_n} kg, phosphorus deficient by {unmet_p} kg."
             self.om.add_warning("Nutrient deficient manure application", warning_msg, info_map)
             return
-
-        self.om.add_log(
-            "Manure Application Log",
-            "Manure did not fulfill all nutrient requests. Supplementing with synthetic fertilizer.",
-            info_map,
-        )
-
-        optimal_mix = (
-            self.ONLY_NITROGEN_MIX if unmet_n > 0.0 and unmet_p == 0.0
-            else self._determine_optimal_fertilizer_mix(
-                unmet_n, unmet_p, self.available_fertilizer_mixes
+        elif method in [
+            ManureSupplementMethod.SYNTHETIC_FERTILIZER,
+            ManureSupplementMethod.SYNTHETIC_FERTILIZER_AND_MANURE,
+        ]:
+            self.om.add_log(
+                "Manure Application Log",
+                "Manure did not fulfill all nutrient requests. Supplementing with synthetic fertilizer.",
+                info_map,
             )
-        )
 
-        self._execute_fertilizer_application(
-            optimal_mix,
-            unmet_n,
-            unmet_p,
-            0,
-            application_depth,
-            surface_remainder_fraction,
-            year,
-            day,
-        )
+            optimal_mix = (
+                self.ONLY_NITROGEN_MIX if unmet_n > 0.0 and unmet_p == 0.0
+                else self._determine_optimal_fertilizer_mix(
+                    unmet_n, unmet_p, self.available_fertilizer_mixes
+                )
+            )
+
+            self._execute_fertilizer_application(
+                optimal_mix,
+                unmet_n,
+                unmet_p,
+                0,
+                application_depth,
+                surface_remainder_fraction,
+                year,
+                day,
+            )
+        else:
+            self.om.add_warning(
+                "Manure Application Warning",
+                f"Manure did not fulfill nutrient requests ({unmet_n} kg N, {unmet_p} kg P), "
+                f"but no supplementation was performed due to unrecognized or unsupported method: {method}.",
+                info_map,
+            )
 
     def _record_manure_application(
         self,

--- a/RUFAS/routines/field/field/field.py
+++ b/RUFAS/routines/field/field/field.py
@@ -523,14 +523,32 @@ class Field:
         manure_supplied: NutrientRequestResults | None,
         manure_supplement_method: ManureSupplementMethod,
     ) -> None:
-        info_map = {
-            "class": self.__class__.__name__,
-            "function": self._execute_manure_application.__name__,
-            "suffix": f"field='{self.field_data.name}'",
-            "year": year,
-            "day": day,
-        }
+        """
+        Executes a manure application based on the requested amounts of nutrients.
 
+        Parameters
+        ----------
+        requested_nitrogen : float
+            Minimum amount of nitrogen to be included in this manure application (kg).
+        requested_phosphorus : float
+            Minimum amount of phosphorus to be included in this manure application (kg).
+        requested_manure_type : ManureType
+            Enum option indicating the type of manure applied.
+        field_coverage : float
+            Fraction of the field this manure is applied to (unitless).
+        application_depth : float
+            Depth at which fertilizer is injected into the soil (mm).
+        surface_remainder_fraction : float
+            Fraction of fertilizer applied that remains on the soil surface after application (unitless).
+        year : int
+            Calendar year in which this manure application occurs.
+        day : int
+            Julian day on which this manure application occurs.
+        manure_supplied : NutrientRequestResults | None
+            An object containing the information that defines a manure application.
+        manure_supplement_method : ManureSupplementMethod
+            Enum option indicating how to supplement the manure application.
+        """
         if manure_supplied:
             supplied_nitrogen, supplied_phosphorus, application_depth, surface_remainder_fraction = \
                 self._apply_and_record_manure_application(
@@ -540,16 +558,25 @@ class Field:
         else:
             supplied_nitrogen = supplied_phosphorus = 0.0
 
-        self._record_requested_manure_application(
-            requested_nitrogen, requested_phosphorus, field_coverage,
-            application_depth, surface_remainder_fraction, year, day
+        self._record_manure_application(
+            dry_matter_mass=0.0,
+            dry_matter_fraction=0.0,
+            field_coverage=field_coverage,
+            nitrogen=requested_nitrogen,
+            phosphorus=requested_phosphorus,
+            potassium=None,
+            application_depth=application_depth,
+            surface_remainder_fraction=surface_remainder_fraction,
+            year=year,
+            day=day,
+            output_name="manure_request",
         )
 
         self._handle_unmet_nutrients(
             requested_nitrogen, requested_phosphorus,
             supplied_nitrogen, supplied_phosphorus,
             application_depth, surface_remainder_fraction,
-            manure_supplement_method, year, day, info_map
+            manure_supplement_method, year, day,
         )
 
     def _apply_and_record_manure_application(
@@ -562,6 +589,31 @@ class Field:
         year: int,
         day: int
     ) -> tuple[float, float, float, float]:
+        """
+        Applies the manure and records the application.
+
+        Parameters
+        ----------
+        manure_supplied : NutrientRequestResults
+            An object containing the information that defines a manure application.
+        manure_type : ManureType
+            Enum option indicating the type of manure applied.
+        field_coverage : float
+            Fraction of the field this manure is applied to (unitless).
+        application_depth : float
+            Depth at which fertilizer is injected into the soil (mm).
+        surface_remainder_fraction : float
+            Fraction of fertilizer applied that remains on the soil surface after application (unitless).
+        year : int
+            Calendar year in which this manure application occurs.
+        day : int
+            Julian day on which this manure application occurs.
+
+        Returns
+        -------
+        tuple[float, float, float, float]
+            The supplied nitrogen and phosphorus amounts, application depth, and surface remainder fraction.
+        """
         self._add_manure_water(manure_supplied, manure_type)
 
         supplied_nitrogen = manure_supplied.nitrogen
@@ -610,6 +662,25 @@ class Field:
         year: int,
         day: int,
     ) -> tuple[float, float]:
+        """
+        Validates the application depth and surface remainder fraction for a manure application.
+
+        Parameters
+        ----------
+        application_depth : float
+            Depth at which fertilizer is injected into the soil (mm).
+        surface_remainder_fraction : float
+            Fraction of fertilizer applied that remains on the soil surface after application (unitless).
+        year : int
+            Calendar year in which this manure application occurs.
+        day : int
+            Julian day on which this manure application occurs.
+
+        Returns
+        -------
+        tuple[float, float]
+            The validated application depth and surface remainder fraction.
+        """
         error_name = "manure_application_error"
 
         if (application_depth == 0.0 and surface_remainder_fraction != 1.0) or (
@@ -627,30 +698,6 @@ class Field:
 
         return application_depth, surface_remainder_fraction
 
-    def _record_requested_manure_application(
-        self,
-        nitrogen: float,
-        phosphorus: float,
-        field_coverage: float,
-        application_depth: float,
-        surface_remainder_fraction: float,
-        year: int,
-        day: int,
-    ) -> None:
-        self._record_manure_application(
-            dry_matter_mass=0.0,
-            dry_matter_fraction=0.0,
-            field_coverage=field_coverage,
-            nitrogen=nitrogen,
-            phosphorus=phosphorus,
-            potassium=None,
-            application_depth=application_depth,
-            surface_remainder_fraction=surface_remainder_fraction,
-            year=year,
-            day=day,
-            output_name="manure_request",
-        )
-
     def _handle_unmet_nutrients(
         self,
         requested_n: float,
@@ -662,8 +709,39 @@ class Field:
         method: ManureSupplementMethod,
         year: int,
         day: int,
-        info_map: dict,
     ) -> None:
+        """
+        Handles the situation where the manure application does not meet the requested nutrient requirements.
+
+        Parameters
+        ----------
+        requested_n : float
+            Minimum amount of nitrogen to be included in this manure application (kg).
+        requested_p : float
+            Minimum amount of phosphorus to be included in this manure application (kg).
+        supplied_n : float
+            Amount of nitrogen supplied by the manure application (kg).
+        supplied_p : float
+            Amount of phosphorus supplied by the manure application (kg).
+        application_depth : float
+            Depth at which fertilizer is injected into the soil (mm).
+        surface_remainder_fraction : float
+            Fraction of fertilizer applied that remains on the soil surface after application (unitless).
+        method : ManureSupplementMethod
+            Enum option indicating how to supplement the manure application.
+        year : int
+            Calendar year in which this manure application occurs.
+        day : int
+            Julian day on which this manure application occurs.
+
+        """
+        info_map = {
+            "class": self.__class__.__name__,
+            "function": self._handle_unmet_nutrients.__name__,
+            "suffix": f"field='{self.field_data.name}'",
+            "year": year,
+            "day": day,
+        }
         unmet_n = max(0.0, requested_n - supplied_n)
         unmet_p = max(0.0, requested_p - supplied_p)
 

--- a/RUFAS/routines/field/field/field.py
+++ b/RUFAS/routines/field/field/field.py
@@ -691,6 +691,11 @@ class Field:
         -------
         tuple[float, float]
             The validated application depth and surface remainder fraction.
+
+        Raises
+        ------
+        ValueError
+            If the soil layers are not initialized or if the bottom depth is not set for the last soil layer.
         """
         error_name = "manure_application_error"
 
@@ -702,7 +707,15 @@ class Field:
             )
             return 0.0, 1.0
 
-        max_depth = self.soil.data.soil_layers[-1].bottom_depth
+        soil_layers = self.soil.data.soil_layers
+        if not soil_layers:
+            raise ValueError("soil_layers is not initialized")
+
+        bottom_layer = soil_layers[-1]
+        if bottom_layer.bottom_depth is None:
+            raise ValueError("bottom_depth is not set for the last soil layer")
+
+        max_depth = bottom_layer.bottom_depth
         if application_depth > max_depth:
             self._record_nutrient_application_error(application_depth, None, error_name, year, day)
             application_depth = max_depth

--- a/RUFAS/routines/field/field/field.py
+++ b/RUFAS/routines/field/field/field.py
@@ -523,45 +523,6 @@ class Field:
         manure_supplied: NutrientRequestResults | None,
         manure_supplement_method: ManureSupplementMethod,
     ) -> None:
-        """
-        Receives a manure application request result and the corresponding ManureEvent data and executes
-        the application of manure to the field.
-
-        Parameters
-        ----------
-        requested_nitrogen : float
-            Mass of nitrogen requested to be in this manure application (kg)
-        requested_phosphorus : float
-            Mass of phosphorus requested to be in this manure application (kg)
-        requested_manure_type : ManureType
-            The type of manure for which the application request will be made.
-        field_coverage : float
-            Fraction of the field this manure is applied to (unitless)
-        application_depth : float
-            Depth at which fertilizer is injected into the soil (mm).
-        surface_remainder_fraction : float
-            Fraction of fertilizer applied that remains on the soil surface after application (unitless).
-        year : int
-            Calendar year in which this manure application occurs.
-        day : int
-            Julian day on which this manure application occurs.
-        manure_supplied : NutrientRequestResults
-            An object containing the manure application information.
-        manure_supplement_method : ManureSupplementMethod
-            The method that will be used to supplement nutrient deficiency.
-
-        Notes
-        -----
-        Because potassium is not currently specified in the manure request results, it is recorded as None. This method
-        also checks for invalid application depths and surface remainder fractions. If invalid values are found, they
-        are corrected, an error is logged to the OutputManager, and execution continues with the new values.
-
-        If the manure supplied by the Manure module does not meet or exceed the requested nutrients amounts, then either
-        a) a warning will be raised to the OutputManager that the manure supplied was nutrient deficient, or b) an
-        optimized chemical fertilizer application will be created and executed to supplement the nutrient deficiencies.
-        This behavior is regulated by the `supplement_manure_nutrient_deficiencies` attribute of the `FieldData` class.
-
-        """
         info_map = {
             "class": self.__class__.__name__,
             "function": self._execute_manure_application.__name__,
@@ -570,72 +531,118 @@ class Field:
             "day": day,
         }
 
-        if manure_supplied is not None:
-            self._add_manure_water(manure_supplied, requested_manure_type)
-
-            supplied_nitrogen = manure_supplied.nitrogen
-            supplied_phosphorus = manure_supplied.phosphorus
-
-            total_inorganic_nitrogen_fraction = (
-                manure_supplied.nitrogen / manure_supplied.dry_matter
-            ) * manure_supplied.inorganic_nitrogen_fraction
-            total_organic_nitrogen_fraction = (
-                manure_supplied.nitrogen / manure_supplied.dry_matter
-            ) * manure_supplied.organic_nitrogen_fraction
-
-            invalid_depth_and_remainder_fraction = (application_depth == 0.0 and surface_remainder_fraction != 1.0) or (
-                application_depth > 0.0 and surface_remainder_fraction == 1.0
-            )
-
-            error_name = "manure_application_error"
-            if invalid_depth_and_remainder_fraction:
-                self._record_nutrient_application_error(
-                    application_depth, surface_remainder_fraction, error_name, year, day
+        if manure_supplied:
+            supplied_nitrogen, supplied_phosphorus, application_depth, surface_remainder_fraction = \
+                self._apply_and_record_manure_application(
+                    manure_supplied, requested_manure_type, field_coverage,
+                    application_depth, surface_remainder_fraction, year, day
                 )
-                application_depth = 0.0
-                surface_remainder_fraction = 1.0
-
-            if application_depth > self.soil.data.soil_layers[-1].bottom_depth:
-                self._record_nutrient_application_error(application_depth, None, error_name, year, day)
-                application_depth = self.soil.data.soil_layers[-1].bottom_depth
-
-            self.manure_applicator.apply_machine_manure(
-                dry_matter_mass=manure_supplied.dry_matter,
-                dry_matter_fraction=manure_supplied.dry_matter_fraction,
-                total_phosphorus_mass=manure_supplied.phosphorus,
-                field_coverage=field_coverage,
-                application_depth=application_depth,
-                surface_remainder_fraction=surface_remainder_fraction,
-                field_size=self.field_data.field_size,
-                inorganic_nitrogen_fraction=total_inorganic_nitrogen_fraction,
-                ammonium_fraction=manure_supplied.ammonium_nitrogen_fraction,
-                organic_nitrogen_fraction=total_organic_nitrogen_fraction,
-                water_extractable_inorganic_phosphorus_fraction=manure_supplied.inorganic_phosphorus_fraction,
-            )
-
-            self._record_manure_application(
-                dry_matter_mass=manure_supplied.dry_matter,
-                dry_matter_fraction=manure_supplied.dry_matter_fraction,
-                field_coverage=field_coverage,
-                nitrogen=manure_supplied.nitrogen,
-                phosphorus=manure_supplied.phosphorus,
-                potassium=None,
-                application_depth=application_depth,
-                surface_remainder_fraction=surface_remainder_fraction,
-                year=year,
-                day=day,
-                output_name="manure_application",
-            )
         else:
-            supplied_nitrogen = 0.0
-            supplied_phosphorus = 0.0
+            supplied_nitrogen = supplied_phosphorus = 0.0
 
+        self._record_requested_manure_application(
+            requested_nitrogen, requested_phosphorus, field_coverage,
+            application_depth, surface_remainder_fraction, year, day
+        )
+
+        self._handle_unmet_nutrients(
+            requested_nitrogen, requested_phosphorus,
+            supplied_nitrogen, supplied_phosphorus,
+            application_depth, surface_remainder_fraction,
+            manure_supplement_method, year, day, info_map
+        )
+
+    def _apply_and_record_manure_application(
+        self,
+        manure_supplied: NutrientRequestResults,
+        manure_type: ManureType,
+        field_coverage: float,
+        application_depth: float,
+        surface_remainder_fraction: float,
+        year: int,
+        day: int
+    ) -> tuple[float, float, float, float]:
+        self._add_manure_water(manure_supplied, manure_type)
+
+        supplied_nitrogen = manure_supplied.nitrogen
+        supplied_phosphorus = manure_supplied.phosphorus
+
+        application_depth, surface_remainder_fraction = self._validate_application_depth_and_fraction(
+            application_depth, surface_remainder_fraction, year, day
+        )
+
+        self.manure_applicator.apply_machine_manure(
+            dry_matter_mass=manure_supplied.dry_matter,
+            dry_matter_fraction=manure_supplied.dry_matter_fraction,
+            total_phosphorus_mass=supplied_phosphorus,
+            field_coverage=field_coverage,
+            application_depth=application_depth,
+            surface_remainder_fraction=surface_remainder_fraction,
+            field_size=self.field_data.field_size,
+            inorganic_nitrogen_fraction=(supplied_nitrogen / manure_supplied.dry_matter)
+            * manure_supplied.inorganic_nitrogen_fraction,
+            ammonium_fraction=manure_supplied.ammonium_nitrogen_fraction,
+            organic_nitrogen_fraction=(supplied_nitrogen / manure_supplied.dry_matter)
+            * manure_supplied.organic_nitrogen_fraction,
+            water_extractable_inorganic_phosphorus_fraction=manure_supplied.inorganic_phosphorus_fraction,
+        )
+
+        self._record_manure_application(
+            dry_matter_mass=manure_supplied.dry_matter,
+            dry_matter_fraction=manure_supplied.dry_matter_fraction,
+            field_coverage=field_coverage,
+            nitrogen=supplied_nitrogen,
+            phosphorus=supplied_phosphorus,
+            potassium=None,
+            application_depth=application_depth,
+            surface_remainder_fraction=surface_remainder_fraction,
+            year=year,
+            day=day,
+            output_name="manure_application",
+        )
+
+        return supplied_nitrogen, supplied_phosphorus, application_depth, surface_remainder_fraction
+
+    def _validate_application_depth_and_fraction(
+        self,
+        application_depth: float,
+        surface_remainder_fraction: float,
+        year: int,
+        day: int,
+    ) -> tuple[float, float]:
+        error_name = "manure_application_error"
+
+        if (application_depth == 0.0 and surface_remainder_fraction != 1.0) or (
+            application_depth > 0.0 and surface_remainder_fraction == 1.0
+        ):
+            self._record_nutrient_application_error(
+                application_depth, surface_remainder_fraction, error_name, year, day
+            )
+            return 0.0, 1.0
+
+        max_depth = self.soil.data.soil_layers[-1].bottom_depth
+        if application_depth > max_depth:
+            self._record_nutrient_application_error(application_depth, None, error_name, year, day)
+            application_depth = max_depth
+
+        return application_depth, surface_remainder_fraction
+
+    def _record_requested_manure_application(
+        self,
+        nitrogen: float,
+        phosphorus: float,
+        field_coverage: float,
+        application_depth: float,
+        surface_remainder_fraction: float,
+        year: int,
+        day: int,
+    ) -> None:
         self._record_manure_application(
             dry_matter_mass=0.0,
             dry_matter_fraction=0.0,
             field_coverage=field_coverage,
-            nitrogen=requested_nitrogen,
-            phosphorus=requested_phosphorus,
+            nitrogen=nitrogen,
+            phosphorus=phosphorus,
             potassium=None,
             application_depth=application_depth,
             surface_remainder_fraction=surface_remainder_fraction,
@@ -644,48 +651,54 @@ class Field:
             output_name="manure_request",
         )
 
-        unmet_nitrogen_demand = max(0.0, requested_nitrogen - supplied_nitrogen)
-        unmet_phosphorus_demand = max(0.0, requested_phosphorus - supplied_phosphorus)
+    def _handle_unmet_nutrients(
+        self,
+        requested_n: float,
+        requested_p: float,
+        supplied_n: float,
+        supplied_p: float,
+        application_depth: float,
+        surface_remainder_fraction: float,
+        method: ManureSupplementMethod,
+        year: int,
+        day: int,
+        info_map: dict,
+    ) -> None:
+        unmet_n = max(0.0, requested_n - supplied_n)
+        unmet_p = max(0.0, requested_p - supplied_p)
 
-        if unmet_nitrogen_demand == 0.0 and unmet_phosphorus_demand == 0.0:
+        if unmet_n == 0.0 and unmet_p == 0.0:
             self.om.add_log("Manure Application Log", "Manure fulfilled all nutrient requests.", info_map)
             return
 
-        if manure_supplement_method == ManureSupplementMethod.NONE:
-            warning_name = "Nutrient deficient manure application"
-            warning_message = (
-                f"Manure nitrogen deficient by {unmet_nitrogen_demand} kg, manure phosphorus "
-                f"deficient by {unmet_phosphorus_demand} kg."
-            )
-            self.om.add_warning(warning_name, warning_message, info_map)
+        if method == ManureSupplementMethod.NONE:
+            warning_msg = f"Manure nitrogen deficient by {unmet_n} kg, phosphorus deficient by {unmet_p} kg."
+            self.om.add_warning("Nutrient deficient manure application", warning_msg, info_map)
             return
-        elif manure_supplement_method in [
-            ManureSupplementMethod.SYNTHETIC_FERTILIZER,
-            ManureSupplementMethod.SYNTHETIC_FERTILIZER_AND_MANURE,
-        ]:
-            self.om.add_log(
-                "Manure Application Log",
-                "Manure did not fulfill all nutrient requests. Supplementing with synthetic fertilizer.",
-                info_map,
+
+        self.om.add_log(
+            "Manure Application Log",
+            "Manure did not fulfill all nutrient requests. Supplementing with synthetic fertilizer.",
+            info_map,
+        )
+
+        optimal_mix = (
+            self.ONLY_NITROGEN_MIX if unmet_n > 0.0 and unmet_p == 0.0
+            else self._determine_optimal_fertilizer_mix(
+                unmet_n, unmet_p, self.available_fertilizer_mixes
             )
-            if unmet_nitrogen_demand > 0.0 and unmet_phosphorus_demand == 0.0:
-                optimal_mix = self.ONLY_NITROGEN_MIX
-            else:
-                optimal_mix = self._determine_optimal_fertilizer_mix(
-                    unmet_nitrogen_demand,
-                    unmet_phosphorus_demand,
-                    self.available_fertilizer_mixes,
-                )
-            self._execute_fertilizer_application(
-                optimal_mix,
-                unmet_nitrogen_demand,
-                unmet_phosphorus_demand,
-                0,
-                application_depth,
-                surface_remainder_fraction,
-                year,
-                day,
-            )
+        )
+
+        self._execute_fertilizer_application(
+            optimal_mix,
+            unmet_n,
+            unmet_p,
+            0,
+            application_depth,
+            surface_remainder_fraction,
+            year,
+            day,
+        )
 
     def _record_manure_application(
         self,

--- a/RUFAS/routines/field/field/field.py
+++ b/RUFAS/routines/field/field/field.py
@@ -550,7 +550,7 @@ class Field:
             Enum option indicating how to supplement the manure application.
         """
         if manure_supplied:
-            supplied_nitrogen, supplied_phosphorus, application_depth, surface_remainder_fraction = (
+            application_summary = (
                 self._apply_and_record_manure_application(
                     manure_supplied,
                     requested_manure_type,
@@ -562,7 +562,12 @@ class Field:
                 )
             )
         else:
-            supplied_nitrogen = supplied_phosphorus = 0.0
+            application_summary = {
+                "supplied_nitrogen": 0.0,
+                "supplied_phosphorus": 0.0,
+                "application_depth": application_depth,
+                "surface_remainder_fraction": surface_remainder_fraction,
+            }
 
         self._record_manure_application(
             dry_matter_mass=0.0,
@@ -571,8 +576,8 @@ class Field:
             nitrogen=requested_nitrogen,
             phosphorus=requested_phosphorus,
             potassium=None,
-            application_depth=application_depth,
-            surface_remainder_fraction=surface_remainder_fraction,
+            application_depth=application_summary["application_depth"],
+            surface_remainder_fraction=application_summary["surface_remainder_fraction"],
             year=year,
             day=day,
             output_name="manure_request",
@@ -581,10 +586,10 @@ class Field:
         self._handle_unmet_nutrients(
             requested_nitrogen,
             requested_phosphorus,
-            supplied_nitrogen,
-            supplied_phosphorus,
-            application_depth,
-            surface_remainder_fraction,
+            application_summary["supplied_nitrogen"],
+            application_summary["supplied_phosphorus"],
+            application_summary["application_depth"],
+            application_summary["surface_remainder_fraction"],
             manure_supplement_method,
             year,
             day,
@@ -664,7 +669,12 @@ class Field:
             output_name="manure_application",
         )
 
-        return supplied_nitrogen, supplied_phosphorus, application_depth, surface_remainder_fraction
+        return {
+            "supplied_nitrogen": supplied_nitrogen,
+            "supplied_phosphorus": supplied_phosphorus,
+            "application_depth": application_depth,
+            "surface_remainder_fraction": surface_remainder_fraction,
+        }
 
     def _validate_application_depth_and_fraction(
         self,

--- a/RUFAS/routines/field/field/field.py
+++ b/RUFAS/routines/field/field/field.py
@@ -550,16 +550,14 @@ class Field:
             Enum option indicating how to supplement the manure application.
         """
         if manure_supplied:
-            application_summary = (
-                self._apply_and_record_manure_application(
-                    manure_supplied,
-                    requested_manure_type,
-                    field_coverage,
-                    application_depth,
-                    surface_remainder_fraction,
-                    year,
-                    day,
-                )
+            application_summary = self._apply_and_record_manure_application(
+                manure_supplied,
+                requested_manure_type,
+                field_coverage,
+                application_depth,
+                surface_remainder_fraction,
+                year,
+                day,
             )
         else:
             application_summary = {

--- a/RUFAS/routines/field/field/field.py
+++ b/RUFAS/routines/field/field/field.py
@@ -734,10 +734,10 @@ class Field:
 
     def _handle_unmet_nutrients(
         self,
-        requested_n: float,
-        requested_p: float,
-        supplied_n: float,
-        supplied_p: float,
+        requested_nitrogen: float,
+        requested_phosphorus: float,
+        supplied_nitrogen: float,
+        supplied_phosphorus: float,
         application_depth: float,
         surface_remainder_fraction: float,
         method: ManureSupplementMethod,
@@ -749,13 +749,13 @@ class Field:
 
         Parameters
         ----------
-        requested_n : float
+        requested_nitrogen : float
             Minimum amount of nitrogen to be included in this manure application (kg).
-        requested_p : float
+        requested_phosphorus : float
             Minimum amount of phosphorus to be included in this manure application (kg).
-        supplied_n : float
+        supplied_nitrogen : float
             Amount of nitrogen supplied by the manure application (kg).
-        supplied_p : float
+        supplied_phosphorus : float
             Amount of phosphorus supplied by the manure application (kg).
         application_depth : float
             Depth at which fertilizer is injected into the soil (mm).
@@ -776,8 +776,8 @@ class Field:
             "year": year,
             "day": day,
         }
-        unmet_n = max(0.0, requested_n - supplied_n)
-        unmet_p = max(0.0, requested_p - supplied_p)
+        unmet_n = max(0.0, requested_nitrogen - supplied_nitrogen)
+        unmet_p = max(0.0, requested_phosphorus - supplied_phosphorus)
 
         if unmet_n == 0.0 and unmet_p == 0.0:
             self.om.add_log("Manure Application Log", "Manure fulfilled all nutrient requests.", info_map)

--- a/RUFAS/routines/field/field/field.py
+++ b/RUFAS/routines/field/field/field.py
@@ -550,11 +550,17 @@ class Field:
             Enum option indicating how to supplement the manure application.
         """
         if manure_supplied:
-            supplied_nitrogen, supplied_phosphorus, application_depth, surface_remainder_fraction = \
+            supplied_nitrogen, supplied_phosphorus, application_depth, surface_remainder_fraction = (
                 self._apply_and_record_manure_application(
-                    manure_supplied, requested_manure_type, field_coverage,
-                    application_depth, surface_remainder_fraction, year, day
+                    manure_supplied,
+                    requested_manure_type,
+                    field_coverage,
+                    application_depth,
+                    surface_remainder_fraction,
+                    year,
+                    day,
                 )
+            )
         else:
             supplied_nitrogen = supplied_phosphorus = 0.0
 
@@ -573,10 +579,15 @@ class Field:
         )
 
         self._handle_unmet_nutrients(
-            requested_nitrogen, requested_phosphorus,
-            supplied_nitrogen, supplied_phosphorus,
-            application_depth, surface_remainder_fraction,
-            manure_supplement_method, year, day,
+            requested_nitrogen,
+            requested_phosphorus,
+            supplied_nitrogen,
+            supplied_phosphorus,
+            application_depth,
+            surface_remainder_fraction,
+            manure_supplement_method,
+            year,
+            day,
         )
 
     def _apply_and_record_manure_application(
@@ -587,7 +598,7 @@ class Field:
         application_depth: float,
         surface_remainder_fraction: float,
         year: int,
-        day: int
+        day: int,
     ) -> tuple[float, float, float, float]:
         """
         Applies the manure and records the application.
@@ -764,10 +775,9 @@ class Field:
             )
 
             optimal_mix = (
-                self.ONLY_NITROGEN_MIX if unmet_n > 0.0 and unmet_p == 0.0
-                else self._determine_optimal_fertilizer_mix(
-                    unmet_n, unmet_p, self.available_fertilizer_mixes
-                )
+                self.ONLY_NITROGEN_MIX
+                if unmet_n > 0.0 and unmet_p == 0.0
+                else self._determine_optimal_fertilizer_mix(unmet_n, unmet_p, self.available_fertilizer_mixes)
             )
 
             self._execute_fertilizer_application(

--- a/RUFAS/routines/field/field/field.py
+++ b/RUFAS/routines/field/field/field.py
@@ -602,7 +602,7 @@ class Field:
         surface_remainder_fraction: float,
         year: int,
         day: int,
-    ) -> tuple[float, float, float, float]:
+    ) -> dict[str, float]:
         """
         Applies the manure and records the application.
 

--- a/changelog.md
+++ b/changelog.md
@@ -141,6 +141,7 @@ v0.9.2
 - [2322](https://github.com/RuminantFarmSystems/MASM/pull/2322) - [minor change] [Github action] Make unauthorized files change check to log and trigger exit at the end of the second step.
 - [2331](https://github.com/RuminantFarmSystems/MASM/pull/2331) - [minor change] [Github action] Fixing failed final check.
 - [2314](https://github.com/RuminantFarmSystems/MASM/pull/2314) - [minor change] [Animal] Report Herd Summary Statistics for Starting Animal Population.
+- [2332](https://github.com/RuminantFarmSystems/MASM/pull/2332) - [minor change] [Crop & Soil]] Refactor `Field._execute_manure_application()` and increase test coverage of field.py to 100%.
 
 
 ### v0.9.2

--- a/tests/soil_crop_tests/field_tests/test_field.py
+++ b/tests/soil_crop_tests/field_tests/test_field.py
@@ -1745,13 +1745,7 @@ def test_apply_and_record_manure_application(mocker: MockerFixture) -> None:
     field._record_manure_application = mocker.MagicMock()
 
     result = field._apply_and_record_manure_application(
-        manure_supplied,
-        manure_type,
-        coverage,
-        original_depth,
-        original_remainder,
-        year,
-        day
+        manure_supplied, manure_type, coverage, original_depth, original_remainder, year, day
     )
 
     assert result == (60.0, 30.0, validated_depth, validated_remainder)
@@ -1798,7 +1792,7 @@ def test_apply_and_record_manure_application(mocker: MockerFixture) -> None:
         (50.0, 1.0, 150.0, 0.0, 1.0, True),
         (200.0, 0.5, 150.0, 150.0, 0.5, True),
         (75.0, 0.5, 150.0, 75.0, 0.5, False),
-    ]
+    ],
 )
 def test_validate_application_depth_and_fraction(
     mocker: MockerFixture,
@@ -1807,7 +1801,7 @@ def test_validate_application_depth_and_fraction(
     soil_max_depth: float,
     expected_depth: float,
     expected_remainder: float,
-    expect_log: bool
+    expect_log: bool,
 ) -> None:
     """Tests that the application depth and fraction are validated correctly."""
     field = Field(field_data=MagicMock(name="test", field_size=1.2))
@@ -1832,10 +1826,21 @@ def test_validate_application_depth_and_fraction(
         (50.0, 50.0, 50.0, 50.0, ManureSupplementMethod.SYNTHETIC_FERTILIZER, 0.0, 0.0, True, False, False, False),
         (60.0, 40.0, 50.0, 40.0, ManureSupplementMethod.NONE, 10.0, 0.0, False, True, False, False),
         (60.0, 40.0, 50.0, 40.0, ManureSupplementMethod.SYNTHETIC_FERTILIZER, 10.0, 0.0, True, False, True, True),
-        (80.0, 80.0, 50.0, 50.0, ManureSupplementMethod.SYNTHETIC_FERTILIZER_AND_MANURE, 30.0, 30.0, True, False, True,
-         False),
+        (
+            80.0,
+            80.0,
+            50.0,
+            50.0,
+            ManureSupplementMethod.SYNTHETIC_FERTILIZER_AND_MANURE,
+            30.0,
+            30.0,
+            True,
+            False,
+            True,
+            False,
+        ),
         (70.0, 70.0, 50.0, 50.0, "UNSUPPORTED_METHOD", 20.0, 20.0, False, True, False, False),
-    ]
+    ],
 )
 def test_handle_unmet_nutrients(
     mocker: MockerFixture,
@@ -1849,7 +1854,7 @@ def test_handle_unmet_nutrients(
     expect_log: bool,
     expect_warn: bool,
     expect_fertilizer: bool,
-    only_nitrogen_unmet: bool
+    only_nitrogen_unmet: bool,
 ) -> None:
     """Tests that the handling of unmet nutrients is performed correctly."""
     field = Field(field_data=MagicMock(name="test", field_size=1.2))

--- a/tests/soil_crop_tests/field_tests/test_field.py
+++ b/tests/soil_crop_tests/field_tests/test_field.py
@@ -1602,7 +1602,11 @@ def test_execute_manure_application(
 ) -> None:
     """Tests that manure is applied to the soil correctly."""
     field = Field(field_data=FieldData(name="test", field_size=1.4))
-    field._add_manure_water = mocker.MagicMock()
+    mock_add_manure_water = mocker.patch.object(
+        field,
+        "_add_manure_water",
+        return_value=None,
+    )
     field.manure_applicator.apply_machine_manure = MagicMock()
     field._record_manure_application = MagicMock()
     field._determine_optimal_fertilizer_mix = MagicMock(return_value="expected_optimal_mix")
@@ -1627,7 +1631,7 @@ def test_execute_manure_application(
     expected_total_organic_fraction = 0.06
 
     if supplied_manure is not None:
-        field._add_manure_water.assert_called_once_with(supplied_manure, manure_type)
+        mock_add_manure_water.assert_called_once_with(supplied_manure, manure_type)
         field.manure_applicator.apply_machine_manure.assert_called_once_with(
             dry_matter_mass=supplied_manure.dry_matter,
             dry_matter_fraction=supplied_manure.dry_matter_fraction,

--- a/tests/soil_crop_tests/field_tests/test_field.py
+++ b/tests/soil_crop_tests/field_tests/test_field.py
@@ -1623,8 +1623,8 @@ def test_execute_manure_application(
         ManureSupplementMethod.NONE,
     )
 
-    expected_total_inorganic_fraction = 0.14  # equal to (50.0 / 250.0) * 0.7
-    expected_total_organic_fraction = 0.06  # equal to (50.0 / 250.0) * 0.3
+    expected_total_inorganic_fraction = 0.14
+    expected_total_organic_fraction = 0.06
 
     if supplied_manure is not None:
         field._add_manure_water.assert_called_once_with(supplied_manure, manure_type)
@@ -1711,6 +1711,252 @@ def test_execute_manure_application(
             )
 
 
+def test_apply_and_record_manure_application(mocker: MockerFixture) -> None:
+    """Tests that the manure application is applied and recorded correctly."""
+    field = Field(field_data=MagicMock(name="test", field_size=1.2))
+
+    manure_supplied = NutrientRequestResults(
+        nitrogen=60.0,
+        phosphorus=30.0,
+        dry_matter=200.0,
+        dry_matter_fraction=0.35,
+        organic_nitrogen_fraction=0.3,
+        inorganic_nitrogen_fraction=0.7,
+        ammonium_nitrogen_fraction=0.25,
+        organic_phosphorus_fraction=0.4,
+        inorganic_phosphorus_fraction=0.6,
+    )
+
+    manure_type = ManureType.LIQUID
+    coverage = 0.85
+    original_depth = 150.0
+    original_remainder = 0.5
+    year = 2025
+    day = 100
+
+    validated_depth = 120.0
+    validated_remainder = 0.65
+
+    field._add_manure_water = mocker.MagicMock()
+    field._validate_application_depth_and_fraction = mocker.MagicMock(
+        return_value=(validated_depth, validated_remainder)
+    )
+    field.manure_applicator = mocker.MagicMock()
+    field._record_manure_application = mocker.MagicMock()
+
+    result = field._apply_and_record_manure_application(
+        manure_supplied,
+        manure_type,
+        coverage,
+        original_depth,
+        original_remainder,
+        year,
+        day
+    )
+
+    assert result == (60.0, 30.0, validated_depth, validated_remainder)
+
+    field._add_manure_water.assert_called_once_with(manure_supplied, manure_type)
+
+    field._validate_application_depth_and_fraction.assert_called_once_with(
+        original_depth, original_remainder, year, day
+    )
+
+    field.manure_applicator.apply_machine_manure.assert_called_once_with(
+        dry_matter_mass=manure_supplied.dry_matter,
+        dry_matter_fraction=manure_supplied.dry_matter_fraction,
+        total_phosphorus_mass=manure_supplied.phosphorus,
+        field_coverage=coverage,
+        application_depth=validated_depth,
+        surface_remainder_fraction=validated_remainder,
+        field_size=1.2,
+        inorganic_nitrogen_fraction=pytest.approx((60.0 / 200.0) * 0.7),
+        ammonium_fraction=manure_supplied.ammonium_nitrogen_fraction,
+        organic_nitrogen_fraction=pytest.approx((60.0 / 200.0) * 0.3),
+        water_extractable_inorganic_phosphorus_fraction=manure_supplied.inorganic_phosphorus_fraction,
+    )
+
+    field._record_manure_application.assert_called_once_with(
+        dry_matter_mass=manure_supplied.dry_matter,
+        dry_matter_fraction=manure_supplied.dry_matter_fraction,
+        field_coverage=coverage,
+        nitrogen=60.0,
+        phosphorus=30.0,
+        potassium=None,
+        application_depth=validated_depth,
+        surface_remainder_fraction=validated_remainder,
+        year=year,
+        day=day,
+        output_name="manure_application",
+    )
+
+
+@pytest.mark.parametrize(
+    "depth, remainder, soil_max_depth, expected_depth, expected_remainder, expect_log",
+    [
+        (0.0, 0.5, 150.0, 0.0, 1.0, True),
+        (50.0, 1.0, 150.0, 0.0, 1.0, True),
+        (200.0, 0.5, 150.0, 150.0, 0.5, True),
+        (75.0, 0.5, 150.0, 75.0, 0.5, False),
+    ]
+)
+def test_validate_application_depth_and_fraction(
+    mocker: MockerFixture,
+    depth: float,
+    remainder: float,
+    soil_max_depth: float,
+    expected_depth: float,
+    expected_remainder: float,
+    expect_log: bool
+) -> None:
+    """Tests that the application depth and fraction are validated correctly."""
+    field = Field(field_data=MagicMock(name="test", field_size=1.2))
+    field.soil = MagicMock()
+    field.soil.data.soil_layers = [MagicMock(bottom_depth=soil_max_depth)]
+    field._record_nutrient_application_error = mocker.MagicMock()
+
+    result = field._validate_application_depth_and_fraction(depth, remainder, 2025, 101)
+
+    assert result == (expected_depth, expected_remainder)
+
+    if expect_log:
+        field._record_nutrient_application_error.assert_called()
+    else:
+        field._record_nutrient_application_error.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "requested_n, requested_p, supplied_n, supplied_p, method, unmet_n, unmet_p, expect_log, expect_warn,"
+    "expect_fertilizer, only_nitrogen_unmet",
+    [
+        (50.0, 50.0, 50.0, 50.0, ManureSupplementMethod.SYNTHETIC_FERTILIZER, 0.0, 0.0, True, False, False, False),
+        (60.0, 40.0, 50.0, 40.0, ManureSupplementMethod.NONE, 10.0, 0.0, False, True, False, False),
+        (60.0, 40.0, 50.0, 40.0, ManureSupplementMethod.SYNTHETIC_FERTILIZER, 10.0, 0.0, True, False, True, True),
+        (80.0, 80.0, 50.0, 50.0, ManureSupplementMethod.SYNTHETIC_FERTILIZER_AND_MANURE, 30.0, 30.0, True, False, True,
+         False),
+        (70.0, 70.0, 50.0, 50.0, "UNSUPPORTED_METHOD", 20.0, 20.0, False, True, False, False),
+    ]
+)
+def test_handle_unmet_nutrients(
+    mocker: MockerFixture,
+    requested_n: float,
+    requested_p: float,
+    supplied_n: float,
+    supplied_p: float,
+    method: ManureSupplementMethod,
+    unmet_n: float,
+    unmet_p: float,
+    expect_log: bool,
+    expect_warn: bool,
+    expect_fertilizer: bool,
+    only_nitrogen_unmet: bool
+) -> None:
+    """Tests that the handling of unmet nutrients is performed correctly."""
+    field = Field(field_data=MagicMock(name="test", field_size=1.2))
+    field.om = MagicMock()
+    field.ONLY_NITROGEN_MIX = "100_0_0"
+    field.available_fertilizer_mixes = ["mix1", "mix2"]
+    field._determine_optimal_fertilizer_mix = mocker.MagicMock(return_value="optimal_mix")
+    field._execute_fertilizer_application = mocker.MagicMock()
+
+    info_map = {"function": "test", "day": 150, "year": 2025}
+
+    application_depth = 100.0
+    surface_remainder = 0.5
+
+    field._handle_unmet_nutrients(
+        requested_n,
+        requested_p,
+        supplied_n,
+        supplied_p,
+        application_depth,
+        surface_remainder,
+        method,
+        2025,
+        150,
+        info_map,
+    )
+
+    if expect_log:
+        field.om.add_log.assert_called()
+    else:
+        field.om.add_log.assert_not_called()
+
+    if expect_warn:
+        field.om.add_warning.assert_called()
+    else:
+        field.om.add_warning.assert_not_called()
+
+    if expect_fertilizer:
+        if only_nitrogen_unmet:
+            field._determine_optimal_fertilizer_mix.assert_not_called()
+            field._execute_fertilizer_application.assert_called_once_with(
+                "100_0_0",
+                unmet_n,
+                unmet_p,
+                0,
+                application_depth,
+                surface_remainder,
+                2025,
+                150,
+            )
+        else:
+            field._determine_optimal_fertilizer_mix.assert_called_once_with(
+                unmet_n, unmet_p, field.available_fertilizer_mixes
+            )
+            field._execute_fertilizer_application.assert_called_once_with(
+                "optimal_mix",
+                unmet_n,
+                unmet_p,
+                0,
+                application_depth,
+                surface_remainder,
+                2025,
+                150,
+            )
+    else:
+        field._execute_fertilizer_application.assert_not_called()
+
+
+def test_record_requested_manure_application(mocker: MockerFixture) -> None:
+    """Tests that the requested manure application is recorded correctly."""
+    field = Field(field_data=MagicMock(name="test", field_size=1.2))
+    field._record_manure_application = mocker.MagicMock()
+
+    nitrogen = 75.0
+    phosphorus = 50.0
+    coverage = 0.9
+    depth = 120.0
+    remainder = 0.6
+    year = 2025
+    day = 150
+
+    field._record_requested_manure_application(
+        nitrogen=nitrogen,
+        phosphorus=phosphorus,
+        field_coverage=coverage,
+        application_depth=depth,
+        surface_remainder_fraction=remainder,
+        year=year,
+        day=day,
+    )
+
+    field._record_manure_application.assert_called_once_with(
+        dry_matter_mass=0.0,
+        dry_matter_fraction=0.0,
+        field_coverage=coverage,
+        nitrogen=nitrogen,
+        phosphorus=phosphorus,
+        potassium=None,
+        application_depth=depth,
+        surface_remainder_fraction=remainder,
+        year=year,
+        day=day,
+        output_name="manure_request",
+    )
+
+
+
 @pytest.mark.parametrize(
     "depth,remainder,expected_depth,expected_remainder,invalid_combination",
     [
@@ -1737,8 +1983,8 @@ def test_execute_manure_application_with_invalid_args(
     )
     field = Field(field_data=FieldData(name="test", field_size=1.89))
     field.soil.data.soil_layers[-1].bottom_depth = 950.0
-    expected_total_inorganic_fraction = 0.15  # equal to (50.0 / 100.0) * 0.3
-    expected_total_organic_fraction = 0.35  # equal to (50.0 / 100.0) * 0.7
+    expected_total_inorganic_fraction = 0.15
+    expected_total_organic_fraction = 0.35
     field._add_manure_water = mocker.MagicMock()
 
     with (

--- a/tests/soil_crop_tests/field_tests/test_field.py
+++ b/tests/soil_crop_tests/field_tests/test_field.py
@@ -1737,12 +1737,24 @@ def test_apply_and_record_manure_application(mocker: MockerFixture) -> None:
     validated_depth = 120.0
     validated_remainder = 0.65
 
-    field._add_manure_water = mocker.MagicMock()
-    field._validate_application_depth_and_fraction = mocker.MagicMock(
-        return_value=(validated_depth, validated_remainder)
+    mock_add_manure_water = mocker.patch.object(
+        field,
+        "_add_manure_water",
+        return_value=None,
     )
-    field.manure_applicator = mocker.MagicMock()
-    field._record_manure_application = mocker.MagicMock()
+    mock_validate_application_depth_and_fraction = mocker.patch.object(
+        field,
+        "_validate_application_depth_and_fraction",
+        return_value=(validated_depth, validated_remainder),
+    )
+    mock_manure_applicator = mocker.patch.object(
+        field.manure_applicator,
+        "apply_machine_manure",
+        return_value=None,
+    )
+    mock_record_manure_application = mocker.patch.object(
+        field, "_record_manure_application", return_value=None
+    )
 
     result = field._apply_and_record_manure_application(
         manure_supplied, manure_type, coverage, original_depth, original_remainder, year, day
@@ -1750,13 +1762,13 @@ def test_apply_and_record_manure_application(mocker: MockerFixture) -> None:
 
     assert result == (60.0, 30.0, validated_depth, validated_remainder)
 
-    field._add_manure_water.assert_called_once_with(manure_supplied, manure_type)
+    mock_add_manure_water.assert_called_once_with(manure_supplied, manure_type)
 
-    field._validate_application_depth_and_fraction.assert_called_once_with(
+    mock_validate_application_depth_and_fraction.assert_called_once_with(
         original_depth, original_remainder, year, day
     )
 
-    field.manure_applicator.apply_machine_manure.assert_called_once_with(
+    mock_manure_applicator.assert_called_once_with(
         dry_matter_mass=manure_supplied.dry_matter,
         dry_matter_fraction=manure_supplied.dry_matter_fraction,
         total_phosphorus_mass=manure_supplied.phosphorus,
@@ -1770,7 +1782,7 @@ def test_apply_and_record_manure_application(mocker: MockerFixture) -> None:
         water_extractable_inorganic_phosphorus_fraction=manure_supplied.inorganic_phosphorus_fraction,
     )
 
-    field._record_manure_application.assert_called_once_with(
+    mock_record_manure_application.assert_called_once_with(
         dry_matter_mass=manure_supplied.dry_matter,
         dry_matter_fraction=manure_supplied.dry_matter_fraction,
         field_coverage=coverage,
@@ -1807,16 +1819,21 @@ def test_validate_application_depth_and_fraction(
     field = Field(field_data=MagicMock(name="test", field_size=1.2))
     field.soil = MagicMock()
     field.soil.data.soil_layers = [MagicMock(bottom_depth=soil_max_depth)]
-    field._record_nutrient_application_error = mocker.MagicMock()
+    # field._record_nutrient_application_error = mocker.MagicMock()
+    mock_record_nutrient_application_error = mocker.patch.object(
+        field,
+        "_record_nutrient_application_error",
+        return_value=None,
+    )
 
     result = field._validate_application_depth_and_fraction(depth, remainder, 2025, 101)
 
     assert result == (expected_depth, expected_remainder)
 
     if expect_log:
-        field._record_nutrient_application_error.assert_called()
+        mock_record_nutrient_application_error.assert_called()
     else:
-        field._record_nutrient_application_error.assert_not_called()
+        mock_record_nutrient_application_error.assert_not_called()
 
 
 def test_validate_application_depth_and_fraction_raises_for_missing_soil_layers() -> None:
@@ -1880,9 +1897,20 @@ def test_handle_unmet_nutrients(
     field = Field(field_data=MagicMock(name="test", field_size=1.2))
     field.om = MagicMock()
     field.ONLY_NITROGEN_MIX = "100_0_0"
-    field.available_fertilizer_mixes = ["mix1", "mix2"]
-    field._determine_optimal_fertilizer_mix = mocker.MagicMock(return_value="optimal_mix")
-    field._execute_fertilizer_application = mocker.MagicMock()
+    field.available_fertilizer_mixes = {
+        "mix1": {"N": 0.0, "P": 0.0},
+        "mix2": {"N": 0.0, "P": 0.0},
+    }
+    mock_determine_optimal_fertilizer_mix = mocker.patch.object(
+        field,
+        "_determine_optimal_fertilizer_mix",
+        return_value="optimal_mix",
+    )
+    mock_execute_fertilizer_application = mocker.patch.object(
+        field,
+        "_execute_fertilizer_application",
+        return_value=None,
+    )
 
     application_depth = 100.0
     surface_remainder = 0.5
@@ -1911,8 +1939,8 @@ def test_handle_unmet_nutrients(
 
     if expect_fertilizer:
         if only_nitrogen_unmet:
-            field._determine_optimal_fertilizer_mix.assert_not_called()
-            field._execute_fertilizer_application.assert_called_once_with(
+            mock_determine_optimal_fertilizer_mix.assert_not_called()
+            mock_execute_fertilizer_application.assert_called_once_with(
                 "100_0_0",
                 unmet_n,
                 unmet_p,
@@ -1923,10 +1951,10 @@ def test_handle_unmet_nutrients(
                 150,
             )
         else:
-            field._determine_optimal_fertilizer_mix.assert_called_once_with(
+            mock_determine_optimal_fertilizer_mix.assert_called_once_with(
                 unmet_n, unmet_p, field.available_fertilizer_mixes
             )
-            field._execute_fertilizer_application.assert_called_once_with(
+            mock_execute_fertilizer_application.assert_called_once_with(
                 "optimal_mix",
                 unmet_n,
                 unmet_p,
@@ -1937,7 +1965,7 @@ def test_handle_unmet_nutrients(
                 150,
             )
     else:
-        field._execute_fertilizer_application.assert_not_called()
+        mock_execute_fertilizer_application.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -1968,7 +1996,12 @@ def test_execute_manure_application_with_invalid_args(
     field.soil.data.soil_layers[-1].bottom_depth = 950.0
     expected_total_inorganic_fraction = 0.15
     expected_total_organic_fraction = 0.35
-    field._add_manure_water = mocker.MagicMock()
+    mock_add_manure_water = mocker.patch.object(
+        field,
+        "_add_manure_water",
+        new_callable=MagicMock,
+        return_value=None,
+    )
 
     with (
         patch(
@@ -2006,7 +2039,7 @@ def test_execute_manure_application_with_invalid_args(
             ManureSupplementMethod.NONE,
         )
 
-        field._add_manure_water.assert_called_once_with(supplied_nutrients, ManureType.LIQUID)
+        mock_add_manure_water.assert_called_once_with(supplied_nutrients, ManureType.LIQUID)
         if invalid_combination:
             patched_error.assert_called_once_with(depth, remainder, "manure_application_error", 2000, 133)
         else:

--- a/tests/soil_crop_tests/field_tests/test_field.py
+++ b/tests/soil_crop_tests/field_tests/test_field.py
@@ -1918,45 +1918,6 @@ def test_handle_unmet_nutrients(
         field._execute_fertilizer_application.assert_not_called()
 
 
-def test_record_requested_manure_application(mocker: MockerFixture) -> None:
-    """Tests that the requested manure application is recorded correctly."""
-    field = Field(field_data=MagicMock(name="test", field_size=1.2))
-    field._record_manure_application = mocker.MagicMock()
-
-    nitrogen = 75.0
-    phosphorus = 50.0
-    coverage = 0.9
-    depth = 120.0
-    remainder = 0.6
-    year = 2025
-    day = 150
-
-    field._record_requested_manure_application(
-        nitrogen=nitrogen,
-        phosphorus=phosphorus,
-        field_coverage=coverage,
-        application_depth=depth,
-        surface_remainder_fraction=remainder,
-        year=year,
-        day=day,
-    )
-
-    field._record_manure_application.assert_called_once_with(
-        dry_matter_mass=0.0,
-        dry_matter_fraction=0.0,
-        field_coverage=coverage,
-        nitrogen=nitrogen,
-        phosphorus=phosphorus,
-        potassium=None,
-        application_depth=depth,
-        surface_remainder_fraction=remainder,
-        year=year,
-        day=day,
-        output_name="manure_request",
-    )
-
-
-
 @pytest.mark.parametrize(
     "depth,remainder,expected_depth,expected_remainder,invalid_combination",
     [

--- a/tests/soil_crop_tests/field_tests/test_field.py
+++ b/tests/soil_crop_tests/field_tests/test_field.py
@@ -1758,7 +1758,12 @@ def test_apply_and_record_manure_application(mocker: MockerFixture) -> None:
         manure_supplied, manure_type, coverage, original_depth, original_remainder, year, day
     )
 
-    assert result == (60.0, 30.0, validated_depth, validated_remainder)
+    assert result == {
+        "supplied_nitrogen": 60.0,
+        "supplied_phosphorus": 30.0,
+        "application_depth": validated_depth,
+        "surface_remainder_fraction": validated_remainder,
+    }
 
     mock_add_manure_water.assert_called_once_with(manure_supplied, manure_type)
 

--- a/tests/soil_crop_tests/field_tests/test_field.py
+++ b/tests/soil_crop_tests/field_tests/test_field.py
@@ -1752,9 +1752,7 @@ def test_apply_and_record_manure_application(mocker: MockerFixture) -> None:
         "apply_machine_manure",
         return_value=None,
     )
-    mock_record_manure_application = mocker.patch.object(
-        field, "_record_manure_application", return_value=None
-    )
+    mock_record_manure_application = mocker.patch.object(field, "_record_manure_application", return_value=None)
 
     result = field._apply_and_record_manure_application(
         manure_supplied, manure_type, coverage, original_depth, original_remainder, year, day
@@ -1764,9 +1762,7 @@ def test_apply_and_record_manure_application(mocker: MockerFixture) -> None:
 
     mock_add_manure_water.assert_called_once_with(manure_supplied, manure_type)
 
-    mock_validate_application_depth_and_fraction.assert_called_once_with(
-        original_depth, original_remainder, year, day
-    )
+    mock_validate_application_depth_and_fraction.assert_called_once_with(original_depth, original_remainder, year, day)
 
     mock_manure_applicator.assert_called_once_with(
         dry_matter_mass=manure_supplied.dry_matter,

--- a/tests/soil_crop_tests/field_tests/test_field.py
+++ b/tests/soil_crop_tests/field_tests/test_field.py
@@ -1819,6 +1819,26 @@ def test_validate_application_depth_and_fraction(
         field._record_nutrient_application_error.assert_not_called()
 
 
+def test_validate_application_depth_and_fraction_raises_for_missing_soil_layers() -> None:
+    field = Field(field_data=MagicMock(name="test", field_size=1.2))
+    field.soil = MagicMock()
+    field.soil.data.soil_layers = None
+
+    with pytest.raises(ValueError, match="soil_layers is not initialized"):
+        field._validate_application_depth_and_fraction(50.0, 0.5, 2025, 101)
+
+
+def test_validate_application_depth_and_fraction_raises_for_missing_bottom_depth() -> None:
+    field = Field(field_data=MagicMock(name="test", field_size=1.2))
+    field.soil = MagicMock()
+    mock_layer = MagicMock()
+    mock_layer.bottom_depth = None
+    field.soil.data.soil_layers = [mock_layer]
+
+    with pytest.raises(ValueError, match="bottom_depth is not set for the last soil layer"):
+        field._validate_application_depth_and_fraction(50.0, 0.5, 2025, 101)
+
+
 @pytest.mark.parametrize(
     "requested_n, requested_p, supplied_n, supplied_p, method, unmet_n, unmet_p, expect_log, expect_warn,"
     "expect_fertilizer, only_nitrogen_unmet",
@@ -1864,8 +1884,6 @@ def test_handle_unmet_nutrients(
     field._determine_optimal_fertilizer_mix = mocker.MagicMock(return_value="optimal_mix")
     field._execute_fertilizer_application = mocker.MagicMock()
 
-    info_map = {"function": "test", "day": 150, "year": 2025}
-
     application_depth = 100.0
     surface_remainder = 0.5
 
@@ -1879,7 +1897,6 @@ def test_handle_unmet_nutrients(
         method,
         2025,
         150,
-        info_map,
     )
 
     if expect_log:


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Refactor `Field.execute_manure_application()` to be more manageable and more easily tested.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2177

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Breaks up `Field.execute_manure_application()` into more single-responsibility functions:
1. `_execute_manure_application` stays as the managerial function for the manure application process.
2. `_apply_and_record_manure_application()` applies the manure and records the application to OM.
3. `_validate_application_depth_and_fraction()` does error handling and adjustments based on bad inputs.
4. `_handle_unmet_nutrients()` handles nutrient shortfalls based on user selected methods of supplementing shortfalls.
5. Adds testing for all these functions to bring coverage to 100%.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
The version of `Field._execute_manure_application()` is too large and too difficult to test as it stands.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Functionalities were extracted to try and make the multiple different aspects `Field._execute_manure_application()` was previously handling.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
1. The original unit test for `Field._execute_manure_application()` is still in the test file. It passes and I think functions almost as an integration test with the functions now broken up.

2. I went back to PR #2171 to get the inputs that I used to test the original expansion of `_execute_manure_application()`. I used this filter to capture the associated results:

```
{
    "multiple": [
{    
  "name": "ManRequest",
    "filters": [
      "ManureManager._record_manure_request_results.*"
    ],
    "variables": [".*"]
  },
{
  "name": "ManApplication",
    "filters": [
      ".*manure_appli.*"
    ],
    "variables": [".*"]
  }
    ]
  }
```
These were tested on dev and on this branch and results were identical.

3. Unfortunately end-to-end testing is currently not functioning (there's a separate issue open for this that I'm working on). I have a fix on the `e2e-fix` branch. That branch is up to date with dev as far as Field is concerned. I ran e2e testing there and updated the expected results so they would pass. I then switched over to this feature branch, made the same tweaks to the metadata and expected Feed Storage results, and ran end to end testing and it passed. So essentially the results for C&S on dev match the results for this branch. I wish this was more easily replicated for others but it's really not right now.