### PR TITLE
[Feed] Adds Purchased Feed Buffer default

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -279,6 +279,7 @@ v0.9.2
 - [2660](https://github.com/RuminantFarmSystems/MASM/pull/2660) - [minor change] [InputChange][NoOutputChange][Input][Properties] Adds task property to allow running simulations using inputs from external repos.
 - [2653](https://github.com/RuminantFarmSystems/MASM/pull/2653) - [minor change] [NoInputChange][NoOutputChange][Unit Test] Separate Unit Tests for `photosynthesize()` and `partition_biomass()` in `allocate_biomass()`.
 - [2655](https://github.com/RuminantFarmSystems/MASM/pull/2655) - [minor change] [Animal] [InputChange] [NoOutputChange] Updated RationManager class to allow for more flexibility in user inputs in Feed input file.
+- [2673](https://github.com/RuminantFarmSystems/MASM/pull/2673) - [minor change] [Feed] [InputChange] [NoOutputChange] Adds a default for purchased feed buffer of 0.15.
 
 ### v0.9.2
 

--- a/input/metadata/properties/default.json
+++ b/input/metadata/properties/default.json
@@ -3896,7 +3896,8 @@
           "type": "number",
           "description": "Fractional number 0 to 1 as a cushion for feed purchases to help plan for herd fluctuations and feed shrink.",
           "minimum": 0,
-          "maximum": 1
+          "maximum": 1,
+          "default": 0.15
         }
       }
     },


### PR DESCRIPTION
### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2661

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Adds a `default` for  `buffer` of `0.15` to the default properties json file.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
Not currently in use and caused some confusing errors when new feed inputs were created that didn't include the buffer.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Added `default` for `buffer` to properties json.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
For the `example_freestall` metadata simulation, it uses the `example_Midwest_feed.json` feed input file. Go into this file and remove any/all of the `buffer` fields for the purchased feeds and try to run a simulation. This should work now.

### Input Changes
<!-- Provide a short summary describing input modifications. -->
<!-- Please include the things that are added, deleted, or modified. -->
Added `default` for `buffer` to properties json.

### Output Changes
<!-- List all the output variable/function modifications with a short summary. -->
<!-- """- `Class.Function.VariableName`: description""" -->
- N/A

#### Filter
<!-- Provide a filter that can be used to handle the output changes. -->

```json

```
