### PR TITLE
use parallel processing only when the number of workers is gt 1

### DIFF
--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -155,9 +155,9 @@ class TaskManager:
         self.output_manager.add_log(
             "Task Manager workers", f"Task Manager is going to run {workers} in parallel.", info_map
         )
-        self.pool = multiprocessing.Pool(
-            workers, maxtasksperchild=1
-        )  # maxtasksperchild=1 to maintain isolation between tasks and ensure no memory leaks happens in IO Managers
+        self.pool = multiprocessing.Pool(workers, maxtasksperchild=1) if workers > 1 else None
+        # maxtasksperchild=1 to maintain isolation between tasks and ensure no memory leaks happens in IO Managers
+
         parsed_single_run_args, parsed_multi_run_args = self._parse_input_tasks()
         self.output_manager.add_log(
             "Task Manager parsed tasks",
@@ -491,7 +491,10 @@ class TaskManager:
             workers=workers,
             metadata_path=metadata_path,
         )
-        results = self.pool.imap(task_with_args, single_run_args)
+        if self.pool is not None:
+            results = self.pool.imap(task_with_args, single_run_args)
+        else:
+            results = (task_with_args(v) for v in single_run_args)
         failed = []
         for result in results:
             if result is not None:

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -149,6 +149,11 @@ def test_task_manager_start(
         metadata_depth_limit=metadata_depth_limit,
     )
 
+    if workers > 1:
+        assert isinstance(tm.pool, multiprocessing.pool.Pool)
+    else:
+        assert tm.pool is None
+
     mock_run_startup_sequence.assert_called_once_with(
         verbosity=verbosity,
         exclude_info_maps=exclude_info_maps,


### PR DESCRIPTION
### Context
Multiprocessing in RuFaS can be problematic for some deployment environments.

### What & Why
RuFaS currently [instantiates a `multiprocessing.Pool`](https://github.com/RuminantFarmSystems/RuFaS/blob/0f70b6d6861cd656e16a433278c758c9e7519525/RUFAS/task_manager.py#L158) for running the simulation `Task`s, regardless of the number of the latter. In the case of running only one `Task`, using `multiprocessing.Pool` is not necessary and can be replaced by a sequential calculation. This replacement is beneficial for users who deploy the code to AWS Lambda services (like our team) where multiprocessing with Pool is not supported.

### How
This feature can be performed with minimal modifications to the code, by:
1. assigning `self.pool` to `None` if the number of workers is 1 ([here](https://github.com/RuminantFarmSystems/RuFaS/blob/0f70b6d6861cd656e16a433278c758c9e7519525/RUFAS/task_manager.py#L158-L160)):
```python
self.pool = multiprocessing.Pool(workers, maxtasksperchild=1) if workers > 1 else None

```
2. switching between parallel or sequential processing depending on the value of pool ([here](https://github.com/RuminantFarmSystems/RuFaS/blob/0f70b6d6861cd656e16a433278c758c9e7519525/RUFAS/task_manager.py#L494))
```python
if self.pool is not None:
    results = self.pool.imap(task_with_args, single_run_args)
else:
    results = (task_with_args(v) for v in single_run_args)
```

### Test plan
test_task_manager.test_task_manager_start() was modified so that to verify that a `multiprocessing.Pool` is only initiated when the number of `workers` is greater than 1


### Input Changes
None

### Output Changes
None

#### Filter
-

```json

```
