### PR TITLE
Fix Simple `noqa`s in codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-1255%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-1249%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 
 # RuFaS: Ruminant Farm Systems

--- a/RUFAS/EEE/tractor.py
+++ b/RUFAS/EEE/tractor.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Any
 from .tractor_implement import TractorImplement
 from RUFAS.util import Utility
 from RUFAS.input_manager import InputManager
@@ -34,7 +34,7 @@ class Tractor:
         herd_size: int | None = None,
         application_depth: float | None = None,
         tillage_implement: TillageImplement | None = None,
-        harvest_type: HarvestOperation | None = None
+        harvest_type: HarvestOperation | None = None,
     ) -> None:
         """
         Initializes the Tractor object with the tractor size or calculates it based on the provided herd size.
@@ -76,12 +76,12 @@ class Tractor:
                 self.tractor_size,
                 tillage_implement,
                 application_depth,
-                harvest_type
+                harvest_type,
             )
             for operation_type in self.operation_types
         ]
         constants = input_manager.get_data("EEE_constants.constants")
-        self.constants_by_ID = Utility.convert_list_to_dict_by_key(constants, "ID")
+        self.constants_by_ID: dict[Any, dict[str, Any]] = Utility.convert_list_to_dict_by_key(constants, "ID")
 
     def herd_size_to_tractor_size(self, herd_size: int) -> TractorSize:
         """
@@ -97,43 +97,82 @@ class Tractor:
         else:
             return TractorSize.LARGE
 
-    def determine_operation_type(self, application_depth: float | None = None) -> List[OperationType]:  # noqa C901
+    def determine_operation_type(self, application_depth: float | None = None) -> List[OperationType]:
         """
         Assigns a specific field operation based on the general name for the operation and the crop type for harvest
         operations or depth for nutrient application.
         Implements Helper Function 421 in EEE Functions file.
         """
         if self.operation_event == FieldOperationEvent.HARVEST:
-            if self.crop_type in [
-                "alfalfa_hay",
-                "alfalfa_silage",
-                "alfalfa_baleage",
-                "tall_fescue_hay",
-                "tall_fescue_silage",
-                "tall_fescue_baleage",
-            ]:
-                return [OperationType.MOWING, OperationType.WINDROWING, OperationType.COLLECTION]
-            else:
-                return [OperationType.COLLECTION]
+            return self._determine_harvest_operation_types()
         elif self.operation_event == FieldOperationEvent.FERTILIZER_APPLICATION:
-            if application_depth == 0:
-                return [OperationType.FERTILIZER_APPLICATION_SURFACE]
-            elif application_depth > 0:
-                return [OperationType.FERTILIZER_APPLICATION_BELOW_SURFACE]
+            return self._determine_fertilizer_application_operation_types(application_depth)
         elif self.operation_event == FieldOperationEvent.MANURE_APPLICATION:
-            if application_depth == 0:
-                return [OperationType.LIQUID_MANURE_APPLICATION_SURFACE]
-            elif application_depth > 0:
-                return [OperationType.LIQUID_MANURE_APPLICATION_BELOW_SURFACE]
+            return self._determine_manure_application_operation_types(application_depth)
         elif self.operation_event == FieldOperationEvent.PLANTING:
             return [OperationType.PLANTING]
         elif self.operation_event == FieldOperationEvent.TILLING:
             return [OperationType.TILLING]
 
