### PR TITLE
[Testing][E2E Testing] Improve e2e testing console reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-96%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3209%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3172%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-96%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3201%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3203%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-3203%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-96%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-3209%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 ---
 

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import collections
 import json
 import os
 import sys
@@ -206,7 +205,7 @@ class OutputManager(object):
                 },
             )
             self.time = None
-            self._variables_usage_counter: Counter[str] = collections.Counter()
+            self._variables_usage_counter: Counter[str] = Counter()
             self.is_end_to_end_testing_run: bool = False
             self.is_first_post_processing: bool = True
 
@@ -2111,6 +2110,84 @@ class OutputManager(object):
                 f"Finished task: {task_id} with {errors_count} error(s), "
                 f"{warnings_count} warning(s), and {logs_count} log(s).\n"
             )
+
+    def summarize_e2e_test_results(self, json_output_directory: Path, output_prefixes: list[str]) -> None:
+        """
+        Summarizes the end-to-end test results by gathering the results from all the e2e tests and readies them to be
+        printed out to the console.
+        This method is intended to be called at the end of an end-to-end testing run.
+        """
+        info_map = {
+            "class": self.__class__.__name__,
+            "function": self.summarize_e2e_test_results.__name__,
+        }
+        self.add_log("Attempting to open e2e test results directory", "Opening e2e test results directory", info_map)
+        module_header_mapping_dict = {"comparison_animal": "Animal", "comparison_crop_and_soil": "CropAndSoil",
+                                      "comparison_manure": "Manure"}
+        e2e_results_summary: dict[str, dict[str, str]] = {
+            prefix: {header: "n/a" for header in module_header_mapping_dict.values()}
+            for prefix in output_prefixes
+        }
+        e2e_results: list[dict[str, Any]] = []
+        all_results_files = os.listdir(json_output_directory)
+        for filename in all_results_files:
+            if "comparison" not in filename.lower() or not filename.endswith(".json"):
+                continue
+            file_path = json_output_directory / filename
+            try:
+                with open(file_path, "r") as file:
+                    data: dict[str, Any] = json.load(file)
+            except Exception as exc:
+                self.add_error("File path invalid.", f"Failed to read {file_path}: {exc}", info_map)
+                continue
+
+            matched_prefix = next((prefix for prefix in output_prefixes if prefix.lower() in filename.lower()), None)
+            if matched_prefix is None:
+                self.add_error("Invalid e2e output prefix", f"No matching output_prefix found in filename: {filename}",
+                               info_map)
+                continue
+
+            for key, value in data.items():
+                if key == "DISCLAIMER":
+                    continue
+                e2e_results.append({
+                    "prefix": matched_prefix,
+                    "module": self._normalize_module_header(key),
+                    "result": value["values"][0]
+                })
+
+        for result in e2e_results:
+            prefix = result["prefix"]
+            module = result["module"]
+            e2e_results_summary[prefix][module] = result["result"]
+
+        self._print_e2e_results_summary(e2e_results_summary)
+
+    def _print_e2e_results_summary(self, e2e_results_summary):
+        """
+        Prints the end-to-end results summary to the console.
+        """
+        sys.stdout.write("Summary of e2e results:\n\n")
+        for prefix, results in e2e_results_summary.items():
+            sys.stdout.write(f"{prefix} results:\n")
+            for module, result in results.items():
+                result = "Passing" if result is True else "Failing" if result is False else result
+                sys.stdout.write(f"  {module}: {result}\n")
+            sys.stdout.write("\n")
+
+    @staticmethod
+    def _normalize_module_header(json_key: str) -> str:
+        """
+        Normalizes the module header from a JSON key.
+        """
+        module = json_key.split(".", 1)[0].lower()
+        if module == "animal":
+            return "Animal"
+        if module in {"cropandsoil", "crop_and_soil", "cropsoil", "cropsandsoil"}:
+            return "CropAndSoil"
+        if module == "manure":
+            return "Manure"
+        return json_key.split(".", 1)[0]
 
     def set_exclude_info_maps_flag(self, exclude_info_maps: bool) -> None:
         """

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -2129,7 +2129,8 @@ class OutputManager(object):
             "class": self.__class__.__name__,
             "function": self.summarize_e2e_test_results.__name__,
         }
-        self.add_log("Attempting to open e2e test results directory", "Opening e2e test results directory", info_map)
+        self.add_log("Attempting to open e2e test results directory",
+                     "Opening e2e test results directory to read results files", info_map)
         module_headers: list[str] = ["Animal", "CropAndSoil", "Manure"]
         e2e_results_summary: dict[str, dict[str, bool | str]] = {
             prefix: {header: "n/a" for header in module_headers} for prefix in output_prefixes
@@ -2158,6 +2159,9 @@ class OutputManager(object):
                     continue
                 module = self._normalize_module_header(key)
                 e2e_results_summary[matched_prefix][module] = value["values"][0]
+
+        self.add_log("Successfully opened e2e test results directory", "Directory opened and files successfully read",
+                     info_map)
 
         self._print_e2e_results_summary(e2e_results_summary)
 

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -2129,8 +2129,11 @@ class OutputManager(object):
             "class": self.__class__.__name__,
             "function": self.summarize_e2e_test_results.__name__,
         }
-        self.add_log("Attempting to open e2e test results directory",
-                     "Opening e2e test results directory to read results files", info_map)
+        self.add_log(
+            "Attempting to open e2e test results directory",
+            "Opening e2e test results directory to read results files",
+            info_map,
+        )
         module_headers: list[str] = ["Animal", "CropAndSoil", "Manure"]
         e2e_results_summary: dict[str, dict[str, bool | str]] = {
             prefix: {header: "n/a" for header in module_headers} for prefix in output_prefixes
@@ -2160,8 +2163,9 @@ class OutputManager(object):
                 module = self._normalize_module_header(key)
                 e2e_results_summary[matched_prefix][module] = value["values"][0]
 
-        self.add_log("Successfully opened e2e test results directory", "Directory opened and files successfully read",
-                     info_map)
+        self.add_log(
+            "Successfully opened e2e test results directory", "Directory opened and files successfully read", info_map
+        )
 
         self._print_e2e_results_summary(e2e_results_summary)
 

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -2116,19 +2116,24 @@ class OutputManager(object):
         Summarizes the end-to-end test results by gathering the results from all the e2e tests and readies them to be
         printed out to the console.
         This method is intended to be called at the end of an end-to-end testing run.
+
+        Parameters
+        ----------
+        json_output_directory : Path
+            The directory where the JSON output files are located.
+        output_prefixes : list[str]
+            A list of output prefixes to look for in the filenames.
         """
         info_map = {
             "class": self.__class__.__name__,
             "function": self.summarize_e2e_test_results.__name__,
         }
         self.add_log("Attempting to open e2e test results directory", "Opening e2e test results directory", info_map)
-        module_header_mapping_dict = {"comparison_animal": "Animal", "comparison_crop_and_soil": "CropAndSoil",
-                                      "comparison_manure": "Manure"}
+        module_headers: list[str] = ["Animal", "CropAndSoil", "Manure"]
         e2e_results_summary: dict[str, dict[str, str]] = {
-            prefix: {header: "n/a" for header in module_header_mapping_dict.values()}
+            prefix: {header: "n/a" for header in module_headers}
             for prefix in output_prefixes
         }
-        e2e_results: list[dict[str, Any]] = []
         all_results_files = os.listdir(json_output_directory)
         for filename in all_results_files:
             if "comparison" not in filename.lower() or not filename.endswith(".json"):
@@ -2150,16 +2155,8 @@ class OutputManager(object):
             for key, value in data.items():
                 if key == "DISCLAIMER":
                     continue
-                e2e_results.append({
-                    "prefix": matched_prefix,
-                    "module": self._normalize_module_header(key),
-                    "result": value["values"][0]
-                })
-
-        for result in e2e_results:
-            prefix = result["prefix"]
-            module = result["module"]
-            e2e_results_summary[prefix][module] = result["result"]
+                module = self._normalize_module_header(key)
+                e2e_results_summary[matched_prefix][module] = value["values"][0]
 
         self._print_e2e_results_summary(e2e_results_summary)
 

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -2181,7 +2181,7 @@ class OutputManager(object):
         module = json_key.split(".", 1)[0].lower()
         if module == "animal":
             return "Animal"
