### PR TITLE
[DataValidator] Improves and fixes DataValidator data-fixing error messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-1711%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-1683%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # RuFaS: Ruminant Farm Systems
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-1712%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-1684%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 
 # RuFaS: Ruminant Farm Systems

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-1710%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-1674%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # RuFaS: Ruminant Farm Systems
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-1702%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-1710%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # RuFaS: Ruminant Farm Systems
 

--- a/RUFAS/data_validator.py
+++ b/RUFAS/data_validator.py
@@ -1286,7 +1286,7 @@ class DataValidator:
 
         variable_parent: dict[str | int, Any] | list[Any] = data
         for key in element_hierarchy[:-1]:
-            variable_parent = variable_parent[str(key)] if type(variable_parent) is dict \
+            variable_parent = variable_parent[key] if isinstance(variable_parent, dict) \
                 else variable_parent[int(key)]
 
         element_path = ".".join([str(element) for element in element_hierarchy])
@@ -1294,9 +1294,8 @@ class DataValidator:
             f"Violates properties defined in metadata properties section '{properties_blob_key}'."
         )
         if "default" not in variable_properties.keys():
-            invalid_value = variable_parent.get(str(element_hierarchy[-1]), "missing required value") if type(
-                variable_parent
-            ) is dict else variable_parent[int(element_hierarchy[-1])]
+            invalid_value = variable_parent.get(element_hierarchy[-1], "missing required value") if \
+                isinstance(variable_parent, dict) else variable_parent[int(element_hierarchy[-1])]
             error_message = (
                 f"Variable: '{element_hierarchy[-1]}' has invalid value: '{invalid_value}'"
                 f", and cannot be changed to a default value. {properties_violation_message}"

--- a/RUFAS/data_validator.py
+++ b/RUFAS/data_validator.py
@@ -772,8 +772,19 @@ class DataValidator:
 
         type_to_validator_map: dict[
             str,
-            Callable[[list[int | str], dict[str, Any], dict[str | int, Any] | list[Any],
-                      bool, str, ElementsCounter, bool, set[str]], bool],
+            Callable[
+                [
+                    list[int | str],
+                    dict[str, Any],
+                    dict[str | int, Any] | list[Any],
+                    bool,
+                    str,
+                    ElementsCounter,
+                    bool,
+                    set[str],
+                ],
+                bool,
+            ],
         ] = {
             "array": self._array_type_validator,
             "object": self._object_type_validator,
@@ -1286,16 +1297,18 @@ class DataValidator:
 
         variable_parent: dict[str | int, Any] | list[Any] = data
         for key in element_hierarchy[:-1]:
-            variable_parent = variable_parent[key] if isinstance(variable_parent, dict) \
-                else variable_parent[int(key)]
+            variable_parent = variable_parent[key] if isinstance(variable_parent, dict) else variable_parent[int(key)]
 
         element_path = ".".join([str(element) for element in element_hierarchy])
         properties_violation_message = (
             f"Violates properties defined in metadata properties section '{properties_blob_key}'."
         )
         if "default" not in variable_properties.keys():
-            invalid_value = variable_parent.get(element_hierarchy[-1], "missing required value") if \
-                isinstance(variable_parent, dict) else variable_parent[int(element_hierarchy[-1])]
+            invalid_value = (
+                variable_parent.get(element_hierarchy[-1], "missing required value")
+                if isinstance(variable_parent, dict)
+                else variable_parent[int(element_hierarchy[-1])]
+            )
             error_message = (
                 f"Variable: '{element_hierarchy[-1]}' has invalid value: '{invalid_value}'"
                 f", and cannot be changed to a default value. {properties_violation_message}"
@@ -1557,8 +1570,9 @@ class DataValidator:
                 formatted_path_elems.append(f"{raw_path_elem}")
         return ".".join(formatted_path_elems)
 
-    def extract_value_by_key_list(self, data: list[Any] | dict[str | int, Any],
-                                  variable_path: Sequence[str | int]) -> Any:
+    def extract_value_by_key_list(
+        self, data: list[Any] | dict[str | int, Any], variable_path: Sequence[str | int]
+    ) -> Any:
         """
         Extracts a value from a nested list or dictionary using a list of keys (int or str).
 

--- a/RUFAS/data_validator.py
+++ b/RUFAS/data_validator.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 import re
 from enum import Enum
-from typing import Any, Callable, Union, Sequence
+from typing import Any, Callable, Sequence
 
 from RUFAS.util import Aggregator
 
@@ -717,7 +717,7 @@ class DataValidator:
         self,
         variable_properties: dict[str, Any],
         variable_path: list[str | int],
-        data: dict[str, Any],
+        data: dict[str | int, Any] | list[Any],
         eager_termination: bool,
         properties_blob_key: str,
         elements_counter: "ElementsCounter",
@@ -729,11 +729,11 @@ class DataValidator:
 
         Parameters
         ----------
-        variable_properties : Dict[str, Any]
+        variable_properties : dict[str, Any]
             A dictionary containing properties relevant to the validation.
-        variable_path : List[str | int]
+        variable_path : list[str | int]
             The path to the variable being validated.
-        data : Dict[str, Any]
+        data : dict[str | int, Any] | list[Any]
             The data to be validated.
         eager_termination : bool
             If True, the process will be terminated as soon as finding invalid data and failing to fix it.
@@ -772,9 +772,8 @@ class DataValidator:
 
         type_to_validator_map: dict[
             str,
-            Callable[
-                [list[int | str], dict[str, Any], dict[str, Any], bool, str, ElementsCounter, bool, set[str]], bool
-            ],
+            Callable[[list[int | str], dict[str, Any], dict[str | int, Any] | list[Any],
+                      bool, str, ElementsCounter, bool, set[str]], bool],
         ] = {
             "array": self._array_type_validator,
             "object": self._object_type_validator,
@@ -804,12 +803,12 @@ class DataValidator:
         if data_type not in fixable_data_types:
             if not is_valid:
                 error_message = (
-                    f"Variable: '{path}' has invalid or missing values and its data type is not fixable."
+                    f"Variable: '{path}' data type '{data_type}' is not fixable by Input Manager."
                     f" Please check the inputs."
                 )
                 self.event_logs.append(
                     {
-                        "error": "Validation: invalid input data not able to be fixed",
+                        "error": "Validation: data type is not fixable by Input Manager",
                         "message": error_message,
                         "info_map": info_map,
                     }
@@ -826,16 +825,6 @@ class DataValidator:
             elements_counter.increment(ElementState.FIXED)
             return True
         else:
-            error_message = (
-                f"Variable: '{path}' has invalid or missing values and failed to fix. Please check the inputs."
-            )
-            self.event_logs.append(
-                {
-                    "error": "Validation: invalid input data not able to be fixed",
-                    "message": error_message,
-                    "info_map": info_map,
-                }
-            )
             elements_counter.increment(ElementState.INVALID)
             return False
 
@@ -920,7 +909,7 @@ class DataValidator:
         self,
         variable_path: list[str | int],
         variable_properties: dict[str, Any],
-        data: dict[str, Any],
+        data: dict[str | int, Any] | list[Any],
         eager_termination: bool,
         properties_blob_key: str,
         elements_counter: "ElementsCounter",
@@ -932,11 +921,11 @@ class DataValidator:
 
         Parameters
         ----------
-        variable_path : List[str | int]
+        variable_path : list[str | int]
             The path to the variable being validated.
-        variable_properties : Dict[str, Any]
+        variable_properties : dict[str, Any]
             The metadata properties for the variable being validated.
-        data : Dict[str, Any]
+        data : data: dict[str | Any] | list[Any]
             The data to be validated.
         eager_termination : bool
             If True, the process will be terminated upon finding invalid data.
@@ -988,7 +977,7 @@ class DataValidator:
         self,
         variable_path: list[str | int],
         variable_properties: dict[str, Any],
-        data: dict[str, Any],
+        data: dict[str | int, Any] | list[Any],
         eager_termination: bool,
         properties_blob_key: str,
         elements_counter: ElementsCounter,
@@ -1000,11 +989,11 @@ class DataValidator:
 
         Parameters
         ----------
-        variable_path : List[str | int]
+        variable_path : list[str | int]
             The path to the variable being validated.
-        variable_properties : Dict[str, Any]
+        variable_properties : dict[str, Any]
             The metadata properties for the variable being validated.
-        data : Dict[str, Any]
+        data : dict[str | int, Any] | list[Any]
             The data to be validated.
         eager_termination : bool
             If True, the process will be terminated upon finding invalid data.
@@ -1088,7 +1077,7 @@ class DataValidator:
         self,
         variable_path: list[str | int],
         variable_properties: dict[str, Any],
-        data: dict[str, Any],
+        data: dict[str | int, Any] | list[Any],
         eager_termination: bool,
         properties_blob_key: str,
         elements_counter: "ElementsCounter",
@@ -1150,7 +1139,7 @@ class DataValidator:
         self,
         variable_path: list[str | int],
         variable_properties: dict[str, Any],
-        data: dict[str, Any],
+        data: dict[str | int, Any] | list[Any],
         eager_termination: bool,
         properties_blob_key: str,
         elements_counter: "ElementsCounter",
@@ -1224,7 +1213,7 @@ class DataValidator:
         self,
         variable_path: list[str | int],
         variable_properties: dict[str, Any],
-        data: dict[str, Any],
+        data: dict[str | int, Any] | list[Any],
         eager_termination: bool,
         properties_blob_key: str,
         elements_counter: "ElementsCounter",
@@ -1264,8 +1253,8 @@ class DataValidator:
     def _fix_data(
         self,
         variable_properties: dict[str, Any],
-        element_hierarchy: list[Union[str, int]],
-        data: dict[str, Any],
+        element_hierarchy: list[str | int],
+        data: dict[str | int, Any] | list[Any],
         properties_blob_key: str,
     ) -> bool:
         """
@@ -1276,10 +1265,10 @@ class DataValidator:
         variable_properties : dict[str, Any]
             The properties for the variable of interest.
 
-        element_hierarchy: list
+        element_hierarchy: list[str | int]
             A list indicating the path to reach the variable of interest in self.__metadata and self.__pool.
 
-        data: dict[str, Any]
+        data: dict[str | int, Any] | list[Any]
             A buffer dictionary that holds the data for validation and fixing.
 
         properties_blob_key : str
@@ -1295,17 +1284,21 @@ class DataValidator:
             "function": DataValidator._fix_data.__name__,
         }
 
-        variable_parent = data
+        variable_parent: dict[str | int, Any] | list[Any] = data
         for key in element_hierarchy[:-1]:
-            variable_parent = variable_parent[key]
+            variable_parent = variable_parent[str(key)] if type(variable_parent) is dict \
+                else variable_parent[int(key)]
 
         element_path = ".".join([str(element) for element in element_hierarchy])
         properties_violation_message = (
             f"Violates properties defined in metadata properties section '{properties_blob_key}'."
         )
         if "default" not in variable_properties.keys():
+            invalid_value = variable_parent.get(str(element_hierarchy[-1]), "missing required value") if type(
+                variable_parent
+            ) is dict else variable_parent[int(element_hierarchy[-1])]
             error_message = (
-                f"Variable: '{element_path}' has invalid value: {variable_parent[element_hierarchy[-1]]}"
+                f"Variable: '{element_hierarchy[-1]}' has invalid value: '{invalid_value}'"
                 f", and cannot be changed to a default value. {properties_violation_message}"
             )
             self.event_logs.append(
@@ -1318,9 +1311,10 @@ class DataValidator:
             return False
 
         if type(variable_parent) is list:
-            original_invalid_value = variable_parent[element_hierarchy[-1]]
+            original_invalid_value = variable_parent[int(element_hierarchy[-1])]
         else:
-            original_invalid_value = variable_parent.get(element_hierarchy[-1])
+            assert type(variable_parent) is dict
+            original_invalid_value = variable_parent.get(str(element_hierarchy[-1]))
 
         warning_message = (
             f"Variable: '{element_path}' has value: {original_invalid_value}. {properties_violation_message}"
@@ -1328,8 +1322,11 @@ class DataValidator:
         self.event_logs.append(
             {"warning": "Validation: invalid data found", "message": warning_message, "info_map": info_map}
         )
-
-        variable_parent[element_hierarchy[-1]] = variable_properties["default"]
+        if type(variable_parent) is list:
+            variable_parent[int(element_hierarchy[-1])] = variable_properties["default"]
+        else:
+            assert type(variable_parent) is dict
+            variable_parent[str(element_hierarchy[-1])] = variable_properties["default"]
 
         warning_message = (
             f"Invalid data fixed: '{element_path}' value changed from {original_invalid_value} to "
@@ -1341,7 +1338,7 @@ class DataValidator:
 
     def _extract_data_by_key_list(
         self,
-        data: list[Any] | dict[str, Any],
+        data: dict[str | int, Any] | list[Any],
         variable_path: Sequence[str | int],
         variable_properties: dict[str, Any],
         called_during_initialization: bool,
@@ -1561,7 +1558,8 @@ class DataValidator:
                 formatted_path_elems.append(f"{raw_path_elem}")
         return ".".join(formatted_path_elems)
 
-    def extract_value_by_key_list(self, data: list[Any] | dict[str, Any], variable_path: Sequence[str | int]) -> Any:
+    def extract_value_by_key_list(self, data: list[Any] | dict[str | int, Any],
+                                  variable_path: Sequence[str | int]) -> Any:
         """
         Extracts a value from a nested list or dictionary using a list of keys (int or str).
 

--- a/changelog.md
+++ b/changelog.md
@@ -281,6 +281,7 @@ v0.9.2
 - [2655](https://github.com/RuminantFarmSystems/MASM/pull/2655) - [minor change] [Animal] [InputChange] [NoOutputChange] Updated RationManager class to allow for more flexibility in user inputs in Feed input file.
 - [2670](https://github.com/RuminantFarmSystems/MASM/pull/2670) - [minor change] [Animal] [InputChange] [NoOutputChange] Updated Animal module unit testing to 100% coverage.
 - [2673](https://github.com/RuminantFarmSystems/MASM/pull/2673) - [minor change] [Feed] [InputChange] [NoOutputChange] Adds a default for purchased feed buffer of 0.15.
+- [2675](https://github.com/RuminantFarmSystems/MASM/pull/2675) - [minor change] [DataValidator] [NoInputChange] [NoOutputChange] Fixes and clarifies data fixing error messaging for IM.
 
 ### v0.9.2
 

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -8,7 +8,7 @@ from pytest_mock import MockerFixture
 from RUFAS.data_validator import DataValidator, ElementState, ElementsCounter, CrossValidator
 
 
-def mock_input_array_data_for_fix_data() -> Dict[str, Dict[str, Any] | List[Any]]:
+def mock_input_array_data_for_fix_data() -> dict[str | int, Any] | list[Any]:
     return {
         "element1": [1, 2, 3],
         "element2": [1, 2, 3, 4, 5],
@@ -41,7 +41,7 @@ def mock_input_array_data_for_fix_data() -> Dict[str, Dict[str, Any] | List[Any]
 )
 def test_bool_type_validator(
     input_data_value: bool,
-    dummy_variable_properties: Dict[str, Any],
+    dummy_variable_properties: dict[str, Any],
     expected_result: bool,
     mocker: MockerFixture,
 ) -> None:
@@ -50,9 +50,9 @@ def test_bool_type_validator(
     """
     # Arrange
     var_path: list[str | int] = ["dummy_var_path"]
-    variable_properties: Dict[str, Any] = dummy_variable_properties
+    variable_properties: dict[str, Any] = dummy_variable_properties
     dummy_properties_key = "dummy_variable_properties"
-    dummy_input_data = {"a": 1, "b": 2}
+    dummy_input_data: dict[str | int, Any] | list[Any] = {"a": 1, "b": 2}
     dummy_counter = mocker.MagicMock(autospec=ElementsCounter)
     unused_bool_input = False
     patch_extract = mocker.patch.object(DataValidator, "_extract_data_by_key_list", return_value=input_data_value)
@@ -116,7 +116,7 @@ def test_bool_type_validator(
 )
 def test_number_type_validator(
     dummy_value: int,
-    dummy_variable_properties: Dict[str, int],
+    dummy_variable_properties: dict[str, int],
     expected_result: bool,
     mocker: MockerFixture,
 ) -> None:
@@ -124,7 +124,7 @@ def test_number_type_validator(
 
     # Arrange
     dummy_var_path: list[str | int] = ["dummy_num"]
-    dummy_input_data = {"a": 1}
+    dummy_input_data: dict[str | int, Any] | list[Any] = {"a": 1}
     dummy_properties_key = "dummy_variable_properties"
     unused_bool_input = False
     dummy_counter = mocker.MagicMock(autospec=ElementsCounter)
@@ -181,7 +181,7 @@ def test_string_type_validator(
     """Unit test for _string_type_validator function in file input_manager.py"""
     var_path: list[str | int] = ["dummy_var_path"]
     dummy_properties_key = "dummy_variable_properties"
-    dummy_input_data = {"a": 1, "b": 2}
+    dummy_input_data: dict[str | int, Any] | list[Any] = {"a": 1, "b": 2}
     dummy_counter = mocker.MagicMock(autospec=ElementsCounter)
     unused_bool_input = False
     patch_extract = mocker.patch.object(DataValidator, "_extract_data_by_key_list", return_value=dummy_value)
@@ -264,18 +264,20 @@ def test_fix_array_type_fixable_data(
     expected_result: bool,
 ) -> None:
     """Unit test for fixable array-type data for _fix_data function in file input_manager.py"""
-
-    dummy_input_data = mock_input_array_data_for_fix_data()
+    dummy_input_data: dict[str | int, Any] | list[Any] = mock_input_array_data_for_fix_data()
     dummy_properties_key = "dummy_variable_properties"
     properties_violation_message = (
         f"Violates properties defined in metadata properties section '{dummy_properties_key}'."
     )
-    variable_parent = dummy_input_data
+    variable_parent: dict[str | int, Any] | list[Any] = dummy_input_data
     for key in dummy_element_hierarchy[:-1]:
-        variable_parent = variable_parent[key]
+        if isinstance(variable_parent, list):
+            variable_parent = variable_parent[int(key)]
+        else:
+            variable_parent = variable_parent[key] if isinstance(key, str | int) else variable_parent[str(key)]
     element_path = ".".join([str(element) for element in dummy_element_hierarchy])
-    if type(variable_parent) is list:
-        original_invalid_value = variable_parent[dummy_element_hierarchy[-1]]
+    if isinstance(variable_parent, list):
+        original_invalid_value = variable_parent[int(dummy_element_hierarchy[-1])]
     else:
         original_invalid_value = variable_parent.get(dummy_element_hierarchy[-1])
     info_map = {
@@ -362,17 +364,21 @@ def test_fix_array_type_critical_data(
     expected_result: bool,
 ) -> None:
     """Unit test for critical array-type data for _fix_data function in file input_manager.py"""
-    dummy_input_data = mock_input_array_data_for_fix_data()
+    dummy_input_data: dict[str, Any] | list[Any] = mock_input_array_data_for_fix_data()
     dummy_properties_key = "dummy_variable_properties"
-    element_path = ".".join([str(element) for element in dummy_element_hierarchy])
     variable_parent = dummy_input_data
     for key in dummy_element_hierarchy[:-1]:
-        variable_parent = variable_parent[key]
+        if isinstance(variable_parent, list):
+            variable_parent = variable_parent[int(key)]
+        else:
+            variable_parent = variable_parent[key]
     properties_violation_message = (
         f"Violates properties defined in metadata properties section '{dummy_properties_key}'."
     )
+    invalid_value = variable_parent.get(dummy_element_hierarchy[-1], "missing required value") if \
+        isinstance(variable_parent, dict) else variable_parent[int(dummy_element_hierarchy[-1])]
     error_message = (
-        f"Variable: '{element_path}' has invalid value: {variable_parent[dummy_element_hierarchy[-1]]}"
+        f"Variable: '{dummy_element_hierarchy[-1]}' has invalid value: '{invalid_value}'"
         f", and cannot be changed to a default value. {properties_violation_message}"
     )
     info_map = {
@@ -629,15 +635,17 @@ def test_fix_string_type_critical_data(
     """Unit test for critical string-type data for _fix_data function in file input_manager.py"""
     dummy_input_data = mock_input_array_data_for_fix_data()
     dummy_properties_key = "dummy_variable_properties"
-    element_path = ".".join([str(element) for element in dummy_element_hierarchy])
     variable_parent = dummy_input_data
     for key in dummy_element_hierarchy[:-1]:
-        variable_parent = variable_parent[key]
+        variable_parent = variable_parent[key] if isinstance(variable_parent, dict) \
+            else variable_parent[int(key)]
     properties_violation_message = (
         f"Violates properties defined in metadata properties section '{dummy_properties_key}'."
     )
+    invalid_value = variable_parent.get(str(dummy_element_hierarchy[-1]), "missing required value") if \
+        isinstance(variable_parent, dict) else variable_parent[int(dummy_element_hierarchy[-1])]
     error_message = (
-        f"Variable: '{element_path}' has invalid value: {variable_parent[dummy_element_hierarchy[-1]]}"
+        f"Variable: '{dummy_element_hierarchy[-1]}' has invalid value: '{invalid_value}'"
         f", and cannot be changed to a default value. {properties_violation_message}"
     )
     info_map = {
@@ -789,7 +797,7 @@ def test_fix_number_type_fixable_data(
 
 
 @pytest.mark.parametrize(
-    "dummy_variable_properties, dummy_element_hierarchy, expected_result, " "expected_warning_call_count",
+    "dummy_variable_properties, dummy_element_hierarchy, expected_result,",
     [
         (
             {
@@ -799,7 +807,6 @@ def test_fix_number_type_fixable_data(
             },
             ["element6"],
             False,
-            0,
         ),
         (
             {
@@ -809,7 +816,6 @@ def test_fix_number_type_fixable_data(
             },
             ["element7"],
             False,
-            0,
         ),
         (
             {
@@ -819,7 +825,6 @@ def test_fix_number_type_fixable_data(
             },
             ["element8"],
             False,
-            0,
         ),
         (
             {
@@ -829,7 +834,6 @@ def test_fix_number_type_fixable_data(
             },
             ["element9", "element10"],
             False,
-            0,
         ),
     ],
 )
@@ -837,20 +841,23 @@ def test_fix_number_type_critical_data(
     dummy_variable_properties: dict[str, Any],
     dummy_element_hierarchy: list[str],
     expected_result: bool,
-    expected_warning_call_count: int,
 ) -> None:
     """Unit test for critical number-type data for _fix_data function in file input_manager.py"""
-    dummy_input_data = mock_input_array_data_for_fix_data()
+    dummy_input_data: dict[str | int, Any] | list[Any] = mock_input_array_data_for_fix_data()
     dummy_properties_key = "dummy_variable_properties"
-    element_path = ".".join([str(element) for element in dummy_element_hierarchy])
-    variable_parent = dummy_input_data
+    variable_parent: dict[str | int, Any] | list[Any] = dummy_input_data
     for key in dummy_element_hierarchy[:-1]:
-        variable_parent = variable_parent[key]
+        if isinstance(variable_parent, list):
+            variable_parent = variable_parent[int(key)]
+        else:
+            variable_parent = variable_parent[key]
     properties_violation_message = (
         f"Violates properties defined in metadata properties section '{dummy_properties_key}'."
     )
+    invalid_value = variable_parent.get(dummy_element_hierarchy[-1], "missing required value") if \
+        isinstance(variable_parent, dict) else variable_parent[int(dummy_element_hierarchy[-1])]
     error_message = (
-        f"Variable: '{element_path}' has invalid value: {variable_parent[dummy_element_hierarchy[-1]]}"
+        f"Variable: '{dummy_element_hierarchy[-1]}' has invalid value: '{invalid_value}'"
         f", and cannot be changed to a default value. {properties_violation_message}"
     )
     info_map = {

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -375,8 +375,11 @@ def test_fix_array_type_critical_data(
     properties_violation_message = (
         f"Violates properties defined in metadata properties section '{dummy_properties_key}'."
     )
-    invalid_value = variable_parent.get(dummy_element_hierarchy[-1], "missing required value") if \
-        isinstance(variable_parent, dict) else variable_parent[int(dummy_element_hierarchy[-1])]
+    invalid_value = (
+        variable_parent.get(dummy_element_hierarchy[-1], "missing required value")
+        if isinstance(variable_parent, dict)
+        else variable_parent[int(dummy_element_hierarchy[-1])]
+    )
     error_message = (
         f"Variable: '{dummy_element_hierarchy[-1]}' has invalid value: '{invalid_value}'"
         f", and cannot be changed to a default value. {properties_violation_message}"
@@ -637,13 +640,15 @@ def test_fix_string_type_critical_data(
     dummy_properties_key = "dummy_variable_properties"
     variable_parent = dummy_input_data
     for key in dummy_element_hierarchy[:-1]:
-        variable_parent = variable_parent[key] if isinstance(variable_parent, dict) \
-            else variable_parent[int(key)]
+        variable_parent = variable_parent[key] if isinstance(variable_parent, dict) else variable_parent[int(key)]
     properties_violation_message = (
         f"Violates properties defined in metadata properties section '{dummy_properties_key}'."
     )
-    invalid_value = variable_parent.get(str(dummy_element_hierarchy[-1]), "missing required value") if \
-        isinstance(variable_parent, dict) else variable_parent[int(dummy_element_hierarchy[-1])]
+    invalid_value = (
+        variable_parent.get(str(dummy_element_hierarchy[-1]), "missing required value")
+        if isinstance(variable_parent, dict)
+        else variable_parent[int(dummy_element_hierarchy[-1])]
+    )
     error_message = (
         f"Variable: '{dummy_element_hierarchy[-1]}' has invalid value: '{invalid_value}'"
         f", and cannot be changed to a default value. {properties_violation_message}"
@@ -854,8 +859,11 @@ def test_fix_number_type_critical_data(
     properties_violation_message = (
         f"Violates properties defined in metadata properties section '{dummy_properties_key}'."
     )
-    invalid_value = variable_parent.get(dummy_element_hierarchy[-1], "missing required value") if \
-        isinstance(variable_parent, dict) else variable_parent[int(dummy_element_hierarchy[-1])]
+    invalid_value = (
+        variable_parent.get(dummy_element_hierarchy[-1], "missing required value")
+        if isinstance(variable_parent, dict)
+        else variable_parent[int(dummy_element_hierarchy[-1])]
+    )
     error_message = (
         f"Variable: '{dummy_element_hierarchy[-1]}' has invalid value: '{invalid_value}'"
         f", and cannot be changed to a default value. {properties_violation_message}"

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -258,9 +258,9 @@ def test_string_type_validator(
     ],
 )
 def test_fix_array_type_fixable_data(
-    dummy_variable_properties: Dict[str, Any],
-    dummy_element_hierarchy: List[str],
-    expected_value: List[Any],
+    dummy_variable_properties: dict[str, Any],
+    dummy_element_hierarchy: list[str | int],
+    expected_value: list[Any],
     expected_result: bool,
 ) -> None:
     """Unit test for fixable array-type data for _fix_data function in file input_manager.py"""
@@ -296,7 +296,10 @@ def test_fix_array_type_fixable_data(
 
     variable_to_check = dummy_input_data
     for key in dummy_element_hierarchy:
-        variable_to_check = variable_to_check[key]
+        if isinstance(variable_to_check, list):
+            variable_to_check = variable_to_check[int(key)]
+        else:
+            variable_to_check = variable_to_check[key]
     assert variable_to_check == expected_value
     assert result == expected_result
     assert dv.event_logs == [
@@ -359,14 +362,14 @@ def test_fix_array_type_fixable_data(
     ],
 )
 def test_fix_array_type_critical_data(
-    dummy_variable_properties: Dict[str, Any],
-    dummy_element_hierarchy: List[str],
+    dummy_variable_properties: dict[str, Any],
+    dummy_element_hierarchy: list[str | int],
     expected_result: bool,
 ) -> None:
     """Unit test for critical array-type data for _fix_data function in file input_manager.py"""
-    dummy_input_data: dict[str, Any] | list[Any] = mock_input_array_data_for_fix_data()
+    dummy_input_data: dict[str | int, Any] | list[Any] = mock_input_array_data_for_fix_data()
     dummy_properties_key = "dummy_variable_properties"
-    variable_parent = dummy_input_data
+    variable_parent: dict[str | int, Any] | list[Any] = dummy_input_data
     for key in dummy_element_hierarchy[:-1]:
         if isinstance(variable_parent, list):
             variable_parent = variable_parent[int(key)]
@@ -475,22 +478,25 @@ def mock_input_string_data_for_fix_data() -> dict[str, str | dict[str, Any]]:
 )
 def test_fix_string_type_fixable_data(
     dummy_variable_properties: dict[str, Any],
-    dummy_element_hierarchy: list[str],
+    dummy_element_hierarchy: list[str | int],
     expected_value: str,
     expected_result: bool,
 ) -> None:
     """Unit test for fixable string-type data for _fix_data function in file input_manager.py"""
-    dummy_input_data = mock_input_array_data_for_fix_data()
+    dummy_input_data: dict[str | int, Any] | list[Any] = mock_input_array_data_for_fix_data()
     dummy_properties_key = "dummy_variable_properties"
     properties_violation_message = (
         f"Violates properties defined in metadata properties section '{dummy_properties_key}'."
     )
-    variable_parent = dummy_input_data
+    variable_parent: dict[str | int, Any] | list[Any] = dummy_input_data
     for key in dummy_element_hierarchy[:-1]:
-        variable_parent = variable_parent[key]
+        if isinstance(variable_parent, list):
+            variable_parent = variable_parent[int(key)]
+        else:
+            variable_parent = variable_parent[key]
     element_path = ".".join([str(element) for element in dummy_element_hierarchy])
-    if type(variable_parent) is list:
-        original_invalid_value = variable_parent[dummy_element_hierarchy[-1]]
+    if isinstance(variable_parent, list):
+        original_invalid_value = variable_parent[int(dummy_element_hierarchy[-1])]
     else:
         original_invalid_value = variable_parent.get(dummy_element_hierarchy[-1])
     info_map = {
@@ -507,10 +513,13 @@ def test_fix_string_type_fixable_data(
         dummy_properties_key,
     )
 
-    variable_to_check = dummy_input_data
+    variable_to_check: dict[str | int, Any] | list[Any] = dummy_input_data
     for key in dummy_element_hierarchy:
-        variable_to_check = variable_to_check[key]
-    assert variable_to_check == expected_value
+        if isinstance(variable_to_check, list):
+            variable_to_check = variable_to_check[int(key)]
+        else:
+            variable_to_check = variable_to_check[key]
+    assert str(variable_to_check) == expected_value
     assert result == expected_result
     assert dv.event_logs == [
         {
@@ -532,10 +541,9 @@ def test_fix_string_type_fixable_data(
 
 def test_fix_string_type_csv_data() -> None:
     """Unit test for fixable number-type data from a csv array for _fix_data function in file input_manager.py"""
-
-    dummy_input_data = {"element1": [1, 2, 3, 4, 5]}
+    dummy_input_data: dict[str | int, Any] | list[Any] = {"element1": [1, 2, 3, 4, 5]}
     dummy_variable_properties = {"type": "number", "maximum": 4, "default": 3}
-    dummy_element_hierarchy = ["element1", 4]
+    dummy_element_hierarchy: list[str | int] = ["element1", 4]
     dummy_properties_key = "dummy_variable_properties"
     element_path = ".".join([str(element) for element in dummy_element_hierarchy])
     properties_violation_message = (
@@ -545,13 +553,16 @@ def test_fix_string_type_csv_data() -> None:
         "class": DataValidator.__name__,
         "function": DataValidator._fix_data.__name__,
     }
-    variable_parent = dummy_input_data
+    variable_parent: dict[str | int, Any] | list[Any] = dummy_input_data
     for key in dummy_element_hierarchy[:-1]:
-        variable_parent = variable_parent[key]
-    if type(variable_parent) is list:
-        original_invalid_value = variable_parent[dummy_element_hierarchy[-1]]
+        if isinstance(variable_parent, list):
+            variable_parent = variable_parent[int(key)]
+        else:
+            variable_parent = variable_parent[key]
+    if isinstance(variable_parent, list):
+        original_invalid_value = variable_parent[int(dummy_element_hierarchy[-1])]
     else:
-        original_invalid_value = variable_parent.get(dummy_element_hierarchy[-1])
+        original_invalid_value = variable_parent[dummy_element_hierarchy[-1]]
 
     dv: DataValidator = DataValidator()
     result = dv._fix_data(
@@ -563,8 +574,12 @@ def test_fix_string_type_csv_data() -> None:
 
     fixed_variable = dummy_input_data
     for key in dummy_element_hierarchy:
-        fixed_variable = fixed_variable[key]
+        if isinstance(fixed_variable, list):
+            fixed_variable = fixed_variable[int(key)]
+        else:
+            fixed_variable = fixed_variable[key]
 
+    assert isinstance(fixed_variable, int)
     assert fixed_variable == 3
     assert result
     assert dv.event_logs == [
@@ -632,7 +647,7 @@ def test_fix_string_type_csv_data() -> None:
 )
 def test_fix_string_type_critical_data(
     dummy_variable_properties: dict[str, Any],
-    dummy_element_hierarchy: list[str],
+    dummy_element_hierarchy: list[str | int],
     expected_result: bool,
 ) -> None:
     """Unit test for critical string-type data for _fix_data function in file input_manager.py"""
@@ -691,7 +706,7 @@ def mock_input_number_data_for_fix_data() -> Dict[str, Dict[str, int] | int]:
 
 
 @pytest.mark.parametrize(
-    "dummy_variable_properties, dummy_element_hierarchy, expected_value, expected_result, expected_warning_call_count",
+    "dummy_variable_properties, dummy_element_hierarchy, expected_value, expected_result",
     [
         (
             {
@@ -703,7 +718,6 @@ def mock_input_number_data_for_fix_data() -> Dict[str, Dict[str, int] | int]:
             ["element1"],
             5,
             True,
-            2,
         ),
         (
             {
@@ -715,7 +729,6 @@ def mock_input_number_data_for_fix_data() -> Dict[str, Dict[str, int] | int]:
             ["element2"],
             0,
             True,
-            2,
         ),
         (
             {
@@ -727,7 +740,6 @@ def mock_input_number_data_for_fix_data() -> Dict[str, Dict[str, int] | int]:
             ["element3"],
             5,
             True,
-            2,
         ),
         (
             {
@@ -739,31 +751,32 @@ def mock_input_number_data_for_fix_data() -> Dict[str, Dict[str, int] | int]:
             ["element4", "element5"],
             5,
             True,
-            2,
         ),
     ],
 )
 def test_fix_number_type_fixable_data(
     dummy_variable_properties: dict[str, Any],
-    dummy_element_hierarchy: list[str],
+    dummy_element_hierarchy: list[str | int],
     expected_value: str,
     expected_result: bool,
-    expected_warning_call_count: int,
 ) -> None:
     """Unit test for fixable number-type data for _fix_data function in file input_manager.py"""
-    dummy_input_data = mock_input_array_data_for_fix_data()
+    dummy_input_data: dict[str | int, Any] | list[Any] = mock_input_array_data_for_fix_data()
     dummy_properties_key = "dummy_variable_properties"
     properties_violation_message = (
         f"Violates properties defined in metadata properties section '{dummy_properties_key}'."
     )
-    variable_parent = dummy_input_data
+    variable_parent: dict[str | int, Any] | list[Any] = dummy_input_data
     for key in dummy_element_hierarchy[:-1]:
-        variable_parent = variable_parent[key]
+        if isinstance(variable_parent, list):
+            variable_parent = variable_parent[int(key)]
+        else:
+            variable_parent = variable_parent[key]
     element_path = ".".join([str(element) for element in dummy_element_hierarchy])
-    if type(variable_parent) is list:
-        original_invalid_value = variable_parent[dummy_element_hierarchy[-1]]
+    if isinstance(variable_parent, list):
+        original_invalid_value = variable_parent[int(dummy_element_hierarchy[-1])]
     else:
-        original_invalid_value = variable_parent.get(dummy_element_hierarchy[-1])
+        original_invalid_value = variable_parent[dummy_element_hierarchy[-1]]
     info_map = {
         "class": DataValidator.__name__,
         "function": DataValidator._fix_data.__name__,
@@ -780,7 +793,10 @@ def test_fix_number_type_fixable_data(
 
     variable_to_check = dummy_input_data
     for key in dummy_element_hierarchy:
-        variable_to_check = variable_to_check[key]
+        if isinstance(variable_to_check, list):
+            variable_to_check = variable_to_check[int(key)]
+        else:
+            variable_to_check = variable_to_check[key]
     assert variable_to_check == expected_value
     assert result == expected_result
     assert dv.event_logs == [
@@ -844,7 +860,7 @@ def test_fix_number_type_fixable_data(
 )
 def test_fix_number_type_critical_data(
     dummy_variable_properties: dict[str, Any],
-    dummy_element_hierarchy: list[str],
+    dummy_element_hierarchy: list[str | int],
     expected_result: bool,
 ) -> None:
     """Unit test for critical number-type data for _fix_data function in file input_manager.py"""
@@ -929,8 +945,8 @@ def test_fix_number_type_critical_data(
     ],
 )
 def test_extract_value_by_key_list(
-    input_data: Union[List[Any], Dict[str, Any]],
-    variable_path: List[Union[str, int]],
+    input_data: dict[str | int, Any] | list[Any],
+    variable_path: list[Union[str, int]],
     expected: Optional[Any],
     expected_exception: Optional[Type[Exception]],
 ) -> None:
@@ -1022,9 +1038,9 @@ def test_convert_variable_path_to_str(variable_path: List[Union[str, int]], expe
 )
 def test_object_type_validator(
     mocker: MockerFixture,
-    variable_path: List[Union[str, int]],
-    variable_properties: Dict[str, Any],
-    input_data: Dict[str, Any],
+    variable_path: list[Union[str, int]],
+    variable_properties: dict[str, Any],
+    input_data: dict[str | int, Any] | list[Any],
     eager_termination: bool,
     properties_blob_key: str,
     expected_result: bool,
@@ -1280,9 +1296,9 @@ def test_validate_array_container_properties(
 )
 def test_array_type_validator(
     mocker: MockerFixture,
-    variable_path: List[Union[str, int]],
-    variable_properties: Dict[str, Any],
-    input_data: Dict[str, Any],
+    variable_path: list[str | int],
+    variable_properties: dict[str, Any],
+    input_data: dict[str | int, Any] | list[Any],
     eager_termination: bool,
     properties_blob_key: str,
     patch_extract_return: Any,
@@ -1366,7 +1382,7 @@ def test_validate_input_by_type(
     # Arrange
     variable_properties = {"type": data_type}
     variable_path: List[Union[str, int]] = ["path", "to", "variable"]
-    input_data = {"path": {"to": {"variable": input_value}}}
+    input_data: dict[str | int, Any] | list[Any] = {"path": {"to": {"variable": input_value}}}
     eager_termination = False
     properties_blob_key = "blobKey"
     elements_counter = mocker.MagicMock()
@@ -1412,7 +1428,7 @@ def test_validate_input_by_type_key_error() -> None:
     variable_properties = {"a": "b"}
     variable_path: list[Union[str, int]] = ["valid_key"]
     properties_blob_key = "dummy_properties_blob_key"
-    input_data = {"valid_key": {"another_valid_key": "value"}}
+    input_data: dict[str | int, Any] | list[Any] = {"valid_key": {"another_valid_key": "value"}}
     eager_termination = False
     elements_counter = ElementsCounter()
     dv = DataValidator()
@@ -1937,9 +1953,9 @@ def test_validate_metadata_properties_keys(
 
 def test_extract_input_data_by_key_list_no_error(mocker: MockerFixture) -> None:
     """Unit tests for making sure data were extracted when no error"""
-    dummy_input_data: Dict[str, Any] = {"a": 1, "b": 2}
+    dummy_input_data: dict[str | int, Any] | list[Any] = {"a": 1, "b": 2}
     dummy_var_path: list[str | int] = ["dummy_var_path"]
-    dummy_var_properties: Dict[str, Any] = {"pattern": r"cow", "minimum_length": 1, "maximum_length": 5}
+    dummy_var_properties: dict[str, Any] = {"pattern": r"cow", "minimum_length": 1, "maximum_length": 5}
     dummy_value = 1
     patch_extract = mocker.patch.object(DataValidator, "extract_value_by_key_list", return_value=dummy_value)
     patch_log_missing_data = mocker.patch.object(DataValidator, "_log_missing_data")
@@ -1986,8 +2002,8 @@ def test_extract_input_data_by_key_list_key_error(
     var_path: List[str | int], var_name: str, called_during_initialization: bool, mocker: MockerFixture
 ) -> None:
     """Unit tests for making sure data were extracted when error occurs"""
-    dummy_input_data: Dict[str, Any] = {"a": 1, "b": 2}
-    dummy_var_properties: Dict[str, Any] = {"pattern": r"cow", "minimum_length": 1, "maximum_length": 5}
+    dummy_input_data: dict[str | int, Any] | list[Any] = {"a": 1, "b": 2}
+    dummy_var_properties: dict[str, Any] = {"pattern": r"cow", "minimum_length": 1, "maximum_length": 5}
     patch_extract = mocker.patch.object(DataValidator, "extract_value_by_key_list", side_effect=KeyError)
     patch_log_missing_data = mocker.patch.object(DataValidator, "_log_missing_data")
     dv = DataValidator()


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Clears up the messaging when invalid data is fixed or attempted to be fixed by DataValidator to make for easier invalid input diagnosis by user.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2663

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
- Fixes an unplanned-for KeyError when input data is missing and the error message is attempting to be helpful by referencing what's missing back to the user.
- Clears up messaging between a data fixing error regarding a missing piece of invalid critical data and the messaging on trying to fix an invalid piece of critical data that is an unfixable type (i.e. an array or object).

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
The KeyError was causing unhelpful traceback error messaging and even masking the actual error message because the KeyError was not accounted for. Addressing these issues makes these types of input errors easier for the user to diagnose and fix themselves.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
- In `DataValidator._fix_data()`removed a potentially KeyError raising reference to data that may be missing while correcting the message itself to actually provide the missing data and clarify what is going wrong in the input validation process.
- Removed some duplicative error messaging around unfixable data
- Clarified error messaging around trying to fix an invalid array/object type (not currently allowed by RUFAS).

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Recreate one of the errors that prompted this issue in the first place:
1. In `default.json` properties remove the `default` for `buffer`:
<img width="947" height="130" alt="Screenshot 2025-12-09 at 11 37 56 AM" src="https://github.com/user-attachments/assets/57608cf9-2bcc-4411-9fb6-3a8c029d2fb5" />

2. In the feed input file the simulation is using (`example_Midwest_feed.json` if doing the `example_freestall_task`), remove one of the `buffers` from the purchased feed section.

3. Run the simulation and look at the resulting error messages (this is my example but you will see something similar).
<img width="1397" height="189" alt="Screenshot 2025-12-09 at 11 44 08 AM" src="https://github.com/user-attachments/assets/c401ad1b-bef4-4168-bb9b-f071b67233e8" />

4. Compare those to this:
<img width="1383" height="734" alt="Screenshot 2025-12-09 at 11 42 29 AM" src="https://github.com/user-attachments/assets/7a0d7f92-c62e-439b-a750-f72aee47cc0e" />

### Input Changes
<!-- Provide a short summary describing input modifications. -->
<!-- Please include the things that are added, deleted, or modified. -->


### Output Changes
<!-- List all the output variable/function modifications with a short summary. -->
<!-- """- `Class.Function.VariableName`: description""" -->
- N/A

#### Filter
<!-- Provide a filter that can be used to handle the output changes. -->

```json

```
