### PR TITLE
Ration percentages error

### DIFF
--- a/RUFAS/biophysical/animal/ration/ration_manager.py
+++ b/RUFAS/biophysical/animal/ration/ration_manager.py
@@ -121,8 +121,8 @@ class RationManager:
             info_map["animal_combination"] = animal_combo.value
             info_map["units"] = MeasurementUnits.PERCENT
             if abs(total_percentage_of_ration - 100.0) > ration_config["user_defined_ration_percentages"]["tolerance"]:
-                error_msg = f"Invalid user-defined ration for {animal_combo.value}. Ration percentages sum to"
-                f"{total_percentage_of_ration}. Simulation will be halted."
+                error_msg = (f"Invalid user-defined ration for {animal_combo.value}. Ration percentages sum to " 
+                f"{total_percentage_of_ration}. Simulation will be halted.")
                 cls._om.add_error("invalid_user_defined_ration_found", error_msg, info_map)
                 invalid_ration_found = True
             else:

--- a/RUFAS/biophysical/animal/ration/ration_manager.py
+++ b/RUFAS/biophysical/animal/ration/ration_manager.py
@@ -120,9 +120,10 @@ class RationManager:
             info_map["ration"] = ration
             info_map["animal_combination"] = animal_combo.value
             info_map["units"] = MeasurementUnits.PERCENT
-            if abs(total_percentage_of_ration - 100.0) > ration_config["user_defined_ration_percentages"]["tolerance"]:
-                error_msg = (f"Invalid user-defined ration for {animal_combo.value}. Ration percentages sum to " 
-                f"{total_percentage_of_ration}. Simulation will be halted.")
+            if abs(total_percentage_of_ration - 100.0) > (ration_config["user_defined_ration_percentages"]
+                                                          ["tolerance"] * 100):
+                error_msg = (f"Invalid user-defined ration for {animal_combo.value}. Ration percentages sum to "
+                             f"{total_percentage_of_ration}. Simulation will be halted.")
                 cls._om.add_error("invalid_user_defined_ration_found", error_msg, info_map)
                 invalid_ration_found = True
             else:

--- a/changelog.md
+++ b/changelog.md
@@ -308,6 +308,7 @@ v0.9.2
 
 - [2760](https://github.com/RuminantFarmSystems/RuFaS/pull/2760) - [minor change] [NoInputChange] [OutputChange] [Feed][Emission] Implement dictionary reporting structure for feed deduction data
 - [2742](https://github.com/RuminantFarmSystems/RuFaS/pull/2742) - [minor change] [NoInputChange] [NoOutputChange] Add logs for variables contributing to aggregated reports.
+- [2873](https://github.com/RuminantFarmSystems/RuFaS/pull/2873) - [minor change] [NoInputChange] [NoOutputChange] Updated ration percentage error message and corrected behavior.
 
 ### v0.9.2
 

--- a/tests/test_biophysical/test_animal/test_ration/test_ration_manager.py
+++ b/tests/test_biophysical/test_animal/test_ration/test_ration_manager.py
@@ -30,7 +30,7 @@ def invalid_ration_config() -> dict[str, dict[str, list[dict[str, int | float]] 
             "growing": [{"feed_type": 201, "ration_percentage": 60.0}, {"feed_type": 202, "ration_percentage": 50.0}],
             "close_up": [{"feed_type": 301, "ration_percentage": 90.0}, {"feed_type": 302, "ration_percentage": 10.0}],
             "lac_cow": [{"feed_type": 401, "ration_percentage": 85.0}, {"feed_type": 402, "ration_percentage": 25.0}],
-            "tolerance": 0.1,
+            "tolerance": 0.01,
         }
     }
 


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
Error message was only reporting first line.
Additional potential tweak to the raising of this error, see the "why" section.

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Simple error message fix.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
Additional error message context - the tolerance value used here to raise the error seems to assume the value is a percentage, when it is actually a fraction (hence the new `* 100` part of the check).  See https://github.com/RuminantFarmSystems/RuFaS/issues/2875 to update users, as the description in the metadata is wrong on test.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Can check this by knocking a digit or two off a user defined ration percentage in the default feed example.

Updated unit test to new tolerance logic.

### Input Changes
<!-- Provide a short summary describing input modifications. -->
<!-- Please include the things that are added, deleted, or modified. -->
None

### Output Changes
<!-- List all the output variable/function modifications with a short summary. -->
<!-- """- `Class.Function.VariableName`: description""" -->
None

#### Filter
<!-- Provide a filter that can be used to handle the output changes. -->

```json

```
