### PR TITLE
Prevent feed inventory tracking error due to small amount of feed request reamaining due to rounding error

### DIFF
--- a/RUFAS/biophysical/feed_storage/feed_manager.py
+++ b/RUFAS/biophysical/feed_storage/feed_manager.py
@@ -625,6 +625,8 @@ class FeedManager:
             for feed in available_feeds:
                 amount_to_deduct = min(amount, feed.dry_matter_mass)
                 amount -= amount_to_deduct
+                if amount < 0.001:
+                    amount = 0
 
                 if isinstance(feed, PurchasedFeed):
                     feed.remove_dry_matter_mass(amount_to_deduct)

--- a/changelog.md
+++ b/changelog.md
@@ -189,14 +189,15 @@ v0.9.2
 - [2438](https://github.com/RuminantFarmSystems/RuFaS/pull/2438) - [minor change] [GitHub Actions] Updates the Sphinx documentation workflow to deploy to GitHub Pages via the gh-pages branch and removes build artifacts from the main branch.
 - [2443](https://github.com/RuminantFarmSystems/RuFaS/pull/2443) - [minor change] [metadata] Moves input/metadata/task_manager_metadata.json to input/task_manager_metadata.json and updates the corresponding entries in the code.
 - [2453](https://github.com/RuminantFarmSystems/RuFaS/pull/2453) - [minor change] [Code Owners] Create CODEOWNERS file.
-- [2454](https://github.com/RuminantFarmSystems/RuFaS/pull/2453) - [minor change] [Code Owners] Add Contributors file.
-- [2455](https://github.com/RuminantFarmSystems/RuFaS/pull/2453) - [minor change] [Code Owners] Update ReadMe file.
+- [2454](https://github.com/RuminantFarmSystems/RuFaS/pull/2454) - [minor change] [Code Owners] Add Contributors file.
+- [2455](https://github.com/RuminantFarmSystems/RuFaS/pull/2455) - [minor change] [Code Owners] Update ReadMe file.
 - [2456](https://github.com/RuminantFarmSystems/RuFaS/pull/2456) - [minor change] [Animal] Updated milking fraction value, parity 5 default.
 - [2458](https://github.com/RuminantFarmSystems/RuFaS/pull/2458) - [minor change] [Animal] Added docstring and equation ID to attempt_optimization.
 - [2459](https://github.com/RuminantFarmSystems/RuFaS/pull/2459) - [minor change] [Readme] Updated links in readme.
 - [2457](https://github.com/RuminantFarmSystems/RuFaS/pull/2457) - [minor change] [Documentation] Added scientific documentation folder with first PDFs.
 - [2426](https://github.com/RuminantFarmSystems/RuFaS/pull/2426) - [minor change] [Animal] Adds a warning when the days_in_preg_when_dry is set to less than or equal to the 3rd preg check day.
 - [2369](https://github.com/RuminantFarmSystems/MASM/pull/2369) - [minor change] [Licensing] Addition of licensing documents to repository.
+- [2462](https://github.com/RuminantFarmSystems/MASM/pull/2462) - [minor change] [Feed] Bug fix to prevent rounding error in feed inventory tracking
 
 ### v0.9.2
 


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Add a chek to zero out amount of remaining feed request if it is less than 1 g

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #
The `deduct_feeds_from_inventory` method in `feed_manager.py` was resulting in errors because the amount of feed requested was not being fully zeroed out.  See the screenshot below: 
![image](https://github.com/user-attachments/assets/96af7e84-b79e-4707-b4e5-314cb8819b60)


### What
<!-- Add more detail about the changes that are being made in the pull request. -->
I added a check to see if the remaining amount is less than 1 g (0.001 kg) and, if so, to set the amount remaining to deduct to exactly zero. 

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
I ran the simulation with the two example farms