### PR TITLE
Update Canopy Water Handling

### DIFF
--- a/RUFAS/routines/field/crop/crop.py
+++ b/RUFAS/routines/field/crop/crop.py
@@ -191,36 +191,29 @@ class Crop:
             self._data.cumulative_potential_evapotranspiration = 0.0
             self._data.cumulative_water_uptake = 0.0
 
-    def handle_water_in_canopy(self, precipitation_reaching_soil: float) -> tuple[float, float]:
+    def handle_water_in_canopy(self, available_precipitation: float) -> float:
         """
         Handles the water addition to the crop's canopy and calculates excess water.
 
         Parameters
         ----------
-        precipitation_reaching_soil : float
+        available_precipitation : float
             Amount of water available to reach the soil after considering other crops (mm).
 
         Returns
         -------
         tuple
-            A tuple containing:
-                - Amount of precipitation that reaches the soil after this crop (float)
-                - Excess water that could not be stored in the canopy (float)
+            Amount of precipitation that reaches the soil after this crop (mm).
         """
         canopy_water_excess_capacity = self._data.water_canopy_storage_capacity - self._data.canopy_water
 
-        excess_water_in_canopy = min(0.0, canopy_water_excess_capacity)
-        if excess_water_in_canopy != 0.0:
-            self._data.canopy_water = self._data.water_canopy_storage_capacity
-
         water_taken_to_be_stored = max(0.0, canopy_water_excess_capacity)
-        water_taken_to_be_stored = min(precipitation_reaching_soil, water_taken_to_be_stored)
+        water_taken_to_be_stored = min(available_precipitation, water_taken_to_be_stored)
         self._data.canopy_water += water_taken_to_be_stored
 
-        precipitation_reaching_soil -= water_taken_to_be_stored
-        excess_canopy_water = -1 * excess_water_in_canopy
+        precipitation_reaching_soil = available_precipitation - water_taken_to_be_stored
 
-        return precipitation_reaching_soil, excess_canopy_water
+        return precipitation_reaching_soil
 
     def evaporate_from_canopy(self, evapotranspirative_demand: float) -> float:
         """Wrapper for the canopy evaporation routine."""

--- a/RUFAS/routines/field/field/field.py
+++ b/RUFAS/routines/field/field/field.py
@@ -1651,13 +1651,11 @@ class Field:
         canopy of another.
         """
         precipitation_reaching_soil = precipitation_total
-        excess_canopy_water = 0.0
 
         for crop in self.crops:
-            precipitation_reaching_soil, excess_water = crop.handle_water_in_canopy(precipitation_reaching_soil)
-            excess_canopy_water += excess_water
+            precipitation_reaching_soil = crop.handle_water_in_canopy(precipitation_reaching_soil)
 
-        return precipitation_reaching_soil + excess_canopy_water
+        return precipitation_reaching_soil
 
     def _evaporate_from_crop_canopies(self, evapotranspirative_demand: float) -> float:
         """

