### PR TITLE
Delete .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-/RUFAS/biophysical/animal/ @KFosterReed @JoeWaddell @krb78 @YijingGong @jadamchick @allisterakun @matthew7838 @ew3361zh
-/RUFAS/biophysical/feed_storage/ @allisterakun @matthew7838 @ew3361zh
-/RUFAS/biophysical/manure/ @elle-andreen @allisterakun @matthew7838 @ew3361zh
-* @allisterakun @matthew7838 @ew3361zh @KFosterReed @JoeWaddell @krb78 @YijingGong @jadamchick @pooyahekmati


### PR DESCRIPTION
Deleting `CODEOWNERS` as it was making more confusion than adding clarity. We can bring it back in future if needs be.
