### PR TITLE
Ration_boost

### DIFF
--- a/RUFAS/biophysical/animal/pen.py
+++ b/RUFAS/biophysical/animal/pen.py
@@ -930,15 +930,18 @@ class Pen:
         }
         if self.animal_combination == AnimalCombination.LAC_COW:
             self.reset_milk_production_reduction()
-
+        print(self.animal_combination)
         previous_ration = getattr(self, "ration", None)
         num_attempts = 0
         self.set_animal_nutritional_requirements(temperature=temperature, available_feeds=pen_available_feeds)
         initial_dry_matter_requirement = self.average_nutrition_requirements.dry_matter
         initial_protein_requirement = self.average_nutrition_requirements.metabolizable_protein
+        
+        initial_dry_matter_requirement_fixed = initial_dry_matter_requirement
 
         while True:
             num_attempts += 1
+            print(f"num_attempts = {num_attempts}")
             solution, ration_config = self._attempt_formulation(
                 is_ration_defined_by_user, pen_available_feeds, temperature, previous_ration,
                 initial_dry_matter_requirement,
@@ -946,7 +949,7 @@ class Pen:
             )
 
             if not solution.success:
-                self.ration_optimizer.handle_failed_constraints(
+                constraints_failed_list = self.ration_optimizer.handle_failed_constraints(
                     num_attempts=num_attempts,
                     solution=solution,
                     ration_config=ration_config,
@@ -963,8 +966,31 @@ class Pen:
             if solution.success or (self.animal_combination is not AnimalCombination.LAC_COW):
                 break
 
+            # TODO NOTE that below is only happening for lac cows: if this is reasonable, we can try for all classes
+            if is_ration_defined_by_user and (
+                (initial_dry_matter_requirement_fixed * (1 - AnimalModuleConstants.DMI_CONSTRAINT_FRACTION))
+                < initial_dry_matter_requirement < 
+                (initial_dry_matter_requirement_fixed * (1 + AnimalModuleConstants.DMI_CONSTRAINT_FRACTION))):
+                if bool(set(["NE_total_constraint",
+                        "NE_maintenance_and_activity_constraint",
+                       "NE_lactation_constraint",
+                       "NE_growth_constraint"
+                       "calcium_constraint",
+                       "phosphorus_constraint",
+                       "protein_constraint_lower",
+                       "DMI_constraint_lower"]) & set(constraints_failed_list)):
+                    print("Increasing the initial DMI used in the UDR attempt")
+                    initial_dry_matter_requirement = initial_dry_matter_requirement * 1.1
+                    continue
+                elif bool(set(["protein_constraint_upper",
+                       "DMI_constraint_upper"]) & set(constraints_failed_list)):
+                    print("DECREASING the initial DMI used in the UDR attempt")
+                    initial_dry_matter_requirement = initial_dry_matter_requirement * 0.9
+                    continue
+
             # For lac cow
             if is_ration_defined_by_user:
+                print("tried reducing")
                 if self._reduce_on_lactation_failure_user_defined(info_map=info_map):
                     break
             else:

--- a/RUFAS/biophysical/animal/pen.py
+++ b/RUFAS/biophysical/animal/pen.py
@@ -930,18 +930,18 @@ class Pen:
         }
         if self.animal_combination == AnimalCombination.LAC_COW:
             self.reset_milk_production_reduction()
-        print(self.animal_combination)
+        # print(self.animal_combination)
         previous_ration = getattr(self, "ration", None)
         num_attempts = 0
         self.set_animal_nutritional_requirements(temperature=temperature, available_feeds=pen_available_feeds)
         initial_dry_matter_requirement = self.average_nutrition_requirements.dry_matter
         initial_protein_requirement = self.average_nutrition_requirements.metabolizable_protein
-        
+
         initial_dry_matter_requirement_fixed = initial_dry_matter_requirement
 
         while True:
             num_attempts += 1
-            print(f"num_attempts = {num_attempts}")
+            # print(f"num_attempts = {num_attempts}")
             solution, ration_config = self._attempt_formulation(
                 is_ration_defined_by_user, pen_available_feeds, temperature, previous_ration,
                 initial_dry_matter_requirement,
@@ -969,21 +969,21 @@ class Pen:
             # TODO NOTE that below is only happening for lac cows: if this is reasonable, we can try for all classes
             if is_ration_defined_by_user and (
                 (initial_dry_matter_requirement_fixed * (1 - AnimalModuleConstants.DMI_CONSTRAINT_FRACTION))
-                < initial_dry_matter_requirement < 
-                (initial_dry_matter_requirement_fixed * (1 + AnimalModuleConstants.DMI_CONSTRAINT_FRACTION))):
+                < initial_dry_matter_requirement < (
+                    initial_dry_matter_requirement_fixed * (1 + AnimalModuleConstants.DMI_CONSTRAINT_FRACTION))):
                 if bool(set(["NE_total_constraint",
-                        "NE_maintenance_and_activity_constraint",
-                       "NE_lactation_constraint",
-                       "NE_growth_constraint"
-                       "calcium_constraint",
-                       "phosphorus_constraint",
-                       "protein_constraint_lower",
-                       "DMI_constraint_lower"]) & set(constraints_failed_list)):
-                    print("Increasing the initial DMI used in the UDR attempt")
+                             "NE_maintenance_and_activity_constraint",
+                             "NE_lactation_constraint",
+                             "NE_growth_constraint"
+                             "calcium_constraint",
+                             "phosphorus_constraint",
+                             "protein_constraint_lower",
+                             "DMI_constraint_lower"]) & set(constraints_failed_list)):
+                    # print("Increasing the initial DMI used in the UDR attempt")
                     initial_dry_matter_requirement = initial_dry_matter_requirement * 1.1
                     continue
                 elif bool(set(["protein_constraint_upper",
-                       "DMI_constraint_upper"]) & set(constraints_failed_list)):
+                               "DMI_constraint_upper"]) & set(constraints_failed_list)):
                     print("DECREASING the initial DMI used in the UDR attempt")
                     initial_dry_matter_requirement = initial_dry_matter_requirement * 0.9
                     continue