-        if module in {"cropandsoil", "crop_and_soil", "cropsoil", "cropsandsoil"}:
+        if module == "crop_and_soil":
             return "CropAndSoil"
         if module == "manure":
             return "Manure"

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -2131,7 +2131,7 @@ class OutputManager(object):
         }
         self.add_log("Attempting to open e2e test results directory", "Opening e2e test results directory", info_map)
         module_headers: list[str] = ["Animal", "CropAndSoil", "Manure"]
-        e2e_results_summary: dict[str, dict[str, str]] = {
+        e2e_results_summary: dict[str, dict[str, bool | str]] = {
             prefix: {header: "n/a" for header in module_headers} for prefix in output_prefixes
         }
         all_results_files = os.listdir(json_output_directory)
@@ -2161,7 +2161,7 @@ class OutputManager(object):
 
         self._print_e2e_results_summary(e2e_results_summary)
 
-    def _print_e2e_results_summary(self, e2e_results_summary):
+    def _print_e2e_results_summary(self, e2e_results_summary: dict[str, dict[str, bool | str]]) -> None:
         """
         Prints the end-to-end results summary to the console.
         """

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -2131,8 +2131,7 @@ class OutputManager(object):
         self.add_log("Attempting to open e2e test results directory", "Opening e2e test results directory", info_map)
         module_headers: list[str] = ["Animal", "CropAndSoil", "Manure"]
         e2e_results_summary: dict[str, dict[str, str]] = {
-            prefix: {header: "n/a" for header in module_headers}
-            for prefix in output_prefixes
+            prefix: {header: "n/a" for header in module_headers} for prefix in output_prefixes
         }
         all_results_files = os.listdir(json_output_directory)
         for filename in all_results_files:
@@ -2148,8 +2147,9 @@ class OutputManager(object):
 
             matched_prefix = next((prefix for prefix in output_prefixes if prefix.lower() in filename.lower()), None)
             if matched_prefix is None:
-                self.add_error("Invalid e2e output prefix", f"No matching output_prefix found in filename: {filename}",
-                               info_map)
+                self.add_error(
+                    "Invalid e2e output prefix", f"No matching output_prefix found in filename: {filename}", info_map
+                )
                 continue
 
             for key, value in data.items():

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -9,6 +9,7 @@ from functools import partial
 from pathlib import Path
 from typing import Any, Counter, TextIO, Union, Callable
 
+import collections
 import numpy as np
 import pandas as pd
 import psutil
@@ -205,7 +206,7 @@ class OutputManager(object):
                 },
             )
             self.time = None
-            self._variables_usage_counter: Counter[str] = Counter()
+            self._variables_usage_counter: Counter[str] = collections.Counter()
             self.is_end_to_end_testing_run: bool = False
             self.is_first_post_processing: bool = True
 

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -180,11 +180,16 @@ class TaskManager:
         input_data_csv_import_path: str = task_config.get("input_data_csv_import_path", "")
         is_end_to_end_test_task = (
             True if any(
-                task["task_type"] in [TaskType.END_TO_END_TESTING, TaskType.UPDATE_E2E_TEST_RESULTS]
+                task["task_type"] == TaskType.END_TO_END_TESTING
                 for task in runnable_args) else False
         )
         if is_end_to_end_test_task:
             output_prefixes: list[str] = [runnable_args[i]["output_prefix"] for i in range(len(runnable_args))]
+            self.output_manager.add_log(
+                "Summarizing e2e test results",
+                f"Gathering e2e results for {output_prefixes}...",
+                info_map,
+            )
             json_output_directory = runnable_args[0]["json_output_directory"]
             self.output_manager.summarize_e2e_test_results(json_output_directory, output_prefixes)
 

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -178,10 +178,7 @@ class TaskManager:
         export_input_data_to_csv: bool = task_config.get("export_input_data_to_csv", False)
         input_data_csv_export_path: str = task_config.get("input_data_csv_export_path", "")
         input_data_csv_import_path: str = task_config.get("input_data_csv_import_path", "")