--- a/changelog.md
+++ b/changelog.md
@@ -175,6 +175,7 @@ v0.9.2
 - [2400](https://github.com/RuminantFarmSystems/RuFaS/pull/2400) - [minor change] [Animal] Fixes the bug in heifer first estrus day calculation.
 - [2409](https://github.com/RuminantFarmSystems/RuFaS/pull/2409) - [minor change] [Animal] Adds back code we did not want removed in #2404 and implements original fix in #2404 - fixes incorrect attribute reference in heifer enteric methane calculation and updates references to MilkProduction class attributes.
 - [2414](https://github.com/RuminantFarmSystems/RuFaS/pull/2414) - [minor change] [Animal] Uses utf-8 encoding for saving CSVs from OutputManager.
+- [2421](https://github.com/RuminantFarmSystems/RuFaS/pull/2421) - [minor change] [Soil and Crop] Update Canopy Water handing.
 
 ### v0.9.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -175,7 +175,7 @@ v0.9.2
 - [2400](https://github.com/RuminantFarmSystems/RuFaS/pull/2400) - [minor change] [Animal] Fixes the bug in heifer first estrus day calculation.
 - [2409](https://github.com/RuminantFarmSystems/RuFaS/pull/2409) - [minor change] [Animal] Adds back code we did not want removed in #2404 and implements original fix in #2404 - fixes incorrect attribute reference in heifer enteric methane calculation and updates references to MilkProduction class attributes.
 - [2414](https://github.com/RuminantFarmSystems/RuFaS/pull/2414) - [minor change] [Animal] Uses utf-8 encoding for saving CSVs from OutputManager.
-- [2421](https://github.com/RuminantFarmSystems/RuFaS/pull/2421) - [minor change] [Soil and Crop] Update Canopy Water handing.
+- [2421](https://github.com/RuminantFarmSystems/RuFaS/pull/2421) - [minor change] [Soil and Crop] Update Canopy Water handling.
 
 ### v0.9.2
 

--- a/tests/soil_crop_tests/crop_tests/test_crop.py
+++ b/tests/soil_crop_tests/crop_tests/test_crop.py
@@ -136,11 +136,11 @@ def test_cycle_water_for_crops(
 
 @pytest.mark.parametrize(
     "water_canopy_storage_capacity, initial_canopy_water, precipitation_reaching_soil,"
-    "expected_precipitation_reaching_soil, expected_excess_canopy_water",
+    "expected_precipitation_reaching_soil",
     [
-        (10.0, 5.0, 8.0, 3.0, 0.0),  # Partial canopy storage, no excess water
-        (10.0, 10.0, 5.0, 5.0, 0.0),  # Full canopy storage, no excess water
-        (10.0, 15.0, 10.0, 10.0, 5.0),  # Canopy overfilled, excess water
+        (10.0, 5.0, 8.0, 3.0),  # Partial canopy storage, no excess water
+        (10.0, 10.0, 5.0, 5.0),  # Full canopy storage, no excess water
+        (10.0, 15.0, 10.0, 10.0),  # Canopy overfilled, excess water
     ],
 )
 def test_handle_water_in_canopy(
@@ -150,7 +150,6 @@ def test_handle_water_in_canopy(
     initial_canopy_water: float,
     precipitation_reaching_soil: float,
     expected_precipitation_reaching_soil: float,
-    expected_excess_canopy_water: float,
 ) -> None:
     """Test handle_water_in_canopy() method in crop.py."""
     crop = Crop(mock_crop_data)
@@ -167,12 +166,11 @@ def test_handle_water_in_canopy(
 
     canopy_water_mock.return_value = initial_canopy_water
 
-    actual_precipitation_reaching_soil, actual_excess_canopy_water = crop.handle_water_in_canopy(
+    actual_precipitation_reaching_soil = crop.handle_water_in_canopy(
         precipitation_reaching_soil
     )
 
     assert actual_precipitation_reaching_soil == expected_precipitation_reaching_soil
-    assert actual_excess_canopy_water == expected_excess_canopy_water
 
     expected_canopy_water = min(
         water_canopy_storage_capacity,

--- a/tests/soil_crop_tests/crop_tests/test_crop.py
+++ b/tests/soil_crop_tests/crop_tests/test_crop.py
@@ -166,9 +166,7 @@ def test_handle_water_in_canopy(
 
     canopy_water_mock.return_value = initial_canopy_water
 
-    actual_precipitation_reaching_soil = crop.handle_water_in_canopy(
-        precipitation_reaching_soil
-    )
+    actual_precipitation_reaching_soil = crop.handle_water_in_canopy(precipitation_reaching_soil)
 
     assert actual_precipitation_reaching_soil == expected_precipitation_reaching_soil
 

--- a/tests/soil_crop_tests/field_tests/test_field.py
+++ b/tests/soil_crop_tests/field_tests/test_field.py
@@ -2725,16 +2725,16 @@ def test_get_manure_water(mocker: MockerFixture, water_amount: float, field_name
     [
         (13, 8, 2, 4, 3, 8, 8),  # Fills both pools with some leftover
         (6, 7, 3, 2, 0, 7, 4),  # Fills one pool, puts some in second, none leftover
-        (14, 5, 7, 1, 12, 5, 5),  # Removes from one pool, fills other, some leftover
-        (3, 6, 8, 9, 8, 6, 6),  # Removes from both pools, lots left over
+        (14, 5, 7, 1, 10, 7, 5),  # Removes from one pool, fills other, some leftover
+        (3, 6, 8, 9, 3, 8, 9),  # Removes from both pools, lots left over
         (
             5,
             10,
             3,
             12,
-            2,
+            0,
             8,
-            10,
+            12,
         ),  # Fills one pool as much as possible, removes excess from
         # another
     ],


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2405.

This PR updates canopy water handling:
1. Updates input variable name for `Crop.handle_water_in_canopy()` from `precipitation_reaching_soil` to `available_precipitation`.
2. Updates the `Crop.handle_water_in_canopy()` logic to:
```python
        canopy_water_excess_capacity = self._data.water_canopy_storage_capacity - self._data.canopy_water

        water_taken_to_be_stored = max(0.0, canopy_water_excess_capacity)
        water_taken_to_be_stored = min(available_precipitation, water_taken_to_be_stored)
        self._data.canopy_water += water_taken_to_be_stored

        precipitation_reaching_soil = available_precipitation - water_taken_to_be_stored

        return precipitation_reaching_soil
```
3. Updates the `Field.handle_water_in_crop_canopies()` method:
```python

        for crop in self.crops:
            precipitation_reaching_soil = crop.handle_water_in_canopy(precipitation_total)

        return precipitation_reaching_soil
```


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
