### PR TITLE
[Manure] Handler enum bug fix

### DIFF
--- a/RUFAS/biophysical/manure/handler/handler.py
+++ b/RUFAS/biophysical/manure/handler/handler.py
@@ -217,7 +217,7 @@ class Handler(Processor):
            types, this water volume represents water use by handlers in the pen, such as a barn floor flush system.
 
         """
-        if self.handler_type in ["MANUAL_SCRAPER", "ALLEY_SCRAPER", "FLUSH_SYSTEM"]:
+        if self.handler_type in ["ManualScraper", "AlleyScraper", "FlushSystem"]:
             return num_animals * (cleaning_water_use_rate * (1 - cleaning_water_recycle_fraction))
         else:
             if self.use_parlor_flush:

--- a/changelog.md
+++ b/changelog.md
@@ -200,6 +200,7 @@ v0.9.2
 - [2369](https://github.com/RuminantFarmSystems/MASM/pull/2369) - [minor change] [Licensing] Addition of licensing documents to repository.
 - [2462](https://github.com/RuminantFarmSystems/MASM/pull/2462) - [minor change] [Feed] Bug fix to prevent rounding error in feed inventory tracking.
 - [2464](https://github.com/RuminantFarmSystems/MASM/pull/2464) - [minor change] [E2E] Removes temporary Feed/Storage E2E testing setup files and functions.
+- [2474](https://github.com/RuminantFarmSystems/MASM/pull/2474) - [minor change] [Manure] Fixes a bug in manure handlers that interfered with flushing functionality.
 
 ### v0.9.2
 

--- a/tests/test_biophysical/test_manure/test_handler/test_handler.py
+++ b/tests/test_biophysical/test_manure/test_handler/test_handler.py
@@ -16,16 +16,16 @@ from RUFAS.rufas_time import RufasTime
 @pytest.fixture
 def handler() -> Handler:
     """Default handler instance."""
-    return Handler("handler_name", "MANUAL_SCRAPER", 3, 0.8, False)
+    return Handler("handler_name", "ManualScraper", 3, 0.8, False)
 
 
 def test_process_manure_parlor_cleaning(mocker: MockerFixture) -> None:
     """Tests the main process routine of handler related to parlor cleaning."""
-    handler = ParlorCleaningHandler("handler_name", "Parlor_Cleaning", 3, 0.8, False)
+    handler = ParlorCleaningHandler("handler_name", "ParlorCleaning", 3, 0.8, False)
     mock_fresh_water_volume_used_for_milking = mocker.patch.object(
         handler, "determine_fresh_water_volume_used_for_milking", return_value=0.0
     )
-    handler.handler_type = "PARLOR_CLEANING"
+    handler.handler_type = "ParlorCleaning"
     pen = PenManureData(1, 12, AnimalCombination.LAC_COW, "freestall", 15, 13, StreamType.GENERAL)
     handler.manure_stream = ManureStream(
         water=0.0,
@@ -235,7 +235,7 @@ def test_determine_handler_cleaning_water_volume_parlor_use_flush(
     handler: Handler,
 ) -> None:
     """Tests the calculation of cleaning water volume."""
-    handler.handler_type = "PARLOR_CLEANING"
+    handler.handler_type = "ParlorCleaning"
     handler.use_parlor_flush = True
     assert (
         handler.determine_handler_cleaning_water_volume(
@@ -256,7 +256,7 @@ def test_determine_handler_cleaning_water_volume_parlor_no_flush_(
     handler: Handler,
 ) -> None:
     """Tests the calculation of cleaning water volume."""
-    handler.handler_type = "PARLOR_CLEANING"
+    handler.handler_type = "ParlorCleaning"
     handler.use_parlor_flush = False
     assert (
         handler.determine_handler_cleaning_water_volume(

--- a/tests/test_biophysical/test_manure/test_handler/test_parlor_cleaning.py
+++ b/tests/test_biophysical/test_manure/test_handler/test_parlor_cleaning.py
@@ -14,7 +14,7 @@ from RUFAS.rufas_time import RufasTime
 @pytest.fixture
 def handler() -> ParlorCleaningHandler:
     """Default handler instance."""
-    return ParlorCleaningHandler("handler_name", "PARLOR_CLEANING", 3, 0.8, False)
+    return ParlorCleaningHandler("handler_name", "ParlorCleaning", 3, 0.8, False)
 
 
 def test_process_manure(handler: ParlorCleaningHandler, mocker: MockerFixture) -> None:

--- a/tests/test_biophysical/test_manure/test_handler/test_single_stream_handler.py
+++ b/tests/test_biophysical/test_manure/test_handler/test_single_stream_handler.py
@@ -14,7 +14,7 @@ from RUFAS.rufas_time import RufasTime
 @pytest.fixture
 def handler() -> SingleStreamHandler:
     """Default handler instance."""
-    return SingleStreamHandler("handler_name", "MANUAL_SCRAPER", 50.6, 0.8, False)
+    return SingleStreamHandler("handler_name", "ManualScraper", 50.6, 0.8, False)
 
 
 def test_receive_manure(handler: SingleStreamHandler, mocker: MockerFixture) -> None:


### PR DESCRIPTION
### Context
Some of the logic in manure handlers is based on what type of handler the handler is, which is defined in the user inputs. The input pattern (how handler type is provided) is based on the syntax defined in the `processor_enum.py` file. There was a small bug in `handler.py` in determination of whether to use a flush that was causing flush system and parlor cleaning handlers to not function correctly due to a mismatch in this file vs. how processor types are defined in the enum file. 

### What
Fixes misalignment of handler_type uses with patterns used in manure processor enums file. Logic referenced incorrect syntax for `handler_type`, leading to flushing never occurring, even when designated by used inputs.

### Why
Aligns with expected functionality of these handler types.

### How
Fixes syntax error in code file and tests.

### Test plan
Run model tests, updated tests passed. Also manually confirmed `total_cleaning_water` outputs were as expected once bug was fixed.