### PR TITLE
[DataValidation] Adds input data path origin to error/warning messages in dv

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-1166%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-1165%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 
 # RuFaS: Ruminant Farm Systems

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-1188%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-1166%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 
 # RuFaS: Ruminant Farm Systems

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-1165%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Pytest](https://img.shields.io/badge/Pytest-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-%25-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-1188%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 
 # RuFaS: Ruminant Farm Systems

--- a/RUFAS/data_validator.py
+++ b/RUFAS/data_validator.py
@@ -1413,7 +1413,7 @@ class DataValidator:
                 else variable_parent[int(element_hierarchy[-1])]
             )
             error_message = (
-                f"Variable: '{element_hierarchy[-1]}' has invalid value: '{invalid_value}'"
+                f"Variable: '{element_hierarchy[-1]}' in '{input_path}' has invalid value: '{invalid_value}'"
                 f", and cannot be changed to a default value. {properties_violation_message}"
             )
             self.event_logs.append(
@@ -1432,7 +1432,8 @@ class DataValidator:
             original_invalid_value = variable_parent.get(str(element_hierarchy[-1]))
 
         warning_message = (
-            f"Variable: '{element_path}' has value: {original_invalid_value}. {properties_violation_message}"
+            f"Variable: '{element_path}' in '{input_path}' has value: {original_invalid_value}."
+            f" {properties_violation_message}"
         )
         self.event_logs.append(
             {"warning": "Validation: invalid data found", "message": warning_message, "info_map": info_map}
@@ -1444,7 +1445,7 @@ class DataValidator:
             variable_parent[str(element_hierarchy[-1])] = variable_properties["default"]
 
         warning_message = (
-            f"Invalid data from '{input_path}' fixed: '{element_path}' in value changed from "
+            f"Invalid data from '{input_path}' fixed: '{element_path}' value changed from "
             f"{original_invalid_value} to {variable_properties['default']}. Fix enabled by default value specified in "
             f"'{properties_blob_key}'."
         )

--- a/RUFAS/data_validator.py
+++ b/RUFAS/data_validator.py
@@ -808,6 +808,7 @@ class DataValidator:
         elements_counter: "ElementsCounter",
         called_during_initialization: bool,
         fixable_data_types: set[str],
+        input_path: Path
     ) -> bool:
         """
         Validates the data based on its specified type.
@@ -826,10 +827,12 @@ class DataValidator:
             The metadata properties for the data file being checked.
         elements_counter : ElementsCounter
             A counter to keep track of the number of valid, invalid, and fixed elements.
-        called_during_initialization: bool
+        called_during_initialization : bool
             Boolean variable indicating whether the function is being called during initialization.
-        fixable_data_types: set[str]
+        fixable_data_types : set[str]
             Set enumerating the data types that the caller will attempt to fix while validating data.
+        input_path : Path
+            Reference identifying the origin of the data currently being validated.
 
         Returns
         -------
@@ -869,6 +872,7 @@ class DataValidator:
                     ElementsCounter,
                     bool,
                     set[str],
+                    Path
                 ],
                 bool,
             ],
@@ -883,7 +887,7 @@ class DataValidator:
 
         if data_type not in type_to_validator_map:
             raise ValueError(
-                f"The metadata type of the element '{path}' "
+                f"The metadata type of the element '{path}' in input '{input_path}' "
                 f"is not valid. Supported types are: {type_to_validator_map.keys()}."
             )
 
@@ -896,13 +900,14 @@ class DataValidator:
             elements_counter,
             called_during_initialization,
             fixable_data_types,
+            input_path
         )
 
         if data_type not in fixable_data_types:
             if not is_valid:
                 error_message = (
-                    f"Variable: '{path}' data type '{data_type}' is not fixable by Input Manager."
-                    f" Please check the inputs."
+                    f"Variable: '{path}' data type '{data_type}' from the '{input_path}' "
+                    "is not fixable by Input Manager. Please check the inputs."
                 )
                 self.event_logs.append(
                     {
@@ -917,7 +922,7 @@ class DataValidator:
             elements_counter.increment(ElementState.VALID)
             return True
 
-        is_fixed = self._fix_data(variable_properties, variable_path, data, properties_blob_key)
+        is_fixed = self._fix_data(variable_properties, variable_path, data, properties_blob_key, input_path)
 
         if is_fixed:
             elements_counter.increment(ElementState.FIXED)
@@ -1013,6 +1018,7 @@ class DataValidator:
         elements_counter: "ElementsCounter",
         called_during_initialization: bool,
         fixable_data_types: set[str],
+        input_path: Path
     ) -> bool:
         """
         Validates a data element of type array.
@@ -1035,6 +1041,8 @@ class DataValidator:
             Boolean variable indicating whether the function is being called during initialization.
         fixable_data_types: set[str]
             Set of data types that are fixable.
+        input_path : Path
+            Reference identifying the origin of the data currently being validated.
 
         Returns
         -------
@@ -1043,7 +1051,7 @@ class DataValidator:
         """
 
         array_value = self._extract_data_by_key_list(
-            data, variable_path, variable_properties, called_during_initialization
+            data, variable_path, variable_properties, called_during_initialization, input_path
         )
 
         if variable_properties.get("nullable", False) and array_value is None:
@@ -1065,6 +1073,7 @@ class DataValidator:
                 elements_counter,
                 called_during_initialization,
                 fixable_data_types,
+                input_path
             )
             is_whole_array_acceptable = is_whole_array_acceptable and is_element_acceptable
             if not is_element_acceptable and eager_termination:
@@ -1081,6 +1090,7 @@ class DataValidator:
         elements_counter: ElementsCounter,
         called_during_initialization: bool,
         fixable_data_types: set[str],
+        input_path: Path
     ) -> bool:
         """
         Validates a data element of type object.
@@ -1101,6 +1111,8 @@ class DataValidator:
             A counter to keep track of the number of valid, invalid, and fixed elements.
         called_during_initialization: bool
             Boolean variable indicating whether the function is being called during initialization.
+        input_path : Path
+            Reference identifying the origin of the data currently being validated.
 
         Returns
         -------
@@ -1119,7 +1131,7 @@ class DataValidator:
         }
 
         object_value = self._extract_data_by_key_list(
-            data, variable_path, variable_properties, called_during_initialization
+            data, variable_path, variable_properties, called_during_initialization, input_path
         )
         variable_path_str = self.convert_variable_path_to_str(variable_path)
         properties_violation_message = (
@@ -1129,7 +1141,7 @@ class DataValidator:
             self.event_logs.append(
                 {
                     "warning": "Validation: object is not a dictionary",
-                    "message": f"Variable: '{variable_path_str}' is"
+                    "message": f"Variable: '{variable_path_str}' in '{input_path}' is"
                     f" not an object but has type: {type(object_value)}. "
                     f"{properties_violation_message}",
                     "info_map": info_map,
@@ -1150,6 +1162,7 @@ class DataValidator:
                 elements_counter,
                 called_during_initialization,
                 fixable_data_types,
+                input_path
             )
             is_whole_object_acceptable = is_whole_object_acceptable and is_element_acceptable
             if not is_element_acceptable and eager_termination:
@@ -1160,7 +1173,7 @@ class DataValidator:
             self.event_logs.append(
                 {
                     "warning": "Validation: object contains extraneous data",
-                    "message": f"Variable: '{variable_path_str}' contains "
+                    "message": f"Variable: '{variable_path_str}' in '{input_path}' contains "
                     f"data at key '{key}' that is not specified in "
                     f"the metadata"
                     f" properties. {properties_violation_message}",
@@ -1181,10 +1194,11 @@ class DataValidator:
         elements_counter: "ElementsCounter",
         called_during_initialization: bool,
         fixable_data_types: set[str],
+        input_path: Path
     ) -> bool:
         """Validates an data number element."""
         data_value = self._extract_data_by_key_list(
-            data, variable_path, variable_properties, called_during_initialization
+            data, variable_path, variable_properties, called_during_initialization, input_path
         )
 
         if variable_properties.get("nullable", False) and data_value is None:
@@ -1205,7 +1219,7 @@ class DataValidator:
         if type(data_value) is not float and type(data_value) is not int:
             warning_string = "Validation: value is not a number"
             warning_message = (
-                f"Variable: '{variable_path_str}' has value: {data_value}, is type: "
+                f"Variable: '{variable_path_str}' in '{input_path}' has value: {data_value}, is type: "
                 f"{type(data_value)}. {properties_violation_message}"
             )
             self.event_logs.append({"warning": warning_string, "message": warning_message, "info_map": info_map})
@@ -1215,8 +1229,8 @@ class DataValidator:
             if not is_in_range:
                 warning_name = "Validation: value less than minimum"
                 warning_message = (
-                    f"Variable: '{variable_path_str}' has value: {data_value}, less than minimum value: "
-                    f"{minimum_value: .2f}. {properties_violation_message}"
+                    f"Variable: '{variable_path_str}' in '{input_path}' has value: {data_value}, "
+                    f"less than minimum value: {minimum_value: .2f}. {properties_violation_message}"
                 )
                 self.event_logs.append({"warning": warning_name, "message": warning_message, "info_map": info_map})
                 return False
@@ -1225,8 +1239,8 @@ class DataValidator:
             if not is_in_range:
                 warning_name = "Validation: value greater than maximum"
                 warning_message = (
-                    f"Variable: '{variable_path_str}' has value: {data_value}, greater than maximum value: "
-                    f"{maximum_value: .2f}. {properties_violation_message}"
+                    f"Variable: '{variable_path_str}' in '{input_path}' has value: {data_value}, "
+                    f"greater than maximum value: {maximum_value: .2f}. {properties_violation_message}"
                 )
                 self.event_logs.append({"warning": warning_name, "message": warning_message, "info_map": info_map})
                 return False
@@ -1243,10 +1257,11 @@ class DataValidator:
         elements_counter: "ElementsCounter",
         called_during_initialization: bool,
         fixable_data_types: set[str],
+        input_path: Path
     ) -> bool:
         """Validates a data string element."""
         data_value = self._extract_data_by_key_list(
-            data, variable_path, variable_properties, called_during_initialization
+            data, variable_path, variable_properties, called_during_initialization, input_path
         )
 
         if variable_properties.get("nullable", False) and data_value is None:
@@ -1264,7 +1279,7 @@ class DataValidator:
         if type(data_value) is not str:
             warning_name = "Validation: string variable is not a string"
             warning_message = (
-                f"Variable: '{variable_path_str}' has value: {data_value}, is type: "
+                f"Variable: '{variable_path_str}' in '{input_path}' has value: {data_value}, is type: "
                 f"{type(data_value)}. {properties_violation_message}"
             )
             self.event_logs.append({"warning": warning_name, "message": warning_message, "info_map": info_map})
@@ -1276,8 +1291,8 @@ class DataValidator:
             if not is_valid_string:
                 warning_name = "Validation: string variable does not match pattern"
                 warning_message = (
-                    f"Variable: '{variable_path_str}' has value: '{data_value}', does not match pattern: "
-                    f"{pattern_check}. {properties_violation_message}"
+                    f"Variable: '{variable_path_str}' in '{input_path}' has value: '{data_value}', "
+                    f"does not match pattern: {pattern_check}. {properties_violation_message}"
                 )
                 self.event_logs.append({"warning": warning_name, "message": warning_message, "info_map": info_map})
                 return False
@@ -1289,7 +1304,7 @@ class DataValidator:
             if not is_valid_string:
                 warning_name = "Validation: string length less than minimum"
                 warning_message = (
-                    f"Variable: '{variable_path_str}' has value: '{data_value}', length is less than "
+                    f"Variable: '{variable_path_str}' in '{input_path}' has value: '{data_value}', length is less than "
                     f"minimum length: {minimum_length}. {properties_violation_message}"
                 )
                 self.event_logs.append({"warning": warning_name, "message": warning_message, "info_map": info_map})
@@ -1299,8 +1314,8 @@ class DataValidator:
             if not is_valid_string:
                 warning_name = "Validation: string length greater than maximum"
                 warning_message = (
-                    f"Variable: '{variable_path_str}' has value: '{data_value}', length is greater than "
-                    f"maximum length: {maximum_length}. {properties_violation_message}"
+                    f"Variable: '{variable_path_str}' in '{input_path}' has value: '{data_value}', "
+                    f"length is greater than maximum length: {maximum_length}. {properties_violation_message}"
                 )
                 self.event_logs.append({"warning": warning_name, "message": warning_message, "info_map": info_map})
                 return False
@@ -1317,10 +1332,11 @@ class DataValidator:
         elements_counter: "ElementsCounter",
         called_during_initialization: bool,
         fixable_data_types: set[str],
+        input_path: Path
     ) -> bool:
         """Validates a data bool element."""
         data_value = self._extract_data_by_key_list(
-            data, variable_path, variable_properties, called_during_initialization
+            data, variable_path, variable_properties, called_during_initialization, input_path
         )
 
         if variable_properties.get("nullable", False) and data_value is None:
@@ -1339,7 +1355,7 @@ class DataValidator:
         if type(data_value) is not bool:
             warning_name = "Validation: bool variable is not a bool"
             warning_message = (
-                f"Variable: '{variable_path_str}' has value: '{data_value}', is type: "
+                f"Variable: '{variable_path_str}' in '{input_path}' has value: '{data_value}', is type: "
                 f"'{type(data_value)}'. {properties_violation_message}"
             )
             self.event_logs.append({"warning": warning_name, "message": warning_message, "info_map": info_map})
@@ -1354,6 +1370,7 @@ class DataValidator:
         element_hierarchy: list[str | int],
         data: dict[str | int, Any] | list[Any],
         properties_blob_key: str,
+        input_path: Path
     ) -> bool:
         """
         Attempt to fix the invalid data.
@@ -1362,15 +1379,14 @@ class DataValidator:
         ----------
         variable_properties : dict[str, Any]
             The properties for the variable of interest.
-
         element_hierarchy: list[str | int]
             A list indicating the path to reach the variable of interest in self.__metadata and self.__pool.
-
         data: dict[str | int, Any] | list[Any]
             A buffer dictionary that holds the data for validation and fixing.
-
         properties_blob_key : str
             The metadata properties section keyword for the data file being checked.
+        input_path : Path
+            Reference identifying the origin of the data currently being validated.
 
         Returns
         -------
@@ -1428,8 +1444,8 @@ class DataValidator:
             variable_parent[str(element_hierarchy[-1])] = variable_properties["default"]
 
         warning_message = (
-            f"Invalid data fixed: '{element_path}' value changed from {original_invalid_value} to "
-            f"{variable_properties['default']}. Fix enabled by default value specified in "
+            f"Invalid data from '{input_path}' fixed: '{element_path}' in value changed from "
+            f"{original_invalid_value} to {variable_properties['default']}. Fix enabled by default value specified in "
             f"'{properties_blob_key}'."
         )
         self.event_logs.append({"warning": "Validation: data fixed", "message": warning_message, "info_map": info_map})
@@ -1441,6 +1457,7 @@ class DataValidator:
         variable_path: Sequence[str | int],
         variable_properties: dict[str, Any],
         called_during_initialization: bool,
+        input_path: Path
     ) -> Any:
         """
         Extracts a value from the data based on a specified path and handles missing data by calling
