### PR TITLE
[FeedManager] Remove `available_feeds` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-1170%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-1168%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 
 # RuFaS: Ruminant Farm Systems

--- a/RUFAS/biophysical/feed_storage/feed_manager.py
+++ b/RUFAS/biophysical/feed_storage/feed_manager.py
@@ -51,6 +51,8 @@ class FeedManager:
     ----------
     _om : OutputManager
         Output manager for reporting feed-related data.
+    _available_feeds : list[Feed]
+        A list of the feeds available for storage and purchasing.
     active_storages : dict[StorageType, Storage]
         Contains the list of active farmgrown crop storage units in the simulation and their mapping from StorageType.
     purchased_feed_storage : PurchasedFeedStorage
@@ -59,6 +61,8 @@ class FeedManager:
         Represents the allowances for feed purchases during a planning cycle.
     runtime_purchase_allowance : RuntimePurchaseAllowance
         Represents the allowances for feed purchases during runtime.
+    advanced_purchase_allowance : AdvancePurchaseAllowance
+        Represents the allowances for feeds purchased at the beginning of a ration interval.
     crop_to_rufas_id : dict[str, RUFAS_ID]
         Maps crop configurations to their corresponding RUFAS IDs for harvested crops.
     _cumulative_feed_requests : dict[RUFAS_ID, float]
@@ -107,25 +111,20 @@ class FeedManager:
             sorted_purchased_allowances
         )
 
-        available_feed_ids = [feed.rufas_id for feed in self.available_feeds]
+        available_feed_ids = [feed.rufas_id for feed in self._available_feeds]
         self.crop_to_rufas_id: dict[str, RUFAS_ID] = {}
         for storage in self.active_storages.values():
             if storage.rufas_feed_id in available_feed_ids:
                 self.crop_to_rufas_id[str(storage.crop_name)] = storage.rufas_feed_id
 
-        self._cumulative_feed_requests: dict[RUFAS_ID, float] = {feed.rufas_id: 0.0 for feed in self.available_feeds}
+        self._cumulative_feed_requests: dict[RUFAS_ID, float] = {feed.rufas_id: 0.0 for feed in self._available_feeds}
         self._cumulative_purchased_feeds_fed: dict[RUFAS_ID, float] = {
-            feed.rufas_id: 0.0 for feed in self.available_feeds
+            feed.rufas_id: 0.0 for feed in self._available_feeds
         }
         self._cumulative_farmgrown_feeds_fed: dict[RUFAS_ID, float] = {
-            feed.rufas_id: 0.0 for feed in self.available_feeds
+            feed.rufas_id: 0.0 for feed in self._available_feeds
         }
