### PR TITLE
[Bug fix] Patch a missing comma in freestall task input

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -357,6 +357,7 @@ v1.0.0
 - [2743](https://github.com/RuminantFarmSystems/RuFaS/pull/2743) - [minor change] [NoInputChange] [NoOutputChange] Fix broken IM unit test.
 - [2744](https://github.com/RuminantFarmSystems/RuFaS/pull/2744) - [minor change] [NoInputChange] [NoOutputChange] Update the OM and RG wiki with new report filter options.
 - [2881](https://github.com/RuminantFarmSystems/RuFaS/pull/2881) - [minor change] [NoInputChange] [NoOutputChange] Add v1.0.0 release notes.
+- [2964](https://github.com/RuminantFarmSystems/RuFaS/pull/2964) - [minor change] [NoInputChange] [NoOutputChange] Patched a missing comma in freestall task input
 
 ### v0.9.2
 

--- a/input/data/tasks/example_freestall_task.json
+++ b/input/data/tasks/example_freestall_task.json
@@ -9,7 +9,7 @@
       "random_seed": 42,
       "exclude_info_maps": false,
       "cross_validation_file_paths": [
-        "input/metadata/cross_validation/example_cross_validation.json"
+        "input/metadata/cross_validation/example_cross_validation.json",
         "input/metadata/cross_validation/weather_cross_validation.json"
       ]
     }


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Missing a comma in `example_freestall_task.json` that was accidentally removed on PR#2947. Adding a comma.
### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #

### What
<!-- Add more detail about the changes that are being made in the pull request. -->


### Why
<!-- Discuss why the changes in this pull request are needed or important. -->


### How
<!-- Give an explanation of how this pull request addresses needed changes. -->


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Make sure `python main.py` is running.

### Input Changes
<!-- Provide a short summary describing input modifications. -->
<!-- Please include the things that are added, deleted, or modified. -->


### Output Changes
<!-- List all the output variable/function modifications with a short summary. -->
<!-- """- `Class.Function.VariableName`: description""" -->
- N/A

#### Filter
<!-- Provide a filter that can be used to handle the output changes. -->

```json

```
