### PR TITLE
Fix heifer breeding start

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-89%25-yellowgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3230%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3231%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-89%25-yellowgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3231%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3210%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # Vision
 To support research and sustainable decision-making in ruminant animal production through a state-of-the-art, open-source modeling environment that is continuously adapting as technology and scientific knowledge advance.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-89%25-yellowgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3207%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3208%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 
 # Vision

--- a/RUFAS/biophysical/animal/reproduction/reproduction.py
+++ b/RUFAS/biophysical/animal/reproduction/reproduction.py
@@ -1,4 +1,6 @@
 import math
+import random
+from math import floor
 from typing import Callable, Union, Any, Optional
 
 from scipy.stats import truncnorm
@@ -519,6 +521,45 @@ class Reproduction:
 
         return reproduction_data_stream
 
+    def _simulate_first_estrus(
+        self,
+        reproduction_data_stream: ReproductionDataStream,
+        start_day: int,
+        simulation_day: int,
+        estrus_note: str,
+        avg_estrus_cycle: float,
+        max_cycle_length: float = math.inf,
+    ) -> ReproductionDataStream:
+        """
+        Calculate and set first next estrus day for an heiferII.
+
+        Parameters
+        ----------
+        start_day : int
+            The day to begin the estrus cycle calculation.
+        simulation_day : int
+            The current simulation day.
+        estrus_note : str
+            Note explaining the reason for estrus simulation.
+        avg_estrus_cycle : float
+            Average length of the estrus cycle.
+        max_cycle_length : float, optional
+            Maximum allowable length for the estrus cycle, by default inf.
+
+        Returns
+        -------
+        ReproductionDataStream
+            Updated reproduction datastream after estrus simulation.
+        """
+        estrus_cycle = random.randint(1, floor(avg_estrus_cycle))
+        if abs(estrus_cycle) >= max_cycle_length:
+            estrus_cycle = max_cycle_length - 1
+        self.estrus_day = int(start_day + abs(estrus_cycle))
+        reproduction_data_stream.events.add_event(
+            reproduction_data_stream.days_born, simulation_day, f"{estrus_note} on day {self.estrus_day}"
+        )
+        return reproduction_data_stream
+
     def _simulate_estrus(
         self,
         reproduction_data_stream: ReproductionDataStream,
@@ -576,13 +617,12 @@ class Reproduction:
         else:
             self.reproduction_statistics.ED_days = 0
         if reproduction_data_stream.days_born == AnimalConfig.heifer_breed_start_day:
-            reproduction_data_stream = self._simulate_estrus(
+            reproduction_data_stream = self._simulate_first_estrus(
                 reproduction_data_stream,
                 AnimalConfig.heifer_breed_start_day,
                 simulation_day,
                 animal_constants.ESTRUS_DAY_SCHEDULED_NOTE,
                 AnimalConfig.average_estrus_cycle_heifer,
-                AnimalConfig.std_estrus_cycle_heifer,
             )
         elif reproduction_data_stream.days_born == self.estrus_day:
             reproduction_data_stream = self._handle_generic_estrus_detection(reproduction_data_stream, simulation_day)

--- a/RUFAS/biophysical/animal/reproduction/reproduction.py
+++ b/RUFAS/biophysical/animal/reproduction/reproduction.py
@@ -552,9 +552,9 @@ class Reproduction:
             Updated reproduction datastream after estrus simulation.
         """
         estrus_cycle = random.randint(1, floor(avg_estrus_cycle))
-        if abs(estrus_cycle) >= max_cycle_length:
+        if estrus_cycle >= max_cycle_length:
             estrus_cycle = max_cycle_length - 1
-        self.estrus_day = int(start_day + abs(estrus_cycle))
+        self.estrus_day = start_day + estrus_cycle
         reproduction_data_stream.events.add_event(
             reproduction_data_stream.days_born, simulation_day, f"{estrus_note} on day {self.estrus_day}"
         )

--- a/changelog.md
+++ b/changelog.md
@@ -170,6 +170,7 @@ v0.9.2
 - [2391](https://github.com/RuminantFarmSystems/MASM/pull/2391) - [minor change] [Crop and Soil] Ensures harvesting continues even if the crop is not used for feed.
 - [2390](https://github.com/RuminantFarmSystems/RuFaS/pull/2390) - [minor change] [Animal] Updates unclear and inaccurate heifer repro descriptions and defaults in default metadata properties 
 - [2382](https://github.com/RuminantFarmSystems/RuFaS/pull/2382) - [minor change] [Animal] Fixes the bug in heifer reproduction ED bug when insemination is unsuccessful.
+- [2400](https://github.com/RuminantFarmSystems/RuFaS/pull/2400) - [minor change] [Animal] Fixes the bug in heifer first estrus day calculation.
 
 ### v0.9.2
 

--- a/input/metadata/properties/default.json
+++ b/input/metadata/properties/default.json
@@ -161,7 +161,7 @@
         "description": "General Management",
         "breeding_start_day_h": {
           "type": "number",
-          "description": "Heifer Breeding Start Day (days) -- Days old when RuFaS initiates estrus protocol (first cycle to occur ~21 days later)",
+          "description": "Heifer Breeding Start Day (days) -- Days old when RuFaS initiates estrus detection (first cycle to occur between 1-21 days later)",
           "default": 380,
           "minimum": 0
         },

--- a/tests/test_biophysical/test_animal/reproduction/test_reproduction.py
+++ b/tests/test_biophysical/test_animal/reproduction/test_reproduction.py
@@ -1174,6 +1174,48 @@ def test_set_cow_reproduction_program(
 
 
 @pytest.mark.parametrize(
+    "avg_estrus_cycle, max_cycle_length, estrus_cycle_value, expected_estrus_day",
+    [
+        (21, math.inf, 1, 501),
+        (21, 25, 24, 524),
+        (21, 23, 24, 522),
+    ],
+)
+def test_simulate_first_estrus(
+    avg_estrus_cycle: int,
+    max_cycle_length: float,
+    estrus_cycle_value: int,
+    expected_estrus_day: int,
+    mocker: MockerFixture,
+) -> None:
+    reproduction = Reproduction()
+    reproduction.estrus_day = 0
+
+    mock_outputs = MagicMock(spec=ReproductionOutputs)
+    mock_outputs.days_born = 500
+    mock_outputs.events = MagicMock()
+    mock_outputs.events.add_event = MagicMock()
+
+    mocker.patch("random.randint", return_value=estrus_cycle_value)
+    result = reproduction._simulate_first_estrus(
+        mock_outputs,
+        start_day=500,
+        simulation_day=1000,
+        estrus_note="Estrus simulated",
+        avg_estrus_cycle=avg_estrus_cycle,
+        max_cycle_length=max_cycle_length,
+    )
+
+    assert reproduction.estrus_day == expected_estrus_day
+
+    mock_outputs.events.add_event.assert_called_once_with(
+        mock_outputs.days_born, 1000, f"Estrus simulated on day {expected_estrus_day}"
+    )
+
+    assert result == mock_outputs
+
+
+@pytest.mark.parametrize(
     "avg_estrus_cycle, std_estrus_cycle, max_cycle_length, estrus_cycle_value, expected_estrus_day",
     [
         (21, 3, math.inf, 20, 520),
@@ -1261,7 +1303,7 @@ def test_execute_heifer_ed_protocol(
         animal_type=AnimalType.HEIFER_II, days_in_pregnancy=days_in_pregnancy, days_born=days_born
     )
 
-    mock_simulate_estrus = mocker.patch.object(reproduction, "_simulate_estrus", return_value=mock_outputs)
+    mock_simulate_estrus = mocker.patch.object(reproduction, "_simulate_first_estrus", return_value=mock_outputs)
     mock_handle_generic_estrus = mocker.patch.object(
         reproduction, "_handle_generic_estrus_detection", return_value=mock_outputs
     )


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #1034.

This PR:
- creates a new `_simulate_first_estrus()` function in `reproduction.py` for heiferIIs to determine their first estrus day by randomly drawing an integer from [1, user-defined-average-estrus-cycle] as the estrus cycle length.
- update unit tests


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
