### PR TITLE
[Manure] Liquid manure storage bug fix and addition of missing separation efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-1705%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-1702%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # RuFaS: Ruminant Farm Systems
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-1702%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-1705%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 # RuFaS: Ruminant Farm Systems
 

--- a/RUFAS/biophysical/manure/separator/separator.py
+++ b/RUFAS/biophysical/manure/separator/separator.py
@@ -146,14 +146,13 @@ class Separator(Processor):
             ash=self.held_manure.ash * self.ash_efficiency,
             non_degradable_volatile_solids=self.held_manure.non_degradable_volatile_solids
             * self.volatile_solids_efficiency,
-            degradable_volatile_solids=self.held_manure.degradable_volatile_solids
-            * self.volatile_solids_efficiency,
+            degradable_volatile_solids=self.held_manure.degradable_volatile_solids * self.volatile_solids_efficiency,
             total_solids=solid_manure_total_solids,
             volume=solid_manure_volume,
             methane_production_potential=self.held_manure.methane_production_potential,
             pen_manure_data=None,
             bedding_non_degradable_volatile_solids=self.held_manure.bedding_non_degradable_volatile_solids
-            * self.volatile_solids_efficiency
+            * self.volatile_solids_efficiency,
         )
         solid_stream_name = "SeparatedSolids"
         solid_manure_stream_dict = asdict(solid_manure_stream)

--- a/RUFAS/biophysical/manure/separator/separator.py
+++ b/RUFAS/biophysical/manure/separator/separator.py
@@ -182,6 +182,7 @@ class Separator(Processor):
             methane_production_potential=self.held_manure.methane_production_potential,
             pen_manure_data=None,
             bedding_non_degradable_volatile_solids=self.held_manure.bedding_non_degradable_volatile_solids
+            * (1 - self.volatile_solids_efficiency),
         )
         liquid_stream_name = "SeparatedLiquid"
         self._report_manure_stream(liquid_manure_stream, liquid_stream_name, time.simulation_day)

--- a/RUFAS/biophysical/manure/storage/anaerobic_lagoon.py
+++ b/RUFAS/biophysical/manure/storage/anaerobic_lagoon.py
@@ -167,20 +167,20 @@ class AnaerobicLagoon(Storage):
             storage_methane_from_degradable_volatile_solids + storage_methane_from_non_degradable_volatile_solids
         )
 