-        is_end_to_end_test_task = any(
-            task.get("task_type") == TaskType.END_TO_END_TESTING
-            for task in runnable_args
-        )
+        is_end_to_end_test_task = any(task.get("task_type") == TaskType.END_TO_END_TESTING for task in runnable_args)
         if is_end_to_end_test_task:
             output_prefixes: list[str] = [runnable_args[i]["output_prefix"] for i in range(len(runnable_args))]
             self.output_manager.add_log(

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -178,6 +178,16 @@ class TaskManager:
         export_input_data_to_csv: bool = task_config.get("export_input_data_to_csv", False)
         input_data_csv_export_path: str = task_config.get("input_data_csv_export_path", "")
         input_data_csv_import_path: str = task_config.get("input_data_csv_import_path", "")
+        is_end_to_end_test_task = (
+            True if any(
+                task["task_type"] in [TaskType.END_TO_END_TESTING, TaskType.UPDATE_E2E_TEST_RESULTS]
+                for task in runnable_args) else False
+        )
+        if is_end_to_end_test_task:
+            output_prefixes: list[str] = [runnable_args[i]["output_prefix"] for i in range(len(runnable_args))]
+            json_output_directory = runnable_args[0]["json_output_directory"]
+            self.output_manager.summarize_e2e_test_results(json_output_directory, output_prefixes)
+
         TaskManager.handle_post_processing(
             args={
                 "exclude_info_maps": exclude_info_maps,

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -178,8 +178,9 @@ class TaskManager:
         export_input_data_to_csv: bool = task_config.get("export_input_data_to_csv", False)
         input_data_csv_export_path: str = task_config.get("input_data_csv_export_path", "")
         input_data_csv_import_path: str = task_config.get("input_data_csv_import_path", "")
-        is_end_to_end_test_task = (
-            True if any(task["task_type"] == TaskType.END_TO_END_TESTING for task in runnable_args) else False
+        is_end_to_end_test_task = any(
+            task.get("task_type") == TaskType.END_TO_END_TESTING
+            for task in runnable_args
         )
         if is_end_to_end_test_task:
             output_prefixes: list[str] = [runnable_args[i]["output_prefix"] for i in range(len(runnable_args))]

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -179,9 +179,7 @@ class TaskManager:
         input_data_csv_export_path: str = task_config.get("input_data_csv_export_path", "")
         input_data_csv_import_path: str = task_config.get("input_data_csv_import_path", "")
         is_end_to_end_test_task = (
-            True if any(
-                task["task_type"] == TaskType.END_TO_END_TESTING
-                for task in runnable_args) else False
+            True if any(task["task_type"] == TaskType.END_TO_END_TESTING for task in runnable_args) else False
         )
         if is_end_to_end_test_task:
             output_prefixes: list[str] = [runnable_args[i]["output_prefix"] for i in range(len(runnable_args))]

--- a/changelog.md
+++ b/changelog.md
@@ -229,7 +229,8 @@ v0.9.2
 - [2552](https://github.com/RuminantFarmSystems/MASM/pull/2552) - [minor change] Reduce example run warning count.
 - [2551](https://github.com/RuminantFarmSystems/MASM/pull/2551) - [minor change] Raises error in main.py to direct user to errors file for debugging.
 - [2547](https://github.com/RuminantFarmSystems/MASM/pull/2547) - [minor change] [Input Manager] 1/5 Cross Validation basic setup.
-- [2550](https://github.com/RuminantFarmSystems/MASM/pull/2550) - [minor change] Create metadata for no animal scenario.
+- [2550](https://github.com/RuminantFarmSystems/MASM/pull/2550) - [minor change] Create metadata for no animal scenario.d
+- [2567](https://github.com/RuminantFarmSystems/MASM/pull/2567) - [minor change] Creates and prints e2e testing results summary for all metadata e2e testing runs.
 
 
 ### v0.9.2

--- a/changelog.md
+++ b/changelog.md
@@ -229,7 +229,7 @@ v0.9.2
 - [2552](https://github.com/RuminantFarmSystems/MASM/pull/2552) - [minor change] Reduce example run warning count.
 - [2551](https://github.com/RuminantFarmSystems/MASM/pull/2551) - [minor change] Raises error in main.py to direct user to errors file for debugging.
 - [2547](https://github.com/RuminantFarmSystems/MASM/pull/2547) - [minor change] [Input Manager] 1/5 Cross Validation basic setup.
-- [2550](https://github.com/RuminantFarmSystems/MASM/pull/2550) - [minor change] Create metadata for no animal scenario.d
+- [2550](https://github.com/RuminantFarmSystems/MASM/pull/2550) - [minor change] Create metadata for no animal scenario.
 - [2567](https://github.com/RuminantFarmSystems/MASM/pull/2567) - [minor change] Creates and prints e2e testing results summary for all metadata e2e testing runs.
 
 

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -3263,7 +3263,7 @@ def test_print_errors_warnings_logs(
         assert captured.out == expected_output
 
 
-def test_summarize_e2e_test_results_happy_path(
+def test_summarize_e2e_test_results_good_path(
     tmp_path: Path, mock_output_manager: OutputManager, mocker: MockerFixture
 ) -> None:
     """Unit test for the summarize_e2e_test_results() method in OutputManager class."""
@@ -3282,11 +3282,14 @@ def test_summarize_e2e_test_results_happy_path(
 
     mock_output_manager.summarize_e2e_test_results(tmp_path, ["E2E_Animal"])
 
-    mock_add_log.assert_called_once_with(
-        "Attempting to open e2e test results directory",
-        "Opening e2e test results directory",
-        ANY,
-    )
+    info_map = {"class": OutputManager.__name__, "function": OutputManager.summarize_e2e_test_results.__name__}
+    expected_add_log_calls = [
+        call("Attempting to open e2e test results directory",
+             "Opening e2e test results directory to read results files", info_map),
+        call("Successfully opened e2e test results directory", "Directory opened and files successfully read",
+             info_map),
+    ]
+    mock_add_log.assert_has_calls(expected_add_log_calls)
 
     mock_add_error.assert_not_called()
 

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -3263,8 +3263,9 @@ def test_print_errors_warnings_logs(
         assert captured.out == expected_output
 
 
-def test_summarize_e2e_test_results_happy_path(tmp_path: Path, mock_output_manager: OutputManager,
-                                               mocker: MockerFixture) -> None:
+def test_summarize_e2e_test_results_happy_path(
+    tmp_path: Path, mock_output_manager: OutputManager, mocker: MockerFixture
+) -> None:
     """Unit test for the summarize_e2e_test_results() method in OutputManager class."""
     mock_print = mocker.patch.object(mock_output_manager, "_print_e2e_results_summary")
 
@@ -3291,19 +3292,16 @@ def test_summarize_e2e_test_results_happy_path(tmp_path: Path, mock_output_manag
 
     mock_print.assert_called_once()
     (summary_arg,) = mock_print.call_args.args
-    assert summary_arg == {
-        "E2E_Animal": {"Animal": True, "CropAndSoil": False, "Manure": "n/a"}
-    }
+    assert summary_arg == {"E2E_Animal": {"Animal": True, "CropAndSoil": False, "Manure": "n/a"}}
 
 
-def test_summarize_e2e_test_results_invalid_prefix_logs_error(tmp_path: Path, mock_output_manager: OutputManager,
-                                                              mocker: MockerFixture) -> None:
+def test_summarize_e2e_test_results_invalid_prefix_logs_error(
+    tmp_path: Path, mock_output_manager: OutputManager, mocker: MockerFixture
+) -> None:
     """Unit test for the summarize_e2e_test_results() method in OutputManager class with no matching prefix."""
     mock_print = mocker.patch.object(mock_output_manager, "_print_e2e_results_summary")
 
-    (tmp_path / "NoMatch_comparison.json").write_text(
-        json.dumps({"Animal.something": {"values": [True]}})
-    )
+    (tmp_path / "NoMatch_comparison.json").write_text(json.dumps({"Animal.something": {"values": [True]}}))
     mock_add_error = mocker.patch.object(mock_output_manager, "add_error")
 
     mock_output_manager.summarize_e2e_test_results(tmp_path, ["E2E_Animal"])
@@ -3316,13 +3314,12 @@ def test_summarize_e2e_test_results_invalid_prefix_logs_error(tmp_path: Path, mo
 
     mock_print.assert_called_once()
     (summary_arg,) = mock_print.call_args.args
-    assert summary_arg == {
-        "E2E_Animal": {"Animal": "n/a", "CropAndSoil": "n/a", "Manure": "n/a"}
-    }
+    assert summary_arg == {"E2E_Animal": {"Animal": "n/a", "CropAndSoil": "n/a", "Manure": "n/a"}}
 
 
-def test_summarize_e2e_test_results_file_read_error(tmp_path: Path, mock_output_manager: OutputManager,
-                                                    mocker: MockerFixture) -> None:
+def test_summarize_e2e_test_results_file_read_error(
+    tmp_path: Path, mock_output_manager: OutputManager, mocker: MockerFixture
+) -> None:
     """Unit test for the summarize_e2e_test_results() method in OutputManager class with a file read error."""
     mock_print = mocker.patch.object(mock_output_manager, "_print_e2e_results_summary")
 
@@ -3340,13 +3337,12 @@ def test_summarize_e2e_test_results_file_read_error(tmp_path: Path, mock_output_
 
     mock_print.assert_called_once()
     (summary_arg,) = mock_print.call_args.args
-    assert summary_arg == {
-        "E2E_Animal": {"Animal": "n/a", "CropAndSoil": "n/a", "Manure": "n/a"}
-    }
+    assert summary_arg == {"E2E_Animal": {"Animal": "n/a", "CropAndSoil": "n/a", "Manure": "n/a"}}
 
 
-def test__print_e2e_results_summary_formats_output(capsys: CaptureFixture[str], mock_output_manager: OutputManager,
-                                                   mocker: MockerFixture) -> None:
+def test__print_e2e_results_summary_formats_output(
+    capsys: CaptureFixture[str], mock_output_manager: OutputManager, mocker: MockerFixture
+) -> None:
     """Unit test for the _print_e2e_results_summary() method in OutputManager class."""
     summary = {
         "E2E_Animal": {

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -3284,10 +3284,14 @@ def test_summarize_e2e_test_results_good_path(
 
     info_map = {"class": OutputManager.__name__, "function": OutputManager.summarize_e2e_test_results.__name__}
     expected_add_log_calls = [
-        call("Attempting to open e2e test results directory",
-             "Opening e2e test results directory to read results files", info_map),
-        call("Successfully opened e2e test results directory", "Directory opened and files successfully read",
-             info_map),
+        call(
+            "Attempting to open e2e test results directory",
+            "Opening e2e test results directory to read results files",
+            info_map,
+        ),
+        call(
+            "Successfully opened e2e test results directory", "Directory opened and files successfully read", info_map
+        ),
     ]
     mock_add_log.assert_has_calls(expected_add_log_calls)
 

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -10,7 +10,7 @@ import pandas as pd
 import psutil
 import pytest
 from freezegun import freeze_time
-from mock import PropertyMock, mock_open, patch
+from mock import ANY, PropertyMock, mock_open, patch
 from mock.mock import MagicMock, call
 from pytest import CaptureFixture, TempPathFactory, raises
 from pytest_mock.plugin import MockerFixture
@@ -3261,6 +3261,129 @@ def test_print_errors_warnings_logs(
         mock_output_manager.print_errors_warnings_logs_counts(task_id)
         captured = capfd.readouterr()
         assert captured.out == expected_output
+
+
+def test_summarize_e2e_test_results_happy_path(tmp_path: Path, mock_output_manager: OutputManager,
+                                               mocker: MockerFixture) -> None:
+    """Unit test for the summarize_e2e_test_results() method in OutputManager class."""
+    mock_print = mocker.patch.object(mock_output_manager, "_print_e2e_results_summary")
+
+    data = {
+        "Animal.something": {"values": [True]},
+        "crop_and_soil.other": {"values": [False]},
+        "DISCLAIMER": "ignored",
+    }
+    (tmp_path / "E2E_Animal_comparison.json").write_text(json.dumps(data))
+    (tmp_path / "E2E_Animal_notes.json").write_text("{}")
+    (tmp_path / "E2E_Animal_comparison.txt").write_text("text")
+    mock_add_log = mocker.patch.object(mock_output_manager, "add_log")
+    mock_add_error = mocker.patch.object(mock_output_manager, "add_error")
+
+    mock_output_manager.summarize_e2e_test_results(tmp_path, ["E2E_Animal"])
+
+    mock_add_log.assert_called_once_with(
+        "Attempting to open e2e test results directory",
+        "Opening e2e test results directory",
+        ANY,
+    )
+
+    mock_add_error.assert_not_called()
+
+    mock_print.assert_called_once()
+    (summary_arg,) = mock_print.call_args.args
+    assert summary_arg == {
+        "E2E_Animal": {"Animal": True, "CropAndSoil": False, "Manure": "n/a"}
+    }
+
+
+def test_summarize_e2e_test_results_invalid_prefix_logs_error(tmp_path: Path, mock_output_manager: OutputManager,
+                                                              mocker: MockerFixture) -> None:
+    """Unit test for the summarize_e2e_test_results() method in OutputManager class with no matching prefix."""
+    mock_print = mocker.patch.object(mock_output_manager, "_print_e2e_results_summary")
+
+    (tmp_path / "NoMatch_comparison.json").write_text(
+        json.dumps({"Animal.something": {"values": [True]}})
+    )
+    mock_add_error = mocker.patch.object(mock_output_manager, "add_error")
+
+    mock_output_manager.summarize_e2e_test_results(tmp_path, ["E2E_Animal"])
+
+    mock_add_error.assert_any_call(
+        "Invalid e2e output prefix",
+        pytest.helpers.contains("NoMatch_comparison.json") if hasattr(pytest, "helpers") else ANY,
+        ANY,
+    )
+
+    mock_print.assert_called_once()
+    (summary_arg,) = mock_print.call_args.args
+    assert summary_arg == {
+        "E2E_Animal": {"Animal": "n/a", "CropAndSoil": "n/a", "Manure": "n/a"}
+    }
+
+
+def test_summarize_e2e_test_results_file_read_error(tmp_path: Path, mock_output_manager: OutputManager,
+                                                    mocker: MockerFixture) -> None:
+    """Unit test for the summarize_e2e_test_results() method in OutputManager class with a file read error."""
+    mock_print = mocker.patch.object(mock_output_manager, "_print_e2e_results_summary")
+
+    bad_path = tmp_path / "E2E_Animal_comparison.json"
+    bad_path.mkdir()
+    mock_add_error = mocker.patch.object(mock_output_manager, "add_error")
+
+    mock_output_manager.summarize_e2e_test_results(tmp_path, ["E2E_Animal"])
+
+    mock_add_error.assert_any_call(
+        "File path invalid.",
+        ANY,
+        ANY,
+    )
+
+    mock_print.assert_called_once()
+    (summary_arg,) = mock_print.call_args.args
+    assert summary_arg == {
+        "E2E_Animal": {"Animal": "n/a", "CropAndSoil": "n/a", "Manure": "n/a"}
+    }
+
+
+def test__print_e2e_results_summary_formats_output(capsys: CaptureFixture[str], mock_output_manager: OutputManager,
+                                                   mocker: MockerFixture) -> None:
+    """Unit test for the _print_e2e_results_summary() method in OutputManager class."""
+    summary = {
+        "E2E_Animal": {
+            "Animal": True,
+            "CropAndSoil": False,
+            "Manure": "n/a",
+        }
+    }
+
+    OutputManager._print_e2e_results_summary(mock_output_manager, summary)
+
+    out = capsys.readouterr().out
+    expected = (
+        "Summary of e2e results:\n\n"
+        "E2E_Animal results:\n"
+        "  Animal: Passing\n"
+        "  CropAndSoil: Failing\n"
+        "  Manure: n/a\n"
+        "\n"
+    )
+    assert out == expected
+
+
+@pytest.mark.parametrize(
+    "key, expected",
+    [
+        ("Animal.foo", "Animal"),
+        ("crop_and_soil.bar", "CropAndSoil"),
+        ("CropSoil.baz", "CropAndSoil"),
+        ("cropsandsoil.qux", "CropAndSoil"),
+        ("manure.moo", "Manure"),
+        ("Other.stuff", "Other"),
+        ("weirdkey", "weirdkey"),
+    ],
+)
+def test__normalize_module_header(key: str, expected: str) -> None:
+    assert OutputManager._normalize_module_header(key) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -3371,8 +3371,6 @@ def test__print_e2e_results_summary_formats_output(
     [
         ("Animal.foo", "Animal"),
         ("crop_and_soil.bar", "CropAndSoil"),
-        ("CropSoil.baz", "CropAndSoil"),
-        ("cropsandsoil.qux", "CropAndSoil"),
         ("manure.moo", "Manure"),
         ("Other.stuff", "Other"),
         ("weirdkey", "weirdkey"),

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -120,7 +120,9 @@ def test_task_manager_start(
 
     if not is_end_to_end_test_task:
         mock_parse_input_tasks = mocker.patch.object(tm, "_parse_input_tasks", return_value=([{}], [{}]))
-        mock_expand_multi_runs_to_single_runs = mocker.patch.object(tm, "_expand_multi_runs_to_single_runs", return_value=[{}])
+        mock_expand_multi_runs_to_single_runs = mocker.patch.object(
+            tm, "_expand_multi_runs_to_single_runs", return_value=[{}]
+        )
     else:
         e2e_task = {
             "task_type": TaskType.END_TO_END_TESTING,
@@ -128,7 +130,9 @@ def test_task_manager_start(
             "json_output_directory": Path("out/e2e"),
         }
         mock_parse_input_tasks = mocker.patch.object(tm, "_parse_input_tasks", return_value=([e2e_task], [{}]))
-        mock_expand_multi_runs_to_single_runs = mocker.patch.object(tm, "_expand_multi_runs_to_single_runs", return_value=[])
+        mock_expand_multi_runs_to_single_runs = mocker.patch.object(
+            tm, "_expand_multi_runs_to_single_runs", return_value=[]
+        )
 
     mock_run_tasks = mocker.patch.object(tm, "_run_tasks")
     mock_summarize = mocker.patch.object(mock_output_manager, "summarize_e2e_test_results")
@@ -384,9 +388,7 @@ def test_handle_post_processing(
     mocker.patch.object(mock_output_manager, "dict_to_file_json", return_value=None)
     if not suppress_logs:
         mock_dump_data_logs.call_count == 1
-        mock_dump_all_nondata_pools.assert_called_with(
-            args["logs_directory"], args["exclude_info_maps"], "verbose"
-        )
+        mock_dump_all_nondata_pools.assert_called_with(args["logs_directory"], args["exclude_info_maps"], "verbose")
     else:
         mock_dump_data_logs.assert_not_called()
         mock_dump_all_nondata_pools.assert_not_called()
@@ -470,8 +472,9 @@ def test_handle_end_to_end_testing(
     assert post_processing.call_count == 1
 
 
-def test_handle_update_e2e_test_results(mock_output_manager: OutputManager, task_manager: TaskManager,
-                                        mocker: MockerFixture) -> None:
+def test_handle_update_e2e_test_results(
+    mock_output_manager: OutputManager, task_manager: TaskManager, mocker: MockerFixture
+) -> None:
     """Test that updating end-to-end expected test results executes correctly."""
 
     # Arrange
@@ -520,8 +523,9 @@ def test_handle_post_processing_load_pool(
     mocker.patch.object(mock_input_manager, "dump_get_data_logs", return_value=None)
     mocker.patch("RUFAS.task_manager.InputManager", return_value=mock_input_manager)
     mock_flush_pools = mocker.patch.object(mock_output_manager, "flush_pools", return_value=None)
-    mock_load_variables_pool_from_file = mocker.patch.object(mock_output_manager, "load_variables_pool_from_file",
-                                                             return_value=None)
+    mock_load_variables_pool_from_file = mocker.patch.object(
+        mock_output_manager, "load_variables_pool_from_file", return_value=None
+    )
     mock_set_metadata_prefix = mocker.patch.object(mock_output_manager, "set_metadata_prefix", return_value=None)
 
     mocker.patch.object(mock_output_manager, "dict_to_file_json", return_value=None)

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -66,18 +66,19 @@ def test_task_manager_init(
 
 @pytest.mark.parametrize(
     "verbosity, exclude_info_maps, clear_output_directory, produce_graphics, suppress_log_files, metadata_depth_limit,"
-    "workers",
+    "workers, is_end_to_end_test_task",
     [
-        (LogVerbosity.LOGS, True, True, True, True, 8, 1),
-        (LogVerbosity.CREDITS, True, True, True, True, 8, 2),
-        (LogVerbosity.ERRORS, True, True, True, True, 8, 3),
-        (LogVerbosity.WARNINGS, True, True, True, True, 8, 4),
-        (LogVerbosity.NONE, True, True, True, True, 8, 5),
-        (LogVerbosity.LOGS, False, True, True, True, 8, 6),
-        (LogVerbosity.CREDITS, False, True, True, True, 8, 7),
-        (LogVerbosity.ERRORS, False, True, True, True, 8, 8),
-        (LogVerbosity.WARNINGS, False, True, True, True, 8, 9),
-        (LogVerbosity.NONE, False, True, True, True, 8, 10),
+        (LogVerbosity.LOGS, True, True, True, True, 8, 1, False),
+        (LogVerbosity.CREDITS, True, True, True, True, 8, 2, False),
+        (LogVerbosity.ERRORS, True, True, True, True, 8, 3, False),
+        (LogVerbosity.WARNINGS, True, True, True, True, 8, 4, False),
+        (LogVerbosity.NONE, True, True, True, True, 8, 5, False),
+        (LogVerbosity.LOGS, False, True, True, True, 8, 6, False),
+        (LogVerbosity.CREDITS, False, True, True, True, 8, 7, False),
+        (LogVerbosity.ERRORS, False, True, True, True, 8, 8, False),
+        (LogVerbosity.WARNINGS, False, True, True, True, 8, 9, False),
+        (LogVerbosity.NONE, False, True, True, True, 8, 10, False),
+        (LogVerbosity.ERRORS, False, True, True, True, 8, 8, True),
     ],
 )
 def test_task_manager_start(
@@ -88,25 +89,19 @@ def test_task_manager_start(
     suppress_log_files: bool,
     metadata_depth_limit: int,
     workers: int,
-    mocker: MockerFixture,
-    mock_output_manager: Generator[Any, Any, Any],
+    mocker,
+    mock_output_manager,
+    is_end_to_end_test_task: bool,
 ) -> None:
-    """Unit test for TaskManager.start()"""
-    # Arrange
-    mock_task_manager = TaskManager()
-    mock_parse_input_tasks = mocker.patch.object(mock_task_manager, "_parse_input_tasks", return_value=([{}], [{}]))
-    mock_expand_multi_runs_to_single_runs = mocker.patch.object(
-        mock_task_manager, "_expand_multi_runs_to_single_runs", return_value=[{}]
-    )
-    mock_run_tasks = mocker.patch.object(mock_task_manager, "_run_tasks")
-    mock_get_rufas_version = mocker.patch.object(mock_task_manager, "get_rufas_version", return_value="1.0.0")
-    mock_check_dependencies = mocker.patch.object(mock_task_manager, "check_dependencies")
-    mock_check_python_version = mocker.patch.object(mock_task_manager, "check_python_version")
-    mock_input_manager = mocker.MagicMock(auto_spec=InputManager)
-    mock_start_data = mocker.patch.object(mock_input_manager, "start_data_processing", return_value=True)
-    mock_print_credits = mocker.patch.object(mock_output_manager, "print_credits")
+    """Unit test for TaskManager.start() with and without the e2e summary branch."""
+    tm = TaskManager()
+    tm.output_manager = mock_output_manager
+
+    mock_im = mocker.MagicMock(auto_spec=InputManager)
+    mocker.patch("RUFAS.task_manager.InputManager", return_value=mock_im)
+    mock_start_data = mocker.patch.object(mock_im, "start_data_processing", return_value=True)
     mock_get_data = mocker.patch.object(
-        mock_input_manager,
+        mock_im,
         "get_data",
         return_value={
             "parallel_workers": workers,
@@ -115,25 +110,41 @@ def test_task_manager_start(
             "export_input_data_to_csv": False,
         },
     )
-    mocker.patch("RUFAS.task_manager.InputManager", return_value=mock_input_manager)
-    mock_run_startup_sequence = mocker.patch.object(mock_output_manager, "run_startup_sequence")
-    mock_add_log = mocker.patch.object(mock_output_manager, "add_log")
-    mock_task_manager.output_manager = mock_output_manager
 
-    # Act
-    mock_task_manager.start(
-        Path("metadata/path"),
-        verbosity,
-        exclude_info_maps,
-        Path("output/directory"),
-        Path("logs/directory"),
-        clear_output_directory,
-        produce_graphics,
-        suppress_log_files,
-        metadata_depth_limit,
+    mock_run_startup_sequence = mocker.patch.object(mock_output_manager, "run_startup_sequence")
+    mock_print_credits = mocker.patch.object(mock_output_manager, "print_credits")
+    mock_add_log = mocker.patch.object(mock_output_manager, "add_log")
+    mocker.patch.object(tm, "get_rufas_version", return_value="1.0.0")
+    mocker.patch.object(tm, "check_dependencies")
+    mocker.patch.object(tm, "check_python_version")
+
+    if not is_end_to_end_test_task:
+        mocker.patch.object(tm, "_parse_input_tasks", return_value=([{}], [{}]))
+        mocker.patch.object(tm, "_expand_multi_runs_to_single_runs", return_value=[{}])
+    else:
+        e2e_task = {
+            "task_type": TaskType.END_TO_END_TESTING,
+            "output_prefix": "test_prefix",
+            "json_output_directory": Path("out/e2e"),
+        }
+        mocker.patch.object(tm, "_parse_input_tasks", return_value=([e2e_task], [{}]))
+        mocker.patch.object(tm, "_expand_multi_runs_to_single_runs", return_value=[])
+
+    mock_run_tasks = mocker.patch.object(tm, "_run_tasks")
+    mock_summarize = mocker.patch.object(mock_output_manager, "summarize_e2e_test_results")
+
+    tm.start(
+        metadata_path=Path("metadata/path"),
+        verbosity=verbosity,
+        exclude_info_maps=exclude_info_maps,
+        output_directory=Path("output/directory"),
+        logs_directory=Path("logs/directory"),
+        clear_output_directory=clear_output_directory,
+        produce_graphics=produce_graphics,
+        suppress_log_files=suppress_log_files,
+        metadata_depth_limit=metadata_depth_limit,
     )
 
-    # Assert
     mock_run_startup_sequence.assert_called_once_with(
         verbosity=verbosity,
         exclude_info_maps=exclude_info_maps,
@@ -149,28 +160,50 @@ def test_task_manager_start(
         is_end_to_end_testing_run=False,
     )
 
-    info_map = {
-        "class": TaskManager.__name__,
-        "function": TaskManager.start.__name__,
-    }
+    info_map = {"class": TaskManager.__name__, "function": TaskManager.start.__name__}
+    expanded_len = 1 if is_end_to_end_test_task else 2
     expected_add_log_calls = [
         call("Task Manager Start", "Task Manager Started.", info_map),
         call("Task Manager workers", f"Task Manager is going to run {workers} in parallel.", info_map),
         call("Task Manager parsed tasks", "Parsed 2 tasks args.", info_map),
-        call("Task Manager expanded tasks", "Expanded task args to 2. Starting the tasks...", info_map),
+        call("Task Manager expanded tasks", f"Expanded task args to {expanded_len}. Starting the tasks...", info_map),
     ]
     mock_add_log.assert_has_calls(expected_add_log_calls)
+
     mock_start_data.assert_called_once_with(Path("metadata/path"))
     mock_get_data.assert_called_once_with("tasks")
-    mock_parse_input_tasks.assert_called_once()
-    mock_expand_multi_runs_to_single_runs.assert_called_once()
-    mock_run_tasks.assert_called_once_with(
-        [{"task_id": "1/2"}, {"task_id": "2/2"}], produce_graphics, metadata_depth_limit, workers, Path("metadata/path")
-    )
-    mock_get_rufas_version.assert_called_once()
-    mock_check_dependencies.assert_called_once()
-    mock_check_python_version.assert_called_once()
+    tm._parse_input_tasks.assert_called_once()
+    tm._expand_multi_runs_to_single_runs.assert_called_once()
+
+    if not is_end_to_end_test_task:
+        mock_run_tasks.assert_called_once_with(
+            [{"task_id": "1/2"}, {"task_id": "2/2"}],
+            produce_graphics,
+            metadata_depth_limit,
+            workers,
+            Path("metadata/path"),
+        )
+        mock_summarize.assert_not_called()
+    else:
+        args, _kwargs = mock_run_tasks.call_args
+        runnable_passed = args[0]
+        assert len(runnable_passed) == 1
+        assert runnable_passed[0]["task_id"] == "1/1"
+        assert args[1] == produce_graphics
+        assert args[2] == metadata_depth_limit
+        assert args[3] == workers
+        assert args[4] == Path("metadata/path")
+
+        mock_output_manager.add_log.assert_any_call(
+            "Summarizing e2e test results",
+            "Gathering e2e results for ['test_prefix']...",
+            info_map,
+        )
+        mock_summarize.assert_called_once_with(Path("out/e2e"), ["test_prefix"])
+
     mock_print_credits.assert_called_once_with("1.0.0")
+    tm.check_dependencies.assert_called_once()
+    tm.check_python_version.assert_called_once()
 
 
 def test_task_manager_start_invalid_data(mocker: MockerFixture, mock_output_manager: Generator[Any, Any, Any]) -> None:

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -58,7 +58,7 @@ def test_invalid_task_type_from_string() -> None:
 
 def test_task_manager_init(
     task_manager: TaskManager,
-    mock_output_manager: Generator[Any, Any, Any],
+    mock_output_manager: OutputManager,
 ) -> None:
     """Unit test for TaskManager.__init__()"""
     assert task_manager.output_manager is mock_output_manager
@@ -89,8 +89,8 @@ def test_task_manager_start(
     suppress_log_files: bool,
     metadata_depth_limit: int,
     workers: int,
-    mocker,
-    mock_output_manager,
+    mocker: MockerFixture,
+    mock_output_manager: OutputManager,
     is_end_to_end_test_task: bool,
 ) -> None:
     """Unit test for TaskManager.start() with and without the e2e summary branch."""
@@ -115,20 +115,20 @@ def test_task_manager_start(
     mock_print_credits = mocker.patch.object(mock_output_manager, "print_credits")
     mock_add_log = mocker.patch.object(mock_output_manager, "add_log")
     mocker.patch.object(tm, "get_rufas_version", return_value="1.0.0")
-    mocker.patch.object(tm, "check_dependencies")
-    mocker.patch.object(tm, "check_python_version")
+    mock_check_dependencies = mocker.patch.object(tm, "check_dependencies")
+    mock_check_python_version = mocker.patch.object(tm, "check_python_version")
 
     if not is_end_to_end_test_task:
-        mocker.patch.object(tm, "_parse_input_tasks", return_value=([{}], [{}]))
-        mocker.patch.object(tm, "_expand_multi_runs_to_single_runs", return_value=[{}])
+        mock_parse_input_tasks = mocker.patch.object(tm, "_parse_input_tasks", return_value=([{}], [{}]))
+        mock_expand_multi_runs_to_single_runs = mocker.patch.object(tm, "_expand_multi_runs_to_single_runs", return_value=[{}])
     else:
         e2e_task = {
             "task_type": TaskType.END_TO_END_TESTING,
             "output_prefix": "test_prefix",
             "json_output_directory": Path("out/e2e"),
         }
-        mocker.patch.object(tm, "_parse_input_tasks", return_value=([e2e_task], [{}]))
-        mocker.patch.object(tm, "_expand_multi_runs_to_single_runs", return_value=[])
+        mock_parse_input_tasks = mocker.patch.object(tm, "_parse_input_tasks", return_value=([e2e_task], [{}]))
+        mock_expand_multi_runs_to_single_runs = mocker.patch.object(tm, "_expand_multi_runs_to_single_runs", return_value=[])
 
     mock_run_tasks = mocker.patch.object(tm, "_run_tasks")
     mock_summarize = mocker.patch.object(mock_output_manager, "summarize_e2e_test_results")
@@ -172,8 +172,8 @@ def test_task_manager_start(
 
     mock_start_data.assert_called_once_with(Path("metadata/path"))
     mock_get_data.assert_called_once_with("tasks")
-    tm._parse_input_tasks.assert_called_once()
-    tm._expand_multi_runs_to_single_runs.assert_called_once()
+    mock_parse_input_tasks.assert_called_once()
+    mock_expand_multi_runs_to_single_runs.assert_called_once()
 
     if not is_end_to_end_test_task:
         mock_run_tasks.assert_called_once_with(
@@ -194,7 +194,7 @@ def test_task_manager_start(
         assert args[3] == workers
         assert args[4] == Path("metadata/path")
 
-        mock_output_manager.add_log.assert_any_call(
+        mock_add_log.assert_any_call(
             "Summarizing e2e test results",
             "Gathering e2e results for ['test_prefix']...",
             info_map,
@@ -202,11 +202,11 @@ def test_task_manager_start(
         mock_summarize.assert_called_once_with(Path("out/e2e"), ["test_prefix"])
 
     mock_print_credits.assert_called_once_with("1.0.0")
-    tm.check_dependencies.assert_called_once()
-    tm.check_python_version.assert_called_once()
+    mock_check_dependencies.assert_called_once()
+    mock_check_python_version.assert_called_once()
 
 
-def test_task_manager_start_invalid_data(mocker: MockerFixture, mock_output_manager: Generator[Any, Any, Any]) -> None:
+def test_task_manager_start_invalid_data(mocker: MockerFixture, mock_output_manager: OutputManager) -> None:
     """Test TaskManager.start() with invalid input data."""
     mock_task_manager = TaskManager()
     mocker.patch.object(mock_task_manager, "check_python_version")
@@ -237,7 +237,7 @@ def test_task_manager_start_invalid_data(mocker: MockerFixture, mock_output_mana
     )
 
 
-def test_set_random_seed(mock_output_manager: Generator[Any, Any, Any], mocker: MockerFixture) -> None:
+def test_set_random_seed(mock_output_manager: OutputManager, mocker: MockerFixture) -> None:
     """Unit test for TaskManager.set_random_seed() with no specified random seed."""
     mock_task_manager = TaskManager()
     mock_add_log = mocker.patch.object(mock_output_manager, "add_log")
@@ -250,7 +250,7 @@ def test_set_random_seed(mock_output_manager: Generator[Any, Any, Any], mocker: 
     )
 
 
-def test_set_random_seed_zero(mock_output_manager: Generator[Any, Any, Any], mocker: MockerFixture) -> None:
+def test_set_random_seed_zero(mock_output_manager: OutputManager, mocker: MockerFixture) -> None:
     """Unit test for TaskManager.set_random_seed() when 0 is passed as random seed."""
     mock_task_manager = TaskManager()
     mock_randint = mocker.patch("RUFAS.task_manager.random.randint", return_value=4321)
@@ -267,7 +267,7 @@ def test_set_random_seed_zero(mock_output_manager: Generator[Any, Any, Any], moc
 
 @pytest.mark.parametrize("seed, expected", [(12345, 12345), (0, 4321)])
 def test_set_random_seed_with_parameters(
-    seed: int, expected: int, mock_output_manager: Generator[Any, Any, Any], mocker: MockerFixture
+    seed: int, expected: int, mock_output_manager: OutputManager, mocker: MockerFixture
 ) -> None:
     """Unit test for TaskManager.set_random_seed() with specified random seed."""
     mock_task_manager = TaskManager()
@@ -351,7 +351,7 @@ def test_expand_multi_runs_to_single_runs(task_manager: TaskManager) -> None:
 @pytest.mark.parametrize("suppress_logs", [True, False])
 def test_handle_post_processing(
     task_manager: TaskManager,
-    mock_output_manager: Generator[Any, Any, Any],
+    mock_output_manager: OutputManager,
     suppress_logs: bool,
     mocker: MockerFixture,
 ) -> None:
@@ -371,6 +371,7 @@ def test_handle_post_processing(
     mock_input_manager = mocker.MagicMock(auto_spec=InputManager)
     mock_flush_pool = mocker.patch.object(mock_input_manager, "flush_pool", return_value=None)
     mock_dump_data_logs = mocker.patch.object(mock_input_manager, "dump_get_data_logs", return_value=None)
+    mock_dump_all_nondata_pools = mocker.patch.object(mock_output_manager, "dump_all_nondata_pools", return_value=None)
     task_manager.handle_post_processing(
         args=args,
         input_manager=mock_input_manager,
@@ -383,19 +384,19 @@ def test_handle_post_processing(
     mocker.patch.object(mock_output_manager, "dict_to_file_json", return_value=None)
     if not suppress_logs:
         mock_dump_data_logs.call_count == 1
-        mock_output_manager.dump_all_nondata_pools.assert_called_with(
+        mock_dump_all_nondata_pools.assert_called_with(
             args["logs_directory"], args["exclude_info_maps"], "verbose"
         )
     else:
         mock_dump_data_logs.assert_not_called()
-        mock_output_manager.dump_all_nondata_pools.assert_not_called()
+        mock_dump_all_nondata_pools.assert_not_called()
 
     mock_flush_pool.assert_called_once()
 
 
 def test_handle_post_processing_export_input_tocsv(
     task_manager: TaskManager,
-    mock_output_manager: Generator[Any, Any, Any],
+    mock_output_manager: OutputManager,
     mocker: MockerFixture,
 ) -> None:
     """Unit test for TaskManager.handle_post_processing() when load_pool_from_file is set to True."""
@@ -403,8 +404,7 @@ def test_handle_post_processing_export_input_tocsv(
     mocker.patch.object(mock_input_manager, "dump_get_data_logs", return_value=None)
     mocker.patch("RUFAS.task_manager.InputManager", return_value=mock_input_manager)
 
-    # mocker.patch.object(mock_output_manager, "dict_to_file_json", return_value=None)
-    mocker.patch.object(Utility, "combine_saved_input_csv", return_value=None)
+    mock_combine_saved_input_csv = mocker.patch.object(Utility, "combine_saved_input_csv", return_value=None)
 
     args = {
         "filters_directory": Path("/fake/filters"),
@@ -429,7 +429,7 @@ def test_handle_post_processing_export_input_tocsv(
         export_input_data_to_csv=True,
     )
 
-    Utility.combine_saved_input_csv.assert_called_once_with(
+    mock_combine_saved_input_csv.assert_called_once_with(
         TaskManager.INPUT_DATA_CSV_WORKING_FOLDER,
         args["input_data_csv_export_path"],
         args["input_data_csv_import_path"],
@@ -437,7 +437,7 @@ def test_handle_post_processing_export_input_tocsv(
 
 
 def test_handle_end_to_end_testing(
-    mock_output_manager: Generator[Any, Any, Any], task_manager: TaskManager, mocker: MockerFixture
+    mock_output_manager: OutputManager, task_manager: TaskManager, mocker: MockerFixture
 ) -> None:
     """Test that end-to-end testing is executed correctly."""
     sim_engine_run_tasks = mocker.patch.object(TaskManager, "_handle_simulation_engine_run_tasks")
@@ -470,7 +470,8 @@ def test_handle_end_to_end_testing(
     assert post_processing.call_count == 1
 
 
-def test_handle_update_e2e_test_results(mock_output_manager, task_manager: TaskManager, mocker) -> None:
+def test_handle_update_e2e_test_results(mock_output_manager: OutputManager, task_manager: TaskManager,
+                                        mocker: MockerFixture) -> None:
     """Test that updating end-to-end expected test results executes correctly."""
 
     # Arrange
@@ -511,13 +512,17 @@ def test_handle_update_e2e_test_results(mock_output_manager, task_manager: TaskM
 
 def test_handle_post_processing_load_pool(
     task_manager: TaskManager,
-    mock_output_manager: Generator[Any, Any, Any],
+    mock_output_manager: OutputManager,
     mocker: MockerFixture,
 ) -> None:
     """Unit test for TaskManager.handle_post_processing() when load_pool_from_file is set to True."""
     mock_input_manager = mocker.MagicMock(auto_spec=InputManager)
     mocker.patch.object(mock_input_manager, "dump_get_data_logs", return_value=None)
     mocker.patch("RUFAS.task_manager.InputManager", return_value=mock_input_manager)
+    mock_flush_pools = mocker.patch.object(mock_output_manager, "flush_pools", return_value=None)
+    mock_load_variables_pool_from_file = mocker.patch.object(mock_output_manager, "load_variables_pool_from_file",
+                                                             return_value=None)
+    mock_set_metadata_prefix = mocker.patch.object(mock_output_manager, "set_metadata_prefix", return_value=None)
 
     mocker.patch.object(mock_output_manager, "dict_to_file_json", return_value=None)
 
@@ -542,14 +547,14 @@ def test_handle_post_processing_load_pool(
         load_pool_from_file=True,
     )
 
-    mock_output_manager.flush_pools.assert_called_once()
-    mock_output_manager.load_variables_pool_from_file.assert_called_once_with(args["output_pool_path"])
-    mock_output_manager.set_metadata_prefix.assert_called_once_with("reload")
+    mock_flush_pools.assert_called_once()
+    mock_load_variables_pool_from_file.assert_called_once_with(args["output_pool_path"])
+    mock_set_metadata_prefix.assert_called_once_with("reload")
 
 
 def test_handle_post_processing_save_result(
     task_manager: TaskManager,
-    mock_output_manager: Generator[Any, Any, Any],
+    mock_output_manager: OutputManager,
     mocker: MockerFixture,
 ) -> None:
     """Unit test for TaskManager.handle_post_processing() when save_result is set to True."""
@@ -558,6 +563,7 @@ def test_handle_post_processing_save_result(
     mocker.patch("RUFAS.task_manager.InputManager", return_value=mock_input_manager)
 
     mocker.patch.object(mock_output_manager, "dict_to_file_json", return_value=None)
+    mock_save_results = mocker.patch.object(mock_output_manager, "save_results", return_value=None)
 
     args = {
         "filters_directory": Path("/fake/filters"),
@@ -580,7 +586,7 @@ def test_handle_post_processing_save_result(
         save_results=True,
     )
 
-    mock_output_manager.save_results.assert_called_once_with(
+    mock_save_results.assert_called_once_with(
         args["filters_directory"],
         args["exclude_info_maps"],
         False,
@@ -597,7 +603,7 @@ def test_handle_post_processing_save_result(
 def test_input_data_audit(
     suppress_logs: bool,
     export_input_data_to_csv: bool,
-    mock_output_manager: Generator[Any, Any, Any],
+    mock_output_manager: OutputManager,
     task_manager: TaskManager,
     mocker: MockerFixture,
 ) -> None:
@@ -618,11 +624,12 @@ def test_input_data_audit(
     mocve_export_pool_to_csv = mocker.patch.object(mock_input_manager, "export_pool_to_csv", return_value=None)
     mocker.patch("RUFAS.task_manager.InputManager", return_value=mock_input_manager)
     task_manager.input_manager = mock_input_manager
+    mock_add_log = mocker.patch.object(mock_output_manager, "add_log", return_value=None)
 
     result = task_manager.handle_input_data_audit(args, mock_input_manager, mock_output_manager, True)
     assert result
     if not suppress_logs:
-        mock_output_manager.add_log.assert_called_with(
+        mock_add_log.assert_called_with(
             "Saving metadata properties",
             f"Saving metadata properties {args['metadata_file_path']} at {args['logs_directory']}",
             {"class": "TaskManager", "function": "handle_input_data_audit", "units": MeasurementUnits.UNITLESS},
@@ -651,7 +658,6 @@ def test_input_data_audit(
     ],
 )
 def test_task(
-    mock_output_manager: Generator[Any, Any, Any],
     task_manager: TaskManager,
     mocker: MockerFixture,
     task_type: TaskType,
@@ -695,7 +701,7 @@ def test_task(
         mock_handler.assert_called_once()
 
 
-def test_task_invalid_data(mocker: MockerFixture, mock_output_manager: Generator[Any, Any, Any]) -> None:
+def test_task_invalid_data(mocker: MockerFixture, mock_output_manager: OutputManager) -> None:
     """Unit test for TaskManager.task() with invalid data"""
     task_manager = TaskManager()
     mock_im_init = mocker.patch.object(InputManager, "__init__", return_value=None)
@@ -762,7 +768,7 @@ def test_task_invalid_data(mocker: MockerFixture, mock_output_manager: Generator
     mock_handle_post_processing.assert_called_once()
 
 
-def test_task_failed(mock_output_manager: Generator[Any, Any, Any], task_manager: TaskManager) -> None:
+def test_task_failed(task_manager: TaskManager) -> None:
     """Tests that error were handled correctly"""
     args = {
         "task_type": "failure",
@@ -800,7 +806,7 @@ def test_handle_herd_initialization(
     save_animals: bool,
     save_animals_directory: Path,
     task_manager: TaskManager,
-    mock_output_manager: Generator[Any, Any, Any],
+    mock_output_manager: OutputManager,
     mocker: MockerFixture,
 ) -> None:
     """Unit test for TaskManager.handle_herd_initializaition()"""
@@ -808,6 +814,7 @@ def test_handle_herd_initialization(
     mock_herd_factory = mocker.patch("RUFAS.biophysical.animal.herd_factory.HerdFactory")
     mock_herd_factory_init = mocker.patch("RUFAS.task_manager.HerdFactory", return_value=mock_herd_factory)
     mock_initialize_herd = mocker.patch.object(mock_herd_factory, "initialize_herd")
+    mock_add_log = mocker.patch.object(mock_output_manager, "add_log", return_value=None)
 
     task_manager.handle_herd_initializaition(args, mock_output_manager)
 
@@ -820,14 +827,14 @@ def test_handle_herd_initialization(
         call("Herd initialization start", "Initializing herd data...", info_map),
         call("Herd initialization complete", "Herd data initialized.", info_map),
     ]
-    mock_output_manager.add_log.assert_has_calls(om_add_log_call_list)
+    mock_add_log.assert_has_calls(om_add_log_call_list)
 
     mock_herd_factory_init.assert_called_once_with(init_herd, save_animals, save_animals_directory)
     mock_initialize_herd.assert_called_once()
 
 
 def test_single_simulation_run(
-    task_manager: TaskManager, mock_output_manager: Generator[Any, Any, Any], mocker: MockerFixture
+    task_manager: TaskManager, mock_output_manager: OutputManager, mocker: MockerFixture
 ) -> None:
     """Unit test for TaskManager.handle_single_simulation_run()"""
     mock_handle_herd_initializaition = mocker.patch.object(TaskManager, "handle_herd_initializaition")
@@ -839,6 +846,7 @@ def test_single_simulation_run(
         "RUFAS.task_manager.SimulationEngine", return_value=mock_simulation_engine
     )
     mock_simulate = mocker.patch.object(mock_simulation_engine, "simulate")
+    mock_add_log = mocker.patch.object(mock_output_manager, "add_log", return_value=None)
 
     task_manager.handle_single_simulation_run(args, mock_output_manager)
 
@@ -853,7 +861,7 @@ def test_single_simulation_run(
         call("Starting the simulation", "Starting the simulation", info_map),
         call("Simulation completed", "Simulation completed", info_map),
     ]
-    mock_output_manager.add_log.assert_has_calls(om_add_log_call_list)
+    mock_add_log.assert_has_calls(om_add_log_call_list)
 
     mock_simulation_engine_init.assert_called_once()
     mock_simulate.assert_called_once()
@@ -1347,7 +1355,6 @@ def test_expand_sensitivity_analysis_args(
     multi_run_args: dict[str, Any],
     expected_output_prefixes: list[str],
     expected_input_patches: list[dict[str, dict[str, dict[str, Any]]]],
-    mock_output_manager: Generator[Any, Any, Any],
     task_manager: TaskManager,
 ) -> None:
     """Unit test for TaskManager._expand_sensitivity_analysis_args() with fractional_factorial and sobol methods
@@ -1455,7 +1462,7 @@ def test_expand_sensitivity_analysis_args(
 )
 def test_expand_sensitivity_analysis_args_invalid_sampler(
     multi_run_args: dict[str, Any],
-    mock_output_manager: Generator[Any, Any, Any],
+    mock_output_manager: OutputManager,
     task_manager: TaskManager,
     mocker: MockerFixture,
 ) -> None:
@@ -1731,7 +1738,7 @@ def test_run_tasks_fail(
     produce_graphics: bool,
     metadata_depth_limit: int,
     task_return_values: list[str | None],
-    mock_output_manager: Generator[Any, Any, Any],
+    mock_output_manager: OutputManager,
     task_manager: TaskManager,
     mocker: MockerFixture,
 ) -> None:
@@ -1741,6 +1748,7 @@ def test_run_tasks_fail(
     mock_task.side_effect = task_return_values
 
     mock_om_init = mocker.patch("RUFAS.task_manager.OutputManager", return_value=mock_output_manager)
+    mock_add_error = mocker.patch.object(mock_output_manager, "add_error", return_value=None)
 
     mock_pool = mocker.patch("multiprocessing.Pool")
 
@@ -1758,7 +1766,7 @@ def test_run_tasks_fail(
     mock_om_init.assert_called_once()
     info_map = {"class": TaskManager.__name__, "function": TaskManager._run_tasks.__name__}
     failed = [fail for fail in task_return_values if fail is not None]
-    mock_output_manager.add_error.assert_called_once_with(
+    mock_add_error.assert_called_once_with(
         "Task(s) failed", f"Failed task(s) and output prefix are: {failed}", info_map
     )
 


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Adds a summary report of the e2e test results from all e2e metadata's tested.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2544

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
 - Adds new functionality in OM to summarize and print out e2e results for each module for each e2e test metadata at the end of e2e testing.
 - Supports and calls this new functionality in TM after the e2e task is run (but not the e2e update task).

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
With e2e testing now simultaneously running 3 separate e2e metadata tasks - open lot, freestall, and no-animal - we are getting staggered results in the console and it is difficult to catch the results for each individual e2e module test for each e2e test metadata task. This provides a way to summarize the results of the tests once they are all complete so no failed test is missed.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
- Added one main function in OM that is called by TM after all e2e testing metadata tests are run. This function:
  - Opens the e2e testing results folder
  - Looks for all the `comparison` files (the ones with the pass/fail result of the e2e test for each module)
  - Opens that file and adds the test result to the dict of results for each module for each e2e test metadata
 
Once this process is complete, the summary results are printed to the console.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->

My process for testing this out:
- Ran end to end testing to see what the output looks like
- Went into the expected results and changed a couple of the expected results values (even a small change to the disclaimer message will work) and then reran e2e testing to ensure the summary would accurately display failures
- Ran a normal simulation to ensure this wasn't being displayed in the output
- Ran e2e test update to make sure it wasn't printing out for that task