+    def _determine_fertilizer_application_operation_types(self, application_depth: float | None) -> list[OperationType]:
+        """
+        Determines the types of fertilizer application operations required based on the application depth.
+
+        Returns
+        -------
+        list[OperationType]
+            A list of operation types required for the fertilizer application.
+        """
+        assert (
+            application_depth is not None and application_depth >= 0
+        ), "Application depth must be provided and non-negative for fertilizer application."
+        if application_depth > 0:
+            return [OperationType.FERTILIZER_APPLICATION_BELOW_SURFACE]
+        else:
+            return [OperationType.FERTILIZER_APPLICATION_SURFACE]
+
+    def _determine_manure_application_operation_types(self, application_depth: float | None) -> list[OperationType]:
+        """
+        Determines the types of manure application operations required based on the application depth.
+
+        Returns
+        -------
+        list[OperationType]
+            A list of operation types required for the manure application.
+        """
+        assert (
+            application_depth is not None and application_depth >= 0
+        ), "Application depth must be provided and non-negative for manure application."
+        if application_depth > 0:
+            return [OperationType.LIQUID_MANURE_APPLICATION_BELOW_SURFACE]
+        else:
+            return [OperationType.LIQUID_MANURE_APPLICATION_SURFACE]
+
+    def _determine_harvest_operation_types(self) -> list[OperationType]:
+        """
+        Determines the types of harvest operations required based on the crop type.
+
+        Returns
+        -------
+        list[OperationType]
+            A list of operation types required for harvesting the crop.
+        """
+        if self.crop_type in [
+            "alfalfa_hay",
+            "alfalfa_silage",
+            "alfalfa_baleage",
+            "tall_fescue_hay",
+            "tall_fescue_silage",
+            "tall_fescue_baleage",
+        ]:
+            return [OperationType.MOWING, OperationType.WINDROWING, OperationType.COLLECTION]
+        else:
+            return [OperationType.COLLECTION]
+
     @property
     def PTO_kW(self) -> float:
         """Constants 589, 592, 595 in EEE Functions file"""
