### PR TITLE
Update Root Depth for Perennial Crops in Establishment Year

### DIFF
--- a/RUFAS/routines/field/crop/crop.py
+++ b/RUFAS/routines/field/crop/crop.py
@@ -126,7 +126,7 @@ class Crop:
         return self._phosphorus_uptake
 
     def perform_daily_crop_update(
-        self, current_conditions: CurrentDayConditions, field_data: FieldData, soil_data: SoilData
+        self, current_conditions: CurrentDayConditions, field_data: FieldData, soil_data: SoilData, time: RufasTime
     ) -> None:
         """
         Updates the crop for the current day.
@@ -148,7 +148,7 @@ class Crop:
             current_conditions.min_air_temperature,
             current_conditions.max_air_temperature,
         )
-        self._root_development.develop_roots()
+        self._root_development.develop_roots(time)
         self._nitrogen_uptake.uptake(soil_data)
         self._phosphorus_uptake.uptake(soil_data)
         self._growth_constraints.constrain_growth(

--- a/RUFAS/routines/field/crop/root_development.py
+++ b/RUFAS/routines/field/crop/root_development.py
@@ -32,7 +32,7 @@ class RootDevelopment:
     def develop_roots(self, time: RufasTime) -> None:
         """
         Main root development function that updates the root_fraction and root_depth attributes.
-        
+
         Parameters
         ----------
         time : RufasTime

--- a/RUFAS/routines/field/crop/root_development.py
+++ b/RUFAS/routines/field/crop/root_development.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from RUFAS.routines.field.crop.crop_data import CropData
+from RUFAS.rufas_time import RufasTime
 
 """
 This module is based upon the "Root Development" section of the SWAT model (5.2.1.3)
@@ -29,7 +30,7 @@ class RootDevelopment:
         # data reference
         self.data = crop_data or CropData()  # defaults if not given
 
-    def develop_roots(self) -> None:
+    def develop_roots(self, time: RufasTime) -> None:
         """
         Main root development function that updates the root_fraction and root_depth attributes.
 
@@ -42,7 +43,7 @@ class RootDevelopment:
         self.data.root_fraction = self._determine_root_fraction(self.data.heat_fraction)
 
         # update root depth
-        if self.data.is_perennial:
+        if self.data.is_perennial and time.current_calendar_year != self.data.planting_year:
             self.data.root_depth = self.data.max_root_depth  # Note: assumption of SWAT
         else:
             self.data.root_depth = self._determine_root_depth(self.data.max_root_depth, self.data.heat_fraction)

--- a/RUFAS/routines/field/crop/root_development.py
+++ b/RUFAS/routines/field/crop/root_development.py
@@ -27,24 +27,26 @@ class RootDevelopment:
     """
 
     def __init__(self, crop_data: Optional[CropData] = None):
-        # data reference
-        self.data = crop_data or CropData()  # defaults if not given
+        self.data = crop_data or CropData()
 
     def develop_roots(self, time: RufasTime) -> None:
         """
         Main root development function that updates the root_fraction and root_depth attributes.
+        
+        Parameters
+        ----------
+        time : RufasTime
+            The current time in the simulation.
 
         Notes
         -----
         root_depth attributes are updated differently depending upon whether the plant is perennial.
 
         """
-        # update root fraction
         self.data.root_fraction = self._determine_root_fraction(self.data.heat_fraction)
 
-        # update root depth
         if self.data.is_perennial and time.current_calendar_year != self.data.planting_year:
-            self.data.root_depth = self.data.max_root_depth  # Note: assumption of SWAT
+            self.data.root_depth = self.data.max_root_depth
         else:
             self.data.root_depth = self._determine_root_depth(self.data.max_root_depth, self.data.heat_fraction)
 

--- a/RUFAS/routines/field/field/field.py
+++ b/RUFAS/routines/field/field/field.py
@@ -1434,7 +1434,7 @@ class Field:
         self._cycle_water(current_conditions, time)
 
         for crop in self.crops:
-            crop.perform_daily_crop_update(current_conditions, self.field_data, self.soil.data)
+            crop.perform_daily_crop_update(current_conditions, self.field_data, self.soil.data, time)
 
     def _cycle_water(self, current_conditions: CurrentDayConditions, time: RufasTime) -> None:
         """

