### PR TITLE
Fix Phosphorus Calculation for Animal Manure Excretions

### DIFF
--- a/RUFAS/biophysical/animal/digestive_system/digestive_system.py
+++ b/RUFAS/biophysical/animal/digestive_system/digestive_system.py
@@ -197,4 +197,4 @@ class DigestiveSystem:
         else:
             fecal_phosphorus = phosphorus_endogenous_loss
 
-        return urine_phosphorus_required, fecal_phosphorus
+        return fecal_phosphorus, urine_phosphorus_required 

--- a/RUFAS/biophysical/animal/nutrients/nutrients.py
+++ b/RUFAS/biophysical/animal/nutrients/nutrients.py
@@ -28,18 +28,20 @@ class Nutrients:
         self.ration_phosphorus_concentration = 0.0
         self.phosphorus_for_gestation = 0.0
         self.phosphorus_for_gestation_required_for_calf = 0.0
+        self._dry_matter_intake = 0.0
 
     def perform_daily_phosphorus_update(self, nutrients_inputs: NutrientsInputs) -> None:
         """Manages animal's daily phosphorus update."""
-        dry_matter_intake = self._get_dry_matter_intake()
-        self._calculate_phosphorus_requirements(nutrients_inputs, dry_matter_intake)
+        self._calculate_phosphorus_requirements(nutrients_inputs)
         self._calculate_total_animal_phosphorus()
 
-    def _get_dry_matter_intake(self) -> float:
-        """Get ration data for animal dry matter intake."""
-        # Not sure where ration will be or how it will be tied to a particular animal (currently done by pen)
-        # But assuming it's not an attribute of the animal, we will need this info from ration.
-        return 0.0
+    def set_dry_matter_intake(self, dry_matter_intake: float) -> None:
+        """Set the dry matter intake for the animal according to the provided ration."""
+        self._dry_matter_intake = dry_matter_intake
+
+    def set_phosphorus_intake(self, phosphorus_intake: float) -> None:
+        """Set the phosphorus intake for the animal according to the provided ration."""
+        self.phosphorus_intake = phosphorus_intake
 
     def _calculate_total_animal_phosphorus(self) -> None:
         """Calculates the total phosphorus for the animal.
@@ -68,11 +70,9 @@ class Nutrients:
             + (self.phosphorus_reserves - previous_phosphorus_reserves)
         )
 
-    def _calculate_phosphorus_requirements(self, nutrients_inputs: NutrientsInputs, dry_matter_intake: float) -> None:
+    def _calculate_phosphorus_requirements(self, nutrients_inputs: NutrientsInputs) -> None:
         """Calculates animal's phosphorus requirements"""
-        self.phosphorus_endogenous_loss = self._calculate_phosphorus_endogenous_loss(
-            nutrients_inputs, dry_matter_intake
-        )
+        self.phosphorus_endogenous_loss = self._calculate_phosphorus_endogenous_loss(nutrients_inputs)
 
         urine_production_phosphorus = 0.000002 * nutrients_inputs.body_weight * GeneralConstants.KG_TO_GRAMS
 
@@ -92,7 +92,7 @@ class Nutrients:
         )
 
     def _calculate_phosphorus_endogenous_loss(
-        self, nutrients_inputs: NutrientsInputs, dry_matter_intake: float
+        self, nutrients_inputs: NutrientsInputs
     ) -> float:
         """Calculates phosphorus required for endogenous loss based on animal type.
 
@@ -101,9 +101,9 @@ class Nutrients:
         RuFaS Phosphorus Animal Module documentation sections A.1A-D.E.1, A.1EF.E.1.
         """
         if not nutrients_inputs.animal_type.is_cow:
-            return 0.0008 * dry_matter_intake * GeneralConstants.KG_TO_GRAMS
+            return 0.0008 * self._dry_matter_intake * GeneralConstants.KG_TO_GRAMS
         else:
