### PR TITLE
[TaskManager] Use Parallel Processing Only When Workers > 1

### DIFF
--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -166,9 +166,8 @@ class TaskManager:
         self.output_manager.add_log(
             "Task Manager workers", f"Task Manager is going to run {workers} in parallel.", info_map
         )
-        self.pool = multiprocessing.Pool(
-            workers, maxtasksperchild=1
-        )  # maxtasksperchild=1 to maintain isolation between tasks and ensure no memory leaks happens in IO Managers
+        # maxtasksperchild=1 to maintain isolation between tasks and ensure no memory leaks happens in IO Managers
+        self.pool = multiprocessing.Pool(workers, maxtasksperchild=1) if workers > 1 else None
         parsed_single_run_args, parsed_multi_run_args = self._parse_input_tasks()
         self.output_manager.add_log(
             "Task Manager parsed tasks",
@@ -507,7 +506,10 @@ class TaskManager:
             metadata_path=metadata_path,
             output_directory=output_directory,
         )
-        results = self.pool.imap(task_with_args, single_run_args)
+        if self.pool is not None:
+            results = self.pool.map(task_with_args, single_run_args)
+        else:
+            results = list(map(task_with_args, single_run_args))
         failed = []
         for result in results:
             if result is not None:

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -116,6 +116,11 @@ class TaskManager:
         Exception
             If the input data is invalid.
 
