### PR TITLE
[Metadata] Prevent simulation fails when metadata blobs for fields/manure/harvest DNE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-1702%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-1706%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # RuFaS: Ruminant Farm Systems
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-1716%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-1711%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # RuFaS: Ruminant Farm Systems
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-1706%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-1716%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # RuFaS: Ruminant Farm Systems
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-1711%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # RuFaS: Ruminant Farm Systems

--- a/RUFAS/EEE/emissions.py
+++ b/RUFAS/EEE/emissions.py
@@ -283,6 +283,10 @@ class EmissionsEstimator:
         for filter_key in ["manure_applications", "fertilizer_applications"]:
             resource_filter = FARMGROWN_FEEDS_EMISSIONS_AND_RESOURCES_FILTERS[filter_key]
             filtered_data = self.om.filter_variables_pool(resource_filter)
+
+            if len(filtered_data) == 0:
+                continue
+
             date_field: tuple[str, str] = resource_filter["date_fields"]
             year_key, day_key = date_field[0], date_field[1]
             dates = list(
@@ -349,6 +353,8 @@ class EmissionsEstimator:
 
         harvest_filter = FARMGROWN_FEEDS_EMISSIONS_AND_RESOURCES_FILTERS["harvest_yield"]
         filtered_data = self.om.filter_variables_pool(harvest_filter)
+        if len(filtered_data) == 0:
+            return harvest_data
         date_field: tuple[str, str] = harvest_filter["date_fields"]
         year_key, day_key = date_field[0], date_field[1]
         for i, field_name in enumerate(filtered_data["field_name"]["values"]):

--- a/RUFAS/biophysical/field/crop/crop_data_factory.py
+++ b/RUFAS/biophysical/field/crop/crop_data_factory.py
@@ -80,19 +80,21 @@ class CropDataFactory:
 
         im = InputManager()
         unprocessed_crop_configurations = im.get_data("crop_configurations.crop_configurations")
-        for config in unprocessed_crop_configurations:
-            crop_config = cls._manufacture_crop_configuration(config)
-            if (name := crop_config["name"]) in cls._crop_configurations.keys():
-                info_map = {
-                    "class": cls.__name__,
-                    "function": cls.setup_crop_configurations.__name__,
-                    "name": name,
-                }
-                err_name = "Duplicate crop configuration name."
-                err_msg = f"{name=} is used for more than one crop configuration."
-                cls._om.add_error(err_name, err_msg, info_map)
-                raise ValueError(f"{err_name} {err_msg}")
-            cls._crop_configurations[name] = crop_config
+
+        if unprocessed_crop_configurations:
+            for config in unprocessed_crop_configurations:
+                crop_config = cls._manufacture_crop_configuration(config)
+                if (name := crop_config["name"]) in cls._crop_configurations.keys():
+                    info_map = {
+                        "class": cls.__name__,
+                        "function": cls.setup_crop_configurations.__name__,
+                        "name": name,
+                    }
+                    err_name = "Duplicate crop configuration name."
+                    err_msg = f"{name=} is used for more than one crop configuration."
+                    cls._om.add_error(err_name, err_msg, info_map)
+                    raise ValueError(f"{err_name} {err_msg}")
+                cls._crop_configurations[name] = crop_config
 
     @classmethod
     def _manufacture_crop_configuration(cls, config: dict[str, Any]) -> CropConfiguration:

--- a/RUFAS/biophysical/field/manager/field_data_reporter.py
+++ b/RUFAS/biophysical/field/manager/field_data_reporter.py
@@ -30,15 +30,6 @@ class FieldDataReporter:
 
     def send_daily_variables(self, time: RufasTime) -> None:
         """Sends daily variables of soil and crop module to the output manager"""
-        info_map = {
-            "class": self.__class__.__name__,
-            "function": self.send_daily_variables.__name__,
-        }
-        self.om.add_variable(
-            "simulation_day",
-            time.simulation_day,
-            dict(info_map, **{"units": MeasurementUnits.MILLIMETERS, "data_origin": [("Evaporation", "evaporate")]}),
-        )
         for field in self.fields:
             self.send_field_daily_variables(field, time)
 

--- a/RUFAS/biophysical/field/manager/field_data_reporter.py
+++ b/RUFAS/biophysical/field/manager/field_data_reporter.py
@@ -30,6 +30,15 @@ class FieldDataReporter:
 
     def send_daily_variables(self, time: RufasTime) -> None:
         """Sends daily variables of soil and crop module to the output manager"""
+        info_map = {
+            "class": self.__class__.__name__,
+            "function": self.send_daily_variables.__name__,
+        }
+        self.om.add_variable(
+            "simulation_day",
+            time.simulation_day,
+            dict(info_map, **{"units": MeasurementUnits.MILLIMETERS, "data_origin": [("Evaporation", "evaporate")]}),
+        )
         for field in self.fields:
             self.send_field_daily_variables(field, time)
 

--- a/RUFAS/biophysical/field/manager/field_manager.py
+++ b/RUFAS/biophysical/field/manager/field_manager.py
@@ -257,7 +257,6 @@ class FieldManager:
 
         """
         crop_schedules = FieldManager._setup_crop_schedules(crop_rotation_configuration, available_crop_configs)
-        fertilizer
         all_planting_events: list[PlantingEvent] = []
         all_harvest_events: list[HarvestEvent] = []
         for schedule in crop_schedules:

--- a/RUFAS/biophysical/field/manager/field_manager.py
+++ b/RUFAS/biophysical/field/manager/field_manager.py
@@ -288,11 +288,9 @@ class FieldManager:
             om = OutputManager()
             info_map = {
                 "class": FieldManager.__class__.__name__,
-                "function": FieldManager._setup_fertilizer_events.__name__
+                "function": FieldManager._setup_fertilizer_events.__name__,
             }
-            om.add_error("No fertilizer data",
-                         "Field data provided with empty fertilizer data.",
-                         info_map)
+            om.add_error("No fertilizer data", "Field data provided with empty fertilizer data.", info_map)
             raise ValueError("No fertilizer data")
         available_fertilizer_mixes: dict[str, dict[str, float]] = {}
         fertilizer_mix_data: list[dict[str, Any]] = fertilizer_data["available_fertilizer_mixes"]
@@ -344,11 +342,9 @@ class FieldManager:
             om = OutputManager()
             info_map = {
                 "class": FieldManager.__class__.__name__,
-                "function": FieldManager._setup_manure_events.__name__
+                "function": FieldManager._setup_manure_events.__name__,
             }
-            om.add_error("No manure data",
-                         "Field data provided with empty manure data.",
-                         info_map)
+            om.add_error("No manure data", "Field data provided with empty manure data.", info_map)
             raise ValueError("No manure data")
         manure_type_strings: list[str] = manure_schedule_data["manure_types"]
         manure_supplement_methods_strings: list[str] = manure_schedule_data["supplement_manure_nutrient_deficiencies"]
@@ -396,11 +392,9 @@ class FieldManager:
             om = OutputManager()
             info_map = {
                 "class": FieldManager.__class__.__name__,
-                "function": FieldManager._setup_tillage_events.__name__
+                "function": FieldManager._setup_tillage_events.__name__,
             }
-            om.add_error("No tillage data",
-                         "Field data provided with empty tillage data.",
-                         info_map)
+            om.add_error("No tillage data", "Field data provided with empty tillage data.", info_map)
             raise ValueError("No tillage data")
         tillage_schedule_instance = TillageSchedule(
             name="tillage_schedule",
@@ -446,11 +440,9 @@ class FieldManager:
             om = OutputManager()
             info_map = {
                 "class": FieldManager.__class__.__name__,
-                "function": FieldManager._setup_fertilizer_events.__name__
+                "function": FieldManager._setup_fertilizer_events.__name__,
             }
-            om.add_error("No crop rotation data",
-                         "Field data provided with empty crop rotation data.",
-                         info_map)
+            om.add_error("No crop rotation data", "Field data provided with empty crop rotation data.", info_map)
             raise ValueError("No crop rotation data")
 
         for index, rotation in enumerate(crop_rotation_data):

--- a/RUFAS/biophysical/field/manager/field_manager.py
+++ b/RUFAS/biophysical/field/manager/field_manager.py
@@ -440,7 +440,7 @@ class FieldManager:
             om = OutputManager()
             info_map = {
                 "class": FieldManager.__class__.__name__,
-                "function": FieldManager._setup_fertilizer_events.__name__,
+                "function": FieldManager._setup_crop_schedules.__name__,
             }
             om.add_error("No crop rotation data", "Field data provided with empty crop rotation data.", info_map)
             raise ValueError("No crop rotation data")

--- a/RUFAS/biophysical/field/manager/field_manager.py
+++ b/RUFAS/biophysical/field/manager/field_manager.py
@@ -257,6 +257,7 @@ class FieldManager:
 
         """
         crop_schedules = FieldManager._setup_crop_schedules(crop_rotation_configuration, available_crop_configs)
+        fertilizer
         all_planting_events: list[PlantingEvent] = []
         all_harvest_events: list[HarvestEvent] = []
         for schedule in crop_schedules:
@@ -284,6 +285,16 @@ class FieldManager:
         """
         im = InputManager()
         fertilizer_data: dict[str, Any] = im.get_data(fertilizer_schedule)
+        if fertilizer_data is None:
+            om = OutputManager()
+            info_map = {
+                "class": FieldManager.__class__.__name__,
+                "function": FieldManager._setup_fertilizer_events.__name__
+            }
+            om.add_error("No fertilizer data",
+                         "Field data provided with empty fertilizer data.",
+                         info_map)
+            raise ValueError("No fertilizer data")
         available_fertilizer_mixes: dict[str, dict[str, float]] = {}
         fertilizer_mix_data: list[dict[str, Any]] = fertilizer_data["available_fertilizer_mixes"]
         for mix in fertilizer_mix_data:
@@ -330,6 +341,16 @@ class FieldManager:
         """
         im = InputManager()
         manure_schedule_data: dict[str, Any] = im.get_data(manure_schedule)
+        if manure_schedule_data is None:
+            om = OutputManager()
+            info_map = {
+                "class": FieldManager.__class__.__name__,
+                "function": FieldManager._setup_manure_events.__name__
+            }
+            om.add_error("No manure data",
+                         "Field data provided with empty manure data.",
+                         info_map)
+            raise ValueError("No manure data")
         manure_type_strings: list[str] = manure_schedule_data["manure_types"]
         manure_supplement_methods_strings: list[str] = manure_schedule_data["supplement_manure_nutrient_deficiencies"]
         manure_supplement_methods: list[ManureSupplementMethod] = [
@@ -372,6 +393,16 @@ class FieldManager:
         """
         im = InputManager()
         tillage_schedule_data: dict[str, Any] = im.get_data(tillage_schedule)
+        if tillage_schedule_data is None:
+            om = OutputManager()
+            info_map = {
+                "class": FieldManager.__class__.__name__,
+                "function": FieldManager._setup_tillage_events.__name__
+            }
+            om.add_error("No tillage data",
+                         "Field data provided with empty tillage data.",
+                         info_map)
+            raise ValueError("No tillage data")
         tillage_schedule_instance = TillageSchedule(
             name="tillage_schedule",
             years=tillage_schedule_data["years"],
@@ -412,6 +443,16 @@ class FieldManager:
         im = InputManager()
         schedules = []
         crop_rotation_data: list[dict[str, Any]] = im.get_data(f"{crop_rotation}.crop_schedules")
+        if crop_rotation_data is None:
+            om = OutputManager()
+            info_map = {
+                "class": FieldManager.__class__.__name__,
+                "function": FieldManager._setup_fertilizer_events.__name__
+            }
+            om.add_error("No crop rotation data",
+                         "Field data provided with empty crop rotation data.",
+                         info_map)
+            raise ValueError("No crop rotation data")
 
         for index, rotation in enumerate(crop_rotation_data):
             crop_species = rotation["crop_species"]

--- a/changelog.md
+++ b/changelog.md
@@ -281,6 +281,7 @@ v0.9.2
 - [2655](https://github.com/RuminantFarmSystems/MASM/pull/2655) - [minor change] [Animal] [InputChange] [NoOutputChange] Updated RationManager class to allow for more flexibility in user inputs in Feed input file.
 - [2670](https://github.com/RuminantFarmSystems/MASM/pull/2670) - [minor change] [Animal] [InputChange] [NoOutputChange] Updated Animal module unit testing to 100% coverage.
 - [2673](https://github.com/RuminantFarmSystems/MASM/pull/2673) - [minor change] [Feed] [InputChange] [NoOutputChange] Adds a default for purchased feed buffer of 0.15.
+- [2674](https://github.com/RuminantFarmSystems/MASM/pull/2674) - [minor change] [Feed] [NoInputChange] [NoOutputChange] Prevent simulation fails when metadata blobs for fields/manure/harvest does not exist.
 
 ### v0.9.2
 

--- a/tests/test_EEE/test_emissions.py
+++ b/tests/test_EEE/test_emissions.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import datetime
 from typing import Any
 
@@ -412,6 +413,21 @@ def test_parse_manure_and_fertilizer_application_data(
     assert mock_om_filter_variables_pool.call_count == 2
 
 
+def test_parse_manure_and_fertilizer_application_no_data(
+    raw_fertilizer_application_data: dict[str, dict[str, list[Any]]],
+    raw_manure_application_data: dict[str, dict[str, list[Any]]],
+    parsed_fertilizer_and_manure_application_data: dict[str, dict[str, dict[int, dict[str, float]]]],
+    em: EmissionsEstimator,
+    mocker: MockerFixture,
+) -> None:
+    mock_om_filter_variables_pool = mocker.patch.object(
+        em.om, "filter_variables_pool", side_effect=[{}, {}]
+    )
+    actual_data = em._parse_manure_and_fertilizer_application_data(datetime.strptime("2013:1", "%Y:%j"))
+    assert actual_data == defaultdict(dict)
+    assert mock_om_filter_variables_pool.call_count == 2
+
+
 def test_parse_crop_to_feed_id_mapping(
     raw_received_crop_data: dict[str, dict[str, list[Any]]],
     expected_crop_to_feed_id_mapping: dict[tuple[str, str], RUFAS_ID],
@@ -451,6 +467,21 @@ def test_parse_farmgrown_feed_deductions_data(
     all_simulation_days = list(range(0, 750))
     actual_data = em._parse_farmgrown_feed_deductions_data(all_simulation_days)
     assert actual_data == expected_farmgrown_feed_deductions_data
+    mock_om_filter_variables_pool.assert_called_once()
+
+
+def test_parse_farmgrown_feed_deductions_no_data(
+    raw_farmgrown_feed_deductions_data: dict[str, dict[str, list[Any]]],
+    expected_farmgrown_feed_deductions_data: dict[RUFAS_ID, dict[int, float]],
+    em: EmissionsEstimator,
+    mocker: MockerFixture,
+) -> None:
+    mock_om_filter_variables_pool = mocker.patch.object(
+        em.om, "filter_variables_pool", return_value={}
+    )
+    all_simulation_days = list(range(0, 750))
+    actual_data = em._parse_farmgrown_feed_deductions_data(all_simulation_days)
+    assert actual_data == defaultdict(dict)
     mock_om_filter_variables_pool.assert_called_once()
 
 

--- a/tests/test_EEE/test_emissions.py
+++ b/tests/test_EEE/test_emissions.py
@@ -420,9 +420,7 @@ def test_parse_manure_and_fertilizer_application_no_data(
     em: EmissionsEstimator,
     mocker: MockerFixture,
 ) -> None:
-    mock_om_filter_variables_pool = mocker.patch.object(
-        em.om, "filter_variables_pool", side_effect=[{}, {}]
-    )
+    mock_om_filter_variables_pool = mocker.patch.object(em.om, "filter_variables_pool", side_effect=[{}, {}])
     actual_data = em._parse_manure_and_fertilizer_application_data(datetime.strptime("2013:1", "%Y:%j"))
     assert actual_data == defaultdict(dict)
     assert mock_om_filter_variables_pool.call_count == 2
@@ -476,9 +474,7 @@ def test_parse_farmgrown_feed_deductions_no_data(
     em: EmissionsEstimator,
     mocker: MockerFixture,
 ) -> None:
-    mock_om_filter_variables_pool = mocker.patch.object(
-        em.om, "filter_variables_pool", return_value={}
-    )
+    mock_om_filter_variables_pool = mocker.patch.object(em.om, "filter_variables_pool", return_value={})
     all_simulation_days = list(range(0, 750))
     actual_data = em._parse_farmgrown_feed_deductions_data(all_simulation_days)
     assert actual_data == defaultdict(dict)

--- a/tests/test_biophysical/test_crop_soil_field/manager_tests/test_field_manager.py
+++ b/tests/test_biophysical/test_crop_soil_field/manager_tests/test_field_manager.py
@@ -1446,6 +1446,7 @@ def test_setup_crop_schedule_schedule_no_data(
     with pytest.raises(ValueError):
         FieldManager._setup_crop_schedules("test_crop_schedule", crop_configs)
 
+
 def test_crop_schedule_setup_error(mocker: MockerFixture, mock_input_manager: InputManager) -> None:
     """Test that crop schedule setup fails correctly when a config is not available."""
     crop_rotations = [

--- a/tests/test_biophysical/test_crop_soil_field/manager_tests/test_field_manager.py
+++ b/tests/test_biophysical/test_crop_soil_field/manager_tests/test_field_manager.py
@@ -395,9 +395,7 @@ def test_setup_fertilizer_schedule(
     mock_input_manager.get_data = input_manager_original_method_states["get_data"]
 
 
-def test_setup_fertilizer_schedule_no_data(
-    mock_input_manager: InputManager
-) -> None:
+def test_setup_fertilizer_schedule_no_data(mock_input_manager: InputManager) -> None:
     """Test when no fertilizer schedule input."""
     mock_input_manager.get_data = mock.MagicMock(return_value=None)
 
@@ -840,9 +838,7 @@ def test_setup_manure_schedule(
     mock_input_manager.get_data = input_manager_original_method_states["get_data"]
 
 
-def test_setup_manure_schedule_no_data(
-    mock_input_manager: InputManager
-) -> None:
+def test_setup_manure_schedule_no_data(mock_input_manager: InputManager) -> None:
     """Test when no manure schedule input."""
     mock_input_manager.get_data = mock.MagicMock(return_value=None)
 
@@ -1266,9 +1262,7 @@ def test_setup_tillage_schedule(
     mock_input_manager.get_data = input_manager_original_method_states["get_data"]
 
 
-def test_setup_tillage_schedule_no_data(
-    mock_input_manager: InputManager
-) -> None:
+def test_setup_tillage_schedule_no_data(mock_input_manager: InputManager) -> None:
     """Test when no tillage input data available."""
     mock_input_manager.get_data = mock.MagicMock(return_value=None)
 
@@ -1436,9 +1430,7 @@ def test_crop_schedule_setup(
     mock_input_manager.get_data = input_manager_original_method_states["get_data"]
 
 
-def test_setup_crop_schedule_schedule_no_data(
-    mock_input_manager: InputManager
-) -> None:
+def test_setup_crop_schedule_schedule_no_data(mock_input_manager: InputManager) -> None:
     """Test when no crop schedule input data available."""
     mock_input_manager.get_data = mock.MagicMock(return_value=None)
     crop_configs = ["alfalfa", "corn", "oats"]
@@ -1982,7 +1974,7 @@ def test_setup_field(
     )
     mock_setup_manure_events = mocker.patch(
         "RUFAS.biophysical.field.manager.field_manager.FieldManager._setup_manure_events",
-        return_value=mock_manure_events
+        return_value=mock_manure_events,
     )
     mock_setup_tillage_events = mocker.patch(
         "RUFAS.biophysical.field.manager.field_manager.FieldManager._setup_tillage_events",

--- a/tests/test_biophysical/test_crop_soil_field/manager_tests/test_field_manager.py
+++ b/tests/test_biophysical/test_crop_soil_field/manager_tests/test_field_manager.py
@@ -1430,8 +1430,7 @@ def test_crop_schedule_setup(
     mock_input_manager.get_data = input_manager_original_method_states["get_data"]
 
 
-def test_setup_crop_schedule_schedule_no_data(mock_input_manager: InputManager,
-                                              mocker: MockerFixture) -> None:
+def test_setup_crop_schedule_schedule_no_data(mock_input_manager: InputManager, mocker: MockerFixture) -> None:
     """Test when no crop schedule input data available."""
     mocker.patch.object(mock_input_manager, "get_data", return_value=None)
     crop_configs = ["alfalfa", "corn", "oats"]

--- a/tests/test_biophysical/test_crop_soil_field/manager_tests/test_field_manager.py
+++ b/tests/test_biophysical/test_crop_soil_field/manager_tests/test_field_manager.py
@@ -395,9 +395,9 @@ def test_setup_fertilizer_schedule(
     mock_input_manager.get_data = input_manager_original_method_states["get_data"]
 
 
-def test_setup_fertilizer_schedule_no_data(mock_input_manager: InputManager) -> None:
+def test_setup_fertilizer_schedule_no_data(mock_input_manager: InputManager, mocker: MockerFixture) -> None:
     """Test when no fertilizer schedule input."""
-    mock_input_manager.get_data = mock.MagicMock(return_value=None)
+    mocker.patch.object(mock_input_manager, "get_data", return_value=None)
 
     with pytest.raises(ValueError):
         FieldManager._setup_fertilizer_events("test_fert_schedule")
@@ -838,9 +838,9 @@ def test_setup_manure_schedule(
     mock_input_manager.get_data = input_manager_original_method_states["get_data"]
 
 
-def test_setup_manure_schedule_no_data(mock_input_manager: InputManager) -> None:
+def test_setup_manure_schedule_no_data(mock_input_manager: InputManager, mocker: MockerFixture) -> None:
     """Test when no manure schedule input."""
-    mock_input_manager.get_data = mock.MagicMock(return_value=None)
+    mocker.patch.object(mock_input_manager, "get_data", return_value=None)
 
     with pytest.raises(ValueError):
         FieldManager._setup_manure_events("test_manure_schedule")
@@ -1262,9 +1262,9 @@ def test_setup_tillage_schedule(
     mock_input_manager.get_data = input_manager_original_method_states["get_data"]
 
 
-def test_setup_tillage_schedule_no_data(mock_input_manager: InputManager) -> None:
+def test_setup_tillage_schedule_no_data(mock_input_manager: InputManager, mocker: MockerFixture) -> None:
     """Test when no tillage input data available."""
-    mock_input_manager.get_data = mock.MagicMock(return_value=None)
+    mocker.patch.object(mock_input_manager, "get_data", return_value=None)
 
     with pytest.raises(ValueError):
         FieldManager._setup_tillage_events("test_tillage_schedule")
@@ -1430,9 +1430,10 @@ def test_crop_schedule_setup(
     mock_input_manager.get_data = input_manager_original_method_states["get_data"]
 
 
-def test_setup_crop_schedule_schedule_no_data(mock_input_manager: InputManager) -> None:
+def test_setup_crop_schedule_schedule_no_data(mock_input_manager: InputManager,
+                                              mocker: MockerFixture) -> None:
     """Test when no crop schedule input data available."""
-    mock_input_manager.get_data = mock.MagicMock(return_value=None)
+    mocker.patch.object(mock_input_manager, "get_data", return_value=None)
     crop_configs = ["alfalfa", "corn", "oats"]
 
     with pytest.raises(ValueError):
@@ -1881,7 +1882,7 @@ def test_setup_soil_error(
     soil_configuration: dict[str, float | int] | dict[str, float | int | None],
     error_message: str,
     mock_input_manager: InputManager,
-    input_manager_original_method_states: Dict[str, Callable],
+    input_manager_original_method_states: Dict[str, Any],
 ) -> None:
     """Tests that errors are raised correctly when invalid soil configurations are passed."""
     mock_input_manager.get_data = mock.MagicMock(return_value=soil_configuration)

--- a/tests/test_biophysical/test_crop_soil_field/manager_tests/test_field_manager.py
+++ b/tests/test_biophysical/test_crop_soil_field/manager_tests/test_field_manager.py
@@ -395,6 +395,16 @@ def test_setup_fertilizer_schedule(
     mock_input_manager.get_data = input_manager_original_method_states["get_data"]
 
 
+def test_setup_fertilizer_schedule_no_data(
+    mock_input_manager: InputManager
+) -> None:
+    """Test when no fertilizer schedule input."""
+    mock_input_manager.get_data = mock.MagicMock(return_value=None)
+
+    with pytest.raises(ValueError):
+        FieldManager._setup_fertilizer_events("test_fert_schedule")
+
+
 @pytest.mark.parametrize(
     "manure_schedule_data,expected_manure_schedule",
     [
@@ -830,6 +840,16 @@ def test_setup_manure_schedule(
     mock_input_manager.get_data = input_manager_original_method_states["get_data"]
 
 
+def test_setup_manure_schedule_no_data(
+    mock_input_manager: InputManager
+) -> None:
+    """Test when no manure schedule input."""
+    mock_input_manager.get_data = mock.MagicMock(return_value=None)
+
+    with pytest.raises(ValueError):
+        FieldManager._setup_manure_events("test_manure_schedule")
+
+
 @pytest.mark.parametrize(
     "tillage_schedule_data,expected_tillage_schedule",
     [
@@ -1246,6 +1266,16 @@ def test_setup_tillage_schedule(
     mock_input_manager.get_data = input_manager_original_method_states["get_data"]
 
 
+def test_setup_tillage_schedule_no_data(
+    mock_input_manager: InputManager
+) -> None:
+    """Test when no tillage input data available."""
+    mock_input_manager.get_data = mock.MagicMock(return_value=None)
+
+    with pytest.raises(ValueError):
+        FieldManager._setup_tillage_events("test_tillage_schedule")
+
+
 @pytest.mark.parametrize(
     "crop_schedule_config,expected",
     [
@@ -1405,6 +1435,16 @@ def test_crop_schedule_setup(
 
     mock_input_manager.get_data = input_manager_original_method_states["get_data"]
 
+
+def test_setup_crop_schedule_schedule_no_data(
+    mock_input_manager: InputManager
+) -> None:
+    """Test when no crop schedule input data available."""
+    mock_input_manager.get_data = mock.MagicMock(return_value=None)
+    crop_configs = ["alfalfa", "corn", "oats"]
+
+    with pytest.raises(ValueError):
+        FieldManager._setup_crop_schedules("test_crop_schedule", crop_configs)
 
 def test_crop_schedule_setup_error(mocker: MockerFixture, mock_input_manager: InputManager) -> None:
     """Test that crop schedule setup fails correctly when a config is not available."""


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
The simulation should run successfully when some input data is missing under reasonable case.
### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2666

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
The simulation should run successfully when all feeds are purchased, and no crop-, field-, manure-application-, or harvest-related metadata blobs are provided in the farm input JSON.
Field-related processing should be skipped entirely in purchased-feeds-only scenarios.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
These cases are reasonable scenarios that could happen, so they should not be crashing the code.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->

- In `crop_data_factor.py`, only set up the configuration if data is given.
- In `field_manager.py`, ensure all schedule data is provided if there's field data. There should still be inputs representing "no schedule" if the field data.
- In `emissions.py`, skip processing for empty filtered data.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
- Updated unit tests.
- SMEs' review on failing scenarios.


### Input Changes
<!-- Provide a short summary describing input modifications. -->
<!-- Please include the things that are added, deleted, or modified. -->
N/A

### Output Changes
<!-- List all the output variable/function modifications with a short summary. -->
<!-- """- `Class.Function.VariableName`: description""" -->
- N/A

#### Filter
<!-- Provide a filter that can be used to handle the output changes. -->

```json

```