@@ -1456,6 +1473,8 @@ class DataValidator:
             The metadata properties for the variable being validated.
         called_during_initialization: bool
             Boolean variable indicating whether the function is being called during initialization.
+        input_path : Path
+            Reference identifying the origin of the data currently being validated.
 
         Returns
         -------
@@ -1473,18 +1492,20 @@ class DataValidator:
         """
         result = None
         try:
-            result = self.extract_value_by_key_list(data, variable_path)
+            result = self.extract_value_by_key_list(data, variable_path, input_path)
         except KeyError:
             var_name: str = [name for name in reversed(variable_path) if type(name) is str][0]
             self._log_missing_data(
                 variable_properties=variable_properties,
                 var_name=var_name,
                 called_during_initialization=called_during_initialization,
+                input_path=input_path
             )
         return result
 
     def _log_missing_data(
-        self, variable_properties: dict[str, Any], var_name: str, called_during_initialization: bool
+        self, variable_properties: dict[str, Any], var_name: str, called_during_initialization: bool,
+        input_path: Path,
     ) -> None:
         """
         Handles logging for missing data for a variable, logging errors or warnings based on the context of
@@ -1498,6 +1519,8 @@ class DataValidator:
             The name of the variable with missing data.
         called_during_initialization: bool
             Boolean variable indicating whether the function is being called during initialization
+        input_path : Path
+            Reference identifying the origin of the data currently being validated.
 
         Raises
         ------
@@ -1512,7 +1535,10 @@ class DataValidator:
         """
         info_map = {"class": DataValidator.__name__, "function": DataValidator._log_missing_data.__name__}
         if not called_during_initialization:
-            error_msg = f"Key {var_name} not found in data. A value is required to update variable during runtime."
+            error_msg = (
+                f"Key {var_name} not found in data from '{input_path}'. "
+                "A value is required to update variable during runtime."
+            )
             self.event_logs.append({"error": "Missing required data", "message": error_msg, "info_map": info_map})
             raise KeyError(error_msg)
 
@@ -1520,23 +1546,20 @@ class DataValidator:
             self.event_logs.append(
                 {
                     "error": "Missing required data",
-                    "message": f"Key {var_name} not found in data. Data value is required for"
-                    f" this "
-                    "variable upon program initialization.",
+                    "message": f"Key {var_name} not found in data from source '{input_path}'. Data value is required "
+                    "for this variable upon program initialization.",
                     "info_map": info_map,
                 }
             )
             raise KeyError(
-                f"Key {var_name} not found in input data. Data value is required for this "
+                f"Key {var_name} not found in input data source '{input_path}'. Data value is required for this "
                 "variable upon program initialization."
             )
         self.event_logs.append(
             {
-                "warning": "Validation: key not found in input data -- data not required upon initialization",
-                "message": f"Key {var_name} not found in data. Data value is not required for "
-                f"this "
-                "variable upon program initialization, setting the variable value "
-                "to None.",
+                "warning": "Validation: key not found in input data. Data not required upon initialization",
+                "message": f"Key {var_name} not found in data source '{input_path}'. Data value is not required for "
+                "this variable upon program initialization, setting the variable value to None.",
                 "info_map": info_map,
             }
         )
@@ -1653,17 +1676,21 @@ class DataValidator:
         return ".".join(formatted_path_elems)
 
     def extract_value_by_key_list(
-        self, data: list[Any] | dict[str | int, Any], variable_path: Sequence[str | int]
+        self, data: list[Any] | dict[str | int, Any], variable_path: Sequence[str | int],
+        input_path: Path | None = None
     ) -> Any:
         """
         Extracts a value from a nested list or dictionary using a list of keys (int or str).
 
         Parameters
         ----------
-        data : List[Any] | Dict[str, Any]
+        data : list[Any] | dict[str, Any]
             The data containing the value to be extracted.
-        variable_path : List[str | int]
+        variable_path : dist[str | int]
             A list of keys to be used to extract the value from the data.
+        input_path : Path | str | None, default=None
+            Reference identifying the origin of the data currently being extracted.
+            None indicates that the extraction process is in-simulation data retrieval.
 
         Returns
         -------
@@ -1716,7 +1743,14 @@ class DataValidator:
             elif isinstance(data, dict) and isinstance(key, str) and key in data:
                 data = data[key]
             else:
