### PR TITLE
[Feeds] Removes feed id maximum limit in properties

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -63,6 +63,7 @@ v1.0.0
 - [2925](https://github.com/RuminantFarmSystems/RuFaS/pull/2925) - [minor change] [NoInputChange] [NoOutputChange] Fix the `graph_and_report` option in report_generation.py.
 - [2907](https://github.com/RuminantFarmSystems/RuFaS/pull/2907) - [minor change] [NoInputChange] [OutputChange] Fix the FarmGrownFeed Emissions unit issue. The mirror issue of [Fix FarmGrownFeed Emissions Unit on test #2908](https://github.com/RuminantFarmSystems/MASM/pull/2908) to update `dev`.
 - [2934](https://github.com/RuminantFarmSystems/RuFaS/pull/2934) - [minor change] [NoInputChange] [NoOutputChange] [Animal][Reproduction] Refactor `Reproduction.execute_cow_ed_protocol()`.
+- [2948](https://github.com/RuminantFarmSystems/RuFaS/pull/2948) - [minor change] [Feeds][NoInputChange] [NoOutputChange] Removes feed id maximums in metadata properties.
 
 
 ### v1.0.0

--- a/input/metadata/properties/default.json
+++ b/input/metadata/properties/default.json
@@ -4285,7 +4285,6 @@
             "type": "number",
             "description": "Calf Feed",
             "minimum": 1,
-            "maximum": 306,
             "default": 155
           },
           "ration_percentage": {
@@ -4305,7 +4304,6 @@
             "type": "number",
             "description": "Growing Heifers Feed",
             "minimum": 1,
-            "maximum": 306,
             "default": 1
           },
           "ration_percentage": {
@@ -4325,7 +4323,6 @@
             "type": "number",
             "description": "Close UP Feed",
             "minimum": 1,
-            "maximum": 306,
             "default": 1
           },
           "ration_percentage": {
@@ -4345,7 +4342,6 @@
             "type": "number",
             "description": "Lactating Cow Feed",
             "minimum": 1,
-            "maximum": 306,
             "default": 1
           },
           "ration_percentage": {
@@ -4377,8 +4373,7 @@
         "type": "object",
         "purchased_feed": {
           "type": "number",
-          "minimum": 1,
-          "maximum": 306
+          "minimum": 1
         },
         "runtime_purchase_allowance": {
           "type": "number",

--- a/input/metadata/properties/default.json
+++ b/input/metadata/properties/default.json
@@ -4217,7 +4217,6 @@
       "properties": {
         "type": "number",
         "minimum": 1,
-        "maximum": 306,
         "default": 155
       }
     },
@@ -4226,8 +4225,7 @@
       "description": "Growing Feeds (HeiferI and HeiferII - return at 20 months) -- HeiferI is the number of youngstock post-weaning and before breeding. Heifer II is the number of heifers eligible for breeding and in early pregnancy.",
       "properties": {
         "type": "number",
-        "minimum": 1,
-        "maximum": 306
+        "minimum": 1
       }
     },
     "close_up_feeds": {
@@ -4235,8 +4233,7 @@
       "description": "Close Up Feeds (HeiferIII and Dry Cows) -- HeiferIII is the number of close-up heifers and Dry Cows are non-lactating cows.",
       "properties": {
         "type": "number",
-        "minimum": 1,
-        "maximum": 306
+        "minimum": 1
       }
     },
     "lac_cow_feeds": {
@@ -4244,8 +4241,7 @@
       "description": "Lactating Cow Feeds",
       "properties": {
         "type": "number",
-        "minimum": 1,
-        "maximum": 306
+        "minimum": 1
       }
     },
     "purchased_feeds": {
@@ -4255,8 +4251,7 @@
         "type": "object",
         "purchased_feed": {
           "type": "number",
-          "minimum": 1,
-          "maximum": 306
+          "minimum": 1
         },
         "purchased_feed_cost": {
           "type": "number",


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Part 1 of a 2 part request to remove the maximum limit on feed id from the properties section of the metadata.
Part 2 is to add a CV rule that checks that the feed for an ID actually exists in the feed library but I think this may require the new CV rules so for now I just added it to the future feed CV rules issue #2889

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2926

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Removes maximums from all the feed-library-associated metadata properties.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
Requested by SMEs. "We want users to be able to create new feeds that reflect what they are feeding on their farms. This default maximum metadata value makes it more difficult for them to do that."

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Removed feed id maximums from properties.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Tried changing a feed id to a number above 306 in the `purchased_feeds` section of the feed input file and ran a simulation - it failed but not at the input validation stage.

### Input Changes
<!-- Provide a short summary describing input modifications. -->
<!-- Please include the things that are added, deleted, or modified. -->


### Output Changes
<!-- List all the output variable/function modifications with a short summary. -->
<!-- """- `Class.Function.VariableName`: description""" -->
- N/A

#### Filter
<!-- Provide a filter that can be used to handle the output changes. -->

```json

```
