### PR TITLE
Fix Methane Leakage Calculation in `ContinuousMix`

### DIFF
--- a/RUFAS/biophysical/manure/digester/continuous_mix.py
+++ b/RUFAS/biophysical/manure/digester/continuous_mix.py
@@ -82,7 +82,7 @@ class ContinuousMix(Digester):
             self._report_continuous_mix_outputs(
                 captured_biogas_volume=0.0,
                 captured_methane_volume=0.0,
-                methane_leakage_volume=0.0,
+                methane_leakage_mass=0.0,
                 simulation_day=time.simulation_day,
             )
             return {}
@@ -103,15 +103,15 @@ class ContinuousMix(Digester):
         self._manure_in_digester = self._destroy_volatile_solids(total_volatile_solids_destruction, time)
         self._manure_in_digester.volume -= total_volatile_solids_destruction / ManureConstants.SLURRY_MANURE_DENSITY
 
-        methane_leakage_volume = self._calculate_methane_leakage(
-            generated_methane_volume, self._biogas_leakage_fraction
+        methane_leakage_mass, methane_leakage_volume = self._calculate_methane_leakage(
+            generated_methane_mass, generated_methane_volume, self._biogas_leakage_fraction
         )
         captured_methane_volume = generated_methane_volume - methane_leakage_volume
 
         self._report_continuous_mix_outputs(
             captured_biogas_volume=captured_biogas_volume,
             captured_methane_volume=captured_methane_volume,
-            methane_leakage_volume=methane_leakage_volume,
+            methane_leakage_mass=methane_leakage_mass,
             simulation_day=time.simulation_day,
         )
 
@@ -228,7 +228,7 @@ class ContinuousMix(Digester):
         self,
         captured_biogas_volume: float,
         captured_methane_volume: float,
-        methane_leakage_volume: float,
+        methane_leakage_mass: float,
         simulation_day: int,
     ) -> None:
         """
@@ -242,8 +242,8 @@ class ContinuousMix(Digester):
              on the current day (m^3).
         captured_methane_volume : float
             Capture methane volume on the current day, after accounting for leakage (m^3).
-        methane_leakage_volume : float
-            Volume of methane lost to the atmosphere through unintended leakage on the current day (m^3).
+        methane_leakage_mass : float
+            The mass of methane lost to the atmosphere through unintended leakage on the current day (kg).
         simulation_day : int
             The current simulation day.
 
@@ -266,10 +266,10 @@ class ContinuousMix(Digester):
             simulation_day,
         )
         self._report_processor_output(
-            "methane_leakage_volume",
-            methane_leakage_volume,
+            "methane_leakage_mass",
+            methane_leakage_mass,
             data_origin_function,
-            MeasurementUnits.CUBIC_METERS,
+            MeasurementUnits.KILOGRAMS,
             simulation_day,
         )
 
@@ -300,21 +300,26 @@ class ContinuousMix(Digester):
         return total_volatile_solids * ManureConstants.ACHIEVABLE_METHANE_EMISSION
 
     @staticmethod
-    def _calculate_methane_leakage(generated_methane_mass: float, leakage_fraction: float) -> float:
+    def _calculate_methane_leakage(
+            generated_methane_mass: float, generated_methane_volume: float, leakage_fraction: float
+    ) -> tuple[float, float]:
         """
         Calculates the mass of methane lost from an anaerobic digester as leakage.
 
         Parameters
         ----------
         generated_methane_mass : float
-            Amount of methane generated within the digester (kg).
+            The mass of methane generated within the digester (kg).
+        generated_methane_mass : float
+            The volume of methane generated within the digester (m^3).
         leakage_fraction : float
             Fraction of generated methane that escapes as leakage (unitless).
 
         Returns
         -------
-        float
-            Mass of methane lost as leakage (kg).
+        tuple[float, float]
+            - Mass of methane lost as leakage (kg).
+            - Volume of methane lost as leakage (m^3).
 
         """
-        return generated_methane_mass * leakage_fraction
+        return generated_methane_mass * leakage_fraction, generated_methane_volume * leakage_fraction

--- a/RUFAS/biophysical/manure/digester/continuous_mix.py
+++ b/RUFAS/biophysical/manure/digester/continuous_mix.py
@@ -301,7 +301,7 @@ class ContinuousMix(Digester):
 
     @staticmethod
     def _calculate_methane_leakage(
-            generated_methane_mass: float, generated_methane_volume: float, leakage_fraction: float
+        generated_methane_mass: float, generated_methane_volume: float, leakage_fraction: float
     ) -> tuple[float, float]:
         """
         Calculates the mass of methane lost from an anaerobic digester as leakage.

