### PR TITLE
Fix LacCow reference in ManureManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-88%25-yellowgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3225%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3226%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 
 # Vision

--- a/RUFAS/routines/manure/pen_manure/manure_manager_pen.py
+++ b/RUFAS/routines/manure/pen_manure/manure_manager_pen.py
@@ -2,6 +2,7 @@ from typing import NamedTuple, Set
 
 from RUFAS.data_structures.pen_manure_data import PenManureData
 from RUFAS.enums import AnimalCombination
+from RUFAS.biophysical.animal.data_types.animal_types import AnimalType
 from RUFAS.routines.manure.pen_manure.pen_manure import PenManure
 
 
@@ -129,6 +130,6 @@ class ManureManagerPen:
 
         exposed_manure_surface_area = exposed_manure_surface_area_by_pen_type[self.pen_type]
 
-        if "LacCow" in self.classes_in_pen:
+        if AnimalType.LAC_COW in self.classes_in_pen:
             return exposed_manure_surface_area.has_lac_cows * self.num_stalls
         return exposed_manure_surface_area.no_lac_cows * self.num_stalls


### PR DESCRIPTION
Updated the reference for animal type, 'LacCow' from a hard coded value to fix the incorrect housing methane emission estimation.

<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #

### What
<!-- Add more detail about the changes that are being made in the pull request. -->

The LacCow membership check now uses the correct enum, so the exposed manure surface area for a 1,000-stall lactating cow freestall pen goes from 2,500 → 3,500 (the expected value).

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->

 That surface area feeds directly into our housing methane emissions calc, so those numbers shifted accordingly.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
