### PR TITLE
[Manure] Fixes NutrientRequestResults Nonetype addition error

### DIFF
--- a/RUFAS/biophysical/manure/manure_manager.py
+++ b/RUFAS/biophysical/manure/manure_manager.py
@@ -946,7 +946,7 @@ class ManureManager:
         removed: dict[str, Any] = {}
 
         original_limiting_nutrients_in_storage = getattr(stored_manure, limiting)
-        if math.isclose(nutrient_removal_proportion, 1.0, abs_tol=1e-3):
+        if math.isclose(nutrient_removal_proportion, 1.0, abs_tol=1e-5):
             limiting_nutrients_to_remove = original_limiting_nutrients_in_storage
         else:
             limiting_nutrients_to_remove = original_limiting_nutrients_in_storage * nutrient_removal_proportion
@@ -960,7 +960,7 @@ class ManureManager:
                 nutrient_removal_proportion, original_amount
             )
             removed[field] = removal_amount
-            updates[field] = round(original_amount - removal_amount, 3)
+            updates[field] = round(original_amount - removal_amount, 5)
 
         new_stream = replace(stored_manure, **updates)
         return new_stream, removed
@@ -986,7 +986,7 @@ class ManureManager:
             The amount of non-limiting nutrients to remove in each storage (kg).
 
         """
-        return round(limiting_nutrient_proportion_to_be_removed * non_limiting_nutrients_amount, 3)
+        return round(limiting_nutrient_proportion_to_be_removed * non_limiting_nutrients_amount, 5)
 
     @staticmethod
     def _determine_limiting_nutrient(
@@ -1047,7 +1047,7 @@ class ManureManager:
             The proportion of limiting nutrient to remove from each storage.
 
         """
-        if math.isclose(limited_nutrient_available, 0.0, abs_tol=1e-6):
+        if math.isclose(limited_nutrient_available, 0.0, abs_tol=1e-5):
             return 0.0
         else:
             return min(limiting_nutrient_requested_mass / limited_nutrient_available, 1)
@@ -1146,8 +1146,8 @@ class ManureManager:
             0, nutrient_request.phosphorus - (on_farm_manure.phosphorus if on_farm_manure else 0)
         )
 
