### PR TITLE
[SimulationEngine] Clean up `SimEng`.`simulate()`

### DIFF
--- a/RUFAS/simulation_engine.py
+++ b/RUFAS/simulation_engine.py
@@ -290,6 +290,21 @@ class SimulationEngine:
 
         self._run_simulation_main_loop()
 
+        self._post_loop_processing()
+
+        t_end_sim = timer.time()
+        total_simulation_time = t_end_sim - t_start_sim
+
+        self._post_loop_reporting()
+
+        self._post_loop_logging(total_simulation_time, info_map)
+
+    def _post_loop_processing(self) -> None:
+        """Runs end-of-simulation calculations for all active modules."""
+        EEEManager.estimate_all()
+
+    def _post_loop_reporting(self) -> None:
+        """Runs end-of-simulation reporting for all active modules."""
         if self.simulate_animals:
             AnimalModuleReporter.report_end_of_simulation(
                 self.herd_manager.herd_statistics,
@@ -300,14 +315,12 @@ class SimulationEngine:
                 self.herd_manager.animal_genetic_history_by_id,
             )
 
+    def _post_loop_logging(self, total_simulation_time: float, info_map: dict[str, str]) -> None:
+        """Logs end-of-simulation warnings and timing for all active modules."""
         if self.simulate_manure:
             ManureExcretionCalculator.emit_dmi_below_min_summary(info_map)
 
-        EEEManager.estimate_all()
-        t_end_sim = timer.time()
-
         self.om.add_log("Simulation complete", "Simulation Completed.", info_map)
-        total_simulation_time = t_end_sim - t_start_sim
         total_simulation_time_log = f"Total simulation time is: {total_simulation_time}"
         self.om.add_log("total_simulation_time", total_simulation_time_log, info_map)
 

--- a/RUFAS/simulation_engine.py
+++ b/RUFAS/simulation_engine.py
@@ -290,20 +290,20 @@ class SimulationEngine:
 
         self._run_simulation_main_loop()
 
-        self._post_loop_processing()
+        self._post_simulation_processing()
 
         t_end_sim = timer.time()
         total_simulation_time = t_end_sim - t_start_sim
 
-        self._post_loop_reporting()
+        self._post_simulation_reporting()
 
-        self._post_loop_logging(total_simulation_time, info_map)
+        self._post_simulation_logging(total_simulation_time, info_map)
 
-    def _post_loop_processing(self) -> None:
+    def _post_simulation_processing(self) -> None:
         """Runs end-of-simulation calculations for all active modules."""
         EEEManager.estimate_all()
 
-    def _post_loop_reporting(self) -> None:
+    def _post_simulation_reporting(self) -> None:
         """Runs end-of-simulation reporting for all active modules."""
         if self.simulate_animals:
             AnimalModuleReporter.report_end_of_simulation(
@@ -315,7 +315,7 @@ class SimulationEngine:
                 self.herd_manager.animal_genetic_history_by_id,
             )
 
-    def _post_loop_logging(self, total_simulation_time: float, info_map: dict[str, str]) -> None:
+    def _post_simulation_logging(self, total_simulation_time: float, info_map: dict[str, str]) -> None:
         """Logs end-of-simulation warnings and timing for all active modules."""
         if self.simulate_manure:
             ManureExcretionCalculator.emit_dmi_below_min_summary(info_map)

