### PR TITLE
[Main.py] Raises error in main.py to help user debug

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,3 +5,4 @@ statistics = True
 max-line-length = 120
 max-complexity = 10
 ignore = E203, W503
+exclude = .git,__pycache__,.venv,venv,build,dist,.mypy_cache,.pytest_cache

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-96%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-3211%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-96%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3214%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3212%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 ---
 
 # RuFaS: Ruminant Farm Systems

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-96%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3210%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3211%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 ---
 
 # RuFaS: Ruminant Farm Systems

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-96%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3213%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3214%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 ---
 
 # RuFaS: Ruminant Farm Systems

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -1573,13 +1573,16 @@ class OutputManager(object):
             report_file_path = report_dir / self.generate_file_name(f"report_{filter_file}", "csv")
             if report_generator.reports:
                 if has_cross_references and has_data_significant_digits:
+                    significant_digits_limited_reports = ', '.join(f"'{report}'"
+                                                                   for report in limited_significant_digits_reports)
+                    cross_referenced_reports = ', '.join(f"'{report}'" for report in cross_ref_reports)
                     self.add_warning(
                         "Report Generation Warning",
-                        "Reports generated have both cross references and data significant digits. Significant digits "
-                        f"were limited for the following reports: "
-                        f"{', '.join(f'\"{report}\"' for report in limited_significant_digits_reports)}. "
+                        "Reports generated have both cross references and data significant digits. "
+                        "Significant digits were limited for the following reports: "
+                        f"{significant_digits_limited_reports}. "
                         "Results may be affected for the following cross-referenced reports: "
-                        f"{', '.join(f'\"{report}\"' for report in cross_ref_reports)}.",
+                        f"{cross_referenced_reports}.",
                         info_map,
                     )
                 self.create_directory(report_dir)

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -1573,9 +1573,10 @@ class OutputManager(object):
             report_file_path = report_dir / self.generate_file_name(f"report_{filter_file}", "csv")
             if report_generator.reports:
                 if has_cross_references and has_data_significant_digits:
-                    significant_digits_limited_reports = ', '.join(f"'{report}'"
-                                                                   for report in limited_significant_digits_reports)
-                    cross_referenced_reports = ', '.join(f"'{report}'" for report in cross_ref_reports)
+                    significant_digits_limited_reports = ", ".join(
+                        f"'{report}'" for report in limited_significant_digits_reports
+                    )
+                    cross_referenced_reports = ", ".join(f"'{report}'" for report in cross_ref_reports)
                     self.add_warning(
                         "Report Generation Warning",
                         "Reports generated have both cross references and data significant digits. "

--- a/changelog.md
+++ b/changelog.md
@@ -225,6 +225,7 @@ v0.9.2
 - [2521](https://github.com/RuminantFarmSystems/MASM/pull/2521) - [minor change] Separate `UserConstants` from `GeneralConstants`.
 - [2534](https://github.com/RuminantFarmSystems/MASM/pull/2534) - [minor change][docs] Update rufas logo.
 - [2529](https://github.com/RuminantFarmSystems/MASM/pull/2529) - [minor change] E2E Testing for No Animal C&S Run.
+- [2551](https://github.com/RuminantFarmSystems/MASM/pull/2551) - [minor change] Raises error in main.py to direct user to errors file for debugging.
 
 
 ### v0.9.2

--- a/main.py
+++ b/main.py
@@ -55,6 +55,7 @@ def main() -> None:
             "Unexpected early termination of the simulation. Please see logs for details.\n",
             info_map,
         )
+        raise RuntimeError(f"An error occurred during simulation: {e} - check error logs for further details.")
 
 
 class CaseInsensitiveArgumentAction(argparse.Action):

--- a/main.py
+++ b/main.py
@@ -55,8 +55,10 @@ def main() -> None:
             "Unexpected early termination of the simulation. Please see logs for details.\n",
             info_map,
         )
-        raise RuntimeError(f"An error occurred during simulation: {e} - check error logs in"
-                           f" '{cmd_arguments.output_dir}' directory for further details.")
+        raise RuntimeError(
+            f"An error occurred during simulation: {e} - check error logs in"
+            f" '{cmd_arguments.output_dir}' directory for further details."
+        )
 
 
 class CaseInsensitiveArgumentAction(argparse.Action):

--- a/main.py
+++ b/main.py
@@ -55,7 +55,8 @@ def main() -> None:
             "Unexpected early termination of the simulation. Please see logs for details.\n",
             info_map,
         )
-        raise RuntimeError(f"An error occurred during simulation: {e} - check error logs for further details.")
+        raise RuntimeError(f"An error occurred during simulation: {e} - check error logs in"
+                           f" '{cmd_arguments.output_dir}' directory for further details.")
 
 
 class CaseInsensitiveArgumentAction(argparse.Action):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -40,6 +40,54 @@ def test_main_success(mock_task_manager, monkeypatch) -> None:  # type: ignore
     )
 
 
+import sys
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+from main import main  # your main() function
+
+
+def test_main_exception_path(monkeypatch, mocker: MockerFixture) -> None:
+    """
+    Forces an exception in TaskManager.start() to test main exception path.
+    """
+    mock_tm_cls = mocker.patch("main.TaskManager")
+    mock_tm = mock_tm_cls.return_value
+    mock_tm.start.side_effect = Exception("main error")
+    mock_om_cls = mocker.patch("main.OutputManager")
+    mock_om = mock_om_cls.return_value
+
+    mocker.patch("main.traceback.format_exc", return_value="FAKE_TRACEBACK")
+    monkeypatch.setattr(
+        sys, "argv", ["prog", "-l", "err_logs", "-i"]
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        main()
+
+    mock_om_cls.assert_called_once()
+
+    assert mock_om.add_error.call_count == 2
+    first_title, first_message, first_info = mock_om.add_error.call_args_list[0].args
+    assert first_title.startswith("Dumping all logs from main.py because of error 'main error'")
+    assert first_message.startswith("This terminal error occurred during runtime. ")
+    assert "FAKE_TRACEBACK" in first_message
+    assert first_info == {"class": "No caller class", "function": "main"}
+
+    mock_om.create_directory.assert_called_once_with(Path("err_logs"))
+    mock_om.dump_all_nondata_pools.assert_called_once_with(Path("err_logs"), True, "block")
+
+    second_title, second_message, second_info = mock_om.add_error.call_args_list[1].args
+    assert second_title == "Early termination"
+    assert "Unexpected early termination of the simulation." in second_message
+    assert second_info == {"class": "No caller class", "function": "main"}
+
+    assert "main error" in str(excinfo.value)
+    assert "check error logs for further details" in str(excinfo.value)
+
+
 def test_parse_gnu_args(mocker: MockerFixture) -> None:
     """Checks that parse_gnu_args() correctly parses the user's input."""
     # Arrange

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -74,7 +74,7 @@ def test_main_exception_path(monkeypatch, mocker: MockerFixture) -> None:
     assert second_info == {"class": "No caller class", "function": "main"}
 
     assert "main error" in str(excinfo.value)
-    assert "check error logs for further details" in str(excinfo.value)
+    assert "check error logs" in str(excinfo.value)
 
 
 def test_parse_gnu_args(mocker: MockerFixture) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -60,9 +60,7 @@ def test_main_exception_path(monkeypatch, mocker: MockerFixture) -> None:
     mock_om = mock_om_cls.return_value
 
     mocker.patch("main.traceback.format_exc", return_value="FAKE_TRACEBACK")
-    monkeypatch.setattr(
-        sys, "argv", ["prog", "-l", "err_logs", "-i"]
-    )
+    monkeypatch.setattr(sys, "argv", ["prog", "-l", "err_logs", "-i"])
 
     with pytest.raises(RuntimeError) as excinfo:
         main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -40,15 +40,6 @@ def test_main_success(mock_task_manager, monkeypatch) -> None:  # type: ignore
     )
 
 
-import sys
-from pathlib import Path
-
-import pytest
-from pytest_mock import MockerFixture
-
-from main import main  # your main() function
-
-
 def test_main_exception_path(monkeypatch, mocker: MockerFixture) -> None:
     """
     Forces an exception in TaskManager.start() to test main exception path.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,10 +1,9 @@
 import argparse
 import sys
 from pathlib import Path
-from typing import Any, Generator
+from unittest.mock import MagicMock
 
 import pytest
-from mock import patch
 from pytest_mock import MockerFixture
 
 from main import CaseInsensitiveArgumentAction, main, parse_gnu_args
@@ -12,12 +11,11 @@ from RUFAS.output_manager import LogVerbosity
 
 
 @pytest.fixture
-def mock_task_manager() -> Generator[Any, Any, Any]:
-    with patch("main.TaskManager") as mock:
-        yield mock
+def mock_task_manager(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("main.TaskManager", autospec=True)
 
 
-def test_main_success(mock_task_manager, monkeypatch) -> None:  # type: ignore
+def test_main_success(mock_task_manager: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:
     mock_instance = mock_task_manager.return_value
     mock_instance.start.return_value = None
 
@@ -40,7 +38,7 @@ def test_main_success(mock_task_manager, monkeypatch) -> None:  # type: ignore
     )
 
 
-def test_main_exception_path(monkeypatch, mocker: MockerFixture) -> None:
+def test_main_exception_path(monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture) -> None:
     """
     Forces an exception in TaskManager.start() to test main exception path.
     """


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Raises the error if the central except block in main.py is triggered. This points the user to the error logs so they can figure out what happened.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2535

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Raises a runtime error at the end of the central except block in main.py.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
There were some situations where an error occurs before OM is set to the verbosity level the user sets in their task. When the error occurred the exception block was triggered in main.py and errors were logged explaining what happened but there was no message to the user to explain where to look nor any error raised to know something had gone wrong.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Added the error raising line at the end of the except block in main.py.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
There were 2 ways I'd seen this come up - running a simulation using a bad path with the `-p` command line arg to point to a different metadata. This is now caught. 

Try running:
`python main.py -p input/data/animal/animal_population.json -c`

The above would fail silently on dev currently. Now it will raise the error that occurs.

The second way I'd heard this happened was from Kaitlyn who hadn't updated her dependencies after we added the check in TaskManager to ensure users have the proper dependencies installed to be able to run RuFaS. For some reason this was not showing up in her console despite this showing up during testing for me and the other devs. This would almost certainly now be caught as well though - I tested both with and without the raised error and both were caught on my machine.