-        denominator = (
+        total_non_degradable_VS = (
             self._manure_to_process.non_degradable_volatile_solids
             + self._manure_to_process.bedding_non_degradable_volatile_solids
         )
 
         if (
-            self._manure_to_process.non_degradable_volatile_solids == 0
-            or self._manure_to_process.bedding_non_degradable_volatile_solids == 0
-            or denominator == 0
+            self._manure_to_process.non_degradable_volatile_solids == 0.0
+            or self._manure_to_process.bedding_non_degradable_volatile_solids == 0.0
+            or total_non_degradable_VS == 0.0
         ):
-            bedding_to_manure_non_degradable_volatile_solids_ratio = 0
+            bedding_to_manure_non_degradable_volatile_solids_ratio = 0.0
         else:
             bedding_to_manure_non_degradable_volatile_solids_ratio = (
-                self._manure_to_process.bedding_non_degradable_volatile_solids / denominator
+                self._manure_to_process.bedding_non_degradable_volatile_solids / total_non_degradable_VS
             )
 
         storage_methane_burned = 0.0

--- a/RUFAS/biophysical/manure/storage/anaerobic_lagoon.py
+++ b/RUFAS/biophysical/manure/storage/anaerobic_lagoon.py
@@ -166,13 +166,24 @@ class AnaerobicLagoon(Storage):
         total_methane = (
             storage_methane_from_degradable_volatile_solids + storage_methane_from_non_degradable_volatile_solids
         )
-        bedding_to_manure_non_degradable_volatile_solids_ratio = (
-            self._manure_to_process.bedding_non_degradable_volatile_solids
-            / (
-                self._manure_to_process.non_degradable_volatile_solids
-                + self._manure_to_process.bedding_non_degradable_volatile_solids
-            )
+
+        denominator = (
+            self._manure_to_process.non_degradable_volatile_solids
+            + self._manure_to_process.bedding_non_degradable_volatile_solids
         )
+
+        if (
+            self._manure_to_process.non_degradable_volatile_solids == 0
+            or self._manure_to_process.bedding_non_degradable_volatile_solids == 0
+            or denominator == 0
+        ):
+            bedding_to_manure_non_degradable_volatile_solids_ratio = 0
+        else:
+            bedding_to_manure_non_degradable_volatile_solids_ratio = (
+                self._manure_to_process.bedding_non_degradable_volatile_solids
+                / denominator
+            )
+
         storage_methane_burned = 0.0
         if self._cover == StorageCover.COVER_AND_FLARE:
             storage_methane_burned, adjusted = self._calculate_cover_and_flare_methane(total_methane)

--- a/RUFAS/biophysical/manure/storage/anaerobic_lagoon.py
+++ b/RUFAS/biophysical/manure/storage/anaerobic_lagoon.py
@@ -180,8 +180,7 @@ class AnaerobicLagoon(Storage):
             bedding_to_manure_non_degradable_volatile_solids_ratio = 0
         else:
             bedding_to_manure_non_degradable_volatile_solids_ratio = (
-                self._manure_to_process.bedding_non_degradable_volatile_solids
-                / denominator
+                self._manure_to_process.bedding_non_degradable_volatile_solids / denominator
             )
 
         storage_methane_burned = 0.0

--- a/RUFAS/biophysical/manure/storage/slurry_storage_outdoor.py
+++ b/RUFAS/biophysical/manure/storage/slurry_storage_outdoor.py
@@ -153,8 +153,7 @@ class SlurryStorageOutdoor(Storage):
             bedding_to_manure_non_degradable_volatile_solids_ratio = 0
         else:
             bedding_to_manure_non_degradable_volatile_solids_ratio = (
-                self._manure_to_process.bedding_non_degradable_volatile_solids
-                / denominator
+                self._manure_to_process.bedding_non_degradable_volatile_solids / denominator
             )
 
         self._manure_to_process.total_solids = max(

--- a/RUFAS/biophysical/manure/storage/slurry_storage_outdoor.py
+++ b/RUFAS/biophysical/manure/storage/slurry_storage_outdoor.py
@@ -139,13 +139,23 @@ class SlurryStorageOutdoor(Storage):
             storage_methane_burned, total_storage_methane = self._calculate_cover_and_flare_methane(
                 total_storage_methane
             )
-        bedding_to_manure_non_degradable_volatile_solids_ratio = (
-            self._manure_to_process.bedding_non_degradable_volatile_solids
-            / (
-                self._manure_to_process.non_degradable_volatile_solids
-                + self._manure_to_process.bedding_non_degradable_volatile_solids
-            )
+
+        denominator = (
+            self._manure_to_process.non_degradable_volatile_solids
+            + self._manure_to_process.bedding_non_degradable_volatile_solids
         )
+
+        if (
+            self._manure_to_process.non_degradable_volatile_solids == 0
+            or self._manure_to_process.bedding_non_degradable_volatile_solids == 0
+            or denominator == 0
+        ):
+            bedding_to_manure_non_degradable_volatile_solids_ratio = 0
+        else:
+            bedding_to_manure_non_degradable_volatile_solids_ratio = (
+                self._manure_to_process.bedding_non_degradable_volatile_solids
+                / denominator
+            )
 
         self._manure_to_process.total_solids = max(
             0.0,

--- a/RUFAS/biophysical/manure/storage/slurry_storage_outdoor.py
+++ b/RUFAS/biophysical/manure/storage/slurry_storage_outdoor.py
@@ -140,20 +140,20 @@ class SlurryStorageOutdoor(Storage):
                 total_storage_methane
             )
 
-        denominator = (
+        total_non_degradable_VS = (
             self._manure_to_process.non_degradable_volatile_solids
             + self._manure_to_process.bedding_non_degradable_volatile_solids
         )
 
         if (
-            self._manure_to_process.non_degradable_volatile_solids == 0
-            or self._manure_to_process.bedding_non_degradable_volatile_solids == 0
-            or denominator == 0
+            self._manure_to_process.non_degradable_volatile_solids == 0.0
+            or self._manure_to_process.bedding_non_degradable_volatile_solids == 0.0
+            or total_non_degradable_VS == 0.0
         ):
-            bedding_to_manure_non_degradable_volatile_solids_ratio = 0
+            bedding_to_manure_non_degradable_volatile_solids_ratio = 0.0
         else:
             bedding_to_manure_non_degradable_volatile_solids_ratio = (
-                self._manure_to_process.bedding_non_degradable_volatile_solids / denominator
+                self._manure_to_process.bedding_non_degradable_volatile_solids / total_non_degradable_VS
             )
 
         self._manure_to_process.total_solids = max(

--- a/RUFAS/biophysical/manure/storage/slurry_storage_underfloor.py
+++ b/RUFAS/biophysical/manure/storage/slurry_storage_underfloor.py
@@ -113,13 +113,23 @@ class SlurryStorageUnderfloor(Storage):
         total_storage_methane = (
             storage_methane_from_degradable_volatile_solids + storage_methane_from_non_degradable_volatile_solids
         )
-        bedding_to_manure_non_degradable_volatile_solids_ratio = (
-            self._manure_to_process.bedding_non_degradable_volatile_solids
-            / (
-                self._manure_to_process.non_degradable_volatile_solids
-                + self._manure_to_process.bedding_non_degradable_volatile_solids
-            )
+
+        denominator = (
+            self._manure_to_process.non_degradable_volatile_solids
+            + self._manure_to_process.bedding_non_degradable_volatile_solids
         )
+
+        if (
+            self._manure_to_process.non_degradable_volatile_solids == 0
+            or self._manure_to_process.bedding_non_degradable_volatile_solids == 0
+            or denominator == 0
+        ):
+            bedding_to_manure_non_degradable_volatile_solids_ratio = 0
+        else:
+            bedding_to_manure_non_degradable_volatile_solids_ratio = (
+                self._manure_to_process.bedding_non_degradable_volatile_solids
+                / denominator
+            )
 
         self._manure_to_process.total_solids = max(
             0.0,

--- a/RUFAS/biophysical/manure/storage/slurry_storage_underfloor.py
+++ b/RUFAS/biophysical/manure/storage/slurry_storage_underfloor.py
@@ -114,20 +114,20 @@ class SlurryStorageUnderfloor(Storage):
             storage_methane_from_degradable_volatile_solids + storage_methane_from_non_degradable_volatile_solids
         )
 
-        denominator = (
+        total_non_degradable_VS = (
             self._manure_to_process.non_degradable_volatile_solids
             + self._manure_to_process.bedding_non_degradable_volatile_solids
         )
 
         if (
-            self._manure_to_process.non_degradable_volatile_solids == 0
-            or self._manure_to_process.bedding_non_degradable_volatile_solids == 0
-            or denominator == 0
+            self._manure_to_process.non_degradable_volatile_solids == 0.0
+            or self._manure_to_process.bedding_non_degradable_volatile_solids == 0.0
+            or total_non_degradable_VS == 0.0
         ):
-            bedding_to_manure_non_degradable_volatile_solids_ratio = 0
+            bedding_to_manure_non_degradable_volatile_solids_ratio = 0.0
         else:
             bedding_to_manure_non_degradable_volatile_solids_ratio = (
-                self._manure_to_process.bedding_non_degradable_volatile_solids / denominator
+                self._manure_to_process.bedding_non_degradable_volatile_solids / total_non_degradable_VS
             )
 
         self._manure_to_process.total_solids = max(

--- a/RUFAS/biophysical/manure/storage/slurry_storage_underfloor.py
+++ b/RUFAS/biophysical/manure/storage/slurry_storage_underfloor.py
@@ -127,8 +127,7 @@ class SlurryStorageUnderfloor(Storage):
             bedding_to_manure_non_degradable_volatile_solids_ratio = 0
         else:
             bedding_to_manure_non_degradable_volatile_solids_ratio = (
-                self._manure_to_process.bedding_non_degradable_volatile_solids
-                / denominator
+                self._manure_to_process.bedding_non_degradable_volatile_solids / denominator
             )
 
         self._manure_to_process.total_solids = max(

--- a/changelog.md
+++ b/changelog.md
@@ -281,6 +281,7 @@ v0.9.2
 - [2655](https://github.com/RuminantFarmSystems/MASM/pull/2655) - [minor change] [Animal] [InputChange] [NoOutputChange] Updated RationManager class to allow for more flexibility in user inputs in Feed input file.
 - [2670](https://github.com/RuminantFarmSystems/MASM/pull/2670) - [minor change] [Animal] [InputChange] [NoOutputChange] Updated Animal module unit testing to 100% coverage.
 - [2673](https://github.com/RuminantFarmSystems/MASM/pull/2673) - [minor change] [Feed] [InputChange] [NoOutputChange] Adds a default for purchased feed buffer of 0.15.
+- [2676](https://github.com/RuminantFarmSystems/MASM/pull/2673) - [minor change] [Manure] [NoInputChange] [NoOutputChange] Corrects a bug in Separators and adds a check to prevent a bug in Slurry Storage Outdoor, Slurry Storage Underfloor, and Anaerobic Lagoon.
 
 ### v0.9.2
 


### PR DESCRIPTION
This PR addresses two small bugs in the manure module.

<!-- Provide a short summary of the changes this pull request contains. -->

### Context
**Liquid storages:** As part of estimation methane emissions in slurry storage outdoor/underfloor and anaerobic lagoon, the ratio of bedding to manure non-degradable volatile solids (VS) in held manure is calculated and utilized to updated each VS fraction accordingly. If no manure is currently held in the storage, this calculation results in a divide by 0 error being returned, stopping the simulation. 

**Solid liquid separators:** The volatile solids removal efficiency (percent of entering volatile solids that are separated from the raw manure and recovered in the separated solids fraction) was not being applied correctly to bedding non-degradable VS in the liquid output. This resulted in the incorrect quantity of bedding VS leaving the separator with the liquid fraction.

### What
- Adds a check for 0 held bedding or manure non-degradable volatile solids and returns 0 in these cases to prevent a divide by 0 error when these types of storages are empty.
- Adding missing separation efficiency for bedding non-degradable volatile solids to separators.

### Why
Prevent an inappropriate divide by 0 error and correct the quantity of bedding VS in the liquid fraction leaving separators.

### How
See "What"

### Test plan
Manually confirmed separators were now calculating correct quantity of liquid fraction bedding ndVS. The sum of liquid and solid fraction bedding ndVS is equal to value of raw manure ndVS entering separator.

To test changes to liquid manure storages, I added a second storage (`slurry_storage_outdoor_lac2`) following the first storage (`slurry_storage_outdoor_lac1`) in the example freestall scenario. This configuration causes the second storage to be empty for 120 days, which previously triggered the divide by 0 bug. Those changes are reflected in the attached files that can be used to test this PR:

[example_freestall_processor_configs.json](https://github.com/user-attachments/files/24108183/example_freestall_processor_configs.json)
[example_freestall_processor_connections.json](https://github.com/user-attachments/files/24108179/example_freestall_processor_connections.json)

I tested the simulation the processor type of `slurry_storage_outdoor_lac2` set to slurry storage outdoor, slurry storage underfloor, and anaerobic lagoon to confirm all 3 processors are now working correctly. I also ran pytest and checked flake8 errors.

### Input Changes
No input changes.

### Output Changes
No output variable changes. Output variable value changes are limited to correcting the value of bedding ndVS in separator liquid fraction, which was previously overestimated.

#### Filter
```json
Manure.*
```