--- a/changelog.md
+++ b/changelog.md
@@ -175,6 +175,7 @@ v0.9.2
 - [2400](https://github.com/RuminantFarmSystems/RuFaS/pull/2400) - [minor change] [Animal] Fixes the bug in heifer first estrus day calculation.
 - [2409](https://github.com/RuminantFarmSystems/RuFaS/pull/2409) - [minor change] [Animal] Adds back code we did not want removed in #2404 and implements original fix in #2404 - fixes incorrect attribute reference in heifer enteric methane calculation and updates references to MilkProduction class attributes.
 - [2414](https://github.com/RuminantFarmSystems/RuFaS/pull/2414) - [minor change] [Animal] Uses utf-8 encoding for saving CSVs from OutputManager.
+- [2420](https://github.com/RuminantFarmSystems/RuFaS/pull/2420) - [minor change] [Crop and Soil] Update Root Depth for Perennial Crops in Establishment Year.
 
 ### v0.9.2
 

--- a/tests/soil_crop_tests/crop_tests/test_crop.py
+++ b/tests/soil_crop_tests/crop_tests/test_crop.py
@@ -64,9 +64,10 @@ def test_perform_daily_crop_update(
     )
     mock_field_data = mocker.Mock(spec=FieldData)
     mock_soil_data = mocker.Mock(spec=SoilData)
+    mock_time = mocker.Mock(spec=RufasTime)
 
     # Call the method
-    crop.perform_daily_crop_update(mock_conditions, mock_field_data, mock_soil_data)
+    crop.perform_daily_crop_update(mock_conditions, mock_field_data, mock_soil_data, mock_time)
 
     # Assertions
     if should_update:

--- a/tests/soil_crop_tests/crop_tests/test_root_development.py
+++ b/tests/soil_crop_tests/crop_tests/test_root_development.py
@@ -1,9 +1,11 @@
-from unittest.mock import PropertyMock, patch
+from unittest.mock import PropertyMock
 
 import pytest
+from pytest_mock import MockerFixture
 
 from RUFAS.routines.field.crop.crop_data import CropData
 from RUFAS.routines.field.crop.root_development import RootDevelopment
+from RUFAS.rufas_time import RufasTime
 
 from tests.soil_crop_tests.sample_crop_configuration import SAMPLE_CROP_CONFIGURATION
 
@@ -56,34 +58,64 @@ def test_determine_root_depth(maxd: int, heatfrac: float) -> None:
 
 
 @pytest.mark.parametrize(
-    "maxd, expected_root_depth, heatfrac, is_perennial",
+    "maxd, expected_root_depth, heatfrac, is_perennial, is_planting_year",
     [
-        (1, 1.0, 0.5, True),
-        (1, 1.0, 0.3, True),
-        (1, 1.0, 0, True),
-        (1, 1.0, 1, True),
-        (1, 1.0, 1.2, True),
-        (0, 0.0, 0.5, True),
-        (100, 100.0, 0.5, True),
-        (1, 1.0, 0.5, False),
-        (0.75, 0.5625, 0.3, False),
-        (0.0, 0.0, 0, False),
-        (1, 1.0, 1, False),
-        (1, 1.0, 1.2, False),
-        (0, 0.0, 0.5, False),
-        (100, 100.0, 0.5, False),
+        (1, 1.0, 0.5, True, True),
+        (1, 0.75, 0.3, True, True),
+        (1, 0.0, 0, True, True),
+        (1, 1.0, 1, True, True),
+        (1, 1.0, 1.2, True, True),
+        (0, 0.0, 0.5, True, True),
+        (100, 100.0, 0.5, True, True),
+        (1, 1.0, 0.5, False, True),
+        (0.75, 0.5625, 0.3, False, True),
+        (0.0, 0.0, 0, False, True),
+        (1, 1.0, 1, False, True),
+        (1, 1.0, 1.2, False, True),
+        (0, 0.0, 0.5, False, True),
+        (100, 100.0, 0.5, False, True),
+        (1, 1.0, 0.5, True, False),
+        (1, 1.0, 0.3, True, False),
+        (1, 1.0, 0, True, False),
+        (1, 1.0, 1, True, False),
+        (1, 1.0, 1.2, True, False),
+        (0, 0.0, 0.5, True, False),
+        (100, 100.0, 0.5, True, False),
+        (1, 1.0, 0.5, False, False),
+        (0.75, 0.5625, 0.3, False, False),
+        (0.0, 0.0, 0, False, False),
+        (1, 1.0, 1, False, False),
+        (1, 1.0, 1.2, False, False),
+        (0, 0.0, 0.5, False, False),
+        (100, 100.0, 0.5, False, False),
     ],
 )
 def test_develop_roots(
-    mock_crop_data: CropData, maxd: int, expected_root_depth: float, heatfrac: float, is_perennial: bool
+        mock_crop_data: CropData,
+        maxd: int,
+        expected_root_depth: float,
+        heatfrac: float,
+        is_perennial: bool,
+        is_planting_year: bool,
+        mocker: MockerFixture,
 ) -> None:
     """Integration test for main root development function develop_roots()."""
-    with patch.object(CropData, "heat_fraction", new_callable=PropertyMock, return_value=heatfrac):
-        mock_crop_data.max_root_depth = maxd
-        mock_crop_data.is_perennial = is_perennial
-        rd = RootDevelopment(mock_crop_data)
+    mock_crop_data.planting_year = 2018
+    mock_crop_data.max_root_depth = maxd
+    mock_crop_data.is_perennial = is_perennial
+    mocker.patch.object(
+        CropData, "heat_fraction", new_callable=PropertyMock, return_value=heatfrac
+    )
 
-        rd.develop_roots()
+    mocker.patch("RUFAS.rufas_time.RufasTime.__init__", return_value=None)
+    mock_time = RufasTime()
+    current_calendar_year = 2018 if is_planting_year else 2020
+    mocker.patch.object(
+        RufasTime, "current_calendar_year", new_callable=PropertyMock, return_value=current_calendar_year
+    )
+    rd = RootDevelopment(mock_crop_data)
 
-        assert mock_crop_data.root_fraction == RootDevelopment._determine_root_fraction(heatfrac)
-        assert mock_crop_data.root_depth == expected_root_depth
+    rd.develop_roots(mock_time)
+
+    assert mock_crop_data.root_fraction == RootDevelopment._determine_root_fraction(heatfrac)
+    assert mock_crop_data.root_depth == expected_root_depth

--- a/tests/soil_crop_tests/crop_tests/test_root_development.py
+++ b/tests/soil_crop_tests/crop_tests/test_root_development.py
@@ -91,21 +91,19 @@ def test_determine_root_depth(maxd: int, heatfrac: float) -> None:
     ],
 )
 def test_develop_roots(
-        mock_crop_data: CropData,
-        maxd: int,
-        expected_root_depth: float,
-        heatfrac: float,
-        is_perennial: bool,
-        is_planting_year: bool,
-        mocker: MockerFixture,
+    mock_crop_data: CropData,
+    maxd: int,
+    expected_root_depth: float,
+    heatfrac: float,
+    is_perennial: bool,
+    is_planting_year: bool,
+    mocker: MockerFixture,
 ) -> None:
     """Integration test for main root development function develop_roots()."""
     mock_crop_data.planting_year = 2018
     mock_crop_data.max_root_depth = maxd
     mock_crop_data.is_perennial = is_perennial
-    mocker.patch.object(
-        CropData, "heat_fraction", new_callable=PropertyMock, return_value=heatfrac
-    )
+    mocker.patch.object(CropData, "heat_fraction", new_callable=PropertyMock, return_value=heatfrac)
 
     mocker.patch("RUFAS.rufas_time.RufasTime.__init__", return_value=None)
     mock_time = RufasTime()


### PR DESCRIPTION
### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2402.

This PR updates the logic of root depth calculation for perennial crops in establishment year:
1. The `root_depth` is set to the `max_root_depth` only if the crop is perennial AND `current_calendar_year != planting_year`.
2. Updates `Field. _execute_daily_processes()` and `Crop. perform_daily_crop_update()` to pass along the `time` object, so that `RootDevelopment. develop_roots()` can reference the `current_calendar_year`.
3. Updates all affected unit tests.


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
