### PR TITLE
Add "None" as Valid Cow Repro Method in "animal_population_properties"

### DIFF
--- a/RUFAS/biophysical/animal/herd_manager.py
+++ b/RUFAS/biophysical/animal/herd_manager.py
@@ -1494,7 +1494,7 @@ class HerdManager:
             "1": (sum(parity_1_calving_age) / len(parity_1_calving_age)) if len(parity_1_calving_age) > 0 else 0,
             "2": (sum(parity_2_calving_age) / len(parity_2_calving_age)) if len(parity_2_calving_age) > 0 else 0,
             "3": (sum(parity_3_calving_age) / len(parity_3_calving_age)) if len(parity_3_calving_age) > 0 else 0,
-            "4": (sum(parity_4_calving_age) / len(parity_4_calving_age)) if len(parity_3_calving_age) > 0 else 0,
+            "4": (sum(parity_4_calving_age) / len(parity_4_calving_age)) if len(parity_4_calving_age) > 0 else 0,
             "5": (sum(parity_5_calving_age) / len(parity_5_calving_age)) if len(parity_5_calving_age) > 0 else 0,
             "greater_than_3": (
                 (sum(parity_greater_than_3_calving_age) / len(parity_greater_than_3_calving_age))

--- a/changelog.md
+++ b/changelog.md
@@ -174,6 +174,7 @@ v0.9.2
 - [2399](https://github.com/RuminantFarmSystems/RuFaS/pull/2399) - [minor change] [Crop and Soil] Change infiltration value in ManureApplication to default of 0.4.
 - [2400](https://github.com/RuminantFarmSystems/RuFaS/pull/2400) - [minor change] [Animal] Fixes the bug in heifer first estrus day calculation.
 - [2409](https://github.com/RuminantFarmSystems/RuFaS/pull/2409) - [minor change] [Animal] Adds back code we did not want removed in #2404 and implements original fix in #2404 - fixes incorrect attribute reference in heifer enteric methane calculation and updates references to MilkProduction class attributes.
+- [2415](https://github.com/RuminantFarmSystems/RuFaS/pull/2415) - [minor change] [Animal] Add "None" as valid cow repro sub methods.
 
 
 ### v0.9.2

--- a/input/metadata/properties/default.json
+++ b/input/metadata/properties/default.json
@@ -1318,17 +1318,17 @@
         "cow_presynch_program": {
           "type": "string",
           "description": "Cow PreSynch Protocol.",
-          "pattern": "^(PreSynch|Double OvSynch|G6G)$"
+          "pattern": "^(PreSynch|Double OvSynch|G6G|None)$"
         },
         "cow_ovsynch_program": {
           "type": "string",
           "description": "Reproduction Program",
-          "pattern": "^(OvSynch 56|OvSynch 48|CoSynch 72|5d CoSynch)$"
+          "pattern": "^(OvSynch 56|OvSynch 48|CoSynch 72|5d CoSynch|None)$"
         },
         "cow_resynch_program": {
           "type": "string",
           "description": "Cow ReSynch Protocol.",
-          "pattern": "^(TAIafterPD|TAIbeforePD|PGFatPD)$"
+          "pattern": "^(TAIafterPD|TAIbeforePD|PGFatPD|None)$"
         },
         "days_in_milk": {
           "type": "number",


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->

- Fix a typo in HerdManager when calculating calving age by parity, where zero parity 4 cows would lead to the simulation crashing
- Added "None" as an option for "cow_presynch_program", "cow_ovsynch_program", and "cow_resynch_program" for the "animal_population_properties" section of the metadata properties to match the "animal_properties"


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