+                if input_path is not None:
+                    raise KeyError(
+                        f"There is an error at key {key} in path {variable_path} "
+                        f"from input source '{input_path}'. Data cannot be extracted."
+                    )
+
                 raise KeyError(f"There is an error at key {key} in the path {variable_path}. Data cannot be extracted.")
+
         return data
 
 

--- a/RUFAS/data_validator.py
+++ b/RUFAS/data_validator.py
@@ -1689,7 +1689,7 @@ class DataValidator:
         ----------
         data : list[Any] | dict[str, Any]
             The data containing the value to be extracted.
-        variable_path : dist[str | int]
+        variable_path : list[str | int]
             A list of keys to be used to extract the value from the data.
         input_path : Path | str | None, default=None
             Reference identifying the origin of the data currently being extracted.

--- a/RUFAS/data_validator.py
+++ b/RUFAS/data_validator.py
@@ -808,7 +808,7 @@ class DataValidator:
         elements_counter: "ElementsCounter",
         called_during_initialization: bool,
         fixable_data_types: set[str],
-        input_path: Path
+        input_path: Path,
     ) -> bool:
         """
         Validates the data based on its specified type.
@@ -872,7 +872,7 @@ class DataValidator:
                     ElementsCounter,
                     bool,
                     set[str],
-                    Path
+                    Path,
                 ],
                 bool,
             ],
@@ -900,7 +900,7 @@ class DataValidator:
             elements_counter,
             called_during_initialization,
             fixable_data_types,
-            input_path
+            input_path,
         )
 
         if data_type not in fixable_data_types:
@@ -1018,7 +1018,7 @@ class DataValidator:
         elements_counter: "ElementsCounter",
         called_during_initialization: bool,
         fixable_data_types: set[str],
-        input_path: Path
+        input_path: Path,
     ) -> bool:
         """
         Validates a data element of type array.
@@ -1073,7 +1073,7 @@ class DataValidator:
                 elements_counter,
                 called_during_initialization,
                 fixable_data_types,
-                input_path
+                input_path,
             )
             is_whole_array_acceptable = is_whole_array_acceptable and is_element_acceptable
             if not is_element_acceptable and eager_termination:
@@ -1090,7 +1090,7 @@ class DataValidator:
         elements_counter: ElementsCounter,
         called_during_initialization: bool,
         fixable_data_types: set[str],
-        input_path: Path
+        input_path: Path,
     ) -> bool:
         """
         Validates a data element of type object.
@@ -1162,7 +1162,7 @@ class DataValidator:
                 elements_counter,
                 called_during_initialization,
                 fixable_data_types,
-                input_path
+                input_path,
             )
             is_whole_object_acceptable = is_whole_object_acceptable and is_element_acceptable
             if not is_element_acceptable and eager_termination:
@@ -1194,7 +1194,7 @@ class DataValidator:
         elements_counter: "ElementsCounter",
         called_during_initialization: bool,
         fixable_data_types: set[str],
-        input_path: Path
+        input_path: Path,
     ) -> bool:
         """Validates an data number element."""
         data_value = self._extract_data_by_key_list(
@@ -1257,7 +1257,7 @@ class DataValidator:
         elements_counter: "ElementsCounter",
         called_during_initialization: bool,
         fixable_data_types: set[str],
-        input_path: Path
+        input_path: Path,
     ) -> bool:
         """Validates a data string element."""
         data_value = self._extract_data_by_key_list(
@@ -1332,7 +1332,7 @@ class DataValidator:
         elements_counter: "ElementsCounter",
         called_during_initialization: bool,
         fixable_data_types: set[str],
-        input_path: Path
+        input_path: Path,
     ) -> bool:
         """Validates a data bool element."""
         data_value = self._extract_data_by_key_list(
@@ -1370,7 +1370,7 @@ class DataValidator:
         element_hierarchy: list[str | int],
         data: dict[str | int, Any] | list[Any],
         properties_blob_key: str,
-        input_path: Path
+        input_path: Path,
     ) -> bool:
         """
         Attempt to fix the invalid data.
@@ -1457,7 +1457,7 @@ class DataValidator:
         variable_path: Sequence[str | int],
         variable_properties: dict[str, Any],
         called_during_initialization: bool,
-        input_path: Path
+        input_path: Path,
     ) -> Any:
         """
         Extracts a value from the data based on a specified path and handles missing data by calling
@@ -1499,12 +1499,15 @@ class DataValidator:
                 variable_properties=variable_properties,
                 var_name=var_name,
                 called_during_initialization=called_during_initialization,
-                input_path=input_path
+                input_path=input_path,
             )
         return result
 
     def _log_missing_data(
-        self, variable_properties: dict[str, Any], var_name: str, called_during_initialization: bool,
+        self,
+        variable_properties: dict[str, Any],
+        var_name: str,
+        called_during_initialization: bool,
         input_path: Path,
     ) -> None:
         """
@@ -1676,8 +1679,7 @@ class DataValidator:
         return ".".join(formatted_path_elems)
 
     def extract_value_by_key_list(
-        self, data: list[Any] | dict[str | int, Any], variable_path: Sequence[str | int],
-        input_path: Path | None = None
+        self, data: list[Any] | dict[str | int, Any], variable_path: Sequence[str | int], input_path: Path | None = None
     ) -> Any:
         """
         Extracts a value from a nested list or dictionary using a list of keys (int or str).

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -847,6 +847,7 @@ class InputManager:
                     elements_counter=self.elements_counter,
                     called_during_initialization=True,
                     fixable_data_types=FIXABLE_INPUT_DATA_TYPES,
+                    input_path=file_path
                 )
 
                 valid_data = valid_data and is_element_acceptable
@@ -1071,7 +1072,7 @@ class InputManager:
         }
         element_hierarchy = data_address.split(".")
         try:
-            data_value = self.data_validator.extract_value_by_key_list(self.__pool, element_hierarchy)
+            data_value = self.data_validator.extract_value_by_key_list(self.__pool, element_hierarchy, None)
             timestamp = Utility.get_timestamp(include_millis=True)
             self.__get_data_logs_pool[timestamp] = f"InputManager.get_data() called for {element_hierarchy}."
             return deepcopy(data_value)

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -847,7 +847,7 @@ class InputManager:
                     elements_counter=self.elements_counter,
                     called_during_initialization=True,
                     fixable_data_types=FIXABLE_INPUT_DATA_TYPES,
-                    input_path=file_path
+                    input_path=file_path,
                 )
 
                 valid_data = valid_data and is_element_acceptable

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -1449,13 +1449,13 @@ class InputManager:
         if elements_counter.invalid_elements > 0:
             self.om.add_error(
                 "Invalid variable",
-                f"Variable {variable_name} from {input_path} has invalid components. "
+                f"Variable {variable_name} from '{input_path}' has invalid components. "
                 "Only successfully validated components are added to InputManager pool during runtime.",
                 info_map,
             )
             if eager_termination:
                 raise ValueError(
-                    f"Variable {variable_name} from {input_path} has invalid components. "
+                    f"Variable {variable_name} from '{input_path}' has invalid components. "
                     "Only successfully validated components are added to InputManager pool during runtime."
                 )
             return False
@@ -1687,7 +1687,7 @@ class InputManager:
         if not (isinstance(data, dict)):
             self.om.add_error(
                 "Incorrect variable type",
-                f"Variable {variable_name} from {input_path} has type {type(data)}; does not match "
+                f"Variable {variable_name} from '{input_path}' has type {type(data)}; does not match "
                 f"the expected type of `dict[str, Any]`.",
                 info_map,
             )

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -493,7 +493,7 @@ class InputManager:
                 data=input_data,
                 properties_blob_key=properties_blob_key,
                 eager_termination=eager_termination,
-                input_path=file_path
+                input_path=file_path,
             )
         except (TypeError, ValueError, PermissionError) as exc:
             self.om.add_error(
@@ -1387,7 +1387,7 @@ class InputManager:
         input_data: dict[str, Any],
         properties_blob_key: str,
         eager_termination: bool,
-        input_path: Path
+        input_path: Path,
     ) -> bool:
         """
         Adds a variable to the pool after validating its data against specified metadata properties.
@@ -1566,7 +1566,7 @@ class InputManager:
         eager_termination: bool,
         properties_blob_key: str,
         elements_counter: "ElementsCounter",
-        input_path: Path
+        input_path: Path,
     ) -> dict[str, Any]:
         """
         Validate input data based on metadata properties.
@@ -1607,7 +1607,7 @@ class InputManager:
                 elements_counter=elements_counter,
                 called_during_initialization=False,
                 fixable_data_types=FIXABLE_INPUT_DATA_TYPES,
-                input_path=input_path
+                input_path=input_path,
             )
 
             if is_element_acceptable:
@@ -1645,7 +1645,7 @@ class InputManager:
         data: dict[str, Any],
         properties_blob_key: str,
         eager_termination: bool,
-        input_path: Path
+        input_path: Path,
     ) -> bool:
         """
         Adds a variable to the InputManager's pool after validating it against metadata.
@@ -1705,7 +1705,7 @@ class InputManager:
                 input_data=data,
                 properties_blob_key=properties_blob_key,
                 eager_termination=eager_termination,
-                input_path=input_path
+                input_path=input_path,
             )
             return add_variable_success
         else:

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -477,7 +477,8 @@ class InputManager:
             )
             return False
         try:
-            input_data = data_loader(Path(file_path_value))
+            file_path = Path(file_path_value)
+            input_data = data_loader(file_path)
         except Exception as exc:
             self.om.add_error(
                 "Runtime metadata load failure",
@@ -492,6 +493,7 @@ class InputManager:
                 data=input_data,
                 properties_blob_key=properties_blob_key,
                 eager_termination=eager_termination,
+                input_path=file_path
             )
         except (TypeError, ValueError, PermissionError) as exc:
             self.om.add_error(
@@ -1072,7 +1074,7 @@ class InputManager:
         }
         element_hierarchy = data_address.split(".")
         try:
-            data_value = self.data_validator.extract_value_by_key_list(self.__pool, element_hierarchy, None)
+            data_value = self.data_validator.extract_value_by_key_list(self.__pool, element_hierarchy)
             timestamp = Utility.get_timestamp(include_millis=True)
             self.__get_data_logs_pool[timestamp] = f"InputManager.get_data() called for {element_hierarchy}."
             return deepcopy(data_value)
@@ -1385,6 +1387,7 @@ class InputManager:
         input_data: dict[str, Any],
         properties_blob_key: str,
         eager_termination: bool,
+        input_path: Path
     ) -> bool:
         """
         Adds a variable to the pool after validating its data against specified metadata properties.
@@ -1407,6 +1410,8 @@ class InputManager:
             The key in the metadata properties against which the data is validated.
         eager_termination : bool
             Flag indicating whether the function should return early in case of invalid data.
+        input_path : Path
+            Reference identifying the origin of the data currently being validated.
 
         Returns
         -------
@@ -1434,7 +1439,7 @@ class InputManager:
             return modifiable
 
         validated_data = self._validate_data(
-            data, metadata_properties, eager_termination, properties_blob_key, elements_counter
+            data, metadata_properties, eager_termination, properties_blob_key, elements_counter, input_path
         )
 
         if validated_data:
@@ -1444,14 +1449,14 @@ class InputManager:
         if elements_counter.invalid_elements > 0:
             self.om.add_error(
                 "Invalid variable",
-                f"Variable {variable_name} has invalid components. Only successfully validated components are "
-                f"added to InputManager pool during runtime.",
+                f"Variable {variable_name} from {input_path} has invalid components. "
+                "Only successfully validated components are added to InputManager pool during runtime.",
                 info_map,
             )
             if eager_termination:
                 raise ValueError(
-                    f"Variable {variable_name} has invalid components. Only successfully validated components are added"
-                    f" to InputManager pool during runtime."
+                    f"Variable {variable_name} from {input_path} has invalid components. "
+                    "Only successfully validated components are added to InputManager pool during runtime."
                 )
             return False
 
@@ -1561,6 +1566,7 @@ class InputManager:
         eager_termination: bool,
         properties_blob_key: str,
         elements_counter: "ElementsCounter",
+        input_path: Path
     ) -> dict[str, Any]:
         """
         Validate input data based on metadata properties.
@@ -1578,6 +1584,8 @@ class InputManager:
             The key in the metadata properties against which the data is validated.
         elements_counter : ElementsCounter
             An ElementsCounter object to keep track of status of variables.
+        input_path : Path
+            Reference identifying the origin of the data currently being validated.
 
         Returns
         -------
@@ -1599,6 +1607,7 @@ class InputManager:
                 elements_counter=elements_counter,
                 called_during_initialization=False,
                 fixable_data_types=FIXABLE_INPUT_DATA_TYPES,
+                input_path=input_path
             )
 
             if is_element_acceptable:
@@ -1636,6 +1645,7 @@ class InputManager:
         data: dict[str, Any],
         properties_blob_key: str,
         eager_termination: bool,
+        input_path: Path
     ) -> bool:
         """
         Adds a variable to the InputManager's pool after validating it against metadata.
@@ -1656,6 +1666,8 @@ class InputManager:
         eager_termination : bool
             If True, a ValueError will be raised from _add_variable_to_pool() when the variable is invalid.
             If False, the function returns False.
+        input_path : Path
+            Reference identifying the origin of the data currently being validated.
 
         Returns
         -------
@@ -1675,7 +1687,7 @@ class InputManager:
         if not (isinstance(data, dict)):
             self.om.add_error(
                 "Incorrect variable type",
-                f"Variable {variable_name} has type {type(data)}, does not match "
+                f"Variable {variable_name} from {input_path} has type {type(data)}; does not match "
                 f"the expected type of `dict[str, Any]`.",
                 info_map,
             )
@@ -1693,6 +1705,7 @@ class InputManager:
                 input_data=data,
                 properties_blob_key=properties_blob_key,
                 eager_termination=eager_termination,
+                input_path=input_path
             )
             return add_variable_success
         else:

--- a/changelog.md
+++ b/changelog.md
@@ -82,6 +82,7 @@ v1.0.0
 - [3000](https://github.com/RuminantFarmSystems/RuFaS/pull/3000) - [minor change] [NoInputChange] [NoOutputChange] Updated the error messages for all biophysical modules.
 - [2715](https://github.com/RuminantFarmSystems/RuFaS/pull/2715) - [minor change] [Animal] [NoInputChange] [OutputChange] Renames the 305-day milk yield output from `milk_production_305days_herd_mean` to `milk_305_day_yield_herd_mean`, splits the calculation into a pure Wood's-curve integral and a per-cow simulation estimate, and adds L1/L2/L3+ herd-level reporting.
 - [3022](https://github.com/RuminantFarmSystems/RuFaS/pull/3022) - [minor change] [Tests] [NoInputChange] [NoOutputChange] Adds missing changelog entry for #2715 and fixes the one mypy error it introduced by typing the `history` parameter of `_make_milk_production` in `test_milk_production.py`.
+- [3024](https://github.com/RuminantFarmSystems/RuFaS/pull/3024) - [minor change] [DataValidator] [NoInputChange] [NoOutputChange] Adds path to input to error/warning messages in `DataValidator` for easier invalid input fixing.
 
 ### v1.0.0
 

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -49,6 +49,7 @@ def test_bool_type_validator(
     Unit test for function _bool_type_validator in file input_manager.py
     """
     # Arrange
+    input_path: Path = Path("path/to/input")
     var_path: list[str | int] = ["dummy_var_path"]
     variable_properties: dict[str, Any] = dummy_variable_properties
     dummy_properties_key = "dummy_variable_properties"
@@ -70,10 +71,12 @@ def test_bool_type_validator(
         dummy_counter,
         unused_bool_input,
         {"string", "number", "bool"},
+        input_path
     )
 
     # Assert
-    patch_extract.assert_called_once_with(dummy_input_data, var_path, variable_properties, unused_bool_input)
+    patch_extract.assert_called_once_with(dummy_input_data, var_path, variable_properties, unused_bool_input,
+                                          input_path)
     if dummy_variable_properties.get("nullable", False) is False:
         patch_path_to_str.assert_called_once_with(var_path)
     if not expected_result:
@@ -89,7 +92,7 @@ def test_bool_type_validator(
             {
                 "warning": "Validation: bool variable is not a bool",
                 "message": (
-                    f"Variable: '{variable_path_str}' has value: '{input_data_value}', is type: "
+                    f"Variable: '{variable_path_str}' in '{input_path}' has value: '{input_data_value}', is type: "
                     f"'{type(input_data_value)}'. {properties_violation_message}"
                 ),
                 "info_map": info_map,
@@ -123,6 +126,7 @@ def test_number_type_validator(
     """Unit test for function _number_type_validator in file input_manager.py"""
 
     # Arrange
+    input_path: Path = Path("path/to/input")
     dummy_var_path: list[str | int] = ["dummy_num"]
     dummy_input_data: dict[str | int, Any] | list[Any] = {"a": 1}
     dummy_properties_key = "dummy_variable_properties"
@@ -142,10 +146,11 @@ def test_number_type_validator(
         dummy_counter,
         unused_bool_input,
         {"string", "number", "bool"},
+        input_path
     )
 
     patch_extract.assert_called_once_with(
-        dummy_input_data, dummy_var_path, dummy_variable_properties, unused_bool_input
+        dummy_input_data, dummy_var_path, dummy_variable_properties, unused_bool_input, input_path
     )
     if dummy_variable_properties.get("nullable", False) is False:
         patch_path_to_str.assert_called_once_with(dummy_var_path)
@@ -179,6 +184,7 @@ def test_string_type_validator(
     mocker: MockerFixture,
 ) -> None:
     """Unit test for _string_type_validator function in file input_manager.py"""
+    input_path: Path = Path("path/to/input")
     var_path: list[str | int] = ["dummy_var_path"]
     dummy_properties_key = "dummy_variable_properties"
     dummy_input_data: dict[str | int, Any] | list[Any] = {"a": 1, "b": 2}
@@ -198,9 +204,11 @@ def test_string_type_validator(
         dummy_counter,
         unused_bool_input,
         {"string", "number", "bool"},
+        input_path
     )
 
-    patch_extract.assert_called_once_with(dummy_input_data, var_path, dummy_variable_properties, unused_bool_input)
+    patch_extract.assert_called_once_with(dummy_input_data, var_path, dummy_variable_properties, unused_bool_input,
+                                          input_path)
     if dummy_variable_properties.get("nullable", False) is False:
         patch_path_to_str.assert_called_once_with(var_path)
     assert result == expected_result
@@ -264,6 +272,7 @@ def test_fix_array_type_fixable_data(
     expected_result: bool,
 ) -> None:
     """Unit test for fixable array-type data for _fix_data function in file input_manager.py"""
+    input_path: Path = Path("path/to/input")
     dummy_input_data: dict[str | int, Any] | list[Any] = mock_input_array_data_for_fix_data()
     dummy_properties_key = "dummy_variable_properties"
     properties_violation_message = (
@@ -292,6 +301,7 @@ def test_fix_array_type_fixable_data(
         dummy_element_hierarchy,
         dummy_input_data,
         dummy_properties_key,
+        input_path
     )
 
     variable_to_check = dummy_input_data
@@ -305,13 +315,13 @@ def test_fix_array_type_fixable_data(
     assert dv.event_logs == [
         {
             "warning": "Validation: invalid data found",
-            "message": f"Variable: '{element_path}' has value:"
+            "message": f"Variable: '{element_path}' in '{input_path}' has value:"
             f" {original_invalid_value}. {properties_violation_message}",
             "info_map": info_map,
         },
         {
             "warning": "Validation: data fixed",
-            "message": f"Invalid data fixed: '{element_path}' value changed from"
+            "message": f"Invalid data from '{input_path}' fixed: '{element_path}' value changed from"
             f" {original_invalid_value} to "
             f"{dummy_variable_properties['default']}. Fix enabled by default value specified in "
             f"'{dummy_properties_key}'.",
@@ -367,6 +377,7 @@ def test_fix_array_type_critical_data(
     expected_result: bool,
 ) -> None:
     """Unit test for critical array-type data for _fix_data function in file input_manager.py"""
+    input_path: Path = Path("path/to/input")
     dummy_input_data: dict[str | int, Any] | list[Any] = mock_input_array_data_for_fix_data()
     dummy_properties_key = "dummy_variable_properties"
     variable_parent: dict[str | int, Any] | list[Any] = dummy_input_data
@@ -384,7 +395,7 @@ def test_fix_array_type_critical_data(
         else variable_parent[int(dummy_element_hierarchy[-1])]
     )
     error_message = (
-        f"Variable: '{dummy_element_hierarchy[-1]}' has invalid value: '{invalid_value}'"
+        f"Variable: '{dummy_element_hierarchy[-1]}' in '{input_path}' has invalid value: '{invalid_value}'"
         f", and cannot be changed to a default value. {properties_violation_message}"
     )
     info_map = {
@@ -399,6 +410,7 @@ def test_fix_array_type_critical_data(
         dummy_element_hierarchy,
         dummy_input_data,
         dummy_properties_key,
+        input_path
     )
 
     assert result == expected_result
@@ -483,6 +495,7 @@ def test_fix_string_type_fixable_data(
     expected_result: bool,
 ) -> None:
     """Unit test for fixable string-type data for _fix_data function in file input_manager.py"""
+    input_path: Path = Path("path/to/input")
     dummy_input_data: dict[str | int, Any] | list[Any] = mock_input_array_data_for_fix_data()
     dummy_properties_key = "dummy_variable_properties"
     properties_violation_message = (
@@ -511,6 +524,7 @@ def test_fix_string_type_fixable_data(
         dummy_element_hierarchy,
         dummy_input_data,
         dummy_properties_key,
+        input_path
     )
 
     variable_to_check: dict[str | int, Any] | list[Any] = dummy_input_data
@@ -524,13 +538,13 @@ def test_fix_string_type_fixable_data(
     assert dv.event_logs == [
         {
             "warning": "Validation: invalid data found",
-            "message": f"Variable: '{element_path}' has value:"
+            "message": f"Variable: '{element_path}' in '{input_path}' has value:"
             f" {original_invalid_value}. {properties_violation_message}",
             "info_map": info_map,
         },
         {
             "warning": "Validation: data fixed",
-            "message": f"Invalid data fixed: '{element_path}' value changed from"
+            "message": f"Invalid data from '{input_path}' fixed: '{element_path}' value changed from"
             f" {original_invalid_value} to "
             f"{dummy_variable_properties['default']}. Fix enabled by default value specified in "
             f"'{dummy_properties_key}'.",
@@ -541,6 +555,7 @@ def test_fix_string_type_fixable_data(
 
 def test_fix_string_type_csv_data() -> None:
     """Unit test for fixable number-type data from a csv array for _fix_data function in file input_manager.py"""
+    input_path: Path = Path("path/to/input")
     dummy_input_data: dict[str | int, Any] | list[Any] = {"element1": [1, 2, 3, 4, 5]}
     dummy_variable_properties = {"type": "number", "maximum": 4, "default": 3}
     dummy_element_hierarchy: list[str | int] = ["element1", 4]
@@ -570,6 +585,7 @@ def test_fix_string_type_csv_data() -> None:
         dummy_element_hierarchy,
         dummy_input_data,
         dummy_properties_key,
+        input_path
     )
 
     fixed_variable = dummy_input_data
@@ -585,13 +601,13 @@ def test_fix_string_type_csv_data() -> None:
     assert dv.event_logs == [
         {
             "warning": "Validation: invalid data found",
-            "message": f"Variable: '{element_path}' has value:"
+            "message": f"Variable: '{element_path}' in '{input_path}' has value:"
             f" {original_invalid_value}. {properties_violation_message}",
             "info_map": info_map,
         },
         {
             "warning": "Validation: data fixed",
-            "message": f"Invalid data fixed: '{element_path}' value changed from"
+            "message": f"Invalid data from '{input_path}' fixed: '{element_path}' value changed from"
             f" {original_invalid_value} to "
             f"{dummy_variable_properties['default']}. Fix enabled by default value specified in "
             f"'{dummy_properties_key}'.",
@@ -651,6 +667,7 @@ def test_fix_string_type_critical_data(
     expected_result: bool,
 ) -> None:
     """Unit test for critical string-type data for _fix_data function in file input_manager.py"""
+    input_path: Path = Path("path/to/input")
     dummy_input_data = mock_input_array_data_for_fix_data()
     dummy_properties_key = "dummy_variable_properties"
     variable_parent = dummy_input_data
@@ -665,7 +682,7 @@ def test_fix_string_type_critical_data(
         else variable_parent[int(dummy_element_hierarchy[-1])]
     )
     error_message = (
-        f"Variable: '{dummy_element_hierarchy[-1]}' has invalid value: '{invalid_value}'"
+        f"Variable: '{dummy_element_hierarchy[-1]}' in '{input_path}' has invalid value: '{invalid_value}'"
         f", and cannot be changed to a default value. {properties_violation_message}"
     )
     info_map = {
@@ -680,6 +697,7 @@ def test_fix_string_type_critical_data(
         dummy_element_hierarchy,
         dummy_input_data,
         dummy_properties_key,
+        input_path
     )
 
     assert result == expected_result
@@ -761,6 +779,7 @@ def test_fix_number_type_fixable_data(
     expected_result: bool,
 ) -> None:
     """Unit test for fixable number-type data for _fix_data function in file input_manager.py"""
+    input_path: Path = Path("path/to/input")
     dummy_input_data: dict[str | int, Any] | list[Any] = mock_input_array_data_for_fix_data()
     dummy_properties_key = "dummy_variable_properties"
     properties_violation_message = (
@@ -789,6 +808,7 @@ def test_fix_number_type_fixable_data(
         dummy_element_hierarchy,
         dummy_input_data,
         dummy_properties_key,
+        input_path
     )
 
     variable_to_check: Any = dummy_input_data
@@ -802,13 +822,13 @@ def test_fix_number_type_fixable_data(
     assert dv.event_logs == [
         {
             "warning": "Validation: invalid data found",
-            "message": f"Variable: '{element_path}' has value:"
+            "message": f"Variable: '{element_path}' in '{input_path}' has value:"
             f" {original_invalid_value}. {properties_violation_message}",
             "info_map": info_map,
         },
         {
             "warning": "Validation: data fixed",
-            "message": f"Invalid data fixed: '{element_path}' value changed from"
+            "message": f"Invalid data from '{input_path}' fixed: '{element_path}' value changed from"
             f" {original_invalid_value} to "
             f"{dummy_variable_properties['default']}. Fix enabled by default value specified in "
             f"'{dummy_properties_key}'.",
@@ -864,6 +884,7 @@ def test_fix_number_type_critical_data(
     expected_result: bool,
 ) -> None:
     """Unit test for critical number-type data for _fix_data function in file input_manager.py"""
+    input_path: Path = Path("path/to/input")
     dummy_input_data: dict[str | int, Any] | list[Any] = mock_input_array_data_for_fix_data()
     dummy_properties_key = "dummy_variable_properties"
     variable_parent: dict[str | int, Any] | list[Any] = dummy_input_data
@@ -881,7 +902,7 @@ def test_fix_number_type_critical_data(
         else variable_parent[int(dummy_element_hierarchy[-1])]
     )
     error_message = (
-        f"Variable: '{dummy_element_hierarchy[-1]}' has invalid value: '{invalid_value}'"
+        f"Variable: '{dummy_element_hierarchy[-1]}' in '{input_path}' has invalid value: '{invalid_value}'"
         f", and cannot be changed to a default value. {properties_violation_message}"
     )
     info_map = {
@@ -896,6 +917,7 @@ def test_fix_number_type_critical_data(
         dummy_element_hierarchy,
         dummy_input_data,
         dummy_properties_key,
+        input_path
     )
 
     assert result == expected_result
@@ -1052,6 +1074,7 @@ def test_object_type_validator(
     """
 
     # Arrange
+    input_path: Path = Path("path/to/input")
     mocker.patch.object(DataValidator, "_extract_data_by_key_list", return_value=patch_extract_return)
     mocker.patch.object(DataValidator, "validate_data_by_type", return_value=patch_validate_return)
     mock_elements_counter = mocker.MagicMock()
@@ -1067,6 +1090,7 @@ def test_object_type_validator(
         mock_elements_counter,
         True,
         {"string", "number", "bool"},
+        input_path
     )
 
     # Assert
@@ -1085,6 +1109,7 @@ def test_object_type_validator_key_removal(
     mocker: MockerFixture, data: dict[str, Any], removed_keys: list[str]
 ) -> None:
     """Tests that extraneous keys are properly removed by the _object_type_validator in Input Manager."""
+    input_path: Path = Path("path/to/input")
     mocker.patch.object(DataValidator, "_extract_data_by_key_list", return_value=data)
     mocker.patch.object(DataValidator, "validate_data_by_type", return_value=True)
     mocker.patch.object(DataValidator, "convert_variable_path_to_str", return_value="dummy path")
@@ -1098,7 +1123,7 @@ def test_object_type_validator_key_removal(
         {
             "warning": "Validation: object contains extraneous data",
             "message": (
-                f"Variable: 'dummy path' contains data at key '{key}' "
+                f"Variable: 'dummy path' in '{input_path}' contains data at key '{key}' "
                 f"that is not specified in the metadata properties. {violation_msg}"
             ),
             "info_map": info_map,
@@ -1115,6 +1140,7 @@ def test_object_type_validator_key_removal(
         mock_elements_counter,
         True,
         {"string", "number", "bool"},
+        input_path
     )
 
     assert result
@@ -1311,6 +1337,7 @@ def test_array_type_validator(
     """
 
     # Arrange
+    input_path: Path = Path("path/to/input")
     mocker.patch.object(DataValidator, "_extract_data_by_key_list", return_value=patch_extract_return)
     mocker.patch.object(DataValidator, "_validate_array_container_properties", return_value=patch_container_valid)
     mocker.patch.object(DataValidator, "validate_data_by_type", return_value=patch_element_valid)
@@ -1328,6 +1355,7 @@ def test_array_type_validator(
         mock_elements_counter,
         True,
         {"string", "number", "bool"},
+        input_path
     )
 
     # Assert
@@ -1380,6 +1408,7 @@ def test_validate_input_by_type(
     """
 
     # Arrange
+    input_path: Path = Path("path/to/input")
     variable_properties = {"type": data_type}
     variable_path: List[Union[str, int]] = ["path", "to", "variable"]
     input_data: dict[str | int, Any] | list[Any] = {"path": {"to": {"variable": input_value}}}
@@ -1403,6 +1432,7 @@ def test_validate_input_by_type(
         elements_counter,
         True,
         {"string", "number", "bool"},
+        input_path
     )
 
     # Assert
@@ -1425,6 +1455,8 @@ def test_validate_input_by_type(
 
 
 def test_validate_input_by_type_key_error() -> None:
+    """Tests validate_data_by_type() method in DataValidator."""
+    input_path: Path = Path("path/to/input")
     variable_properties = {"a": "b"}
     variable_path: list[Union[str, int]] = ["valid_key"]
     properties_blob_key = "dummy_properties_blob_key"
@@ -1444,6 +1476,7 @@ def test_validate_input_by_type_key_error() -> None:
             elements_counter,
             True,
             {"string", "number", "bool"},
+            input_path
         )
 
 
@@ -2482,6 +2515,7 @@ def test_validate_metadata_properties_keys(
 
 def test_extract_input_data_by_key_list_no_error(mocker: MockerFixture) -> None:
     """Unit tests for making sure data were extracted when no error"""
+    input_path: Path = Path("path/to/input")
     dummy_input_data: dict[str | int, Any] | list[Any] = {"a": 1, "b": 2}
     dummy_var_path: list[str | int] = ["dummy_var_path"]
     dummy_var_properties: dict[str, Any] = {"pattern": r"cow", "minimum_length": 1, "maximum_length": 5}
@@ -2495,6 +2529,7 @@ def test_extract_input_data_by_key_list_no_error(mocker: MockerFixture) -> None:
         variable_path=dummy_var_path,
         variable_properties=dummy_var_properties,
         called_during_initialization=True,
+        input_path=input_path
     )
 
     assert result == dummy_value
@@ -2505,10 +2540,12 @@ def test_extract_input_data_by_key_list_no_error(mocker: MockerFixture) -> None:
         variable_path=dummy_var_path,
         variable_properties=dummy_var_properties,
         called_during_initialization=False,
+        input_path=input_path
     )
 
     assert result == dummy_value
-    patch_extract.assert_has_calls([call(dummy_input_data, dummy_var_path), call(dummy_input_data, dummy_var_path)])
+    patch_extract.assert_has_calls([call(dummy_input_data, dummy_var_path, input_path),
+                                    call(dummy_input_data, dummy_var_path, input_path)])
     patch_log_missing_data.assert_not_called()
 
 
@@ -2531,6 +2568,7 @@ def test_extract_input_data_by_key_list_key_error(
     var_path: List[str | int], var_name: str, called_during_initialization: bool, mocker: MockerFixture
 ) -> None:
     """Unit tests for making sure data were extracted when error occurs"""
+    input_path: Path = Path("path/to/input")
     dummy_input_data: dict[str | int, Any] | list[Any] = {"a": 1, "b": 2}
     dummy_var_properties: dict[str, Any] = {"pattern": r"cow", "minimum_length": 1, "maximum_length": 5}
     patch_extract = mocker.patch.object(DataValidator, "extract_value_by_key_list", side_effect=KeyError)
@@ -2542,14 +2580,16 @@ def test_extract_input_data_by_key_list_key_error(
         variable_path=var_path,
         variable_properties=dummy_var_properties,
         called_during_initialization=called_during_initialization,
+        input_path=input_path
     )
 
     assert result is None
-    patch_extract.assert_called_once_with(dummy_input_data, var_path)
+    patch_extract.assert_called_once_with(dummy_input_data, var_path, input_path)
     patch_log_missing_data.assert_called_once_with(
         variable_properties=dummy_var_properties,
         var_name=var_name,
         called_during_initialization=called_during_initialization,
+        input_path=input_path
     )
 
 
@@ -3689,6 +3729,7 @@ def test_validate_data_by_type_raises_for_unsupported_type(mocker: MockerFixture
     """validate_data_by_type raises ValueError when the metadata type is not in the supported map."""
     dv = DataValidator()
     mocker.patch.object(dv, "convert_variable_path_to_str", return_value="root.field")
+    input_path: Path = Path("path/to/input")
 
     with pytest.raises(ValueError, match="is not valid"):
         dv.validate_data_by_type(
@@ -3700,6 +3741,7 @@ def test_validate_data_by_type_raises_for_unsupported_type(mocker: MockerFixture
             elements_counter=mocker.MagicMock(autospec=ElementsCounter),
             called_during_initialization=True,
             fixable_data_types=set(),
+            input_path=input_path
         )
 
 
@@ -3712,6 +3754,7 @@ def test_log_missing_data_raises_when_not_during_initialization() -> None:
             var_name="my_var",
             variable_properties={},
             called_during_initialization=False,
+            input_path=Path("path/to/input")
         )
 
     assert any("Missing required data" in str(log) for log in dv.event_logs)
@@ -3727,6 +3770,7 @@ def test_log_missing_data_raises_when_required_during_initialization(mocker: Moc
             var_name="my_var",
             variable_properties={"modifiability": "required locked"},
             called_during_initialization=True,
+            input_path=Path("path/to/input")
         )
 
     assert any("Missing required data" in str(log) for log in dv.event_logs)
@@ -3741,6 +3785,7 @@ def test_log_missing_data_logs_warning_when_not_required_during_initialization(m
         var_name="my_var",
         variable_properties={"modifiability": "unrequired unlocked"},
         called_during_initialization=True,
+        input_path=Path("path/to/input")
     )
 
     assert any("not required upon initialization" in str(log) for log in dv.event_logs)

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -71,12 +71,13 @@ def test_bool_type_validator(
         dummy_counter,
         unused_bool_input,
         {"string", "number", "bool"},
-        input_path
+        input_path,
     )
 
     # Assert
-    patch_extract.assert_called_once_with(dummy_input_data, var_path, variable_properties, unused_bool_input,
-                                          input_path)
+    patch_extract.assert_called_once_with(
+        dummy_input_data, var_path, variable_properties, unused_bool_input, input_path
+    )
     if dummy_variable_properties.get("nullable", False) is False:
         patch_path_to_str.assert_called_once_with(var_path)
     if not expected_result:
@@ -146,7 +147,7 @@ def test_number_type_validator(
         dummy_counter,
         unused_bool_input,
         {"string", "number", "bool"},
-        input_path
+        input_path,
     )
 
     patch_extract.assert_called_once_with(
@@ -204,11 +205,12 @@ def test_string_type_validator(
         dummy_counter,
         unused_bool_input,
         {"string", "number", "bool"},
-        input_path
+        input_path,
     )
 
-    patch_extract.assert_called_once_with(dummy_input_data, var_path, dummy_variable_properties, unused_bool_input,
-                                          input_path)
+    patch_extract.assert_called_once_with(
+        dummy_input_data, var_path, dummy_variable_properties, unused_bool_input, input_path
+    )
     if dummy_variable_properties.get("nullable", False) is False:
         patch_path_to_str.assert_called_once_with(var_path)
     assert result == expected_result
@@ -297,11 +299,7 @@ def test_fix_array_type_fixable_data(
     dv = DataValidator()
 
     result = dv._fix_data(
-        dummy_variable_properties,
-        dummy_element_hierarchy,
-        dummy_input_data,
-        dummy_properties_key,
-        input_path
+        dummy_variable_properties, dummy_element_hierarchy, dummy_input_data, dummy_properties_key, input_path
     )
 
     variable_to_check = dummy_input_data
@@ -406,11 +404,7 @@ def test_fix_array_type_critical_data(
     dv = DataValidator()
 
     result = dv._fix_data(
-        dummy_variable_properties,
-        dummy_element_hierarchy,
-        dummy_input_data,
-        dummy_properties_key,
-        input_path
+        dummy_variable_properties, dummy_element_hierarchy, dummy_input_data, dummy_properties_key, input_path
     )
 
     assert result == expected_result
@@ -520,11 +514,7 @@ def test_fix_string_type_fixable_data(
     dv = DataValidator()
 
     result = dv._fix_data(
-        dummy_variable_properties,
-        dummy_element_hierarchy,
-        dummy_input_data,
-        dummy_properties_key,
-        input_path
+        dummy_variable_properties, dummy_element_hierarchy, dummy_input_data, dummy_properties_key, input_path
     )
 
     variable_to_check: dict[str | int, Any] | list[Any] = dummy_input_data
@@ -581,11 +571,7 @@ def test_fix_string_type_csv_data() -> None:
 
     dv: DataValidator = DataValidator()
     result = dv._fix_data(
-        dummy_variable_properties,
-        dummy_element_hierarchy,
-        dummy_input_data,
-        dummy_properties_key,
-        input_path
+        dummy_variable_properties, dummy_element_hierarchy, dummy_input_data, dummy_properties_key, input_path
     )
 
     fixed_variable = dummy_input_data
@@ -693,11 +679,7 @@ def test_fix_string_type_critical_data(
     dv = DataValidator()
 
     result = dv._fix_data(
-        dummy_variable_properties,
-        dummy_element_hierarchy,
-        dummy_input_data,
-        dummy_properties_key,
-        input_path
+        dummy_variable_properties, dummy_element_hierarchy, dummy_input_data, dummy_properties_key, input_path
     )
 
     assert result == expected_result
@@ -804,11 +786,7 @@ def test_fix_number_type_fixable_data(
     dv = DataValidator()
 
     result = dv._fix_data(
-        dummy_variable_properties,
-        dummy_element_hierarchy,
-        dummy_input_data,
-        dummy_properties_key,
-        input_path
+        dummy_variable_properties, dummy_element_hierarchy, dummy_input_data, dummy_properties_key, input_path
     )
 
     variable_to_check: Any = dummy_input_data
@@ -913,11 +891,7 @@ def test_fix_number_type_critical_data(
     dv = DataValidator()
 
     result = dv._fix_data(
-        dummy_variable_properties,
-        dummy_element_hierarchy,
-        dummy_input_data,
-        dummy_properties_key,
-        input_path
+        dummy_variable_properties, dummy_element_hierarchy, dummy_input_data, dummy_properties_key, input_path
     )
 
     assert result == expected_result
@@ -1090,7 +1064,7 @@ def test_object_type_validator(
         mock_elements_counter,
         True,
         {"string", "number", "bool"},
-        input_path
+        input_path,
     )
 
     # Assert
@@ -1140,7 +1114,7 @@ def test_object_type_validator_key_removal(
         mock_elements_counter,
         True,
         {"string", "number", "bool"},
-        input_path
+        input_path,
     )
 
     assert result
@@ -1355,7 +1329,7 @@ def test_array_type_validator(
         mock_elements_counter,
         True,
         {"string", "number", "bool"},
-        input_path
+        input_path,
     )
 
     # Assert
@@ -1432,7 +1406,7 @@ def test_validate_input_by_type(
         elements_counter,
         True,
         {"string", "number", "bool"},
-        input_path
+        input_path,
     )
 
     # Assert
@@ -1476,7 +1450,7 @@ def test_validate_input_by_type_key_error() -> None:
             elements_counter,
             True,
             {"string", "number", "bool"},
-            input_path
+            input_path,
         )
 
 
@@ -2529,7 +2503,7 @@ def test_extract_input_data_by_key_list_no_error(mocker: MockerFixture) -> None:
         variable_path=dummy_var_path,
         variable_properties=dummy_var_properties,
         called_during_initialization=True,
-        input_path=input_path
+        input_path=input_path,
     )
 
     assert result == dummy_value
@@ -2540,12 +2514,13 @@ def test_extract_input_data_by_key_list_no_error(mocker: MockerFixture) -> None:
         variable_path=dummy_var_path,
         variable_properties=dummy_var_properties,
         called_during_initialization=False,
-        input_path=input_path
+        input_path=input_path,
     )
 
     assert result == dummy_value
-    patch_extract.assert_has_calls([call(dummy_input_data, dummy_var_path, input_path),
-                                    call(dummy_input_data, dummy_var_path, input_path)])
+    patch_extract.assert_has_calls(
+        [call(dummy_input_data, dummy_var_path, input_path), call(dummy_input_data, dummy_var_path, input_path)]
+    )
     patch_log_missing_data.assert_not_called()
 
 
@@ -2580,7 +2555,7 @@ def test_extract_input_data_by_key_list_key_error(
         variable_path=var_path,
         variable_properties=dummy_var_properties,
         called_during_initialization=called_during_initialization,
-        input_path=input_path
+        input_path=input_path,
     )
 
     assert result is None
@@ -2589,7 +2564,7 @@ def test_extract_input_data_by_key_list_key_error(
         variable_properties=dummy_var_properties,
         var_name=var_name,
         called_during_initialization=called_during_initialization,
-        input_path=input_path
+        input_path=input_path,
     )
 
 
@@ -3741,7 +3716,7 @@ def test_validate_data_by_type_raises_for_unsupported_type(mocker: MockerFixture
             elements_counter=mocker.MagicMock(autospec=ElementsCounter),
             called_during_initialization=True,
             fixable_data_types=set(),
-            input_path=input_path
+            input_path=input_path,
         )
 
 
@@ -3754,7 +3729,7 @@ def test_log_missing_data_raises_when_not_during_initialization() -> None:
             var_name="my_var",
             variable_properties={},
             called_during_initialization=False,
-            input_path=Path("path/to/input")
+            input_path=Path("path/to/input"),
         )
 
     assert any("Missing required data" in str(log) for log in dv.event_logs)
@@ -3770,7 +3745,7 @@ def test_log_missing_data_raises_when_required_during_initialization(mocker: Moc
             var_name="my_var",
             variable_properties={"modifiability": "required locked"},
             called_during_initialization=True,
-            input_path=Path("path/to/input")
+            input_path=Path("path/to/input"),
         )
 
     assert any("Missing required data" in str(log) for log in dv.event_logs)
@@ -3785,7 +3760,7 @@ def test_log_missing_data_logs_warning_when_not_required_during_initialization(m
         var_name="my_var",
         variable_properties={"modifiability": "unrequired unlocked"},
         called_during_initialization=True,
-        input_path=Path("path/to/input")
+        input_path=Path("path/to/input"),
     )
 
     assert any("not required upon initialization" in str(log) for log in dv.event_logs)

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -1733,6 +1733,7 @@ def test_add_variable_to_pool_valid(
 
     # Arrange
     input_manager = InputManager()
+    input_path: Path = Path("path/to/input")
     mocker.patch.object(input_manager, "_InputManager__metadata", mock_metadata_for_add_variable_to_pool)
     mocker.patch.object(input_manager, "_InputManager__pool", starting_im_pool)
     mocker.patch.object(DataValidator, "validate_data_by_type", return_value=True)
@@ -1753,6 +1754,7 @@ def test_add_variable_to_pool_valid(
         input_data=data,
         properties_blob_key=properties_blob_key,
         eager_termination=False,
+        input_path=input_path
     )
 
     # Assert
@@ -1872,6 +1874,7 @@ def test_add_variable_to_pool_invalid(
 
     # Arrange
     input_manager = InputManager()
+    input_path: Path = Path("path/to/input")
     mocker.patch.object(input_manager, "_InputManager__metadata", mock_metadata_for_add_variable_to_pool)
     mocker.patch.object(input_manager, "_InputManager__pool", starting_im_pool)
     mocker.patch.object(DataValidator, "validate_data_by_type", return_value=False)
@@ -1887,6 +1890,7 @@ def test_add_variable_to_pool_invalid(
         input_data=data,
         properties_blob_key=properties_blob_key,
         eager_termination=False,
+        input_path=input_path
     )
 
     # Assert
@@ -2005,6 +2009,7 @@ def test_add_variable_to_pool_eager_termination(
 
     # Arrange
     input_manager = InputManager()
+    input_path: Path = Path("path/to/input")
     mocker.patch.object(input_manager, "_InputManager__metadata", mock_metadata_for_add_variable_to_pool)
     mocker.patch.object(input_manager, "_InputManager__pool", starting_im_pool)
     mocker.patch.object(DataValidator, "validate_data_by_type", return_value=False)
@@ -2021,6 +2026,7 @@ def test_add_variable_to_pool_eager_termination(
             input_data=data,
             properties_blob_key=properties_blob_key,
             eager_termination=True,
+            input_path=input_path
         )
 
     # Assert
@@ -2051,6 +2057,7 @@ def test_add_runtime_variable_to_pool(
 ) -> None:
     mock_check = mocker.patch.object(mock_input_manager, "_metadata_properties_exist", return_value=True)
     mock_add = mocker.patch.object(mock_input_manager, "_add_variable_to_pool", return_value=True)
+    input_path: Path = Path("path/to/input")
 
     with patch("RUFAS.output_manager.OutputManager.add_error") as mock_om_add_error:
         result = mock_input_manager.add_runtime_variable_to_pool(
@@ -2058,6 +2065,7 @@ def test_add_runtime_variable_to_pool(
             data=data,
             properties_blob_key=properties_blob_key,
             eager_termination=False,
+            input_path=input_path
         )
 
     assert result is True
@@ -2068,6 +2076,7 @@ def test_add_runtime_variable_to_pool(
         input_data=data,
         properties_blob_key=properties_blob_key,
         eager_termination=False,
+        input_path=input_path
     )
 
     mocker.patch.object(
@@ -2100,6 +2109,7 @@ def test_add_runtime_variable_to_pool_type_error(
 ) -> None:
     mock_check = mocker.patch.object(mock_input_manager, "_metadata_properties_exist", return_value=True)
     mock_add = mocker.patch.object(mock_input_manager, "_add_variable_to_pool", return_value=True)
+    input_path: Path = Path("path/to/input")
 
     with patch("RUFAS.output_manager.OutputManager.add_error") as mock_om_add_error:
         with pytest.raises(TypeError):
@@ -2108,6 +2118,7 @@ def test_add_runtime_variable_to_pool_type_error(
                 data=data,
                 properties_blob_key=properties_blob_key,
                 eager_termination=False,
+                input_path=input_path
             )
 
         assert mock_om_add_error.call_count == 1
@@ -2144,6 +2155,7 @@ def test_add_runtime_variable_to_pool_invalid_data(
 ) -> None:
     mock_check = mocker.patch.object(mock_input_manager, "_metadata_properties_exist", return_value=True)
     mock_add = mocker.patch.object(mock_input_manager, "_add_variable_to_pool", return_value=False)
+    input_path: Path = Path("path/to/input")
 
     with patch("RUFAS.output_manager.OutputManager.add_error") as mock_om_add_error:
         result = mock_input_manager.add_runtime_variable_to_pool(
@@ -2151,6 +2163,7 @@ def test_add_runtime_variable_to_pool_invalid_data(
             data=data,
             properties_blob_key=properties_blob_key,
             eager_termination=False,
+            input_path=input_path
         )
 
         assert result is False
@@ -2161,6 +2174,7 @@ def test_add_runtime_variable_to_pool_invalid_data(
             input_data=data,
             properties_blob_key=properties_blob_key,
             eager_termination=False,
+            input_path=input_path
         )
 
         mocker.patch.object(
@@ -2182,6 +2196,7 @@ def test_add_runtime_variable_to_pool_metadata_properties_do_not_exist(
 ) -> None:
     mock_check = mocker.patch.object(mock_input_manager, "_metadata_properties_exist", return_value=False)
     mock_add = mocker.patch.object(mock_input_manager, "_add_variable_to_pool", return_value=False)
+    input_path: Path = Path("path/to/input")
 
     with patch("RUFAS.output_manager.OutputManager.add_error") as mock_om_add_error:
         result = mock_input_manager.add_runtime_variable_to_pool(
@@ -2189,6 +2204,7 @@ def test_add_runtime_variable_to_pool_metadata_properties_do_not_exist(
             data={"a": 1},
             properties_blob_key="key2",
             eager_termination=False,
+            input_path=input_path
         )
 
         assert result is False
@@ -2725,6 +2741,7 @@ def test_add_variable_to_pool_nested(
     mocker.patch.object(OutputManager, "add_log")
     patch_for_add_warning = mocker.patch.object(OutputManager, "add_warning")
     mocker.patch.object(OutputManager, "add_error")
+    input_path: Path = Path("path/to/input")
 
     if (not is_modifiable_during_runtime) and eager_termination:
         with pytest.raises(PermissionError):
@@ -2733,6 +2750,7 @@ def test_add_variable_to_pool_nested(
                 input_data=data,
                 properties_blob_key=properties_blob_key,
                 eager_termination=eager_termination,
+                input_path=input_path
             )
     elif not is_modifiable_during_runtime:
         assert not input_manager._add_variable_to_pool(
@@ -2740,6 +2758,7 @@ def test_add_variable_to_pool_nested(
             input_data=data,
             properties_blob_key=properties_blob_key,
             eager_termination=eager_termination,
+            input_path=input_path
         )
     else:
         result = input_manager._add_variable_to_pool(
@@ -2747,6 +2766,7 @@ def test_add_variable_to_pool_nested(
             input_data=data,
             properties_blob_key=properties_blob_key,
             eager_termination=False,
+            input_path=input_path
         )
 
         assert result
@@ -3501,13 +3521,14 @@ def test_validate_data(
 ) -> None:
     """Unit test for _validate_data to ensure proper validation"""
     input_manager = InputManager()
+    input_path: Path = Path("path/to/input")
 
     mock_validate_input_by_type = mocker.patch.object(
         DataValidator,
         "validate_data_by_type",
         # fmt: off
         side_effect=lambda variable_path, variable_properties, data, eager_termination, properties_blob_key,
-        elements_counter, called_during_initialization, fixable_data_types:
+        elements_counter, called_during_initialization, fixable_data_types, input_path:
         data.get(variable_path[0]) is not None,
         # fmt: on
     )
@@ -3518,6 +3539,7 @@ def test_validate_data(
         eager_termination=eager_termination,
         properties_blob_key=properties_blob_key,
         elements_counter=elements_counter,
+        input_path=input_path
     )
 
     assert validated_data == expected_validated_data
@@ -3654,6 +3676,7 @@ def test_load_runtime_metadata_success(mock_input_manager: InputManager, mocker:
     mocked_validate = mocker.patch.object(
         mock_input_manager.data_validator, "validate_metadata", return_value=(True, "")
     )
+    mock_input_manager.input_root = tmp_path
     mocked_loader = mocker.patch.object(mock_input_manager, "_load_data_from_csv", return_value={"value": [1]})
     mocked_add = mocker.patch.object(mock_input_manager, "add_runtime_variable_to_pool", return_value=True)
     metadata_exists_spy = mocker.spy(mock_input_manager, "_metadata_properties_exist")
@@ -3669,6 +3692,7 @@ def test_load_runtime_metadata_success(mock_input_manager: InputManager, mocker:
         data={"value": [1]},
         properties_blob_key="commodity_prices_calves_all_dollar_per_kilogram_csv_properties",
         eager_termination=True,
+        input_path=tmp_path / "commodity_prices.calves_all.dollar_per_kilogram.csv",
     )
     metadata_exists_spy.assert_called_once_with(
         "commodity_prices.calves_all.dollar_per_kilogram",

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -1754,7 +1754,7 @@ def test_add_variable_to_pool_valid(
         input_data=data,
         properties_blob_key=properties_blob_key,
         eager_termination=False,
-        input_path=input_path
+        input_path=input_path,
     )
 
     # Assert
@@ -1890,7 +1890,7 @@ def test_add_variable_to_pool_invalid(
         input_data=data,
         properties_blob_key=properties_blob_key,
         eager_termination=False,
-        input_path=input_path
+        input_path=input_path,
     )
 
     # Assert
@@ -2026,7 +2026,7 @@ def test_add_variable_to_pool_eager_termination(
             input_data=data,
             properties_blob_key=properties_blob_key,
             eager_termination=True,
-            input_path=input_path
+            input_path=input_path,
         )
 
     # Assert
@@ -2065,7 +2065,7 @@ def test_add_runtime_variable_to_pool(
             data=data,
             properties_blob_key=properties_blob_key,
             eager_termination=False,
-            input_path=input_path
+            input_path=input_path,
         )
 
     assert result is True
@@ -2076,7 +2076,7 @@ def test_add_runtime_variable_to_pool(
         input_data=data,
         properties_blob_key=properties_blob_key,
         eager_termination=False,
-        input_path=input_path
+        input_path=input_path,
     )
 
     mocker.patch.object(
@@ -2118,7 +2118,7 @@ def test_add_runtime_variable_to_pool_type_error(
                 data=data,
                 properties_blob_key=properties_blob_key,
                 eager_termination=False,
-                input_path=input_path
+                input_path=input_path,
             )
 
         assert mock_om_add_error.call_count == 1
@@ -2163,7 +2163,7 @@ def test_add_runtime_variable_to_pool_invalid_data(
             data=data,
             properties_blob_key=properties_blob_key,
             eager_termination=False,
-            input_path=input_path
+            input_path=input_path,
         )
 
         assert result is False
@@ -2174,7 +2174,7 @@ def test_add_runtime_variable_to_pool_invalid_data(
             input_data=data,
             properties_blob_key=properties_blob_key,
             eager_termination=False,
-            input_path=input_path
+            input_path=input_path,
         )
 
         mocker.patch.object(
@@ -2204,7 +2204,7 @@ def test_add_runtime_variable_to_pool_metadata_properties_do_not_exist(
             data={"a": 1},
             properties_blob_key="key2",
             eager_termination=False,
-            input_path=input_path
+            input_path=input_path,
         )
 
         assert result is False
@@ -2750,7 +2750,7 @@ def test_add_variable_to_pool_nested(
                 input_data=data,
                 properties_blob_key=properties_blob_key,
                 eager_termination=eager_termination,
-                input_path=input_path
+                input_path=input_path,
             )
     elif not is_modifiable_during_runtime:
         assert not input_manager._add_variable_to_pool(
@@ -2758,7 +2758,7 @@ def test_add_variable_to_pool_nested(
             input_data=data,
             properties_blob_key=properties_blob_key,
             eager_termination=eager_termination,
-            input_path=input_path
+            input_path=input_path,
         )
     else:
         result = input_manager._add_variable_to_pool(
@@ -2766,7 +2766,7 @@ def test_add_variable_to_pool_nested(
             input_data=data,
             properties_blob_key=properties_blob_key,
             eager_termination=False,
-            input_path=input_path
+            input_path=input_path,
         )
 
         assert result
@@ -3539,7 +3539,7 @@ def test_validate_data(
         eager_termination=eager_termination,
         properties_blob_key=properties_blob_key,
         elements_counter=elements_counter,
-        input_path=input_path
+        input_path=input_path,
     )
 
     assert validated_data == expected_validated_data


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2877

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Adds `input_path` to warning and error messages throughout data validator for ease of tracking down data validation errors.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
Currently error messages only say the names of the variables that are invalid and possibly the variable data type. This expansion of message to include the source of the variable helps the user make the appropriate fix.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Searched through all warning and error messages and added the input path.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
The best test I've got right now is to try to reproduce Joe's error from the original issue:

```
If you put quotation marks around the first line of the "user_feeds.csv", it'll elicit this error. Slightly different error from putting the second line in quotes, which does give the filename in question.
```

I've tried breaking some other expected rules and I keep seeing CV rules breaking first which I will investigate further.

### Input Changes
<!-- Provide a short summary describing input modifications. -->
<!-- Please include the things that are added, deleted, or modified. -->


### Output Changes
<!-- List all the output variable/function modifications with a short summary. -->
<!-- """- `Class.Function.VariableName`: description""" -->
- N/A

#### Filter
<!-- Provide a filter that can be used to handle the output changes. -->

```json

```