-        self._cumulative_purchased_feeds: dict[RUFAS_ID, float] = {feed.rufas_id: 0.0 for feed in self.available_feeds}
-
-    @property
-    def available_feeds(self) -> list[Feed]:
-        """Returns the list of available feeds."""
-        return self._available_feeds
+        self._cumulative_purchased_feeds: dict[RUFAS_ID, float] = {feed.rufas_id: 0.0 for feed in self._available_feeds}
 
     def _create_all_storages(
         self, feed_storage_configs: dict[str, Any], feed_storage_instances: dict[str, list[str]]
@@ -154,7 +153,7 @@ class FeedManager:
         self._validate_storage_config_names(list(instance_configs_by_name.values()))
         self._validate_crop_field_mapping(list(instance_configs_by_name.values()))
 
-        available_rufas_ids: list[int] = [feed.rufas_id for feed in self.available_feeds]
+        available_rufas_ids: list[int] = [feed.rufas_id for feed in self._available_feeds]
         for instance_name, storage_config in instance_configs_by_name.items():
             storage_type_str = storage_config["storage_type"]
             storage_class = StorageType.get_storage_class(storage_type_str)
@@ -250,9 +249,9 @@ class FeedManager:
 
     def update_available_feed_amounts(self) -> None:
         """Updates the amounts feeds available based on what is currently stored."""
-        rufas_ids_to_query = [feed.rufas_id for feed in self.available_feeds]
+        rufas_ids_to_query = [feed.rufas_id for feed in self._available_feeds]
         available_feed_amounts = self._query_available_feed_totals(rufas_ids_to_query)
-        for feed in self.available_feeds:
+        for feed in self._available_feeds:
             feed.amount_available = available_feed_amounts[feed.rufas_id]
 
     def translate_crop_config_name_to_rufas_id(
@@ -501,7 +500,7 @@ class FeedManager:
         feeds_to_purchase = {id: 0.0 for id in requested_feeds.requested_feed.keys()}
         for feed_id, amount_requested in requested_feeds.requested_feed.items():
             feed_info = next(
-                (available_feed for available_feed in self.available_feeds if available_feed.rufas_id == feed_id), None
+                (available_feed for available_feed in self._available_feeds if available_feed.rufas_id == feed_id), None
             )
             if feed_info is None:
                 self._om.add_error(
@@ -588,7 +587,7 @@ class FeedManager:
         }
         for rufas_id, purchase_amount in feeds_to_purchase.items():
             feed_info = next(
-                (available_feed for available_feed in self.available_feeds if available_feed.rufas_id == rufas_id), None
+                (available_feed for available_feed in self._available_feeds if available_feed.rufas_id == rufas_id), None
             )
             if feed_info is None:
                 raise ValueError(f"Trying to purchase unavailable feed {rufas_id}")
@@ -831,7 +830,7 @@ class FeedManager:
         farmgrown_by_id: DefaultDict[RUFAS_ID, list[HarvestedCrop]] = defaultdict(list)
         purchased_by_id: DefaultDict[RUFAS_ID, list[PurchasedFeed]] = defaultdict(list)
 
-        valid_feed_ids = set(feed.rufas_id for feed in self.available_feeds)
+        valid_feed_ids = set(feed.rufas_id for feed in self._available_feeds)
 
         for storage in self.active_storages.values():
             feed_id: RUFAS_ID = storage.rufas_feed_id
@@ -862,7 +861,7 @@ class FeedManager:
             A set of valid farm-grown feed ids.
         """
         farmgrown_ids: set[RUFAS_ID] = set()
-        valid_feed_ids = set(feed.rufas_id for feed in self.available_feeds)
+        valid_feed_ids = set(feed.rufas_id for feed in self._available_feeds)
         for storage in self.active_storages.values():
             feed_id: RUFAS_ID = storage.rufas_feed_id
             if feed_id in valid_feed_ids:

--- a/RUFAS/biophysical/feed_storage/feed_manager.py
+++ b/RUFAS/biophysical/feed_storage/feed_manager.py
@@ -587,7 +587,8 @@ class FeedManager:
         }
         for rufas_id, purchase_amount in feeds_to_purchase.items():
             feed_info = next(
-                (available_feed for available_feed in self._available_feeds if available_feed.rufas_id == rufas_id), None
+                (available_feed for available_feed in self._available_feeds if available_feed.rufas_id == rufas_id),
+                None,
             )
             if feed_info is None:
                 raise ValueError(f"Trying to purchase unavailable feed {rufas_id}")

--- a/RUFAS/biophysical/feed_storage/feed_manager.py
+++ b/RUFAS/biophysical/feed_storage/feed_manager.py
@@ -61,7 +61,7 @@ class FeedManager:
         Represents the allowances for feed purchases during a planning cycle.
     runtime_purchase_allowance : RuntimePurchaseAllowance
         Represents the allowances for feed purchases during runtime.
-    advanced_purchase_allowance : AdvancePurchaseAllowance
+    advance_purchase_allowance : AdvancePurchaseAllowance
         Represents the allowances for feeds purchased at the beginning of a ration interval.
     crop_to_rufas_id : dict[str, RUFAS_ID]
         Maps crop configurations to their corresponding RUFAS IDs for harvested crops.
@@ -107,7 +107,7 @@ class FeedManager:
         self.runtime_purchase_allowance: RuntimePurchaseAllowance = RuntimePurchaseAllowance(
             sorted_purchased_allowances
         )
-        self.advanced_purchase_allowance: AdvancePurchaseAllowance = AdvancePurchaseAllowance(
+        self.advance_purchase_allowance: AdvancePurchaseAllowance = AdvancePurchaseAllowance(
             sorted_purchased_allowances
         )
 
@@ -522,13 +522,13 @@ class FeedManager:
             amount_to_purchase = max(amount_requested - available_amount, 0.0) * (1 + feed_info.buffer)
             is_fulfillable_with_purchase = (
                 amount_requested - available_amount
-            ) <= self.advanced_purchase_allowance.allowances.get(feed_id, 0.0) + allowance_tolerance
+            ) <= self.advance_purchase_allowance.allowances.get(feed_id, 0.0) + allowance_tolerance
             if not is_fulfillable_with_purchase:
                 self._om.add_warning(
                     "Ration Interval Purchase Warning",
                     f"Requested feed {feed_id} exceeds ration interval purchases allowance. "
                     f"Requested: {amount_requested}, Available: {available_amount}, "
-                    f"Allowance: ${self.advanced_purchase_allowance.allowances.get(feed_id, 0.0)}. "
+                    f"Allowance: ${self.advance_purchase_allowance.allowances.get(feed_id, 0.0)}. "
                     f"Still making full purchase.",
                     info_map,
                 )

--- a/changelog.md
+++ b/changelog.md
@@ -77,6 +77,7 @@ v1.0.0
 - [2984](https://github.com/RuminantFarmSystems/RuFaS/pull/2984) - [minor change] [Manure] [NoInputChange] [NoOutputChange] Adds manure stream compatibility check to Separators to enforce that Separators cannot be first processors in a chain.
 - [2931](https://github.com/RuminantFarmSystems/RuFaS/pull/2931) - [minor change] [NoInputChange] [OutputChange] automatically add "simulation_day" to info_maps when variables are added to OutputManager, improves data padding usability.
 - [2991](https://github.com/RuminantFarmSystems/RuFaS/pull/2991) - [minor change] [NoInputChange] [NoOutputChange] Updated the docstrings in the Crop and Soil module.
+- [3004](https://github.com/RuminantFarmSystems/RuFaS/pull/3004) - [minor change] [NoInputChange] [NoOutputChange] Removes public `available_feeds` property from FeedManager.
 
 ### v1.0.0
 

--- a/tests/test_biophysical/test_feed_storage/test_feed_manager.py
+++ b/tests/test_biophysical/test_feed_storage/test_feed_manager.py
@@ -550,6 +550,7 @@ def test_validate_storage_config_names_duplicate_raises(feed_manager: FeedManage
     assert "['S1']" in msg
     add_error.assert_called_once()
 
+
 def test_update_available_feed_amounts(
     feed_manager: FeedManager, mock_available_feeds: list[Feed], mocker: MockerFixture
 ) -> None:

--- a/tests/test_biophysical/test_feed_storage/test_feed_manager.py
+++ b/tests/test_biophysical/test_feed_storage/test_feed_manager.py
@@ -306,7 +306,7 @@ def test_feed_manager_init(mocker: MockerFixture, storage: Storage) -> None:
     )
 
     assert feed_manager.active_storages == {"Test Storage": storage}
-    assert feed_manager.available_feeds == mock_available_feeds
+    assert feed_manager._available_feeds == mock_available_feeds
 
     mock_create_all_storages.assert_called_once()
     mock_purchased_feed_storage_init.assert_called_once_with(mock_available_feeds)
@@ -550,13 +550,6 @@ def test_validate_storage_config_names_duplicate_raises(feed_manager: FeedManage
     assert "['S1']" in msg
     add_error.assert_called_once()
 
-
-def test_available_feeds(feed_manager: FeedManager, mock_available_feeds: list[Feed]) -> None:
-    """Test for FeedManager available_feeds property."""
-    feed_manager._available_feeds = mock_available_feeds
-    assert feed_manager.available_feeds == mock_available_feeds
-
-
 def test_update_available_feed_amounts(
     feed_manager: FeedManager, mock_available_feeds: list[Feed], mocker: MockerFixture
 ) -> None:
@@ -572,7 +565,7 @@ def test_update_available_feed_amounts(
 
     mock_query_available_feed_totals.assert_called_once_with([feed.rufas_id for feed in mock_available_feeds])
     assert {
-        feed.rufas_id: feed.amount_available for feed in feed_manager.available_feeds
+        feed.rufas_id: feed.amount_available for feed in feed_manager._available_feeds
     } == expected_feeds_amount_available
 
 

--- a/tests/test_biophysical/test_feed_storage/test_feed_manager.py
+++ b/tests/test_biophysical/test_feed_storage/test_feed_manager.py
@@ -217,7 +217,7 @@ def feed_manager(mocker: MockerFixture, mock_available_feeds: list[Feed]) -> Fee
     feed_manager.runtime_purchase_allowance = RuntimePurchaseAllowance(
         [{"purchased_feed": feed.rufas_id, "runtime_purchase_allowance": 10.0} for feed in mock_available_feeds]
     )
-    feed_manager.advanced_purchase_allowance = AdvancePurchaseAllowance(
+    feed_manager.advance_purchase_allowance = AdvancePurchaseAllowance(
         [{"purchased_feed": feed.rufas_id, "advance_purchase_allowance": 10.0} for feed in mock_available_feeds]
     )
 
@@ -269,7 +269,7 @@ def test_feed_manager_init(mocker: MockerFixture, storage: Storage) -> None:
         "__init__",
         return_value=None,
     )
-    mock_advanced_purchase_allowance_init = mocker.patch.object(
+    mock_advance_purchase_allowance_init = mocker.patch.object(
         AdvancePurchaseAllowance,
         "__init__",
         return_value=None,
@@ -321,7 +321,7 @@ def test_feed_manager_init(mocker: MockerFixture, storage: Storage) -> None:
     ]
     mock_planning_cycle_allowance_init.assert_called_once_with(sorted_allowances)
     mock_runtime_purchase_allowance_init.assert_called_once_with(sorted_allowances)
-    mock_advanced_purchase_allowance_init.assert_called_once_with(sorted_allowances)
+    mock_advance_purchase_allowance_init.assert_called_once_with(sorted_allowances)
 
     assert feed_manager.crop_to_rufas_id == {"corn_silage": 1}
     assert feed_manager._cumulative_feed_requests == {1: 0.0, 2: 0.0}


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Removes the public `available_feeds` property from `FeedManager`.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2980

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Removes the public `available_feeds` property and all references from `FeedManager`.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
This public property was used when the FeedManager was the arbiter of the list of available feeds read from the inputs. That now resides in `SimulationEngine` as it is shared/used equally by both `FeedManager` and `HerdManager`. There is no need for it to exist anymore.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Deleted the property from `FeedManager` and updated all the references to the private `_available_feeds` attribute which contained the same information for internal `FeedManager` use.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Updated unit testing.
The references in `SimulationEngine` had already been removed when we switched to having `SimulationEngine` own this data.
Simulation runs as expected.

### Input Changes
<!-- Provide a short summary describing input modifications. -->
<!-- Please include the things that are added, deleted, or modified. -->


### Output Changes
<!-- List all the output variable/function modifications with a short summary. -->
<!-- """- `Class.Function.VariableName`: description""" -->
- N/A

#### Filter
<!-- Provide a filter that can be used to handle the output changes. -->

```json

```