-        pto_mapping = {
+        pto_mapping: dict[TractorSize, float] = {
             TractorSize.SMALL: self.constants_by_ID[SMALL_TRACTOR_PTO_CONSTANT_ID]["Value"],
             TractorSize.MEDIUM: self.constants_by_ID[MEDIUM_TRACTOR_PTO_CONSTANT_ID]["Value"],
             TractorSize.LARGE: self.constants_by_ID[LARGE_TRACTOR_PTO_CONSTANT_ID]["Value"],
@@ -148,7 +187,7 @@ class Tractor:
     @property
     def mass_kg(self) -> float:
         """Constants 591, 594, 597 in EEE Functions file"""
-        mass_mapping = {
+        mass_mapping: dict[TractorSize, float] = {
             TractorSize.SMALL: self.constants_by_ID[SMALL_TRACTOR_MASS_CONSTANT_ID]["Value"],
             TractorSize.MEDIUM: self.constants_by_ID[MEDIUM_TRACTOR_MASS_CONSTANT_ID]["Value"],
             TractorSize.LARGE: self.constants_by_ID[LARGE_TRACTOR_MASS_CONSTANT_ID]["Value"],
@@ -158,7 +197,7 @@ class Tractor:
     @property
     def speed_km_hr(self) -> float:
         """Constant 598 in EEE Functions file"""
-        return self.constants_by_ID[TRACTOR_SPEED_CONSTANT_ID]["Value"]
+        return float(self.constants_by_ID[TRACTOR_SPEED_CONSTANT_ID]["Value"])
 
     def calculate_axel_power(self, implement: TractorImplement) -> float:
         """

--- a/RUFAS/biophysical/field/soil/nitrogen_cycling/mineralization_decomp.py
+++ b/RUFAS/biophysical/field/soil/nitrogen_cycling/mineralization_decomp.py
@@ -174,16 +174,17 @@ class MineralizationDecomposition:
         The values of the constant used to determine the nitrogen and phosphorus terms are 25 and 200, respectively.
 
         """
-        nitrogen_term = (  # noqa: F841
+        nitrogen_term = (
             MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(
                 carbon_nitrogen_ratio, 25
             )
         )
-        phosphorus_term = (  # noqa: F841
-            MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(  # noqa: F841, E501
+        phosphorus_term = (
+            MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(
                 carbon_phosphorus_ratio, 200
             )
         )
+        assert nitrogen_term and phosphorus_term
         # temporary fix to replace the process based method for the effect of the soil C, N, and P on the decomposition
         # rate factor
         return 1

--- a/RUFAS/biophysical/field/soil/nitrogen_cycling/mineralization_decomp.py
+++ b/RUFAS/biophysical/field/soil/nitrogen_cycling/mineralization_decomp.py
@@ -174,15 +174,11 @@ class MineralizationDecomposition:
         The values of the constant used to determine the nitrogen and phosphorus terms are 25 and 200, respectively.
 
         """
-        nitrogen_term = (
-            MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(
-                carbon_nitrogen_ratio, 25
-            )
+        nitrogen_term = MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(
+            carbon_nitrogen_ratio, 25
         )
-        phosphorus_term = (
-            MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(
-                carbon_phosphorus_ratio, 200
-            )
+        phosphorus_term = MineralizationDecomposition._calculate_nutrient_term_for_residue_composition_factor(
+            carbon_phosphorus_ratio, 200
         )
         assert nitrogen_term and phosphorus_term
         # temporary fix to replace the process based method for the effect of the soil C, N, and P on the decomposition

--- a/RUFAS/biophysical/manure/manure_manager.py
+++ b/RUFAS/biophysical/manure/manure_manager.py
@@ -83,7 +83,7 @@ class ManureManager:
         self._populate_adjacency_matrix(processor_connections_by_name)
 
         self._validate_adjacency_matrix()
-        self._processing_order = self._traverse_adjacency_matrix()  # noqa
+        self._processing_order = self._traverse_adjacency_matrix()
 
     def run_daily_update(
         self, manure_streams: dict[str, ManureStream], time: RufasTime, current_day_conditions: CurrentDayConditions

--- a/changelog.md
+++ b/changelog.md
@@ -41,6 +41,7 @@ v1.0.0
 - [2836](https://github.com/RuminantFarmSystems/MASM/pull/2836) - [minor change] [Tests] [NoInputChange] [NoOutputChange] Clears all mypy errors in test_output_manager.py.
 - [2826](https://github.com/RuminantFarmSystems/MASM/pull/2826) - [minor change] [Animal] [NoInputChange] [NoOutputChange] Adds functionality to data_padder, removes unecessary use of method in ration reporting.
 - [2827](https://github.com/RuminantFarmSystems/MASM/pull/2827) - [minor change] [Metadata] [NoInputChange] [NoOutputChange] Updates ration-related metadata descriptions.
+- [2843](https://github.com/RuminantFarmSystems/MASM/pull/2843) - [minor change] [NoInputChange] [NoOutputChange] Fix Simple `#noqa`s in codebase.
 
 ### v1.0.0
 

--- a/tests/test_EEE/test_tractor.py
+++ b/tests/test_EEE/test_tractor.py
@@ -159,6 +159,89 @@ def test_determine_operation_type(
 
 
 @pytest.mark.parametrize(
+    "application_depth",
+    [None, -1.0],
+)
+def test_fertilizer_application_invalid_depth_raises(
+    application_depth: float | None,
+    EEE_constants: list[dict[str, Any]],
+    tractor_dataset: dict[str, list[Any]],
+    mocker: MockFixture,
+) -> None:
+    """Tests that an invalid application depth raises AssertionError for fertilizer application."""
+    im = InputManager()
+    mocker.patch.object(im, "get_data", side_effect=[deepcopy(EEE_constants)])
+    mocker.patch("RUFAS.EEE.tractor_implement.TractorImplement.__init__", return_value=None)
+    tractor = Tractor(
+        operation_event=FieldOperationEvent.PLANTING,
+        crop_type="alfalfa_hay",
+        tractor_size=TractorSize.SMALL,
+        application_depth=10.0,
+    )
+    with pytest.raises(AssertionError):
+        tractor._determine_fertilizer_application_operation_types(application_depth)
+
+
+@pytest.mark.parametrize(
+    "application_depth",
+    [None, -1.0],
+)
+def test_manure_application_invalid_depth_raises(
+    application_depth: float | None,
+    EEE_constants: list[dict[str, Any]],
+    tractor_dataset: dict[str, list[Any]],
+    mocker: MockFixture,
+) -> None:
+    """Tests that an invalid application depth raises AssertionError for manure application."""
+    im = InputManager()
+    mocker.patch.object(im, "get_data", side_effect=[deepcopy(EEE_constants)])
+    mocker.patch("RUFAS.EEE.tractor_implement.TractorImplement.__init__", return_value=None)
+    tractor = Tractor(
+        operation_event=FieldOperationEvent.PLANTING,
+        crop_type="alfalfa_hay",
+        tractor_size=TractorSize.SMALL,
+        application_depth=10.0,
+    )
+    with pytest.raises(AssertionError):
+        tractor._determine_manure_application_operation_types(application_depth)
+
+
+@pytest.mark.parametrize(
+    "crop_type, expected_operations",
+    [
+        ("alfalfa_hay", [OperationType.MOWING, OperationType.WINDROWING, OperationType.COLLECTION]),
+        ("alfalfa_silage", [OperationType.MOWING, OperationType.WINDROWING, OperationType.COLLECTION]),
+        ("alfalfa_baleage", [OperationType.MOWING, OperationType.WINDROWING, OperationType.COLLECTION]),
+        ("tall_fescue_hay", [OperationType.MOWING, OperationType.WINDROWING, OperationType.COLLECTION]),
+        ("tall_fescue_silage", [OperationType.MOWING, OperationType.WINDROWING, OperationType.COLLECTION]),
+        ("tall_fescue_baleage", [OperationType.MOWING, OperationType.WINDROWING, OperationType.COLLECTION]),
+        ("corn_silage", [OperationType.COLLECTION]),
+        ("winter_wheat_grain", [OperationType.COLLECTION]),
+        (None, [OperationType.COLLECTION]),
+    ],
+)
+def test_determine_harvest_operation_types(
+    crop_type: str | None,
+    expected_operations: list[OperationType],
+    EEE_constants: list[dict[str, Any]],
+    tractor_dataset: dict[str, list[Any]],
+    mocker: MockFixture,
+) -> None:
+    """Tests the harvest operation type determination for all crop types."""
+    im = InputManager()
+    mocker.patch.object(im, "get_data", side_effect=[deepcopy(EEE_constants)])
+    mocker.patch("RUFAS.EEE.tractor_implement.TractorImplement.__init__", return_value=None)
+    tractor = Tractor(
+        operation_event=FieldOperationEvent.PLANTING,
+        crop_type=crop_type,
+        tractor_size=TractorSize.SMALL,
+        application_depth=10.0,
+    )
+    tractor.crop_type = crop_type
+    assert tractor._determine_harvest_operation_types() == expected_operations
+
+
+@pytest.mark.parametrize(
     "tractor_size, expected_pto_kW",
     [
         (TractorSize.SMALL, 55.93),

--- a/tests/test_EEE/test_tractor.py
+++ b/tests/test_EEE/test_tractor.py
@@ -12,7 +12,6 @@ from RUFAS.EEE.tractor import Tractor
 from RUFAS.input_manager import InputManager
 from tests.test_EEE.fixtures import EEE_constants, tractor_dataset, mock_tractor
 
-
 assert EEE_constants is not None
 assert tractor_dataset is not None
 
@@ -41,7 +40,7 @@ def test_herd_size_to_tractor_size(
         FieldOperationEvent.TILLING,
         herd_size=herd_size,
         tillage_implement=TillageImplement.DISK_HARROW,
-        application_depth=10
+        application_depth=10,
     )
     assert specs.tractor_size == expected_size
 

--- a/tests/test_biophysical/test_crop_soil_field/soil_tests/test_soil_data.py
+++ b/tests/test_biophysical/test_crop_soil_field/soil_tests/test_soil_data.py
@@ -483,7 +483,7 @@ def test_zero_silt_clay_warning(mocker: MockerFixture) -> None:
             clay_fraction=0,
         )
     ]
-    data = SoilData(soil_layers=soil_layers, field_size=0.95)  # noqa: F841
+    SoilData(soil_layers=soil_layers, field_size=0.95)
     info_map = {"class": "SoilData", "function": "__post_init__"}
     mock_add.assert_called_once_with(
         "Silt and clay fractions in the soil are 0, which will lead to unreliable "


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2754 

Removed the `#noqa` comments in:
- RUFAS/biophysical/field/soil/nitrogen_cycling/mineralization_decomp.py
- RUFAS/biophysical/manure/manure_manager.py
- RUFAS/EEE/tractor.py
- tests/test_biophysical/test_crop_soil_field/soil_tests/test_soil_data.py

Issues #2844, #2845, #2846, and #2847 are created to refactor other functions in the codebase that requires dedicated effort.


### Input Changes
<!-- Provide a short summary describing input modifications. -->
<!-- Please include the things that are added, deleted, or modified. -->


### Output Changes
<!-- List all the output variable/function modifications with a short summary. -->
<!-- """- `Class.Function.VariableName`: description""" -->
- N/A

#### Filter
<!-- Provide a filter that can be used to handle the output changes. -->

```json

```