--- a/changelog.md
+++ b/changelog.md
@@ -97,8 +97,8 @@ v1.0.0
 - [3050](https://github.com/RuminantFarmSystems/RuFaS/pull/3050) - [minor change] [FieldManager] [SimulationEngine] [NoInputChange] [NoOutputChange] Moves the field config data gathering out of `FieldManager.__init__()` into `SimulationEngine`, passing field data as a parameter instead.
 - [3072](https://github.com/RuminantFarmSystems/RuFaS/pull/3072) - [minor change] [main.py] [NoInputChange] [NoOutputChange] Moves `main.py` into `RUFAS/` for better packaging while maintaining legacy `main.py` script access.
 - [3054](https://github.com/RuminantFarmSystems/RuFaS/pull/3054) - [minor change] [Animal] [Reproduction] [NoInputChange] [NoOutputChange] Adds early-exit guard in presynch and OvSynch hormone schedule setup to skip already-pregnant cows.
-- [3070](https://github.com/RuminantFarmSystems/RuFaS/pull/3070) - [minor change] [InputChange] [NoOutputChange] Removes `random_seed` field from all 6 config input files.
-- [3070](https://github.com/RuminantFarmSystems/RuFaS/pull/3070) - [minor change] [InputChange] [NoOutputChange] Removes the `random_seed` field from all 6 config input files and from 3 config input files in helpful_scripts.
+- [3070](https://github.com/RuminantFarmSystems/RuFaS/pull/3070) - [minor change] [Config] [InputChange] [NoOutputChange] Removes the `random_seed` field from all 6 config input files and from 3 config input files in helpful_scripts.
+- [3087](https://github.com/RuminantFarmSystems/RuFaS/pull/3087) - [minor change] [SimulationEngine] [NoInputChange] [NoOutputChange] Extracts post-loop logic from `SimulationEngine.simulate()` into `_post_loop_processing()`, `_post_loop_reporting()`, and `_post_loop_logging()`.
 
 ### v1.0.0
 

--- a/tests/test_simulation_engine.py
+++ b/tests/test_simulation_engine.py
@@ -155,9 +155,9 @@ def test_simulate(
     # Arrange
     mocker.patch("RUFAS.simulation_engine.timer.time", side_effect=[start_time, end_time])
     mock_run_simulation_main_loop = mocker.patch.object(simulation_engine, "_run_simulation_main_loop")
-    mock_post_loop_processing = mocker.patch.object(simulation_engine, "_post_loop_processing")
-    mock_post_loop_reporting = mocker.patch.object(simulation_engine, "_post_loop_reporting")
-    mock_post_loop_logging = mocker.patch.object(simulation_engine, "_post_loop_logging")
+    mock_post_loop_processing = mocker.patch.object(simulation_engine, "_post_simulation_processing")
+    mock_post_loop_reporting = mocker.patch.object(simulation_engine, "_post_simulation_reporting")
+    mock_post_loop_logging = mocker.patch.object(simulation_engine, "_post_simulation_logging")
 
     info_map = {
         "class": simulation_engine.__class__.__name__,
@@ -186,7 +186,7 @@ def test_post_loop_processing(
     mock_estimate_all = mocker.patch.object(EEEManager, "estimate_all")
 
     # Act
-    simulation_engine._post_loop_processing()
+    simulation_engine._post_simulation_processing()
 
     # Assert
     mock_estimate_all.assert_called_once_with()
@@ -216,7 +216,7 @@ def test_post_loop_reporting(
     )
 
     # Act
-    simulation_engine._post_loop_reporting()
+    simulation_engine._post_simulation_reporting()
 
     # Assert
     if expect_report_call:
@@ -260,7 +260,7 @@ def test_post_loop_logging(
     mock_om_add_log = mocker.patch("RUFAS.output_manager.OutputManager.add_log")
 
     # Act
-    simulation_engine._post_loop_logging(total_simulation_time, info_map)
+    simulation_engine._post_simulation_logging(total_simulation_time, info_map)
 
     # Assert
     if expect_dmi_summary_call:

--- a/tests/test_simulation_engine.py
+++ b/tests/test_simulation_engine.py
@@ -154,44 +154,124 @@ def test_simulate(
     """
     # Arrange
     mocker.patch("RUFAS.simulation_engine.timer.time", side_effect=[start_time, end_time])
-    mock_estimate_emissions = mocker.patch.object(EEEManager, "estimate_all")
     mock_run_simulation_main_loop = mocker.patch.object(simulation_engine, "_run_simulation_main_loop")
-    mock_report_end_of_simulation = mocker.patch(
-        "RUFAS.biophysical.animal.animal_module_reporter.AnimalModuleReporter" ".report_end_of_simulation"
-    )
-    mocker.patch("RUFAS.output_manager.OutputManager.add_variable")
-    mock_om_add_log = mocker.patch("RUFAS.output_manager.OutputManager.add_log")
-
-    mock_time = MagicMock(auto_spec=RufasTime)
-    mock_time.simulation_day = 100
-    simulation_engine.time = mock_time
+    mock_post_loop_processing = mocker.patch.object(simulation_engine, "_post_loop_processing")
+    mock_post_loop_reporting = mocker.patch.object(simulation_engine, "_post_loop_reporting")
+    mock_post_loop_logging = mocker.patch.object(simulation_engine, "_post_loop_logging")
 
     info_map = {
         "class": simulation_engine.__class__.__name__,
         "function": simulation_engine.simulate.__name__,
     }
     expected_simulation_time = end_time - start_time
-    expected_log_message = f"Total simulation time is: {expected_simulation_time}"
 
     # Act
     simulation_engine.simulate()
 
     # Assert
-    mock_run_simulation_main_loop.assert_called_once()
-    assert mock_om_add_log.call_args_list == [
-        call("Simulation complete", "Simulation Completed.", info_map),
-        call("total_simulation_time", expected_log_message, info_map),
-    ]
-    mock_report_end_of_simulation.assert_called_once_with(
-        simulation_engine.herd_manager.herd_statistics,
-        simulation_engine.herd_manager.herd_reproduction_statistics,
-        simulation_engine.time,
-        simulation_engine.herd_manager.heiferII_events_by_id,
-        simulation_engine.herd_manager.cow_events_by_id,
-        simulation_engine.herd_manager.animal_genetic_history_by_id,
+    mock_run_simulation_main_loop.assert_called_once_with()
+    mock_post_loop_processing.assert_called_once_with()
+    mock_post_loop_reporting.assert_called_once_with()
+    mock_post_loop_logging.assert_called_once_with(expected_simulation_time, info_map)
+
+
+def test_post_loop_processing(
+    simulation_engine: SimulationEngine,
+    mocker: MockerFixture,
+) -> None:
+    """
+    Unit test for function _post_loop_processing in simulation_engine.py
+    """
+    # Arrange
+    mock_estimate_all = mocker.patch.object(EEEManager, "estimate_all")
+
+    # Act
+    simulation_engine._post_loop_processing()
+
+    # Assert
+    mock_estimate_all.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    "simulate_animals, expect_report_call",
+    [
+        (True, True),
+        (False, False),
+    ],
+)
+def test_post_loop_reporting(
+    simulation_engine: SimulationEngine,
+    mocker: MockerFixture,
+    simulate_animals: bool,
+    expect_report_call: bool,
+) -> None:
+    """
+    Unit test for function _post_loop_reporting in simulation_engine.py
+    """
+    # Arrange
+    simulation_engine.simulate_animals = simulate_animals
+
+    mock_report_end_of_simulation = mocker.patch(
+        "RUFAS.biophysical.animal.animal_module_reporter.AnimalModuleReporter.report_end_of_simulation"
     )
 
-    mock_estimate_emissions.assert_called_once()
+    # Act
+    simulation_engine._post_loop_reporting()
+
+    # Assert
+    if expect_report_call:
+        mock_report_end_of_simulation.assert_called_once_with(
+            simulation_engine.herd_manager.herd_statistics,
+            simulation_engine.herd_manager.herd_reproduction_statistics,
+            simulation_engine.time,
+            simulation_engine.herd_manager.heiferII_events_by_id,
+            simulation_engine.herd_manager.cow_events_by_id,
+            simulation_engine.herd_manager.animal_genetic_history_by_id,
+        )
+    else:
+        mock_report_end_of_simulation.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "simulate_manure, expect_dmi_summary_call",
+    [
+        (True, True),
+        (False, False),
+    ],
+)
+def test_post_loop_logging(
+    simulation_engine: SimulationEngine,
+    mocker: MockerFixture,
+    simulate_manure: bool,
+    expect_dmi_summary_call: bool,
+) -> None:
+    """
+    Unit test for function _post_loop_logging in simulation_engine.py
+    """
+    # Arrange
+    simulation_engine.simulate_manure = simulate_manure
+    total_simulation_time = 42.5
+    info_map = {"class": "SimulationEngine", "function": "simulate"}
+
+    mock_emit_dmi_summary = mocker.patch(
+        "RUFAS.biophysical.animal.digestive_system.manure_excretion_calculator"
+        ".ManureExcretionCalculator.emit_dmi_below_min_summary"
+    )
+    mock_om_add_log = mocker.patch("RUFAS.output_manager.OutputManager.add_log")
+
+    # Act
+    simulation_engine._post_loop_logging(total_simulation_time, info_map)
+
+    # Assert
+    if expect_dmi_summary_call:
+        mock_emit_dmi_summary.assert_called_once_with(info_map)
+    else:
+        mock_emit_dmi_summary.assert_not_called()
+
+    assert mock_om_add_log.call_args_list == [
+        call("Simulation complete", "Simulation Completed.", info_map),
+        call("total_simulation_time", f"Total simulation time is: {total_simulation_time}", info_map),
+    ]
 
 
 def test_execute_full_farm_daily_simulation(


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Refactors `SimulationEngine.simulate()` by extracting the post-loop logic into three focused helper methods: `_post_loop_processing()`, `_post_loop_reporting()`, and `_post_loop_logging()`.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #2982.
See Clay's comment in #2939 for the original discussion.

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
- Extracted `_post_loop_processing()` from `simulate()` — runs end-of-simulation calculations for all active modules (currently calls `EEEManager.estimate_all()`).
- Extracted `_post_loop_reporting()` from `simulate()` — runs end-of-simulation reporting for all active modules (calls `AnimalModuleReporter.report_end_of_simulation()` when `simulate_animals` is `True`).
- Extracted `_post_loop_logging()` from `simulate()` — logs end-of-simulation warnings and timing (calls `ManureExcretionCalculator.emit_dmi_below_min_summary()` when `simulate_manure` is `True`, and logs simulation completion and total simulation time via `OutputManager.add_log()`). Accepts `total_simulation_time` and `info_map` as parameters.
- Updated `simulate()` to call the three new methods in sequence: `_post_loop_processing()` → timer capture → `_post_loop_reporting()` → `_post_loop_logging()`.


### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
- Updated `test_simulate` to assert that `_post_loop_processing`, `_post_loop_reporting`, and `_post_loop_logging` are each called once with the correct arguments.
- Added `test_post_loop_processing` verifying `EEEManager.estimate_all()` is called.
- Added parametrized `test_post_loop_reporting` covering both `simulate_animals=True` (report called with correct args) and `simulate_animals=False` (report not called).
- Added parametrized `test_post_loop_logging` covering both `simulate_manure=True` (DMI summary called) and `simulate_manure=False` (DMI summary not called), and verifying both `add_log` calls in all cases.
- 99% code coverage maintained. No mypy error count change (1145 on both branch and dev).

### Input Changes
<!-- Provide a short summary describing input modifications. -->
<!-- Please include the things that are added, deleted, or modified. -->
- N/A

### Output Changes
<!-- List all the output variable/function modifications with a short summary. -->
<!-- """- `Class.Function.VariableName`: description""" -->
- N/A

#### Filter
<!-- Provide a filter that can be used to handle the output changes. -->

```json

```