### PR TITLE
[Output Manager] Fixes encoding issue in om

### DIFF
--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -1092,9 +1092,9 @@ class OutputManager(object):
         df = pd.concat([disclaimer_df, df], axis=1)
 
         if direction == "portrait" or direction is None:
-            df.to_csv(path, index=False)
+            df.to_csv(path, index=False, encoding="utf-8")
         elif direction == "landscape":
-            df.T.to_csv(path)
+            df.T.to_csv(path, encoding="utf-8")
         else:
             self.add_error(
                 "Unknown Direction for CSV Output",
@@ -1102,7 +1102,7 @@ class OutputManager(object):
                 f"Saving the output in portrait direction as default.",
                 info_map,
             )
-            df.to_csv(path, index=False)
+            df.to_csv(path, index=False, encoding="utf-8")
 
         self.add_log("save_dict_file_try", f"Successfully saved to {path}.", info_map)
 

--- a/changelog.md
+++ b/changelog.md
@@ -174,7 +174,7 @@ v0.9.2
 - [2399](https://github.com/RuminantFarmSystems/RuFaS/pull/2399) - [minor change] [Crop and Soil] Change infiltration value in ManureApplication to default of 0.4.
 - [2400](https://github.com/RuminantFarmSystems/RuFaS/pull/2400) - [minor change] [Animal] Fixes the bug in heifer first estrus day calculation.
 - [2409](https://github.com/RuminantFarmSystems/RuFaS/pull/2409) - [minor change] [Animal] Adds back code we did not want removed in #2404 and implements original fix in #2404 - fixes incorrect attribute reference in heifer enteric methane calculation and updates references to MilkProduction class attributes.
-
+- [2414](https://github.com/RuminantFarmSystems/RuFaS/pull/2414) - [minor change] [Animal] Uses utf-8 encoding for saving CSVs from OutputManager.
 
 ### v0.9.2
 


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Quick fix to the encoding when saving CSVs from OM

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #N/A

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Adds utf-8 encoding for saving CSVs.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
 To avoid issues with special characters (most notably the degree symbol on Windows machines).

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Updated all csv save functions within `OM._dict_to_file_csv()` to use utf-8 encoding.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
One place to check for sure is to have a filter that collects a variable using the degree C unit:
Try a filter to capture: ManureHandlerDailyOutput_Pen_0_CALF.barn_temperature (°C)

e.g. a json filter with this pattern
`.\*ManureHandlerDailyOutput_Pen_0_CALF.barn_temperature.\*`

In the output csv, the name of the variable should look like:
`ManureHandlerDailyOutput_Pen_0_CALF.barn_temperature (°C)`
For Windows users in particular, it should NOT look like this:
`ManureHandlerDailyOutput_Pen_0_CALF.barn_temperature (Â°C)`
or 
`ManureHandlerDailyOutput_Pen_0_CALF.barn_temperature (Ã°C)`

Also tested it with a filter saving all variables (`.*`) to ensure we wouldn't get anything weird with applying the utf-8 encoding with variables that might not be able to be formatted that way and there were no errors/issues.