### PR TITLE
Heifer ED Bug Fix

### DIFF
--- a/RUFAS/biophysical/animal/reproduction/reproduction.py
+++ b/RUFAS/biophysical/animal/reproduction/reproduction.py
@@ -1074,7 +1074,7 @@ class Reproduction:
 
         reproduction_data_stream = self._simulate_estrus(
             reproduction_data_stream,
-            reproduction_data_stream.days_born,
+            reproduction_data_stream.days_born - 1,
             simulation_day,
             animal_constants.ESTRUS_DAY_SCHEDULED_NOTE,
             average_estrus_cycle,

--- a/changelog.md
+++ b/changelog.md
@@ -167,6 +167,7 @@ v0.9.2
 - [2340](https://github.com/RuminantFarmSystems/MASM/pull/2340) - [minor change] [Animal] Updates the structure of the Mitscherlich Model 3 to calculate enteric CH4 emissions.
 - [2252](https://github.com/RuminantFarmSystems/MASM/pull/2252) - [minor change] [Animal] Adds logic to initialize herds using specific parity distributions.
 - [2390](https://github.com/RuminantFarmSystems/RuFaS/pull/2390) - [minor change] [Animal] Updates unclear and inaccurate heifer repro descriptions and defaults in default metadata properties 
+- [2382](https://github.com/RuminantFarmSystems/RuFaS/pull/2382) - [minor change] [Animal] Fixes the bug in heifer reproduction ED bug when insemination is unsuccessful.
 
 ### v0.9.2
 

--- a/tests/test_biophysical/test_animal/reproduction/test_reproduction.py
+++ b/tests/test_biophysical/test_animal/reproduction/test_reproduction.py
@@ -2423,7 +2423,7 @@ def test_handle_failed_heifer_conception(
 
     mock_simulate_estrus.assert_called_once_with(
         mock_outputs,
-        days_born,
+        days_born - 1,
         simulation_day,
         animal_constants.ESTRUS_DAY_SCHEDULED_NOTE,
         average_estrus_cycle,


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2378 

This PR fixes the following bug:

> When a heifer’s estrus is detected, her AI insemination day is set to the following day. However, if conception from that insemination is not successful, then the resumption of her estrus cycle starts on that day instead of on the previous day. This means that the estrus cycle is shifted by one day for cases when estrus is detected but conception did not occur.

By:

> In the function “_handle_failed_heifer_conception()” in [reproduction.py](http://reproduction.py/), instead of passing in “reproduction_data_stream.days_born” as the “start_day” input to the function “_simulate_estrus()”, we could pass in “reproduction_data_stream.days_born -1”.


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
