### PR TITLE
Ammonium fraction fix

### DIFF
--- a/RUFAS/data_structures/manure_to_crop_soil_connection.py
+++ b/RUFAS/data_structures/manure_to_crop_soil_connection.py
@@ -168,7 +168,7 @@ class NutrientRequestResults:
                 combined_ammonium_nitrogen_fraction = (
                     self.ammonium_nitrogen_fraction * self_inorganic_contribution
                     + other.ammonium_nitrogen_fraction * other_inorganic_contribution
-                )
+                )/(self_inorganic_contribution + other_inorganic_contribution)
             else:
                 combined_ammonium_nitrogen_fraction = self.ammonium_nitrogen_fraction
         else:


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
The combined ammonium fraction that was calculated by the `NutrientRequestResults` was incorrect as it was adding two fractions that needed to be averaged.

### What
This updates the equation for the `combined_ammonium_nitrogen_fraction` to the following:

 ```
(self.ammonium_nitrogen_fraction * self_inorganic_contribution + 
other.ammonium_nitrogen_fraction * other_inorganic_contribution) /
(self_inorganic_contribution + other_inorganic_contribution)
```


### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
We need the average contribution of each manure to the fraction of ammonium N in the in organic N.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Updates the ammonium N fraction calculation in the manure to crop and soil connector

