### PR TITLE
[Inputs] Update inputs from default to example

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -236,6 +236,8 @@ v0.9.2
 - [2571](https://github.com/RuminantFarmSystems/MASM/pull/2571) - [minor change] Revert manure and animal input changes from PR2552.
 - [2572](https://github.com/RuminantFarmSystems/MASM/pull/2572) - [minor change] [Feed][FeedStorage] Switches duplicate crop storage data warning to log.
 - [2563](https://github.com/RuminantFarmSystems/MASM/pull/2563) - [minor change] Changed calculations to support multi method calculations and update inputs.
+- [2581](https://github.com/RuminantFarmSystems/MASM/pull/2581) - [minor change] [Inputs] Update inputs files from default to example metadata and prefixes.
+
 
 ### v0.9.2
 

--- a/input/data/tasks/available_simulation_tasks.json
+++ b/input/data/tasks/available_simulation_tasks.json
@@ -4,14 +4,14 @@
     {
       "task_type": "SIMULATION_SINGLE_RUN",
       "metadata_file_path": "input/metadata/example_freestall_dairy_metadata.json",
-      "output_prefix": "default",
+      "output_prefix": "example",
       "log_verbosity": "errors",
       "random_seed": 42
     },
     {
       "task_type": "SIMULATION_SINGLE_RUN",
       "metadata_file_path": "input/metadata/example_open_lot_metadata.json",
-      "output_prefix": "default",
+      "output_prefix": "example",
       "log_verbosity": "errors",
       "random_seed": 42
     },

--- a/input/data/tasks/available_simulation_tasks.json
+++ b/input/data/tasks/available_simulation_tasks.json
@@ -14,13 +14,6 @@
       "output_prefix": "example",
       "log_verbosity": "errors",
       "random_seed": 42
-    },
-    {
-      "task_type": "SIMULATION_SINGLE_RUN",
-      "metadata_file_path": "input/metadata/testing_metadata.json",
-      "output_prefix": "testing",
-      "log_verbosity": "errors",
-      "random_seed": 0
     }
   ]
 }

--- a/input/data/tasks/dca_update_task.json
+++ b/input/data/tasks/dca_update_task.json
@@ -3,7 +3,7 @@
   "tasks": [
     {
       "task_type": "DATA_COLLECTION_APP_UPDATE",
-      "metadata_file_path": "input/metadata/default_metadata.json",
+      "metadata_file_path": "input/metadata/example_freestall_dairy_metadata.json",
       "output_prefix": "DCA_Update",
       "log_verbosity": "logs"
     }

--- a/input/data/tasks/herd_init_task.json
+++ b/input/data/tasks/herd_init_task.json
@@ -3,7 +3,7 @@
   "tasks": [
     {
       "task_type": "HERD_INITIALIZATION",
-      "metadata_file_path": "input/metadata/default_metadata.json",
+      "metadata_file_path": "input/metadata/example_freestall_dairy_metadata.json",
       "output_prefix": "herd_init",
       "save_animals": true,
       "log_verbosity": "errors",

--- a/input/data/tasks/sample_tasks.json
+++ b/input/data/tasks/sample_tasks.json
@@ -4,13 +4,13 @@
 
     {
       "task_type": "SIMULATION_SINGLE_RUN",
-      "metadata_file_path": "input/metadata/default_metadata.json",
+      "metadata_file_path": "input/metadata/example_freestall_dairy_metadata.json",
       "output_prefix": "Task 1",
       "log_verbosity": "errors"
     },
     {
       "task_type": "SIMULATION_SINGLE_RUN",
-      "metadata_file_path": "input/metadata/default_metadata.json",
+      "metadata_file_path": "input/metadata/example_freestall_dairy_metadata.json",
       "output_prefix": "Task 2",
       "log_verbosity": "errors",
       "random_seed": 42

--- a/input/data/tasks/single_run.json
+++ b/input/data/tasks/single_run.json
@@ -3,7 +3,7 @@
   "tasks": [
     {
       "task_type": "SIMULATION_SINGLE_RUN",
-      "metadata_file_path": "input/metadata/default_metadata.json",
+      "metadata_file_path": "input/metadata/example_freestall_dairy_metadata.json",
       "output_prefix": "Task 2",
       "log_verbosity": "warnings",
       "random_seed": 42

--- a/input/metadata/properties/tasks_properties.json
+++ b/input/metadata/properties/tasks_properties.json
@@ -36,7 +36,7 @@
           "type": "string",
           "pattern": "^(?:[a-zA-Z]:[\\/])?(?:[a-zA-Z0-9._-]+[\\/])*(?:[a-zA-Z0-9._-]+\\.json)$",
           "description": "The path to the metadata JSON files to load and use in the Input Manager of this task",
-          "default": "input/metadata/default_metadata.json"
+          "default": "input/metadata/example_freestall_dairy_metadata.json"
         },
         "properties_file_path": {
           "type": "string",


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Update input files that still have default file usage.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2533

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
The following task json files still point to the old `default_metadata.json` (also check and update each of their `output_prefix` entries:
- `dca_update_task.json`
- `herd_init_task.json`
- `sample_tasks.json`
- `single_run.json`

additionally the following files need to have their `output_prefixes` updated from `default`:
- all tasks in `available_simulation_tasks.json`

Also removed the usage of testing metadata and updated the task property default metadata path.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->


### How
<!-- Give an explanation of how this pull request addresses needed changes. -->


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Run with each modified input.