### PR TITLE
[Inputs][Metadata][Properties] Adds task property to allow running simulations using inputs from external repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-1717%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-1722%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # RuFaS: Ruminant Farm Systems
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-1722%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-1714%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # RuFaS: Ruminant Farm Systems
 

--- a/RUFAS/data_validator.py
+++ b/RUFAS/data_validator.py
@@ -641,7 +641,7 @@ class DataValidator:
         return True, ""
 
     def validate_metadata(
-        self, metadata: dict[str, Any], valid_data_types: set[str], address_to_data: str
+        self, metadata: dict[str, Any], valid_data_types: set[str], address_to_data: str, input_root: str,
     ) -> tuple[bool, str]:
         """Checks that top-level metadata has valid and required keys and values."""
         info_map = {
@@ -682,8 +682,8 @@ class DataValidator:
                     }
                 )
                 return False, f"Invalid type '{data['type']}' in '{key}'. Expected one option from {valid_data_types}"
-
-            if not os.path.isfile(data["path"]):
+            full_path = os.path.join(input_root, data["path"])
+            if not os.path.isfile(full_path):
                 self.event_logs.append(
                     {
                         "error": "Metadata Validation",

--- a/RUFAS/data_validator.py
+++ b/RUFAS/data_validator.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import re
 from enum import Enum
 from typing import Any, Callable, Union, Sequence
@@ -645,7 +646,7 @@ class DataValidator:
         metadata: dict[str, Any],
         valid_data_types: set[str],
         address_to_data: str,
-        input_root: str,
+        input_root: Path,
     ) -> tuple[bool, str]:
         """Checks that top-level metadata has valid and required keys and values."""
         info_map = {

--- a/RUFAS/data_validator.py
+++ b/RUFAS/data_validator.py
@@ -641,7 +641,11 @@ class DataValidator:
         return True, ""
 
     def validate_metadata(
-        self, metadata: dict[str, Any], valid_data_types: set[str], address_to_data: str, input_root: str,
+        self,
+        metadata: dict[str, Any],
+        valid_data_types: set[str],
+        address_to_data: str,
+        input_root: str,
     ) -> tuple[bool, str]:
         """Checks that top-level metadata has valid and required keys and values."""
         info_map = {

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -73,8 +73,9 @@ class InputManager:
         """The setter method for __pool"""
         self.__pool = incoming_pool
 
-    def start_data_processing(self, metadata_path: Path, input_root: Path = Path(""), eager_termination: bool = True
-                              ) -> bool:
+    def start_data_processing(
+        self, metadata_path: Path, input_root: Path = Path(""), eager_termination: bool = True
+    ) -> bool:
         """
         Starts the pipeline for organizing metadata and input data processing.
 
@@ -95,8 +96,9 @@ class InputManager:
         """
         full_metadata_path = os.path.join(input_root, metadata_path)
         self._load_metadata(full_metadata_path)
-        valid, message = self.data_validator.validate_metadata(self.__metadata, VALID_INPUT_TYPES, ADDRESS_TO_INPUTS,
-                                                               input_root)
+        valid, message = self.data_validator.validate_metadata(
+            self.__metadata, VALID_INPUT_TYPES, ADDRESS_TO_INPUTS, input_root
+        )
         if not valid:
             raise ValueError(message)
         self._load_properties()

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -94,7 +94,7 @@ class InputManager:
         bool
             True if data is valid, otherwise False.
         """
-        full_metadata_path = os.path.join(input_root, metadata_path)
+        full_metadata_path = Path(input_root) / metadata_path
         self._load_metadata(full_metadata_path)
         valid, message = self.data_validator.validate_metadata(
             self.__metadata, VALID_INPUT_TYPES, ADDRESS_TO_INPUTS, input_root
@@ -330,7 +330,7 @@ class InputManager:
         }
         valid_data = True
         for file_blob_key, file_details in self.__metadata["files"].items():
-            file_path = os.path.join(input_root, file_details["path"])
+            file_path = Path(input_root) / file_details["path"]
             if file_details["type"] == "json":
                 self.csv_report_generation_list.append(file_blob_key)
 

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -73,7 +73,8 @@ class InputManager:
         """The setter method for __pool"""
         self.__pool = incoming_pool
 
-    def start_data_processing(self, metadata_path: Path, eager_termination: bool = True) -> bool:
+    def start_data_processing(self, metadata_path: Path, input_root: Path = Path(""), eager_termination: bool = True
+                              ) -> bool:
         """
         Starts the pipeline for organizing metadata and input data processing.
 
@@ -81,6 +82,8 @@ class InputManager:
         ----------
         metadata_path : Path
             File path to the metadata.
+        input_root : Path, default=Path("")
+            Root directory for all input files.
         eager_termination : bool, default=True
             If True, the process will be terminated as soon as finding invalid data and failing to fix it.
             If False, the process will be terminated after going through and validating the entire data.
@@ -90,8 +93,10 @@ class InputManager:
         bool
             True if data is valid, otherwise False.
         """
-        self._load_metadata(metadata_path)
-        valid, message = self.data_validator.validate_metadata(self.__metadata, VALID_INPUT_TYPES, ADDRESS_TO_INPUTS)
+        full_metadata_path = os.path.join(input_root, metadata_path)
+        self._load_metadata(full_metadata_path)
+        valid, message = self.data_validator.validate_metadata(self.__metadata, VALID_INPUT_TYPES, ADDRESS_TO_INPUTS,
+                                                               input_root)
         if not valid:
             raise ValueError(message)
         self._load_properties()
@@ -99,7 +104,7 @@ class InputManager:
         if not valid:
             self.om.route_logs(self.data_validator.event_logs)
             raise ValueError(message)
-        is_input_data_valid = self._populate_pool(eager_termination)
+        is_input_data_valid = self._populate_pool(input_root, eager_termination)
         failing_cross_validation_blocks: list[str] = []
         cross_validation_blocks = self.__metadata.get("cross-validation", [])
         if cross_validation_blocks:
@@ -291,17 +296,19 @@ class InputManager:
         except Exception as e:
             raise e
 
-    def _populate_pool(self, eager_termination: bool) -> bool:
+    def _populate_pool(self, input_root: Path, eager_termination: bool) -> bool:
         """
         Loads input files, runs validations on the data from the input files, attempts to fix invalid data,
         then adds data to the pool.
 
         Parameters
         ----------
+        input_root : Path
+            The root directory for all input files.
         eager_termination : bool
             If True, the process will be terminated as soon as finding invalid data and failing to fix it.
-            If False, the process will be terminated after going through and validating the entire data,
-            If invalid data is found.
+            If False, the process will be terminated after going through and validating the entire data
+            if invalid data is found.
 
         Returns
         -------
@@ -315,13 +322,13 @@ class InputManager:
 
         """
 
-        data_type_to_loader_map: Dict[str, Callable[[Path], Dict[str, Any]]] = {
+        data_type_to_loader_map: dict[str, Callable[[Path], dict[str, Any]]] = {
             "json": self._load_data_from_json,
             "csv": self._load_data_from_csv,
         }
         valid_data = True
         for file_blob_key, file_details in self.__metadata["files"].items():
-            file_path = file_details["path"]
+            file_path = os.path.join(input_root, file_details["path"])
             if file_details["type"] == "json":
                 self.csv_report_generation_list.append(file_blob_key)
 

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -74,7 +74,7 @@ class InputManager:
         self.__pool = incoming_pool
 
     def start_data_processing(
-        self, metadata_path: Path, input_root: Path = Path(""), eager_termination: bool = True
+        self, metadata_path: Path, input_root: Path, eager_termination: bool = True
     ) -> bool:
         """
         Starts the pipeline for organizing metadata and input data processing.
@@ -83,7 +83,7 @@ class InputManager:
         ----------
         metadata_path : Path
             File path to the metadata.
-        input_root : Path, default=Path("")
+        input_root : Path
             Root directory for all input files.
         eager_termination : bool, default=True
             If True, the process will be terminated as soon as finding invalid data and failing to fix it.

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -73,9 +73,7 @@ class InputManager:
         """The setter method for __pool"""
         self.__pool = incoming_pool
 
-    def start_data_processing(
-        self, metadata_path: Path, input_root: Path, eager_termination: bool = True
-    ) -> bool:
+    def start_data_processing(self, metadata_path: Path, input_root: Path, eager_termination: bool = True) -> bool:
         """
         Starts the pipeline for organizing metadata and input data processing.
 

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -744,7 +744,8 @@ class TaskManager:
             "units": MeasurementUnits.UNITLESS,
         }
         output_manager.add_log("Validation start", f"Validating data for {args['metadata_file_path']}...", info_map)
-        is_data_valid = input_manager.start_data_processing(Path(args["metadata_file_path"]), eager_termination)
+        is_data_valid = input_manager.start_data_processing(Path(args["metadata_file_path"]), Path(args["input_root"]),
+                                                            eager_termination)
         output_manager.add_log(
             "Validation complete", f"{args['output_prefix']} validation status: {is_data_valid}", info_map
         )

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -744,8 +744,9 @@ class TaskManager:
             "units": MeasurementUnits.UNITLESS,
         }
         output_manager.add_log("Validation start", f"Validating data for {args['metadata_file_path']}...", info_map)
-        is_data_valid = input_manager.start_data_processing(Path(args["metadata_file_path"]), Path(args["input_root"]),
-                                                            eager_termination)
+        is_data_valid = input_manager.start_data_processing(
+            Path(args["metadata_file_path"]), Path(args["input_root"]), eager_termination
+        )
         output_manager.add_log(
             "Validation complete", f"{args['output_prefix']} validation status: {is_data_valid}", info_map
         )

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -130,7 +130,7 @@ class TaskManager:
             "function": TaskManager.start.__name__,
         }
         self.output_manager.add_log("Task Manager Start", "Task Manager Started.", info_map)
-        is_data_valid = self.input_manager.start_data_processing(metadata_path)
+        is_data_valid = self.input_manager.start_data_processing(metadata_path, Path(""))
         task_config: dict[str, Any] = self.input_manager.get_data("tasks")
         for task in task_config.get("tasks", []):
             filters_path = Path(task["filters_directory"])

--- a/changelog.md
+++ b/changelog.md
@@ -274,6 +274,7 @@ v0.9.2
 - [2643](https://github.com/RuminantFarmSystems/MASM/pull/2643) - [minor change] [InputChange][NoOutputChange] Expand task file and dir regex pattern matching.
 - [2633](https://github.com/RuminantFarmSystems/MASM/pull/2633) - [minor change] [NoInputChange][OutputChange][EEE] Refactors the Farmgrown Feed Emissions calculation and reporting.
 - [2600](https://github.com/RuminantFarmSystems/MASM/pull/2600) - [major change] [Animal] [InputChange] [NoOutputChange] Updates energy supply calculations and ration formulation to NASEM standards.
+- [2660](https://github.com/RuminantFarmSystems/MASM/pull/2660) - [minor change] [InputChange][NoOutputChange][Input][Properties] Adds task property to allow running simulations using inputs from external repos.
 
 ### v0.9.2
 

--- a/input/metadata/properties/default.json
+++ b/input/metadata/properties/default.json
@@ -5104,14 +5104,7 @@
       "properties": {
         "type": "number"
       }
-    },
-    "DE": {
-      "type": "array",
-      "description": "",
-      "properties": {
-        "type": "number"
-        }
-      }
+    }
   },
   "manure_management_properties": {
     "data_collection_app_compatible": false,

--- a/input/metadata/properties/tasks_properties.json
+++ b/input/metadata/properties/tasks_properties.json
@@ -37,6 +37,12 @@
           "pattern": "^(?:[a-zA-Z]:[\\\\/]|/)?(?:[a-zA-Z0-9._\\-\\s]+[\\\\/])*(?:[a-zA-Z0-9._\\-\\s]+\\.json)$",
           "description": "The path to the metadata JSON files to load and use in the Input Manager of this task"
         },
+        "input_root": {
+          "type": "string",
+          "pattern": "^([a-zA-Z]:)?[\\\\/]?(?:[a-zA-Z0-9_\\-\\. ]+[\\\\/])*[a-zA-Z0-9_\\-\\. ]*[\\\\/]?$",
+          "description": "Root directory for all input files.",
+          "default": ""
+        },
         "properties_file_path": {
           "type": "string",
           "pattern": "^(?:[a-zA-Z]:[\\\\/]|/)?(?:[a-zA-Z0-9._\\-\\s]+[\\\\/])*(?:[a-zA-Z0-9._\\-\\s]+\\.json)$",

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict, Any, List, Union, Optional, Type
 
 import pytest
@@ -1474,7 +1475,7 @@ def test_validate_input_by_type_key_error() -> None:
 def test_validate_metadata(
     mocker: MockerFixture,
     does_file_exist: bool,
-    metadata: Dict[str, Any],
+    metadata: dict[str, Any],
     expected_exception: bool,
 ) -> None:
     mocker.patch("os.path.isfile", return_value=does_file_exist)
@@ -1485,11 +1486,11 @@ def test_validate_metadata(
     dv = DataValidator()
 
     if expected_exception:
-        valid, message = dv.validate_metadata(metadata, {"json", "csv"}, "files")
+        valid, message = dv.validate_metadata(metadata, {"json", "csv"}, "files", Path(""))
         assert not valid
         assert dv.event_logs == [{"error": "Metadata Validation", "message": mocker.ANY, "info_map": info_map}]
     else:
-        dv.validate_metadata(metadata, {"json", "csv"}, "files")
+        dv.validate_metadata(metadata, {"json", "csv"}, "files", Path(""))
         assert dv.event_logs == [
             {"log": "Metadata Validation", "message": "Top level metadata is valid.", "info_map": info_map}
         ]

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -317,7 +317,7 @@ def test_start_data_processing(
     cv_call = mocker.patch.object(cv_mock, "cross_validate_data", side_effect=side_effect)
     mock_input_manager.data_validator.event_logs.clear()
 
-    result = mock_input_manager.start_data_processing(Path("mock/metadata/path"), eager_termination)
+    result = mock_input_manager.start_data_processing(Path("mock/metadata/path"), Path(""), eager_termination)
 
     assert result is expected_return
 
@@ -419,7 +419,7 @@ def test_populate_pool_valid(
     mocker.patch.object(OutputManager, "add_warning")
 
     # Act
-    result = input_manager._populate_pool(eager_termination=True)
+    result = input_manager._populate_pool(Path(""), eager_termination=True)
 
     # Assert
     assert result
@@ -452,7 +452,7 @@ def test_populate_pool_invalid(
     mocker.patch.object(input_manager, "elements_counter", elements_counter)
 
     # Act
-    result = input_manager._populate_pool(eager_termination=False)
+    result = input_manager._populate_pool(Path(""), eager_termination=False)
 
     # Assert
     assert not result
@@ -480,7 +480,7 @@ def test_populate_pool_partial_invalid(
     mocker.patch.object(OutputManager, "add_warning")
 
     # Act
-    result = input_manager._populate_pool(eager_termination=False)
+    result = input_manager._populate_pool(Path(""), eager_termination=False)
 
     # Assert
     assert result is False
@@ -515,7 +515,7 @@ def test_populate_pool_eager_termination(
     mocker.patch.object(OutputManager, "add_warning")
 
     # Act
-    result = input_manager._populate_pool(eager_termination=True)
+    result = input_manager._populate_pool(Path(""), eager_termination=True)
 
     # Assert
     assert result is False
@@ -541,7 +541,7 @@ def test_populate_pool_raises_keyerror(
     with patch("RUFAS.output_manager.OutputManager.add_log") as add_log:
         with patch("RUFAS.output_manager.OutputManager.add_warning") as add_warning:
             with pytest.raises(KeyError):
-                mock_input_manager._populate_pool(eager_termination=True)
+                mock_input_manager._populate_pool(Path(""), eager_termination=True)
 
             assert add_log.call_count == 0
             assert add_warning.call_count == 0

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -265,7 +265,7 @@ def test_load_data_from_csv_invalid_data_raises_error(
     ],
 )
 def test_start_data_processing(
-    mock_input_manager,
+    mock_input_manager: InputManager,
     mocker: MockerFixture,
     cv_scenario: str,
     eager_termination: bool,
@@ -343,7 +343,7 @@ def test_start_data_processing(
     route_logs.assert_called_once_with(mock_input_manager.data_validator.event_logs)
 
 
-def test_start_data_processing_invalid_metadata_raises(mock_input_manager, mocker: MockerFixture) -> None:
+def test_start_data_processing_invalid_metadata_raises(mock_input_manager: InputManager, mocker: MockerFixture) -> None:
     """If validate_metadata returns (False, msg), it should raise ValueError with that message."""
     mocker.patch.object(mock_input_manager, "_load_metadata")
     mocker.patch.object(type(mock_input_manager.data_validator), "validate_metadata", return_value=(False, "bad meta"))
@@ -358,7 +358,7 @@ def test_start_data_processing_invalid_metadata_raises(mock_input_manager, mocke
 
 
 def test_start_data_processing_invalid_properties_routes_logs_and_raises(
-    mock_input_manager, mocker: MockerFixture
+    mock_input_manager: InputManager, mocker: MockerFixture
 ) -> None:
     """If validate_properties returns (False, msg), it should route logs and then raise ValueError."""
     mocker.patch.object(mock_input_manager, "_load_metadata")

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -351,7 +351,7 @@ def test_start_data_processing_invalid_metadata_raises(mock_input_manager: Input
     mock_validate_props = mocker.patch.object(type(mock_input_manager.data_validator), "validate_properties")
 
     with pytest.raises(ValueError, match="bad meta"):
-        mock_input_manager.start_data_processing(Path("meta"), eager_termination=True)
+        mock_input_manager.start_data_processing(Path("meta"), Path(""), eager_termination=True)
 
     mock_load_props.assert_not_called()
     mock_validate_props.assert_not_called()
@@ -372,7 +372,7 @@ def test_start_data_processing_invalid_properties_routes_logs_and_raises(
     route_logs = mocker.patch.object(mock_input_manager.om, "route_logs")
 
     with pytest.raises(ValueError, match="bad props"):
-        mock_input_manager.start_data_processing(Path("meta"), eager_termination=False)
+        mock_input_manager.start_data_processing(Path("meta"), Path(""), eager_termination=False)
 
     route_logs.assert_called_once_with(mock_input_manager.data_validator.event_logs)
 

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -619,6 +619,7 @@ def test_input_data_audit(
         "suppress_log_files": suppress_logs,
         "export_input_data_to_csv": export_input_data_to_csv,
         "input_data_csv_export_path": Path("/fake/output/saved_input"),
+        "input_root": "",
     }
     mock_input_manager = mocker.MagicMock(auto_spec=InputManager)
     mocker.patch.object(mock_input_manager, "start_data_processing", return_value=True)

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -174,7 +174,7 @@ def test_task_manager_start(
     ]
     mock_add_log.assert_has_calls(expected_add_log_calls)
 
-    mock_start_data.assert_called_once_with(Path("metadata/path"))
+    mock_start_data.assert_called_once_with(Path("metadata/path"), Path(""))
     mock_get_data.assert_called_once_with("tasks")
     mock_parse_input_tasks.assert_called_once()
     mock_expand_multi_runs_to_single_runs.assert_called_once()


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
This adds a new task property `input_root` which a user can use to direct input manager to load files from an external repo.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2646

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Adds new optional input property `input_root` which is used as an extension to help run simulations in other repos from which the user is starting.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
This was requested to be able to test data/inputs in private repos from the public RuFaS repo.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
- Added the new input `input_root` and associated property to the task-properties json.
- Extract that input and pass it to IM for data processing, metadata validation, loading inputs, and populating the input data pool.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Cloned the private RuFaS evaluation repo and ran a simulation from the public repo using input files located in the private repo.

My public-repo task was adapted like this to test the new feature:
<img width="572" height="266" alt="Screenshot 2025-11-24 at 5 43 53 PM" src="https://github.com/user-attachments/assets/44df2592-834f-40a2-b0ad-e429b412fed2" />

A couple notes:
1. There are some issues with the current versions of some of the input files for that task in the private repo. I started correcting some of them but the full task was not able to be run. I was only able to test that it was able to access the correct files using the new input property. The full process of fixing the input files in the private repo to work when being called from the public repo is outlined in a [(comment I made in the issue](https://github.com/RuminantFarmSystems/RuFaS/issues/2646#issuecomment-3572978240) )
2. Note that I used the relative path within the private repo for the metadata address (i.e. not the full path) because I thought it would be less confusing to apply the `input_root` to both the metadata AND all the inputs.
3. I tried doing this as a CLI arg but it seemed like it would get too complicated if the user wanted to run a task with multiple simulations. If that option is desired, I can explore ways to implement it further here or in another task.

### Input Changes
<!-- Provide a short summary describing input modifications. -->
<!-- Please include the things that are added, deleted, or modified. -->
1. Got rid of duplciate `DE` property (unrelated to this PR but PyLance gave me a warning about it so I removed it).
2. Added `input_root` which is the root directory for finding input files. It defaults to `""` which allows the user not to have to include it if they just want to run simulations in the main repo from the main repo.

### Output Changes
<!-- List all the output variable/function modifications with a short summary. -->
<!-- """- `Class.Function.VariableName`: description""" -->
- N/A

#### Filter
<!-- Provide a filter that can be used to handle the output changes. -->

```json

```