--- a/changelog.md
+++ b/changelog.md
@@ -154,6 +154,7 @@ v0.9.2
 - [2292](https://github.com/RuminantFarmSystems/MASM/pull/2292) - [minor change] [Animal] Updates NASEM equations in calculation of gravid uterine weight and protein requirement in cases of negative uterine weight. 
 - [2335](https://github.com/RuminantFarmSystems/MASM/pull/2335) - [minor change] [OutputManager] Increase packaging of data sent to Output Manager.
 - [2338](https://github.com/RuminantFarmSystems/MASM/pull/2338) - [minor change] [Manure] Remove Unused Calculations in AnaerobicDigester.
+- [2355](https://github.com/RuminantFarmSystems/MASM/pull/2355) - [minor change] [Manure] Fix Methane Leakage Calculation in ContinuousMix.
 
 
 ### v0.9.2

--- a/tests/test_biophysical/test_manure/test_digester/test_continuous_mix.py
+++ b/tests/test_biophysical/test_manure/test_digester/test_continuous_mix.py
@@ -242,11 +242,11 @@ def test_calculate_CSTR_methane_volume(total_vol_sols: float, expected: float) -
         (0.0, 0.0, 0.0, 0.0, 0.0),
         (0.0, 0.0, 0.2, 0.0, 0.0),
         (100.0, 88.8, 0.0, 0.0, 0.0),
-        (100.0, 88.8, 0.25, 25.0, 22.2)
-    ]
+        (100.0, 88.8, 0.25, 25.0, 22.2),
+    ],
 )
 def test_calculate_methane_leakage(
-        mass: float, volume: float, leakage: float, expected_mass: float, expected_volume: float
+    mass: float, volume: float, leakage: float, expected_mass: float, expected_volume: float
 ) -> None:
     """Test that methane leakage is calculated correctly."""
     actual_mass, actual_volume = ContinuousMix._calculate_methane_leakage(mass, volume, leakage)

--- a/tests/test_biophysical/test_manure/test_digester/test_continuous_mix.py
+++ b/tests/test_biophysical/test_manure/test_digester/test_continuous_mix.py
@@ -111,7 +111,7 @@ def test_process_manure(
         digester, "_calculate_generated_carbon_dioxide", return_value=(23.3, 66.6)
     )
     destroy_vol_sols = mocker.patch.object(digester, "_destroy_volatile_solids", return_value=manure_stream)
-    methane_leakage = mocker.patch.object(digester, "_calculate_methane_leakage", return_value=9.0)
+    methane_leakage = mocker.patch.object(digester, "_calculate_methane_leakage", return_value=(9.0, 19.62))
     report_outputs = mocker.patch.object(digester, "_report_continuous_mix_outputs")
 
     expected_volume = 499.9663636363636
@@ -198,7 +198,7 @@ def test_destroy_volatile_solids(
     assert add_error.call_count == expected_error_count
 
 
-def test_report_anaerobic_digester_outputs(digester: ContinuousMix, time: RufasTime, mocker: MockerFixture) -> None:
+def test_report_continuous_mix_outputs(digester: ContinuousMix, time: RufasTime, mocker: MockerFixture) -> None:
     """Tests that output variables from an anaerobic digester are calculated correctly."""
     mock_report_manure_stream = mocker.patch.object(digester, "_report_manure_stream")
     mock_report_processor_output = mocker.patch.object(digester, "_report_processor_output")
@@ -210,7 +210,7 @@ def test_report_anaerobic_digester_outputs(digester: ContinuousMix, time: RufasT
     digester._report_continuous_mix_outputs(
         captured_biogas_volume=biogas,
         captured_methane_volume=methane,
-        methane_leakage_volume=methane_leakage,
+        methane_leakage_mass=methane_leakage,
         simulation_day=time.simulation_day,
     )
 
@@ -219,10 +219,10 @@ def test_report_anaerobic_digester_outputs(digester: ContinuousMix, time: RufasT
         call("captured_biogas_volume", biogas, data_origin_function, MeasurementUnits.CUBIC_METERS, simulation_day),
         call("captured_methane_volume", methane, data_origin_function, MeasurementUnits.CUBIC_METERS, simulation_day),
         call(
-            "methane_leakage_volume",
+            "methane_leakage_mass",
             methane_leakage,
             data_origin_function,
-            MeasurementUnits.CUBIC_METERS,
+            MeasurementUnits.KILOGRAMS,
             simulation_day,
         ),
     ]
@@ -237,10 +237,19 @@ def test_calculate_CSTR_methane_volume(total_vol_sols: float, expected: float) -
 
 
 @pytest.mark.parametrize(
-    "methane, leakage, expected", [(0.0, 0.0, 0.0), (0.0, 0.2, 0.0), (100.0, 0.0, 0.0), (100.0, 0.25, 25.0)]
+    "mass, volume, leakage, expected_mass, expected_volume",
+    [
+        (0.0, 0.0, 0.0, 0.0, 0.0),
+        (0.0, 0.0, 0.2, 0.0, 0.0),
+        (100.0, 88.8, 0.0, 0.0, 0.0),
+        (100.0, 88.8, 0.25, 25.0, 22.2)
+    ]
 )
-def test_calculate_methane_leakage(methane: float, leakage: float, expected: float) -> None:
+def test_calculate_methane_leakage(
+        mass: float, volume: float, leakage: float, expected_mass: float, expected_volume: float
+) -> None:
     """Test that methane leakage is calculated correctly."""
-    actual = ContinuousMix._calculate_methane_leakage(methane, leakage)
+    actual_mass, actual_volume = ContinuousMix._calculate_methane_leakage(mass, volume, leakage)
 
-    assert actual == expected
+    assert actual_mass == expected_mass
+    assert actual_volume == expected_volume


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #

The current `_calculate_methane_leakage()` function takes in the `generated_methane_volume` and `biogas_leakage_fraction` and returns the `methane_leakage_volume` by multiplying the current inputs (even though the docstring of this function says we are taking in the mass and returning the mass).

Changes in this PR:
1. Modify the `_calculate_methane_leakage()` function to take in both `generated_methane_mass` and `generated_methane_volume`, along with the `biogas_leakage_fraction`. Then multiply both mass and volume by the leakage fraction, and return both `methane_leakage_volume` and `methane_leakage_mass`.
2. The `methane_leakage_volume` is then used to calculate the `captured_methane_volume` in line 109; we will not make any changes to this.
3. The `methane_leakage_mass` will be reported to the OM; therefore, we changed the `_report_continuous_mix_outputs()` function to expect the mass instead of volume.
4. Finally, update all the docstrings and unit tests.
