### PR TITLE
Update metadata properties for heifer repro inputs 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -166,6 +166,7 @@ v0.9.2
 - [2371](https://github.com/RuminantFarmSystems/MASM/pull/2371) - [minor change] [ReportGenerator] Allow for RG aggregation of np.float()s
 - [2340](https://github.com/RuminantFarmSystems/MASM/pull/2340) - [minor change] [Animal] Updates the structure of the Mitscherlich Model 3 to calculate enteric CH4 emissions.
 - [2252](https://github.com/RuminantFarmSystems/MASM/pull/2252) - [minor change] [Animal] Adds logic to initialize herds using specific parity distributions.
+- [2390](https://github.com/RuminantFarmSystems/RuFaS/pull/2390) - [minor change] [Animal] Updates unclear and inaccurate heifer repro descriptions and defaults in default metadata properties 
 
 ### v0.9.2
 

--- a/input/metadata/properties/default.json
+++ b/input/metadata/properties/default.json
@@ -327,14 +327,14 @@
             "description": "Heifer Reproduction Protocols",
             "estrus_detection_rate": {
               "type": "number",
-              "description": "Estrus Detection Rate (percent) -- The percentage of total heifers in estrus that are detected and inseminated in the ED (Estrus Detection) protocol",
+              "description": "Estrus Detection Rate (fraction) -- The fraction of total heifers in estrus that are detected and inseminated in the ED (Estrus Detection) protocol",
               "default": 0.9,
               "minimum": 0,
               "maximum": 1
             },
             "estrus_conception_rate": {
               "type": "number",
-              "description": "Estrus Conception Rate (percent) -- The percentage of inseminated heifers that become pregnant for heifers bred on estrus detection (ED (Estrus Detection) and SynchED protocols)",
+              "description": "Estrus Conception Rate (fraction) -- The fraction of inseminated heifers that become pregnant for heifers bred on estrus detection (ED (Estrus Detection) and SynchED protocols)",
               "default": 0.6,
               "minimum": 0,
               "maximum": 1
@@ -355,7 +355,7 @@
               },
               "estrus_detection_rate": {
                 "type": "number",
-                "description": "Estrus Detection Rate -- The % of in-heat animals that would be detected and inseminated in the SynchED programs",
+                "description": "Estrus Detection Rate -- The fraction of in-heat heifers that would be detected and inseminated in the SynchED programs",
                 "default": 0.9,
                 "minimum": 0,
                 "maximum": 1

--- a/input/metadata/properties/default.json
+++ b/input/metadata/properties/default.json
@@ -327,15 +327,15 @@
             "description": "Heifer Reproduction Protocols",
             "estrus_detection_rate": {
               "type": "number",
-              "description": "Estrus Detection Rate (percent) -- The percentage of total heifers in estrus that are detected in the ED (Estrus Detection) protocol",
-              "default": 0.6,
+              "description": "Estrus Detection Rate (percent) -- The percentage of total heifers in estrus that are detected and inseminated in the ED (Estrus Detection) protocol",
+              "default": 0.9,
               "minimum": 0,
               "maximum": 1
             },
             "estrus_conception_rate": {
               "type": "number",
-              "description": "Estrus Conception Rate (percent) -- The percentage of inseminated heifers that become pregnant in the ED (Estrus Detection) and SynchED protocols",
-              "default": 0.9,
+              "description": "Estrus Conception Rate (percent) -- The percentage of inseminated heifers that become pregnant for heifers bred on estrus detection (ED (Estrus Detection) and SynchED protocols)",
+              "default": 0.6,
               "minimum": 0,
               "maximum": 1
             },
@@ -348,15 +348,15 @@
               "type": "object",
               "conception_rate": {
                 "type": "number",
-                "description": "Conception Rate -- The conception rate for the heifer reproductive program (default is 0.6)",
+                "description": "Conception Rate -- The conception rate for TAI breedings in the heifer reproductive program",
                 "default": 0.6,
                 "minimum": 0,
                 "maximum": 1
               },
               "estrus_detection_rate": {
                 "type": "number",
-                "description": "Estrus Detection Rate -- The % of in-heat animals that would be detected in the ED (Estrus Detection) programs (default is 0.6)",
-                "default": 0.7,
+                "description": "Estrus Detection Rate -- The % of in-heat animals that would be detected and inseminated in the SynchED programs",
+                "default": 0.9,
                 "minimum": 0,
                 "maximum": 1
               }


### PR DESCRIPTION
Update default values and descriptions for heifer repro inputs in the Metadata properties to match what is in default_animal.json and more clear/accurate descriptions. 

<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #

### What
CR and DR values were switched; added more precise descriptions about which values are relevant to which protocols. 


### Why
So that documentation, metadata properties, and default_animal.json are all consistent with each other and clear to a user. 


### How
<!-- Give an explanation of how this pull request addresses needed changes. -->


### Test plan
Need to verify with SME (@YijingGong ?) that the updated descriptions are accurate. 
