### PR TITLE
[Manure] Adds error protection against the first processor in a chain being a `Separator`

### DIFF
--- a/RUFAS/biophysical/manure/processor.py
+++ b/RUFAS/biophysical/manure/processor.py
@@ -156,6 +156,21 @@ class Processor(ABC):
         bool
             True if the ManureStream can be processed by the Processor, otherwise false.
 
+        Notes
+        -----
+        This check enforces consistency between the processor type and the structure
+        of the incoming manure stream:
+
+        - Housing emissions calculators require `pen_manure_data` to be present.
+        - Non-housing emissions calculators require `pen_manure_data` to be absent.
+
+        This validation is primarily used when assigning the first processor in a
+        manure processing chain. It ensures that only appropriate processor types
+        (e.g., handlers or compatible storages) are used as entry points for a given
+        manure stream.
+
+        A mismatch between processor type and manure stream structure will result in
+        the processor being considered incompatible.
         """
         is_valid_housing_emissions_calculator = (
             True if (self.is_housing_emissions_calculator and manure_stream.pen_manure_data is not None) else False

--- a/RUFAS/biophysical/manure/separator/separator.py
+++ b/RUFAS/biophysical/manure/separator/separator.py
@@ -98,6 +98,13 @@ class Separator(Processor):
             The manure to be processed.
 
         """
+        is_received_manure_valid = self.check_manure_stream_compatibility(manure)
+        if is_received_manure_valid is False:
+            raise ValueError(
+                f"Separator {self.name} was assigned as a first processor. "
+                "The first processor for each manure stream must be either a handler "
+                "or an appropriate storage (open lot, bedded pack, or daily spread)."
+            )
         if self.held_manure is None:
             self.held_manure = manure
         else:

--- a/RUFAS/biophysical/manure/separator/separator.py
+++ b/RUFAS/biophysical/manure/separator/separator.py
@@ -100,9 +100,11 @@ class Separator(Processor):
         """
         is_received_manure_valid = self.check_manure_stream_compatibility(manure)
         if not is_received_manure_valid:
-            error_message = f"Separator {self.name} was assigned as a first processor. " \
-                "The first processor for each manure stream must be either a handler " \
+            error_message = (
+                f"Separator {self.name} was assigned as a first processor. "
+                "The first processor for each manure stream must be either a handler "
                 "or an appropriate storage (open lot, bedded pack, or daily spread)."
+            )
 
             self._om.add_error(
                 "Received Manure Compatibility Error",
@@ -111,7 +113,7 @@ class Separator(Processor):
                     "class": self.__class__.__name__,
                     "function": self.process_manure.__name__,
                     "prefix": self._prefix,
-                }
+                },
             )
             raise ValueError(error_message)
         if self.held_manure is None:

--- a/RUFAS/biophysical/manure/separator/separator.py
+++ b/RUFAS/biophysical/manure/separator/separator.py
@@ -99,12 +99,21 @@ class Separator(Processor):
 
         """
         is_received_manure_valid = self.check_manure_stream_compatibility(manure)
-        if is_received_manure_valid is False:
-            raise ValueError(
-                f"Separator {self.name} was assigned as a first processor. "
-                "The first processor for each manure stream must be either a handler "
+        if not is_received_manure_valid:
+            error_message = f"Separator {self.name} was assigned as a first processor. " \
+                "The first processor for each manure stream must be either a handler " \
                 "or an appropriate storage (open lot, bedded pack, or daily spread)."
+
+            self._om.add_error(
+                "Received Manure Compatibility Error",
+                error_message,
+                info_map={
+                    "class": self.__class__.__name__,
+                    "function": self.process_manure.__name__,
+                    "prefix": self._prefix,
+                }
             )
+            raise ValueError(error_message)
         if self.held_manure is None:
             self.held_manure = manure
         else:

--- a/changelog.md
+++ b/changelog.md
@@ -71,6 +71,7 @@ v1.0.0
 - [2734](https://github.com/RuminantFarmSystems/RuFaS/pull/2734) - [minor change] [InputChange][OutputChange][Animal] Implements the Genetics submodule.
 - [2968](https://github.com/RuminantFarmSystems/RuFaS/pull/2968) - [minor change] [InputChange][OutputChange][Animal] Refactored HerdManager's daily_routine.
 - [2809](https://github.com/RuminantFarmSystems/RuFaS/pull/2809) - [minor change] [Animal] [NoInputChange] [NoOutputChange] Reorders grouping of attributes in some HerdStatistics methods, updates docstrings.
+- [2984](https://github.com/RuminantFarmSystems/RuFaS/pull/2984) - [minor change] [Manure] [NoInputChange] [NoOutputChange] Adds manure stream compatibility check to Separators to enforce that Separators cannot be first processors in a chain.
 
 ### v1.0.0
 

--- a/tests/test_biophysical/test_manure/test_separator/test_separator.py
+++ b/tests/test_biophysical/test_manure/test_separator/test_separator.py
@@ -76,6 +76,23 @@ def test_receive_manure_accumulation(
     assert mock_separator.held_manure == expected, f"Expected {expected}, got {mock_separator.held_manure}"
 
 
+def test_separator_receive_manure_invalid_stream_raises(
+    mock_separator: Separator,
+    mocker: MockerFixture,
+) -> None:
+    """Test that an invalid manure stream raises a ValueError."""
+    mocker.patch.object(
+        mock_separator,
+        "check_manure_stream_compatibility",
+        return_value=False,
+    )
+
+    manure = ManureStream(10, 2, 3, 4, 5, 6, 8, 7, 10, 9, 1.5, 0.24, None)
+
+    with pytest.raises(ValueError, match="first processor"):
+        mock_separator.receive_manure(manure)
+
+
 @pytest.fixture
 def mock_manure_stream() -> ManureStream:
     """ManureStream object for testing."""

--- a/tests/test_biophysical/test_manure/test_separator/test_separator.py
+++ b/tests/test_biophysical/test_manure/test_separator/test_separator.py
@@ -109,7 +109,7 @@ def mock_manure_stream() -> ManureStream:
         volume=200.0,
         methane_production_potential=0.24,
         pen_manure_data=None,
-        bedding_non_degradable_volatile_solids=10
+        bedding_non_degradable_volatile_solids=10,
     )
 
 


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2898

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Adds the compatibility check from `Processor` parent class to `Separator`'s `receive_manure()` method to enforce that it cannot be a first processor in a manure processor chain.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
Separators should not be the first processor in a manure processor chain.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Pretty small change so the `What` should be adequate. One additional change I made is to add some further notes to the `check_manure_stream_compatibility` method since it's not fully understandable right now why that compatibility check is used to enforce whether or not something can be a `first_processor`.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
The issue has 2 input files that can be used to check and see the error is now successfully raised. **IMPORTANT NOTE** the animal file included there doesn't have the current genetics inputs that are on the version of this file on `dev`. This is causing some unexpected cross-validation errors if you try to run it.

My suggested approach is to instead change the `first_processor` in the `LAC_COW` `pen_information` in the `example_freestall_animal.json` input from `lac_alley_scraper` to `screw_press_1`. You should still use the manure configs file in the issue.

This will raise the expected error.

### Input Changes
<!-- Provide a short summary describing input modifications. -->
<!-- Please include the things that are added, deleted, or modified. -->


### Output Changes
<!-- List all the output variable/function modifications with a short summary. -->
<!-- """- `Class.Function.VariableName`: description""" -->
- N/A

#### Filter
<!-- Provide a filter that can be used to handle the output changes. -->

```json

```