-        if math.isclose(remaining_nitrogen, 0.0, abs_tol=1e-6) and math.isclose(
-            remaining_phosphorus, 0.0, abs_tol=1e-6
+        if math.isclose(remaining_nitrogen, 0.0, abs_tol=1e-5) and math.isclose(
+            remaining_phosphorus, 0.0, abs_tol=1e-5
         ):
             return NutrientRequest(
                 nitrogen=0.0,

--- a/RUFAS/biophysical/manure/manure_manager.py
+++ b/RUFAS/biophysical/manure/manure_manager.py
@@ -851,8 +851,9 @@ class ManureManager:
                 amount_supplemental_manure_needed = self._calculate_supplemental_manure_needed(request_result, request)
                 supplemental_manure = FieldManureSupplier.request_nutrients(amount_supplemental_manure_needed)
                 self._record_manure_request_results(supplemental_manure, "off_farm_manure", time)
-                combined_manure = request_result + supplemental_manure
-                return combined_manure
+                if request_result is None:
+                    return supplemental_manure
+                return request_result + supplemental_manure
             return request_result
         else:
             return FieldManureSupplier.request_nutrients(request)
@@ -945,7 +946,10 @@ class ManureManager:
         removed: dict[str, Any] = {}
 
         original_limiting_nutrients_in_storage = getattr(stored_manure, limiting)
-        limiting_nutrients_to_remove = original_limiting_nutrients_in_storage * nutrient_removal_proportion
+        if math.isclose(nutrient_removal_proportion, 1.0, abs_tol=1e-3):
+            limiting_nutrients_to_remove = original_limiting_nutrients_in_storage
+        else:
+            limiting_nutrients_to_remove = original_limiting_nutrients_in_storage * nutrient_removal_proportion
         removed[limiting] = limiting_nutrients_to_remove
 
         updates: dict[str, float] = {limiting: original_limiting_nutrients_in_storage - limiting_nutrients_to_remove}
@@ -956,7 +960,7 @@ class ManureManager:
                 nutrient_removal_proportion, original_amount
             )
             removed[field] = removal_amount
-            updates[field] = original_amount - removal_amount
+            updates[field] = round(original_amount - removal_amount, 3)
 
         new_stream = replace(stored_manure, **updates)
         return new_stream, removed
@@ -982,7 +986,7 @@ class ManureManager:
             The amount of non-limiting nutrients to remove in each storage (kg).
 
         """
-        return limiting_nutrient_proportion_to_be_removed * non_limiting_nutrients_amount
+        return round(limiting_nutrient_proportion_to_be_removed * non_limiting_nutrients_amount, 3)
 
     @staticmethod
     def _determine_limiting_nutrient(
@@ -1043,7 +1047,10 @@ class ManureManager:
             The proportion of limiting nutrient to remove from each storage.
 
         """
-        return min(limiting_nutrient_requested_mass / limited_nutrient_available, 1)
+        if math.isclose(limited_nutrient_available, 0.0, abs_tol=1e-6):
+            return 0.0
+        else:
+            return min(limiting_nutrient_requested_mass / limited_nutrient_available, 1)
 
     def _record_manure_request_results(
         self, manure_request_results: NutrientRequestResults | None, manure_source: str, time: RufasTime

--- a/RUFAS/biophysical/manure/manure_nutrient_manager.py
+++ b/RUFAS/biophysical/manure/manure_nutrient_manager.py
@@ -129,7 +129,7 @@ class ManureNutrientManager:
             [nitrogen_derived_manure_mass, phosphorus_derived_manure_mass]
         )
         info_map = {"class": self.__class__.__name__, "function": self._evaluate_nutrient_request.__name__}
-        if math.isclose(projected_manure_mass, 0.0, abs_tol=1e-6):
+        if math.isclose(projected_manure_mass, 0.0, abs_tol=1e-5):
             self.om.add_warning(
                 "Unable to fulfill request with on-farm manure", "Projected manure mass is zero kg.", info_map
             )

--- a/RUFAS/biophysical/manure/manure_nutrient_manager.py
+++ b/RUFAS/biophysical/manure/manure_nutrient_manager.py
@@ -61,18 +61,18 @@ class ManureNutrientManager:
 
         category_amount_after_renewal = ManureNutrients(
             manure_type=current_pool_by_category.manure_type,
-            nitrogen=max(0.0, current_pool_by_category.nitrogen - removal_details.get("nitrogen", 0)),
-            phosphorus=max(0.0, current_pool_by_category.phosphorus - removal_details.get("phosphorus", 0)),
-            potassium=max(0.0, current_pool_by_category.potassium - removal_details.get("potassium", 0)),
+            nitrogen=max(0.0, current_pool_by_category.nitrogen - removal_details.get("nitrogen", 0.0)),
+            phosphorus=max(0.0, current_pool_by_category.phosphorus - removal_details.get("phosphorus", 0.0)),
+            potassium=max(0.0, current_pool_by_category.potassium - removal_details.get("potassium", 0.0)),
             total_manure_mass=max(
                 0.0,
                 (
                     current_pool_by_category.total_manure_mass
-                    - removal_details.get("water", 0)
-                    - removal_details.get("total_solids", 0)
+                    - removal_details.get("water", 0.0)
+                    - removal_details.get("total_solids", 0.0)
                 ),
             ),
-            dry_matter=max(0.0, current_pool_by_category.dry_matter - removal_details.get("total_solids", 0)),
+            dry_matter=max(0.0, current_pool_by_category.dry_matter - removal_details.get("total_solids", 0.0)),
         )
 
         self.nutrients_by_manure_category[current_pool_by_category.manure_type] = category_amount_after_renewal

--- a/changelog.md
+++ b/changelog.md
@@ -203,6 +203,7 @@ v0.9.2
 - [2392](https://github.com/RuminantFarmSystems/MASM/pull/2392) - [minor change] [Animal] Tracks rate related to each life stage's deaths.
 - [2473](https://github.com/RuminantFarmSystems/MASM/pull/2473) - [minor change] [E2E] Removes TODOs related to temporary Feed/Storage E2E testing setup files and functions.
 - [2474](https://github.com/RuminantFarmSystems/MASM/pull/2474) - [minor change] [Manure] Fixes a bug in manure handlers that interfered with flushing functionality.
+- [2491](https://github.com/RuminantFarmSystems/MASM/pull/2491) - [minor change] [Manure] Fixes a bug in manure request management when trying to supplement a request from a farm that has no on-farm manure.
 
 ### v0.9.2
 

--- a/tests/test_biophysical/test_manure/test_manure_manager/test_manure_manager.py
+++ b/tests/test_biophysical/test_manure/test_manure_manager/test_manure_manager.py
@@ -7,13 +7,16 @@ from pytest_mock import MockerFixture, MockFixture
 
 from RUFAS.biophysical.manure.digester.digester import Digester
 from RUFAS.biophysical.manure.field_manure_supplier import FieldManureSupplier
-from RUFAS.biophysical.manure.manure_manager import ManureManager
+from RUFAS.biophysical.manure.manure_manager import STORAGE_CLASS_TO_TYPE, ManureManager
 from RUFAS.biophysical.manure.manure_nutrient_manager import ManureNutrientManager
 from RUFAS.biophysical.manure.processor import Processor
 from RUFAS.biophysical.manure.separator.separator import Separator
 from RUFAS.biophysical.manure.storage.composting import Composting
+from RUFAS.biophysical.manure.storage.storage import Storage
+from RUFAS.biophysical.manure.storage.storage_cover import StorageCover
 from RUFAS.current_day_conditions import CurrentDayConditions
 from RUFAS.data_structures.animal_to_manure_connection import ManureStream
+from RUFAS.data_structures.manure_nutrients import ManureNutrients
 from RUFAS.data_structures.manure_to_crop_soil_connection import NutrientRequestResults, NutrientRequest
 from RUFAS.data_structures.manure_types import ManureType
 from RUFAS.input_manager import InputManager
@@ -795,6 +798,51 @@ def test_run_daily_update_missing_first_processor_raises_keyerror(
     mock_om.add_error.assert_called_once()
 
 
+@pytest.fixture
+def storage(mocker: MockerFixture) -> Storage:
+    """Storage fixture for testing."""
+    mocker.patch.object(Storage, "__init__", return_value=None)
+    storage = Storage(
+        name="fixture",
+        is_housing_emissions_calculator=False,
+        cover=StorageCover.COVER,
+        storage_time_period=120,
+        surface_area=300.0,
+    )
+    storage.name = "fixture"
+    storage.is_housing_emissions_calculator = False
+    storage._om = OutputManager()
+    storage._cover = StorageCover.COVER
+    storage._storage_time_period = 120
+    storage._surface_area = 300.0
+    storage._received_manure = ManureStream.make_empty_manure_stream()
+    storage.stored_manure = ManureStream.make_empty_manure_stream()
+    storage._prefix = "Storage.fixture"
+    return storage
+
+
+def test_build_nutrient_pools(mocker: MockerFixture, storage: Storage, manure_manager: ManureManager) -> None:
+    """Test that _build_nutrient_pools() correctly adds nutrients to the nutrient manager."""
+    mock_storage = storage
+
+    manure_type = ManureType.LIQUID
+    STORAGE_CLASS_TO_TYPE[type(mock_storage)] = manure_type
+
+    mock_manager = manure_manager
+    mock_manager.all_processors = {"storage1": mock_storage}
+
+    mock_nutrient_manager = mocker.Mock()
+    mock_manager._manure_nutrient_manager = mock_nutrient_manager
+
+    mock_manager._build_nutrient_pools()
+
+    mock_nutrient_manager.add_nutrients.assert_called_once()
+    args, _ = mock_nutrient_manager.add_nutrients.call_args
+    passed_nutrients = args[0]
+    assert isinstance(passed_nutrients, ManureNutrients)
+    assert passed_nutrients.manure_type == manure_type
+
+
 def test_normalize_destination_name_separator_input_suffix(manure_manager: ManureManager) -> None:
     """Test that '_input' suffix is removed if base name is a known separator."""
     manure_manager._all_separators = {"separator1": MagicMock()}
@@ -848,10 +896,15 @@ def test_generate_origin_key_invalid_logs_and_raises(manure_manager: ManureManag
 
 @pytest.mark.parametrize("animals_simulated", [True, False])
 @pytest.mark.parametrize("use_supplemental_manure", [True, False])
-def test_request_nutrients(mocker: MockerFixture, animals_simulated: bool, use_supplemental_manure: bool) -> None:
-    """
-    Unit test for the updated request_nutrients method of the ManureManager class.
-    """
+@pytest.mark.parametrize("request_result_is_none", [True, False])
+def test_request_nutrients(
+    mocker: MockerFixture,
+    animals_simulated: bool,
+    use_supplemental_manure: bool,
+    request_result_is_none: bool,
+) -> None:
+    """Test request_nutrients for all combinations of simulation, supplemental use, and request fulfillment."""
+
     # Arrange
     mock_time = mocker.MagicMock()
     mock_time.current_julian_day = 150
@@ -861,18 +914,27 @@ def test_request_nutrients(mocker: MockerFixture, animals_simulated: bool, use_s
     manure_manager = ManureManager()
     manure_manager._manure_nutrient_manager = ManureNutrientManager()
     manure_manager._om = OutputManager()
-    result = NutrientRequestResults(nitrogen=10.0, phosphorus=5.0, total_manure_mass=50.0)
-    supplemental_result = NutrientRequestResults(nitrogen=5.0, phosphorus=2.5, total_manure_mass=25.0)
+
     mock_nutrient_request = mocker.MagicMock()
-    mock_request = mocker.patch.object(
-        ManureNutrientManager, "handle_nutrient_request", return_value=(result, not use_supplemental_manure)
+    mock_nutrient_request.use_supplemental_manure = use_supplemental_manure
+    mock_nutrient_request.manure_type = ManureType.LIQUID
+
+    request_result = None if request_result_is_none else NutrientRequestResults(nitrogen=10.0, phosphorus=5.0,
+                                                                                total_manure_mass=50.0)
+    supplemental_result = NutrientRequestResults(nitrogen=5.0, phosphorus=2.5, total_manure_mass=25.0)
+    mocker.patch.object(
+        ManureNutrientManager,
+        "handle_nutrient_request",
+        return_value=(request_result, not use_supplemental_manure)
     )
 
-    mock_record = mocker.patch.object(ManureManager, "_record_manure_request_results")
+    mocker.patch.object(ManureManager, "_record_manure_request_results")
     mock_field_request = mocker.patch.object(FieldManureSupplier, "request_nutrients", return_value=supplemental_result)
     mock_remove = mocker.patch.object(ManureManager, "_remove_nutrients_from_storage")
-    mock_calculate = mocker.patch.object(
-        manure_manager, "_calculate_supplemental_manure_needed", return_value=mocker.MagicMock()
+    mocker.patch.object(
+        manure_manager,
+        "_calculate_supplemental_manure_needed",
+        return_value="calculated_supplemental"
     )
 
     # Act
@@ -880,22 +942,20 @@ def test_request_nutrients(mocker: MockerFixture, animals_simulated: bool, use_s
 
     # Assert
     if animals_simulated:
-        mock_request.assert_called_once()
-        # mock_record.assert_called_once()
-        mock_remove.assert_called_once()
-        if not use_supplemental_manure:
-            assert actual_results == result
+        if request_result_is_none:
+            if use_supplemental_manure:
+                mock_field_request.assert_called_once_with("calculated_supplemental")
+                mock_remove.assert_not_called()
+                assert actual_results == supplemental_result
+            else:
+                assert actual_results is None
         else:
-            mock_add_log.assert_called_once_with(
-                "Supplemental manure needed",
-                "Attempting to fulfill manure nutrient request shortfall with supplemental manure.",
-                {"class": manure_manager.__class__.__name__, "function": manure_manager.request_nutrients.__name__},
-            )
-            mock_calculate.assert_called_once_with(result, mock_nutrient_request)
-            mock_field_request.assert_called_once()
-            mock_record.assert_any_call(supplemental_result, "off_farm_manure", mock_time)
-            combined_result = result + supplemental_result
-            assert actual_results == combined_result
+            mock_remove.assert_called_once()
+            if use_supplemental_manure:
+                mock_add_log.assert_called_once()
+                assert actual_results == request_result + supplemental_result
+            else:
+                assert actual_results == request_result
     else:
         mock_field_request.assert_called_once_with(mock_nutrient_request)
         assert actual_results == supplemental_result
@@ -937,6 +997,7 @@ def test_remove_nutrients_from_storage(
     [
         (100.0, 80.0, True, 50.0, 0.5, 50.0, 40, 50.0, 40.0),
         (120.0, 60.0, False, 24.0, 0.4, 72.0, 36.0, 48.0, 24.0),
+        (50.0, 30.0, True, 50.0, 1.0, 0.0, 0.0, 50.0, 30.0)
     ],
 )
 def test_compute_stream_after_removal_with_real_manure_stream(
@@ -1054,6 +1115,7 @@ def test_determine_limiting_nutrient_with_patched_scaling(
         (20.0, 100.0, 0.2),
         (50.0, 50.0, 1.0),
         (120.0, 80.0, 1.0),
+        (120.0, 0.0000001, 0.0),
     ],
 )
 def test_determine_limiting_nutrient_proportion_to_be_removed(
@@ -1065,7 +1127,7 @@ def test_determine_limiting_nutrient_proportion_to_be_removed(
         limiting_nutrient_requested_mass=requested_mass,
         limited_nutrient_available=available,
     )
-    assert pytest.approx(prop, rel=1e-8) == expected_prop
+    assert pytest.approx(prop, rel=1e-5) == expected_prop
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
If there was no manure remaining on a farm when a manure request is made by a field, the `ManureNutrientManager` returns `None`. If the user has opted to supplement this particular request with external manure, it will try to combine whatever is sent from the farm with the supplemental manure `NutrientRequestResults`. If the farm manure is `None`, this will lead to an error from trying to add `None` to a `NutrientRequestResults` object.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2488

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Prevents the simulation-crashing error of trying to combine a `Nonetype` with a `NutrientRequestResults` object which occurs when there's a manure request made with no remaining farm manure and the user has selected to supplement the manure request with external manure.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
If there is no available farm manure and the user wants to use supplemental manure, it should allow 100% supplemental manure and not crash in trying to combine the `None` value returned from the `ManureNutrientManager` with the supplemental manure `NutrientRequestResults` object.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Added a check that if the `NutrientRequestResults` sent from the farm is `None`, then just return the supplemental manure amount without trying to combine it with the manure from the farm.

Additionally, I added some floating point rounding to ensure we're not getting unexpected results from the nutrient removal process from the on-farm manure stores. I chose to round to 3 decimals but this could certainly be more lenient if desired.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
To see the error occur, comment out these lines in `ManureManager.request_nutrients()` and run a simulation:
```
if request_result is None:
   return supplemental_manure
```
You should get this error:
<img width="1411" height="608" alt="Screenshot 2025-07-18 at 5 07 22 PM" src="https://github.com/user-attachments/assets/0b6ef4bf-8b31-476d-94fe-165b93e3917a" />

Then uncomment those lines and rerun the simulation to see the error is fixed.