### PR TITLE
Fixed MYPY error and missing changelog introduced in #2705

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-1166%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-1165%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 
 # RuFaS: Ruminant Farm Systems

--- a/changelog.md
+++ b/changelog.md
@@ -80,6 +80,7 @@ v1.0.0
 - [2991](https://github.com/RuminantFarmSystems/RuFaS/pull/2991) - [minor change] [NoInputChange] [NoOutputChange] Updated the docstrings in the Crop and Soil module.
 - [3004](https://github.com/RuminantFarmSystems/RuFaS/pull/3004) - [minor change] [NoInputChange] [NoOutputChange] Removes public `available_feeds` property from FeedManager.
 - [3000](https://github.com/RuminantFarmSystems/RuFaS/pull/3000) - [minor change] [NoInputChange] [NoOutputChange] Updated the error messages for all biophysical modules.
+- [2715](https://github.com/RuminantFarmSystems/RuFaS/pull/2715) - [minor change] [Animal] [NoInputChange] [OutputChange] Renames the 305-day milk yield output from `milk_production_305days_herd_mean` to `milk_305_day_yield_herd_mean`, splits the calculation into a pure Wood's-curve integral and a per-cow simulation estimate, and adds L1/L2/L3+ herd-level reporting.
 
 ### v1.0.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -81,6 +81,7 @@ v1.0.0
 - [3004](https://github.com/RuminantFarmSystems/RuFaS/pull/3004) - [minor change] [NoInputChange] [NoOutputChange] Removes public `available_feeds` property from FeedManager.
 - [3000](https://github.com/RuminantFarmSystems/RuFaS/pull/3000) - [minor change] [NoInputChange] [NoOutputChange] Updated the error messages for all biophysical modules.
 - [2715](https://github.com/RuminantFarmSystems/RuFaS/pull/2715) - [minor change] [Animal] [NoInputChange] [OutputChange] Renames the 305-day milk yield output from `milk_production_305days_herd_mean` to `milk_305_day_yield_herd_mean`, splits the calculation into a pure Wood's-curve integral and a per-cow simulation estimate, and adds L1/L2/L3+ herd-level reporting.
+- [3022](https://github.com/RuminantFarmSystems/RuFaS/pull/3022) - [minor change] [Tests] [NoInputChange] [NoOutputChange] Adds missing changelog entry for #2715 and fixes the one mypy error it introduced by typing the `history` parameter of `_make_milk_production` in `test_milk_production.py`.
 
 ### v1.0.0
 

--- a/tests/test_biophysical/test_animal/test_milk_production/test_milk_production.py
+++ b/tests/test_biophysical/test_animal/test_milk_production/test_milk_production.py
@@ -8,6 +8,7 @@ from RUFAS.biophysical.animal.animal_constants import DRY
 from RUFAS.biophysical.animal.animal_module_constants import AnimalModuleConstants
 from RUFAS.biophysical.animal.data_types.animal_events import AnimalEvents
 from RUFAS.biophysical.animal.data_types.milk_production import MilkProductionInputs, MilkProductionOutputs
+from RUFAS.biophysical.animal.data_types.milk_production_record import MilkProductionRecord
 from RUFAS.biophysical.animal.milk.milk_production import MilkProduction
 from RUFAS.general_constants import GeneralConstants
 from RUFAS.rufas_time import RufasTime
@@ -365,7 +366,9 @@ def test_calculate_predicted_305_day_milk_yield(
     )
 
 
-def _make_milk_production(l_param: float, m_param: float, n_param: float, history: list) -> MilkProduction:
+def _make_milk_production(
+    l_param: float, m_param: float, n_param: float, history: list[MilkProductionRecord]
+) -> MilkProduction:
     mp = MilkProduction()
     mp.set_wood_parameters(l_param, m_param, n_param)
     mp.milk_production_history = history
@@ -385,7 +388,7 @@ def test_calculate_305_day_milk_yield_falls_back_to_prediction_with_no_history()
 def test_calculate_305_day_milk_yield_uses_available_history() -> None:
     """Partial 305-day milk yield estimates include recorded production history plus a
     Wood's-curve fill for unobserved future DIMs."""
-    milk_production_history = [
+    milk_production_history: list[MilkProductionRecord] = [
         {"simulation_day": 1, "days_in_milk": 1, "milk_production": 100.0, "days_born": 1000},
         {"simulation_day": 2, "days_in_milk": 2, "milk_production": 100.0, "days_born": 1001},
         {"simulation_day": 3, "days_in_milk": 0, "milk_production": 0.0, "days_born": 1002},
@@ -405,7 +408,7 @@ def test_calculate_305_day_milk_yield_uses_available_history() -> None:
 def test_calculate_305_day_milk_yield_fills_unobserved_early_dims() -> None:
     """When the cow's history starts mid-lactation (e.g. mid-lactation at sim start),
     Wood's curve fills in the unobserved early days so the metric is meaningful from day 1."""
-    milk_production_history = [
+    milk_production_history: list[MilkProductionRecord] = [
         {"simulation_day": 1, "days_in_milk": 100, "milk_production": 30.0, "days_born": 1000},
         {"simulation_day": 2, "days_in_milk": 101, "milk_production": 30.0, "days_born": 1001},
         {"simulation_day": 3, "days_in_milk": 102, "milk_production": 30.0, "days_born": 1002},


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Follow-up to [#2715](https://github.com/RuminantFarmSystems/RuFaS/issues/2715).
### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #

### What
<!-- Add more detail about the changes that are being made in the pull request. -->

- Adds the missing changelog entry for [#2715](https://github.com/RuminantFarmSystems/RuFaS/issues/2715).
- Fixes the one new mypy error [#2715](https://github.com/RuminantFarmSystems/RuFaS/issues/2715) introduced in tests/test_biophysical/test_animal/test_milk_production/test_milk_production.py by typing the history parameter of the _make_milk_production helper as list[MilkProductionRecord] (and annotating the two call-site literals so the TypedDict checks pass).

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
[#2715](https://github.com/RuminantFarmSystems/RuFaS/issues/2715) was merged without a changelog entry and bumped the total mypy error count by 1.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->

- mypy RUFAS tests now reports the same 1167 errors / 154 files as the pre-[#2715](https://github.com/RuminantFarmSystems/RuFaS/issues/2715) baseline (was 1168 / 155 after the merge).
- pytest tests/test_biophysical/test_animal/test_milk_production/test_milk_production.py — 40 passed.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->


### Input Changes
<!-- Provide a short summary describing input modifications. -->
<!-- Please include the things that are added, deleted, or modified. -->


### Output Changes
<!-- List all the output variable/function modifications with a short summary. -->
<!-- """- `Class.Function.VariableName`: description""" -->
- N/A

#### Filter
<!-- Provide a filter that can be used to handle the output changes. -->

```json

```
