### PR TITLE
[Animal] Update ration percentage values in example feed files to sum to exact 100.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@ v1.0.0
 - [2757](https://github.com/RuminantFarmSystems/RuFaS/pull/2757) - [minor change] [NoInputChange] [NoOutputChange] Updates version number in `pyproject.toml`.
 - [2690](https://github.com/RuminantFarmSystems/RuFaS/pull/2690) - [minor change] [TaskManager] [NoInputChange] [NoOutputChange] Remove hard-coded name for output folder, use user-defined name instead.
 - [2720](https://github.com/RuminantFarmSystems/MASM/pull/2720) - [minor change] [Emissions] [NoInputChange] [NoOutputChange] Adds FGF emissions reset when there's a harvest-kill operation and there's none of that feed left in storage.
+- [2791](https://github.com/RuminantFarmSystems/MASM/pull/2791) - [minor change] [Animal] [NoInputChange] [NoOutputChange] Updates ration percentage values in example feed files to sum to exactly 100.
 
 ### v1.0.0
 

--- a/input/data/feed/example_Intermountain_feed.json
+++ b/input/data/feed/example_Intermountain_feed.json
@@ -191,7 +191,7 @@
       },
       {
         "feed_type": 305,
-        "ration_percentage": 29.98
+        "ration_percentage": 29.97
       }
     ],
     "tolerance": 0.1

--- a/input/data/feed/example_Midwest_feed.json
+++ b/input/data/feed/example_Midwest_feed.json
@@ -121,7 +121,7 @@
       },
       {
         "feed_type": 302,
-        "ration_percentage": 15.21
+        "ration_percentage": 15.20
       }
     ],
     "close_up": [
@@ -151,7 +151,7 @@
       },
       {
         "feed_type": 302,
-        "ration_percentage": 18.86
+        "ration_percentage": 18.87
       }
     ],
     "lac_cow": [

--- a/input/data/feed/example_Northeast_feed.json
+++ b/input/data/feed/example_Northeast_feed.json
@@ -226,7 +226,7 @@
       },
       {
         "feed_type": 303,
-        "ration_percentage": 22.34
+        "ration_percentage": 22.33
       }
     ],
     "tolerance": 0.1


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Closes #2792

### Context
Several regional example feed input files exist in the repository, which include inclusion percentages for each ingredient.

### What
Update the values of `ration_percentage` for each feed in example feed files so that values for each animal class sum to exactly 100.

### Why
If values of `ration_percentage` for each animal class do not sum to exactly 100, the ration will fail if tolerance is set to 0.0. Some animal classes in some of the example feed files were summing to 100.01 or 99.99. 

### How
Updates `ration_percentage` where need to ensure values within each animal class sum to 100. I modified (either +/- 0.01) the FARM ES byproduct mix in each user defined ration block, where applicable.

### Test plan
I ran each example feed file with tolerance set to 0 with the example freestall scenario to confirm the simulation did not fail with this example ration.

### Input Changes
None

### Output Changes
None