### PR TITLE
[Ration] Update advance purchase allowance to prevent excessive errors for example run

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-1195%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-1198%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 
 # RuFaS: Ruminant Farm Systems

--- a/changelog.md
+++ b/changelog.md
@@ -53,7 +53,8 @@ v1.0.0
 - [2872](https://github.com/RuminantFarmSystems/RuFaS/pull/2872) - [minor change] [NoInputChange] [NoOutputChange] Adds information and links for onboarding videos.
 - [2850](https://github.com/RuminantFarmSystems/RuFaS/pull/2850) - [minor change] [NoInputChange] [NoOutputChange] Refactor `Pen.get_manure_stream()`.
 - [2902](https://github.com/RuminantFarmSystems/RuFaS/pull/2902) - [minor change] [NoInputChange] [NoOutputChange] Add v1.0.0 release notes.
-- [2740](https://github.com/RuminantFarmSystems/RuFaS/pull/2740) - [minor change] [NoInputChange] [NoOutputChange] Added warnings for feed purchases exceeding advance purchase allowance/
+- [2740](https://github.com/RuminantFarmSystems/RuFaS/pull/2740) - [minor change] [NoInputChange] [NoOutputChange] Added warnings for feed purchases exceeding advance purchase allowance.
+- [2924](https://github.com/RuminantFarmSystems/RuFaS/pull/2924) - [minor change] [NoInputChange] [NoOutputChange] Updated advance purchase allowance to prevent excessive errors for example run.
 
 ### v1.0.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -54,7 +54,7 @@ v1.0.0
 - [2850](https://github.com/RuminantFarmSystems/RuFaS/pull/2850) - [minor change] [NoInputChange] [NoOutputChange] Refactor `Pen.get_manure_stream()`.
 - [2902](https://github.com/RuminantFarmSystems/RuFaS/pull/2902) - [minor change] [NoInputChange] [NoOutputChange] Add v1.0.0 release notes.
 - [2740](https://github.com/RuminantFarmSystems/RuFaS/pull/2740) - [minor change] [NoInputChange] [NoOutputChange] Added warnings for feed purchases exceeding advance purchase allowance.
-- [2924](https://github.com/RuminantFarmSystems/RuFaS/pull/2924) - [minor change] [NoInputChange] [NoOutputChange] Updated advance purchase allowance to prevent excessive errors for example run.
+- [2924](https://github.com/RuminantFarmSystems/RuFaS/pull/2924) - [minor change] [NoInputChange] [NoOutputChange] Updated advance purchase allowance to prevent excessive warnings for example run.
 
 ### v1.0.0
 

--- a/input/data/feed/example_Intermountain_feed.json
+++ b/input/data/feed/example_Intermountain_feed.json
@@ -201,55 +201,55 @@
     {
       "purchased_feed": 44,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 51,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 95,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 100,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 108,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 301,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 305,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 202,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 216,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     }
   ]

--- a/input/data/feed/example_Midwest_feed.json
+++ b/input/data/feed/example_Midwest_feed.json
@@ -191,61 +191,61 @@
     {
       "purchased_feed": 23,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 44,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 50,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 95,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 104,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 110,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 202,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 216,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 301,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 302,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     }
   ]

--- a/input/data/feed/example_Northeast_feed.json
+++ b/input/data/feed/example_Northeast_feed.json
@@ -236,61 +236,61 @@
     {
       "purchased_feed": 44,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 10000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 51,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 10000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 94,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 10000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 100,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 110,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 176,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 301,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 303,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 202,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 216,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     }
   ]

--- a/input/data/feed/example_Southwest_feed.json
+++ b/input/data/feed/example_Southwest_feed.json
@@ -176,55 +176,55 @@
     {
       "purchased_feed": 44,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 51,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 95,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 100,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 108,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 202,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 216,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 301,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     },
     {
       "purchased_feed": 305,
       "runtime_purchase_allowance": 1000.0,
-      "advance_purchase_allowance": 1000.0,
+      "advance_purchase_allowance": 1000000.0,
       "planning_cycle_allowance": 1000.0
     }
   ]


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Increase the advance purchase allowance on example feed data to prevent excessive warnings.
### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2914

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Increase the example advance purchase allowance from `1000.0` to `1000000.0`.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
Currently no one is using the advance purchase allowance data so the example data is just arbitrary values, increase the values to prevent example run from flooding the warning logs.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Run with `available_simulation_task` and check that the errors are gone.

### Input Changes
<!-- Provide a short summary describing input modifications. -->
<!-- Please include the things that are added, deleted, or modified. -->


### Output Changes
<!-- List all the output variable/function modifications with a short summary. -->
<!-- """- `Class.Function.VariableName`: description""" -->
- N/A

#### Filter
<!-- Provide a filter that can be used to handle the output changes. -->

```json

```