--- a/RUFAS/biophysical/animal/pen.py
+++ b/RUFAS/biophysical/animal/pen.py
@@ -968,9 +968,11 @@ class Pen:
 
             # TODO NOTE that below is only happening for lac cows: if this is reasonable, we can try for all classes
             if is_ration_defined_by_user and (
-                (initial_dry_matter_requirement_fixed * (1 - AnimalModuleConstants.DMI_CONSTRAINT_FRACTION))
-                < initial_dry_matter_requirement < (
-                    initial_dry_matter_requirement_fixed * (1 + AnimalModuleConstants.DMI_CONSTRAINT_FRACTION))):
+                (initial_dry_matter_requirement_fixed * (
+                    1 - AnimalModuleConstants.DMI_CONSTRAINT_FRACTION + UserDefinedRationManager.tolerance))
+                < initial_dry_matter_requirement < 
+                (initial_dry_matter_requirement_fixed * (
+                    1 + AnimalModuleConstants.DMI_CONSTRAINT_FRACTION - UserDefinedRationManager.tolerance))):
                 if bool(set(["NE_total_constraint",
                              "NE_maintenance_and_activity_constraint",
                              "NE_lactation_constraint",

--- a/RUFAS/biophysical/animal/ration/ration_optimizer.py
+++ b/RUFAS/biophysical/animal/ration/ration_optimizer.py
@@ -1072,5 +1072,5 @@ class RationOptimizer:
             fail_summary,
             dict(info_map, **{"units": fail_summary_units}),
         )
-        
+
         return constraints_failed_list

--- a/RUFAS/biophysical/animal/ration/ration_optimizer.py
+++ b/RUFAS/biophysical/animal/ration/ration_optimizer.py
@@ -874,13 +874,13 @@ class RationOptimizer:
                 user_defined_ration_dictionary[key]
                 / 100
                 * (1 - udr_tolerance)
-                * (ration_config.initial_dry_matter_requirement * AnimalModuleConstants.DMI_requirement_boost)
+                * (ration_config.initial_dry_matter_requirement * AnimalModuleConstants.DMI_REQUIREMENT_BOOST)
             )
             target_upper = (
                 user_defined_ration_dictionary[key]
                 / 100
                 * (1 + udr_tolerance)
-                * (ration_config.initial_dry_matter_requirement * AnimalModuleConstants.DMI_requirement_boost)
+                * (ration_config.initial_dry_matter_requirement * AnimalModuleConstants.DMI_REQUIREMENT_BOOST)
             )
             targetbounds = (max(0.0, target_lower), target_upper)
             user_defined_boundlist.append(targetbounds)

--- a/RUFAS/biophysical/animal/ration/ration_optimizer.py
+++ b/RUFAS/biophysical/animal/ration/ration_optimizer.py
@@ -980,7 +980,7 @@ class RationOptimizer:
         initial_dry_matter_requirement: float,
         initial_protein_requirement: float,
         sim_day: int,
-    ) -> None:
+    ) -> list[str]:
         """
         Handle and log failed constraints during the ration optimization process.
 
@@ -1015,7 +1015,8 @@ class RationOptimizer:
 
         Returns:
         --------
-        None
+        list[str]
+            List of which constraints were failed.
         """
         om = OutputManager()
 
@@ -1071,3 +1072,5 @@ class RationOptimizer:
             fail_summary,
             dict(info_map, **{"units": fail_summary_units}),
         )
+        
+        return constraints_failed_list

