### PR TITLE
[Feed][Reporting] Farmgrown Feed reports cleanup

### DIFF
--- a/RUFAS/biophysical/feed_storage/feed_manager.py
+++ b/RUFAS/biophysical/feed_storage/feed_manager.py
@@ -321,17 +321,18 @@ class FeedManager:
 
     def report_stored_farmgrown_feeds(self, simulation_day: int, reporting_suffix: str) -> None:
         """Outputs total amounts of farmgrown feeds currently stored by the FeedManager."""
-        feed_report: dict[RUFAS_ID, dict[str, float]] = {
-            feed.rufas_id: {"dry_matter_mass": 0.0, "fresh_mass": 0.0} for feed in self._available_feeds
-        }
+        feed_report: dict[RUFAS_ID, dict[str, float]] = {}
 
         for storage in self.active_storages.values():
             for crop in storage.stored:
                 rufas_id = storage.rufas_feed_id
                 if rufas_id not in feed_report:
-                    continue
-                feed_report[rufas_id]["dry_matter_mass"] += crop.dry_matter_mass
-                feed_report[rufas_id]["fresh_mass"] += crop.fresh_mass
+                    feed_report[rufas_id] = {}
+                    feed_report[rufas_id]["dry_matter_mass"] = crop.dry_matter_mass
+                    feed_report[rufas_id]["fresh_mass"] = crop.fresh_mass
+                else:
+                    feed_report[rufas_id]["dry_matter_mass"] += crop.dry_matter_mass
+                    feed_report[rufas_id]["fresh_mass"] += crop.fresh_mass
         info_map = {
             "class": self.__class__.__name__,
             "function": self.report_stored_farmgrown_feeds.__name__,

--- a/RUFAS/biophysical/feed_storage/feed_manager.py
+++ b/RUFAS/biophysical/feed_storage/feed_manager.py
@@ -30,7 +30,6 @@ from RUFAS.output_manager import OutputManager
 from .storage import Storage
 from .purchased_feed_storage import PurchasedFeed, PurchasedFeedStorage
 
-
 """Ratio of the price of an on-farm price to the price of buying that feed from an off farm source."""
 ON_FARM_TO_PURCHASED_PRICE_RATION = 0.01
 

--- a/changelog.md
+++ b/changelog.md
@@ -281,6 +281,7 @@ v0.9.2
 - [2655](https://github.com/RuminantFarmSystems/MASM/pull/2655) - [minor change] [Animal] [InputChange] [NoOutputChange] Updated RationManager class to allow for more flexibility in user inputs in Feed input file.
 - [2670](https://github.com/RuminantFarmSystems/MASM/pull/2670) - [minor change] [Animal] [InputChange] [NoOutputChange] Updated Animal module unit testing to 100% coverage.
 - [2673](https://github.com/RuminantFarmSystems/MASM/pull/2673) - [minor change] [Feed] [InputChange] [NoOutputChange] Adds a default for purchased feed buffer of 0.15.
+- [2678](https://github.com/RuminantFarmSystems/MASM/pull/2678) - [minor change] [Feed] [InputChange] [OutputChange] Removes default reporting 0.0s for FGFs that aren't grown during a simulation.
 
 ### v0.9.2
 

--- a/tests/test_biophysical/test_feed_storage/test_feed_manager.py
+++ b/tests/test_biophysical/test_feed_storage/test_feed_manager.py
@@ -583,7 +583,7 @@ def test_report_stored_farmgrown_feeds(
 
     feed_manager.report_stored_farmgrown_feeds(mock_time, "mock_suffix")
 
-    assert mock_om_add_variable.call_count == 2 * len(mock_available_feeds)
+    assert mock_om_add_variable.call_count == 2 * len(feed_manager.active_storages)
 
 
 def test_manage_daily_feed_request(feed_manager: FeedManager, mocker: MockerFixture) -> None:


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Small cleanup to make the reported FGF in storage a little easier to read.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2637

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Removes default 0.0 reporting for a feed in the FGF reporting function if that feed is not grown and stored on the farm.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
The default 0.0 was initially added as a safety/sanity check during the revamp for the Feed Management module to prove that we weren't seeing ghost feeds reported as grown on the farm.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Rather than pre-populating the FGF reporting dictionary with the entire available feeds ID list, the FGF reporting function now just loops through active storages and adds or updates the amounts in storage. So no 0.0s will be added for feeds that are not grown on the farm during a simulation.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Run a simulation using the example filter from @KFosterReed:

```json
{ 
    "name": "FGF_inventory", 
    "filters": [ "FeedManager.report_stored_farmgrown_feeds.stored_feed_.*.daily_storage_levels" ], 
    "expand_data": true, "use_fill_value_in_gaps": false, "use_fill_value_at_end": false
}
```

And see that there are only columns for feeds that are actually grown during the simulation.

### Input Changes
<!-- Provide a short summary describing input modifications. -->
<!-- Please include the things that are added, deleted, or modified. -->
N/A

### Output Changes
<!-- List all the output variable/function modifications with a short summary. -->
<!-- """- `Class.Function.VariableName`: description""" -->
- As noted above, there will no longer be reports of 0.0 for feeds that are part of the available_feeds dictionary (which includes feed IDs that are only purchased alongside feeds that are both grown and purchased).

#### Filter
<!-- Provide a filter that can be used to handle the output changes. -->
Same filter as above:
```json
{ 
    "name": "FGF_inventory", 
    "filters": [ "FeedManager.report_stored_farmgrown_feeds.stored_feed_.*.daily_storage_levels" ], 
    "expand_data": true, "use_fill_value_in_gaps": false, "use_fill_value_at_end": false
}
```
