### PR TITLE
Lactating_faction_update

### DIFF
--- a/RUFAS/biophysical/animal/herd_factory.py
+++ b/RUFAS/biophysical/animal/herd_factory.py
@@ -576,14 +576,14 @@ class HerdFactory:
             }
 
             parity_input_name = "animal.herd_information.parity_fractions." + str(PARITY_KEY[animal_type][0])
-            parity_fraction_to_use = self.im.get_data("animal.herd_information.lactating_fraction")
+            milking_cow_fraction = self.im.get_data("lactation.milking_cow_fraction")
             if not PARITY_KEY[animal_type][1]:
-                parity_fraction_to_use = 1 - parity_fraction_to_use
+                milking_cow_fraction = 1 - milking_cow_fraction
 
             animal_num = int(
                 round(
                     (self.im.get_data(parity_input_name) * self.im.get_data("animal.herd_information.cow_num"))
-                    * parity_fraction_to_use
+                    * milking_cow_fraction
                 )
             )
         else:

--- a/changelog.md
+++ b/changelog.md
@@ -188,6 +188,7 @@ v0.9.2
 - [2438](https://github.com/RuminantFarmSystems/RuFaS/pull/2438) - [minor change] [GitHub Actions] Updates the Sphinx documentation workflow to deploy to GitHub Pages via the gh-pages branch and removes build artifacts from the main branch.
 - [2443](https://github.com/RuminantFarmSystems/RuFaS/pull/2443) - [minor change] [metadata] Moves input/metadata/task_manager_metadata.json to input/task_manager_metadata.json and updates the corresponding entries in the code.
 - [2453](https://github.com/RuminantFarmSystems/RuFaS/pull/2453) - [minor change] [Code Owners] Create CODEOWNERS file.
+- [####](https://github.com/RuminantFarmSystems/RuFaS/pull/####) - [minor change] [Animal] Updated milking fraction value, parity 5 default.
 
 
 ### v0.9.2

--- a/changelog.md
+++ b/changelog.md
@@ -188,7 +188,7 @@ v0.9.2
 - [2438](https://github.com/RuminantFarmSystems/RuFaS/pull/2438) - [minor change] [GitHub Actions] Updates the Sphinx documentation workflow to deploy to GitHub Pages via the gh-pages branch and removes build artifacts from the main branch.
 - [2443](https://github.com/RuminantFarmSystems/RuFaS/pull/2443) - [minor change] [metadata] Moves input/metadata/task_manager_metadata.json to input/task_manager_metadata.json and updates the corresponding entries in the code.
 - [2453](https://github.com/RuminantFarmSystems/RuFaS/pull/2453) - [minor change] [Code Owners] Create CODEOWNERS file.
-- [####](https://github.com/RuminantFarmSystems/RuFaS/pull/####) - [minor change] [Animal] Updated milking fraction value, parity 5 default.
+- [2456](https://github.com/RuminantFarmSystems/RuFaS/pull/2456) - [minor change] [Animal] Updated milking fraction value, parity 5 default.
 
 
 ### v0.9.2

--- a/input/data/animal/default_animal.json
+++ b/input/data/animal/default_animal.json
@@ -8,13 +8,12 @@
     "replace_num": 500,
     "herd_num": 100,
     "breed": "HO",
-	"lactating_fraction": 0.5,
 	"parity_fractions": {
       "1": 0.36,
       "2": 0.262,
       "3": 0.18,
 	  "4": 0.11,
-	  "5": 0.9
+	  "5": 0.09
 	},
     "annual_milk_yield": null
   },

--- a/input/data/animal/refreshed_default_animal.json
+++ b/input/data/animal/refreshed_default_animal.json
@@ -1,20 +1,19 @@
 {
   "herd_information": {
-    "calf_num": 8,
-    "heiferI_num": 44,
-    "heiferII_num": 38,
-    "heiferIII_num_springers": 5,
-    "cow_num": 100,
-    "replace_num": 500,
-    "herd_num": 100,
-    "breed": "HO",
-	"lactating_fraction": 0.5,
+	"calf_num": 8,
+	"heiferI_num": 44,
+	"heiferII_num": 38,
+	"heiferIII_num_springers": 5,
+	"cow_num": 100,
+	"replace_num": 500,
+	"herd_num": 100,
+	"breed": "HO",
 	"parity_fractions": {
 		"1": 0.36,
 		"2": 0.262,
 		"3": 0.18,
 		"4": 0.11,
-		"5": 0.9
+		"5": 0.09
     },
     "annual_milk_yield": null
   },

--- a/input/metadata/properties/default.json
+++ b/input/metadata/properties/default.json
@@ -71,12 +71,6 @@
         "default": 100,
         "minimum": 6
       },
-      "lactating_fraction":{
-          "type": "number",
-          "description": "Fraction of cows that are lactating. Used during herd initialization.",
-          "default": 0.5,
-          "minimum": 0
-        },
         "replace_num": {
         "type": "number",
         "description": "Replacements (head) -- Number of replacement animals available in the replacement market",


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2446 and #2447

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Removes use of `lactating_fraction` in `default_animal.json`/`refreshed_default_animal.json` and instead uses `milking_cow_fraction` value in the lactation inputs. 

Also fixes type in parity 5 fraction value in `default_animal.json`/`refreshed_default_animal.json`: was 0.9, now 0.09.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->


### How
<!-- Give an explanation of how this pull request addresses needed changes. -->


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
No change in unit tests, as the parity distributions still requires more test coverage. Lactation curve tests remain unaffected.

Given these default herd size of 100, the corrected fraction for parity 5- along with the updated/unified milking cow fraction - led to the expected number of animals. Verified using a simple print statement in `herd_factory.py`, after definition of `animal_num`. 