--- a/input/data/tasks/example_ration_tasks.json
+++ b/input/data/tasks/example_ration_tasks.json
@@ -4,53 +4,53 @@
     {
       "task_type": "SIMULATION_SINGLE_RUN",
       "metadata_file_path": "input/metadata/example_intermountain.json",
-      "output_prefix": "intermountain",
+      "output_prefix": "IM_42",
       "log_verbosity": "errors",
       "random_seed": 42
     },{
       "task_type": "SIMULATION_SINGLE_RUN",
       "metadata_file_path": "input/metadata/example_intermountain_auto.json",
-      "output_prefix": "intermountain_auto",
+      "output_prefix": "IM_A_42",
       "log_verbosity": "errors",
       "random_seed": 42
     },{
       "task_type": "SIMULATION_SINGLE_RUN",
       "metadata_file_path": "input/metadata/example_midwest.json",
-      "output_prefix": "midwest",
+      "output_prefix": "MW_42",
       "log_verbosity": "errors",
       "random_seed": 42
     },
     {
       "task_type": "SIMULATION_SINGLE_RUN",
       "metadata_file_path": "input/metadata/example_midwest_auto.json",
-      "output_prefix": "midwest_auto",
+      "output_prefix": "MW_A_42",
       "log_verbosity": "errors",
       "random_seed": 42
     },{
       "task_type": "SIMULATION_SINGLE_RUN",
       "metadata_file_path": "input/metadata/example_northeast.json",
-      "output_prefix": "northeast",
+      "output_prefix": "NE_42",
       "log_verbosity": "errors",
       "random_seed": 42
     },
     {
       "task_type": "SIMULATION_SINGLE_RUN",
       "metadata_file_path": "input/metadata/example_northeast_auto.json",
-      "output_prefix": "northeast_auto",
+      "output_prefix": "NE_A_42",
       "log_verbosity": "errors",
       "random_seed": 42
     },
     {
       "task_type": "SIMULATION_SINGLE_RUN",
       "metadata_file_path": "input/metadata/example_southwest.json",
-      "output_prefix": "southwest",
+      "output_prefix": "SW_42",
       "log_verbosity": "errors",
       "random_seed": 42
     },
-    {
+    { 
       "task_type": "SIMULATION_SINGLE_RUN",
       "metadata_file_path": "input/metadata/example_southwest_auto.json",
-      "output_prefix": "southwest_auto",
+      "output_prefix": "SW_A_42",
       "log_verbosity": "errors",
       "random_seed": 42
     }

--- a/input/task_manager_metadata.json
+++ b/input/task_manager_metadata.json
@@ -3,7 +3,7 @@
     "tasks": {
       "title": "Task manager data",
       "description": "Configuration file for general simulation parameters.",
-      "path": "input/data/tasks/example_freestall_task.json",
+      "path": "input/data/tasks/example_ration_tasks.json",
       "type": "json",
       "properties": "tasks_properties"
     },

--- a/input/task_manager_metadata.json
+++ b/input/task_manager_metadata.json
@@ -3,7 +3,7 @@
     "tasks": {
       "title": "Task manager data",
       "description": "Configuration file for general simulation parameters.",
-      "path": "input/data/tasks/example_ration_tasks.json",
+      "path": "input/data/tasks/example_freestall_task.json",
       "type": "json",
       "properties": "tasks_properties"
     },


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
First off some kudos: this wound up being more straightforward than expected, mainly because of the tidy code that @matthew7838 wrote! 

This is still a draft, branched off a draft PR, but this PR affects the user defined ration formulation logic.

A problem we regularly run into is that there isn't enough net energy, protein, or dry matter. When using automated methods, this isn't a problem, as there are no "bounds" on inclusion amounts.

However: the user defined method uses a fixed recipe (with some wiggle room, see the tolerance value), which is itself a series of percentages of the _dry matter intake requirement_ as calculated by NRC or NASEM. If those are a little low, there may not be enough net energy (or other requirements). Normally this would result in us dropping milk production, and then as a consequence the requirements are reduced, and we try formulating again. However, this can lead to a downward spiral in which the reduced production and requirements mean we still can't hit their targets, given dry matter predictions. 

In the `dry_matter_intake_limit_fixed` branch (the base for this PR), we have a partial fix for this behavior, but here we go one step further. In this case, we simply boost dry matter intake across the board, by changing the initial dry matter intake requirement estimate/prediction as calculated. Note when reviewing the code: the use of `continue` means that we'll pop back to the start of the while loop, incrementing attempts, but *not* reducing milk production. Once the dry matter intake has been increased to a point where it's likely out of bounds for the upper dry matter intake constraint, we then start reducing milk production as usual.

In some preliminary testing, it seems to be a good solution. Note that this PR I've left in print statements for the moment to diagnose what's going on quickly, and note the differences in the two screenshot snips below:

This branch:
<img width="388" height="404" alt="image" src="https://github.com/user-attachments/assets/8654c567-0b83-49c0-bfae-83e6dd7c0b4e" /> 

This branch with the core logic commented out:
<img width="345" height="529" alt="image" src="https://github.com/user-attachments/assets/b3e00300-fbc4-42a9-a399-571967526509" />

This is just the example freestall diet, so I have yet to test it across the board.


### Why
<!-- Discuss why the changes in this pull request are needed or important. -->


### How
<!-- Give an explanation of how this pull request addresses needed changes. -->


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
This will likely need some clever unit tests to make sure we can trigger both "DMI boosting" and the usual milk production dropping - and also that we can get "DMI reduction" in those edge cases, as well.

Likewise, we need to test it against all example rations, and more if possible!