### PR TITLE
[Inputs][Feed] Remove outdated feed inputs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -257,6 +257,7 @@ v0.9.2
 - [2605](https://github.com/RuminantFarmSystems/MASM/pull/2605) - [minor change] Adds E2E testing for Feed and Feed Storage modules.
 - [2606](https://github.com/RuminantFarmSystems/MASM/pull/2606) - [minor change] Moves Field/Crop/Soil module to `biophysical` and removes `routines` directory.
 - [2612](https://github.com/RuminantFarmSystems/MASM/pull/2612) - [minor change] Remove the generation of `dummy_path` when running unit tests.
+- [2618](https://github.com/RuminantFarmSystems/MASM/pull/2618) - [minor change] Removes outdated example regional feed inputs.
 
 ### v0.9.2
 

--- a/input/data/feed/example_Intermountain_feed.json
+++ b/input/data/feed/example_Intermountain_feed.json
@@ -100,33 +100,6 @@
       "buffer": 0.15
     }
   ],
-  "farm_grown_feeds": [
-    1
-  ],
-  "storage_options": [
-    {
-      "storage_type": "bunker",
-      "moisture": "direct_cut",
-      "additive": "preservative",
-      "packing_density": 14,
-      "inoculation": "heterofermentative",
-      "bunk_type": "open_floor",
-      "ventilation": true,
-      "removal_rate": 6,
-      "initial_dry_matter": 0
-    },
-    {
-      "storage_type": "bunker",
-      "moisture": "direct_cut",
-      "additive": "preservative",
-      "packing_density": 14,
-      "inoculation": "heterofermentative",
-      "bunk_type": "open_floor",
-      "ventilation": true,
-      "removal_rate": 6,
-      "initial_dry_matter": 0
-    }
-  ],
   "milk_reduction_maximum": 0.5,
   "user_defined_ration_percentages": {
     "calf": [

--- a/input/data/feed/example_Northeast_feed.json
+++ b/input/data/feed/example_Northeast_feed.json
@@ -139,33 +139,6 @@
       "buffer": 0.15
     }
   ],
-  "farm_grown_feeds": [
-    1
-  ],
-  "storage_options": [
-    {
-      "storage_type": "bunker",
-      "moisture": "direct_cut",
-      "additive": "preservative",
-      "packing_density": 14,
-      "inoculation": "heterofermentative",
-      "bunk_type": "open_floor",
-      "ventilation": true,
-      "removal_rate": 6,
-      "initial_dry_matter": 0
-    },
-    {
-      "storage_type": "bunker",
-      "moisture": "direct_cut",
-      "additive": "preservative",
-      "packing_density": 14,
-      "inoculation": "heterofermentative",
-      "bunk_type": "open_floor",
-      "ventilation": true,
-      "removal_rate": 6,
-      "initial_dry_matter": 0
-    }
-  ],
   "milk_reduction_maximum": 0.5,
   "user_defined_ration_percentages": {
     "calf": [


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Removes inputs in example regional feed files that are no longer used.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2601

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Removes the following inputs that are no longer used from the example regional feed files:
- `farmgrown_feeds`
- `storage_options`

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
These are not used any longer and can be confusing to users.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Removed them and double checked that their counterparts in the metadata properties were also removed (they already had been removed).

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Minimal checking that everything runs - test-suite passes. These were outdated inputs that no longer had corresponding metadata properties so were just being removed during the data-validation process.