+        Notes
+        -----
+        We set maxtasksperchild=1 to maintain isolation between tasks and ensure no memory
+        leaks happens in IO Managers.
+
         """
         self.input_manager = InputManager(metadata_depth_limit)
         self.output_manager.run_startup_sequence(
@@ -166,7 +171,6 @@ class TaskManager:
         self.output_manager.add_log(
             "Task Manager workers", f"Task Manager is going to run {workers} in parallel.", info_map
         )
-        # maxtasksperchild=1 to maintain isolation between tasks and ensure no memory leaks happens in IO Managers
         self.pool = multiprocessing.Pool(workers, maxtasksperchild=1) if workers > 1 else None
         parsed_single_run_args, parsed_multi_run_args = self._parse_input_tasks()
         self.output_manager.add_log(
@@ -197,6 +201,7 @@ class TaskManager:
                 info_map,
             )
             json_output_directory = runnable_args[0]["json_output_directory"]
+
             self.output_manager.summarize_e2e_test_results(json_output_directory, output_prefixes)
 
         TaskManager.handle_post_processing(

--- a/changelog.md
+++ b/changelog.md
@@ -45,6 +45,7 @@ v1.0.0
 - [2848](https://github.com/RuminantFarmSystems/MASM/pull/2848) - [minor change] [NoInputChange] [NoOutputChange] Justify `deepcopy()` usage.
 - [2843](https://github.com/RuminantFarmSystems/MASM/pull/2843) - [minor change] [NoInputChange] [NoOutputChange] Fix Simple `#noqa`s in codebase.
 - [2852](https://github.com/RuminantFarmSystems/MASM/pull/2852) - [minor change] [NoInputChange] [NoOutputChange] Fix AssertionError on `dev`.
+- [2863](https://github.com/RuminantFarmSystems/MASM/pull/2863) - [minor change] [NoInputChange] [NoOutputChange] Updates TaskManager to avoid using multiprocessing when running single tasks.
 
 ### v1.0.0
 

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -149,6 +149,11 @@ def test_task_manager_start(
         metadata_depth_limit=metadata_depth_limit,
     )
 
+    if workers > 1:
+        assert isinstance(tm.pool, multiprocessing.pool.Pool)
+    else:
+        assert tm.pool is None
+
     mock_run_startup_sequence.assert_called_once_with(
         verbosity=verbosity,
         exclude_info_maps=exclude_info_maps,
@@ -1622,12 +1627,9 @@ def test_run_tasks(
 ) -> None:
     """Unit tests for TaskManager._run_tasks() with all tasks run successfully"""
     task_manager = TaskManager()
-    mock_task = mocker.patch.object(task_manager, "task")
-    mock_task.return_value = None
+    mock_task = mocker.patch.object(task_manager, "task", return_value=None)
 
-    mock_pool = mocker.patch("multiprocessing.Pool")
-    mock_pool.return_value.imap = lambda func, args: map(func, args)
-    task_manager.pool = multiprocessing.Pool(len(single_run_tasks), maxtasksperchild=1)
+    task_manager.pool = None
 
     task_manager._run_tasks(
         single_run_tasks,
@@ -1635,7 +1637,7 @@ def test_run_tasks(
         metadata_depth_limit=metadata_depth_limit,
         workers=1,
         metadata_path=Path("metadata/path"),
-        output_directory=Path("output/"),
+        output_directory=Path("output"),
     )
 
     mock_task_call_list = [
@@ -1645,7 +1647,7 @@ def test_run_tasks(
             produce_graphics=produce_graphics,
             metadata_depth_limit=metadata_depth_limit,
             workers=1,
-            output_directory=Path("output/"),
+            output_directory=Path("output"),
         )
         for single_run_task in single_run_tasks
     ]
@@ -1765,10 +1767,7 @@ def test_run_tasks_fail(
     mock_om_init = mocker.patch("RUFAS.task_manager.OutputManager", return_value=mock_output_manager)
     mock_add_error = mocker.patch.object(mock_output_manager, "add_error", return_value=None)
 
-    mock_pool = mocker.patch("multiprocessing.Pool")
-
-    mock_pool.return_value.imap = lambda func, args: map(func, args)
-    task_manager.pool = multiprocessing.Pool(len(single_run_tasks), maxtasksperchild=1)
+    task_manager.pool = None
 
     task_manager._run_tasks(
         single_run_tasks,
@@ -1776,14 +1775,16 @@ def test_run_tasks_fail(
         metadata_depth_limit=metadata_depth_limit,
         workers=1,
         metadata_path=Path("metadata/path"),
-        output_directory=Path("output/"),
+        output_directory=Path("output"),
     )
 
     mock_om_init.assert_called_once()
     info_map = {"class": TaskManager.__name__, "function": TaskManager._run_tasks.__name__}
     failed = [fail for fail in task_return_values if fail is not None]
     mock_add_error.assert_called_once_with(
-        "Task(s) failed", f"Failed task(s) and output prefix are: {failed}", info_map
+        "Task(s) failed",
+        f"Failed task(s) and output prefix are: {failed}",
+        info_map,
     )
 
 


### PR DESCRIPTION
### Context
Redo of #2685
Multiprocessing in RuFaS can be problematic for some deployment environments.

Issue(s) closed by this pull request: closes #2683

### What & Why
RuFaS currently [instantiates a `multiprocessing.Pool`](https://github.com/RuminantFarmSystems/RuFaS/blob/0f70b6d6861cd656e16a433278c758c9e7519525/RUFAS/task_manager.py#L158) for running the simulation `Task`s, regardless of the number of the latter. In the case of running only one `Task`, using `multiprocessing.Pool` is not necessary and can be replaced by a sequential calculation. This replacement is beneficial for users who deploy the code to AWS Lambda services (like our team) where multiprocessing with Pool is not supported.

### How
This feature can be performed with minimal modifications to the code, by:
1. assigning `self.pool` to `None` if the number of workers is 1 ([here](https://github.com/RuminantFarmSystems/RuFaS/blob/0f70b6d6861cd656e16a433278c758c9e7519525/RUFAS/task_manager.py#L158-L160)):
```python
self.pool = multiprocessing.Pool(workers, maxtasksperchild=1) if workers > 1 else None

```
2. switching between parallel or sequential processing depending on the value of pool ([here](https://github.com/RuminantFarmSystems/RuFaS/blob/0f70b6d6861cd656e16a433278c758c9e7519525/RUFAS/task_manager.py#L494))
```python
if self.pool is not None:
    results = self.pool.imap(task_with_args, single_run_args)
else:
    results = (task_with_args(v) for v in single_run_args)
```

### Test plan
test_task_manager.test_task_manager_start() was modified so that to verify that a `multiprocessing.Pool` is only initiated when the number of `workers` is greater than 1


### Input Changes
None

### Output Changes
None

#### Filter
-

```json

```