-            return 0.001 * dry_matter_intake * GeneralConstants.KG_TO_GRAMS
+            return 0.001 * self._dry_matter_intake * GeneralConstants.KG_TO_GRAMS
 
     def _calculate_phosphorus_for_growth(self, nutrients_inputs: NutrientsInputs) -> float:
         """Calculates phosphorus retained for growth based on animal type.

--- a/RUFAS/biophysical/animal/pen.py
+++ b/RUFAS/biophysical/animal/pen.py
@@ -493,6 +493,8 @@ class Pen:
                 feeds_used=available_feeds, ration_formulation=self.ration, body_weight=animal.body_weight
             )
             animal.nutrition_supply = nutrient_supply
+            animal.nutrients.set_dry_matter_intake(nutrient_supply.dry_matter)
+            animal.nutrients.set_phosphorus_intake(nutrient_supply.phosphorus)
 
     def insert_animals_into_animals_in_pen_map(self, animals: list[Animal]) -> None:
         """
@@ -847,6 +849,8 @@ class Pen:
             animal.nutrition_supply = NutritionSupplyCalculator.calculate_nutrient_supply(
                 feeds_used=feeds_used, ration_formulation=ration_formulation, body_weight=animal.body_weight
             )
+            animal.nutrients.set_dry_matter_intake(animal.nutrition_supply.dry_matter)
+            animal.nutrients.set_phosphorus_intake(animal.nutrition_supply.phosphorus)
 
     def formulate_optimized_ration(
         self,

--- a/tests/test_biophysical/test_animal/test_digestive_system/test_digestive_system.py
+++ b/tests/test_biophysical/test_animal/test_digestive_system/test_digestive_system.py
@@ -225,7 +225,7 @@ def test_process_digestion_unexpected_execution_path(mocker: MockerFixture) -> N
 
 @pytest.mark.parametrize(
     "body_weight, phosphorus_intake, phosphorus_requirement, phosphorus_reserves, phosphorus_endogenous_loss,"
-    "expected_urine_phosphorus_required, expected_fecal_phosphorus",
+    "expected_fecal_phosphorus, expected_urine_phosphorus_required",
     [
         # Case 1: phosphorus_reserves == 0 and phosphorus_intake >= phosphorus_requirement
         (500.0, 40.0, 30.0, 0.0, 5.0, 1.0, 10.0),
@@ -245,8 +245,8 @@ def test_calculate_base_manure(
     phosphorus_requirement: float,
     phosphorus_reserves: float,
     phosphorus_endogenous_loss: float,
-    expected_urine_phosphorus_required: float,
     expected_fecal_phosphorus: float,
+    expected_urine_phosphorus_required: float,
 ) -> None:
     digestive_system = DigestiveSystem()
     actual_urine_phosphorus_required, actual_fecal_phosphorus = digestive_system._calculate_base_manure(

--- a/tests/test_biophysical/test_animal/test_nutrients/test_nutrients.py
+++ b/tests/test_biophysical/test_animal/test_nutrients/test_nutrients.py
@@ -14,9 +14,6 @@ def test_perform_daily_phosphorus_update(mocker: MockerFixture) -> None:
     mock_nutrient_inputs = MagicMock()
     nutrients = Nutrients()
 
-    mock_get_dmi = mocker.patch.object(
-        nutrients, "_get_dry_matter_intake", return_value=10.0
-    )
     mock_calc_phosphorus_requirements = mocker.patch.object(
         nutrients, "_calculate_phosphorus_requirements", return_value=None
     )
@@ -28,17 +25,24 @@ def test_perform_daily_phosphorus_update(mocker: MockerFixture) -> None:
     nutrients.perform_daily_phosphorus_update(mock_nutrient_inputs)
 
     # Assert
-    mock_get_dmi.assert_called_once()
-    mock_calc_phosphorus_requirements.assert_called_once_with(mock_nutrient_inputs, mock_get_dmi.return_value)
+    mock_calc_phosphorus_requirements.assert_called_once_with(mock_nutrient_inputs)
     mock_calc_total_phosphorus.assert_called_once()
 
 
-def test_get_dry_matter_intake() -> None:
-    """Tests that dry matter intake is calculated correctly."""
-    expected = 0.0
+def test_set_dry_matter_intake() -> None:
+    """Tests that dry matter intake is set correctly."""
+    expected = 10.0
     nutrients = Nutrients()
-    result = nutrients._get_dry_matter_intake()
-    assert result == expected
+    nutrients.set_dry_matter_intake(10.0)
+    assert nutrients._dry_matter_intake == expected
+
+
+def test_set_phosphorus_intake() -> None:
+    """Tests that dry matter intake is set correctly."""
+    expected = 10.0
+    nutrients = Nutrients()
+    nutrients.set_phosphorus_intake(10.0)
+    assert nutrients.phosphorus_intake == expected
 
 
 @pytest.mark.parametrize(
@@ -118,9 +122,10 @@ def test_calculate_phosphorus_endogenous_loss(is_cow: bool, dry_matter_intake: f
     nutrients = Nutrients()
     mock_nutrient_inputs = MagicMock()
     mock_nutrient_inputs.animal_type.is_cow = is_cow
+    nutrients._dry_matter_intake = dry_matter_intake
 
     # Act
-    result = nutrients._calculate_phosphorus_endogenous_loss(mock_nutrient_inputs, dry_matter_intake)
+    result = nutrients._calculate_phosphorus_endogenous_loss(mock_nutrient_inputs)
 
     # Assert
     assert result == pytest.approx(expected_loss, rel=1e-3)
@@ -154,6 +159,7 @@ def test_calculate_phosphorus_requirements(
 
     # Arrange
     nutrients = Nutrients()
+    nutrients._dry_matter_intake = 10.0
     mock_nutrient_inputs = MagicMock()
     mock_nutrient_inputs.body_weight = body_weight
 
@@ -173,10 +179,10 @@ def test_calculate_phosphorus_requirements(
         nutrients, "_calculate_animal_phosphorus_requirement", return_value=expected_requirement)
 
     # Act
-    nutrients._calculate_phosphorus_requirements(mock_nutrient_inputs, dry_matter_intake=10.0)
+    nutrients._calculate_phosphorus_requirements(mock_nutrient_inputs)
 
     # Assert
-    mock_endogenous_loss.assert_called_once_with(mock_nutrient_inputs, 10.0)
+    mock_endogenous_loss.assert_called_once_with(mock_nutrient_inputs)
     assert nutrients.phosphorus_endogenous_loss == endogenous_loss
 
     mock_growth_phosphorus.assert_called_once_with(mock_nutrient_inputs)

--- a/tests/test_biophysical/test_animal/test_pen/test_pen.py
+++ b/tests/test_biophysical/test_animal/test_pen/test_pen.py
@@ -662,11 +662,17 @@ def test_add_new_animals(pen: Pen, animals_in_pen: dict[int, Animal], mocker: Mo
         feeds_used=[MagicMock(spec=Feed)],
         body_weight=10,
     )
+    animal_3.nutrients = MagicMock(auto_spec=Nutrients)
+    animal_4.nutrients = MagicMock(auto_spec=Nutrients)
+    mocker.patch.object(animal_3.nutrients, "set_dry_matter_intake")
+    mocker.patch.object(animal_3.nutrients, "set_phosphorus_intake")
+    mocker.patch.object(animal_4.nutrients, "set_dry_matter_intake")
+    mocker.patch.object(animal_4.nutrients, "set_phosphorus_intake")
 
     new_animals = [animal_3, animal_4]
     pen.animals_in_pen = animals_in_pen
     mock_add = mocker.patch.object(pen, "insert_single_animal_into_animals_in_pen_map")
-    mock_supply_2 = MagicMock(spec=NutritionSupply)
+    mock_supply_2 = MagicMock(auto_spec=NutritionSupply)
     mock_set_nutrition_requirements_4 = mocker.patch.object(animal_4, "set_nutrition_requirements")
     mock_set_nutrition_requirements_3 = mocker.patch.object(animal_3, "set_nutrition_requirements")
     mock_calculate = mocker.patch.object(


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #

This PR fixes the missing phosphorus calculation when evaluating the daily manure excretions for animals, by:
- Adding a `_calculate_base_manure()` function in `DigestiveSystem` to calculate the "fecal_phosphorus" and "urine_phosphorus_required".
- Adding a `set_dry_matter_intake()` and a `set_phosphorus_intake()` in `Nutrients` to set the dry matter and phosphorus intake needed for animal daily phosphorus evaluation.
- Update the `_add_new_animals()` and the `set_animal_nutritional_supply()` functions of the `Pen` class to call `Nutrients.set_dry_matter_intake()` and `Nutrients.set_phosphorus_intake()` to update the dry matter and phosphorus intake, whenever we formulate a new ration or an animal is enter a new pen.


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
