### PR TITLE
[Docstrings][Maintenance] Unify tuple docstrings formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
-[![Mypy](https://img.shields.io/badge/Mypy-1144%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Mypy](https://img.shields.io/badge/Mypy-1138%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 
 
 # RuFaS: Ruminant Farm Systems

--- a/RUFAS/biophysical/animal/animal.py
+++ b/RUFAS/biophysical/animal/animal.py
@@ -1915,7 +1915,7 @@ class Animal:
         -------
         tuple[AnimalStatus, NewBornCalfValuesTypedDict | None]
             - The animal status and optional newborn calf data.
-            - Always None to align with the ``ANIMAL_TYPE_TO_LIFE_STAGE_UPDATE_METHOD_MAP`` mapping format.
+            - Optional newborn calf data.
 
         """
         if self.evaluate_heiferIII_for_cow():
@@ -1963,7 +1963,7 @@ class Animal:
         -------
         tuple[AnimalStatus, NewBornCalfValuesTypedDict | None]
             - The updated animal status and, if applicable, configuration for a newborn calf.
-            - Always None to align with the ``ANIMAL_TYPE_TO_LIFE_STAGE_UPDATE_METHOD_MAP`` mapping format.
+            - Optional newborn calf data.
 
         """
         ANIMAL_TYPE_TO_LIFE_STAGE_UPDATE_METHOD_MAP: dict[

--- a/RUFAS/biophysical/animal/animal.py
+++ b/RUFAS/biophysical/animal/animal.py
@@ -1390,9 +1390,9 @@ class Animal:
 
         Returns
         -------
-        tuple (HeiferReproductionProtocol, HeiferTAISubProtocol | HeiferSynchEDSubProtocol)
-            A tuple where the first element is the determined heifer reproduction program and
-            the second element is the corresponding sub-program for the specified reproduction program.
+        tuple[HeiferReproductionProtocol, HeiferTAISubProtocol | HeiferSynchEDSubProtocol]
+            - The determined heifer reproduction program.
+            - The corresponding sub-program for the specified reproduction program.
 
         """
         heifer_reproduction_program_string = args.get("heifer_reproduction_program")
@@ -1709,11 +1709,10 @@ class Animal:
 
         Returns
         -------
-        NewBornCalfValuesTypedDict | None
-            A dictionary containing details related to a newly born calf if a calf is born during this update;
+        tuple[NewBornCalfValuesTypedDict | None, HerdReproductionStatistics]
+            - A dictionary containing details related to a newly born calf if a calf is born during this update;
             otherwise, None.
-        HerdReproductionStatistics
-            A collection of statistical properties related to the animal's reproduction lifecycle.
+            - A collection of statistical properties related to the animal's reproduction lifecycle.
 
         """
         if not (self.animal_type == AnimalType.HEIFER_II or self.animal_type.is_cow):
@@ -1830,9 +1829,8 @@ class Animal:
         Returns
         -------
         tuple[AnimalStatus, None]
-            A tuple where the first value indicates whether the life stage was changed
-            (AnimalStatus.LIFE_STAGE_CHANGED) or remains the same (AnimalStatus.REMAIN).
-            The second value is always None.
+            - Whether the life stage was changed.
+            - Always None to align with the ``ANIMAL_TYPE_TO_LIFE_STAGE_UPDATE_METHOD_MAP`` mapping format.
 
         Notes
         -----
@@ -1856,8 +1854,8 @@ class Animal:
         Returns
         -------
         tuple[AnimalStatus, None]
-            AnimalStatus.LIFE_STAGE_CHANGED, None: If the heiferI transitions to the heifer II life stage.
-            AnimalStatus.REMAIN, None: If the heiferI remains in the current life stage.
+            - The updated status on whether the animal remains in the same life stage or transitions.
+            - Always None to align with the ``ANIMAL_TYPE_TO_LIFE_STAGE_UPDATE_METHOD_MAP`` mapping format.
 
         Notes
         -----
@@ -1882,8 +1880,8 @@ class Animal:
         Returns
         -------
         tuple[AnimalStatus, None]
-            A tuple containing the status of the animal (whether it is sold, its life stage
-            has changed, or it remains in the current state) and None.
+            - Whether it is sold, its life stage has changed, or it remains in the current state).
+            - Always None to align with the ``ANIMAL_TYPE_TO_LIFE_STAGE_UPDATE_METHOD_MAP`` mapping format.
 
         Notes
         -----
@@ -1916,12 +1914,9 @@ class Animal:
         Returns
         -------
         tuple[AnimalStatus, NewBornCalfValuesTypedDict | None]
-            A tuple containing the animal status and optional newborn calf data.
+            - The animal status and optional newborn calf data.
+            - Always None to align with the ``ANIMAL_TYPE_TO_LIFE_STAGE_UPDATE_METHOD_MAP`` mapping format.
 
-            * `AnimalStatus.LIFE_STAGE_CHANGED` and newborn calf configuration
-            if the animal transitions to Cow.
-            * `AnimalStatus.REMAIN` and `None` if the animal remains in the
-            HeiferIII stage.
         """
         if self.evaluate_heiferIII_for_cow():
             newborn_calf_config = self.transition_heiferIII_to_cow(time)
@@ -1941,8 +1936,8 @@ class Animal:
         Returns
         -------
         tuple[AnimalStatus, None]
-            A tuple where the first element indicates whether the life stage has changed or remains the same,
-            and the second element is always None.
+            - Whether the life stage has changed or remains the same.
+            - Always None to align with the ``ANIMAL_TYPE_TO_LIFE_STAGE_UPDATE_METHOD_MAP`` mapping format.
 
         """
         if self.animal_type == AnimalType.LAC_COW and self.is_milking is False:
@@ -1967,7 +1962,8 @@ class Animal:
         Returns
         -------
         tuple[AnimalStatus, NewBornCalfValuesTypedDict | None]
-            A tuple containing the updated animal status and, if applicable, configuration for a newborn calf.
+            - The updated animal status and, if applicable, configuration for a newborn calf.
+            - Always None to align with the ``ANIMAL_TYPE_TO_LIFE_STAGE_UPDATE_METHOD_MAP`` mapping format.
 
         """
         ANIMAL_TYPE_TO_LIFE_STAGE_UPDATE_METHOD_MAP: dict[
@@ -2472,7 +2468,8 @@ class Animal:
         Returns
         -------
         tuple[int, str]
-            Future cull date in simulation days and reason for culling.
+            - Future cull date in simulation days.
+            - Reason for culling.
 
         Notes
         -------

--- a/RUFAS/biophysical/animal/animal_genetics/animal_genetics.py
+++ b/RUFAS/biophysical/animal/animal_genetics/animal_genetics.py
@@ -307,7 +307,9 @@ class Genetics:
         Returns
         -------
         tuple[float, float]
-            EBV for fat and EBV for protein, respectively.
+            - EBV for fat.
+            - EBV for protein.
+
         """
         parity_index = min(parity, 3) if animal_type.is_cow and parity is not None else 0
         fat_accuracy, protein_accuracy = FAT_ACCURACY_BY_PARITY[parity_index], PROTEIN_ACCURACY_BY_PARITY[parity_index]

--- a/RUFAS/biophysical/animal/data_types/animal_population.py
+++ b/RUFAS/biophysical/animal/data_types/animal_population.py
@@ -402,9 +402,8 @@ class AnimalPopulation:
         Returns
         -------
         tuple[float, dict[str, int]]
-            A tuple of:
-            - float: The average of the data.
-            - dict[str, int]: A dictionary containing the distribution of the data.
+            - The average of the data.
+            - A dictionary containing the distribution of the data.
 
         """
         average = AnimalPopulation._average(data)

--- a/RUFAS/biophysical/animal/digestive_system/digestive_system.py
+++ b/RUFAS/biophysical/animal/digestive_system/digestive_system.py
@@ -178,7 +178,6 @@ class DigestiveSystem:
         Returns
         -------
         tuple[float, float]
-            A tuple containing two values:
             - The amount of phosphorus excreted in urine (g).
             - The amount of phosphorus excreted in feces (g).
 

--- a/RUFAS/biophysical/animal/digestive_system/manure_excretion_calculator.py
+++ b/RUFAS/biophysical/animal/digestive_system/manure_excretion_calculator.py
@@ -86,7 +86,7 @@ class ManureExcretionCalculator:
         fecal_phosphorus: float,
         urine_phosphorus_required: float,
         nutrient_amounts: NutritionSupply,
-    ) -> Tuple[float, AnimalManureExcretions]:
+    ) -> tuple[float, AnimalManureExcretions]:
         """
         Calculates the manure excretion values for a calf with information from the ration formulation.
 
@@ -103,11 +103,10 @@ class ManureExcretionCalculator:
 
         Returns
         -------
-        float
-            Total amount of phosphorus excreted by the given animal, g.
-        AnimalManureExcretions
-            A dictionary that contains the manure excretion values as specified
-                in the AnimalManureExcretions class definition.
+        tuple[float, AnimalManureExcretions]
+            - Total amount of phosphorus excreted by the given animal, g.
+            - A dictionary that contains the manure excretion values as specified in the AnimalManureExcretions class
+            definition.
 
         References
         ----------
@@ -189,7 +188,7 @@ class ManureExcretionCalculator:
         fecal_phosphorus: float,
         urine_phosphorus_required: float,
         nutrient_amount: NutritionSupply,
-    ) -> Tuple[float, AnimalManureExcretions]:
+    ) -> tuple[float, AnimalManureExcretions]:
         """
         Calculates the manure excretion values for a growing and close-up heifer with information from the ration
         formulation.
@@ -207,11 +206,10 @@ class ManureExcretionCalculator:
 
         Returns
         -------
-        float
-            Total amount of phosphorus excreted by the given animal, g.
-        AnimalManureExcretions
-            A dictionary that contains the manure excretion values as specified
-                in the AnimalManureExcretions class definition.
+        tuple[float, AnimalManureExcretions]
+            - Total amount of phosphorus excreted by the given animal, (g).
+            - A dictionary that contains the manure excretion values as specified in the AnimalManureExcretions class
+            definition.
 
         Notes
         -----
@@ -331,7 +329,7 @@ class ManureExcretionCalculator:
         fecal_phosphorus: float,
         urine_phosphorus_required: float,
         nutrient_amounts: NutritionSupply,
-    ) -> Tuple[float, AnimalManureExcretions]:
+    ) -> tuple[float, AnimalManureExcretions]:
         """
         Calculates the manure excretion values for a cow with information from the ration formulation.
 
@@ -356,10 +354,10 @@ class ManureExcretionCalculator:
 
         Returns
         -------
-        tuple : [float, AnimalManureExcretions]
-            A tuple of the total amount of phosphorus excreted by the given animal (g) and
-            a dictionary that contains the manure excretion values as specified in the
-            AnimalManureExcretions class definition.
+        tuple[float, AnimalManureExcretions]
+            - The total amount of phosphorus excreted by the given animal (g).
+            - A dictionary that contains the manure excretion values as specified in the AnimalManureExcretions class
+            definition.
 
         Notes
         -----
@@ -393,7 +391,7 @@ class ManureExcretionCalculator:
         fecal_phosphorus: float,
         urine_phosphorus_required: float,
         nutrient_amounts: NutritionSupply,
-    ) -> Tuple[float, AnimalManureExcretions]:
+    ) -> tuple[float, AnimalManureExcretions]:
         """
         Calculates the manure excretion values for a lactating cow with information from the ration formulation.
 
@@ -416,11 +414,10 @@ class ManureExcretionCalculator:
 
         Returns
         -------
-        float
-            Total amount of phosphorus excreted by the given animal, g.
-        AnimalManureExcretions
-            A dictionary that contains the manure excretion values as specified
-                in the AnimalManureExcretions class definition.
+        tuple[float, AnimalManureExcretions]
+            - Total amount of phosphorus excreted by the given animal, g.
+            - A dictionary that contains the manure excretion values as specified in the AnimalManureExcretions class
+            definition.
 
         Notes
         -----
@@ -561,7 +558,7 @@ class ManureExcretionCalculator:
         fecal_phosphorus: float,
         urine_phosphorus_required: float,
         nutrient_amounts: NutritionSupply,
-    ) -> Tuple[float, AnimalManureExcretions]:
+    ) -> tuple[float, AnimalManureExcretions]:
         """Calculates the manure excretion values for a non-lactating cow with information from the ration formulation.
 
         The dry matter ("dm") unit is kg per animal. Crude protein ("CP"), ADF, NDF, lignin, ash, phosphorus, potassium,
@@ -584,11 +581,10 @@ class ManureExcretionCalculator:
 
         Returns
         -------
-        float
-            Total amount of phosphorus excreted by the given animal, g.
-        AnimalManureExcretions
-            A dictionary that contains the manure excretion values as specified
-                in the AnimalManureExcretions class definition.
+        tuple[float, AnimalManureExcretions]
+            - Total amount of phosphorus excreted by the given animal, (g).
+            - A dictionary that contains the manure excretion values as specified in the AnimalManureExcretions class
+            definition.
 
         References
         ----------

--- a/RUFAS/biophysical/animal/digestive_system/manure_excretion_calculator.py
+++ b/RUFAS/biophysical/animal/digestive_system/manure_excretion_calculator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Tuple
+from typing import Any
 
 from RUFAS.biophysical.animal.animal_module_constants import AnimalModuleConstants
 from RUFAS.biophysical.animal.data_types.nutrition_data_structures import NutritionSupply
@@ -729,34 +729,30 @@ class ManureExcretionCalculator:
         total_manure_excreted: float,
         fecal_phosphorus: float,
         urine_phosphorus_required: float,
-    ) -> Tuple[float, float, float, float, float]:
+    ) -> tuple[float, float, float, float, float]:
         """
         Calculates a set of phosphorus excretion values produced by a given animal.
 
         Parameters
         ----------
         daily_milk_production : float
-            Amount of daily milk produced by the animal, kg.
+            Amount of daily milk produced by the animal, (kg).
             This parameter should be set to 0 if this function is called for a non-cow animal.
         total_manure_excreted : float
-            Amount of manure excreted by the animal, kg.
+            Amount of manure excreted by the animal, (kg).
         fecal_phosphorus : float
-            Amount of fecal phosphorus excreted by the animal, g.
+            Amount of fecal phosphorus excreted by the animal, (g).
         urine_phosphorus_required : float
-            Amount of phosphorus required for urine production, g.
+            Amount of phosphorus required for urine production, (g).
 
         Returns
         -------
-        float
-            Total amount of phosphorus excreted by the animal, g.
-        float
-            Fraction of extractable inorganic phosphorus, unitless.
-        float
-            Fraction of water extractable organic phosphorus, unitless.
-        float
-            Amount of manure phosphorus excreted, g.
-        float
-            Fraction of phosphorus in the manure, unitless.
+        tuple[float, float, float, float, float]
+            - Total amount of phosphorus excreted by the animal, (g).
+            - Fraction of extractable inorganic phosphorus, (unitless).
+            - Fraction of water extractable organic phosphorus, (unitless).
+            - Amount of manure phosphorus excreted, (g).
+            - Fraction of phosphorus in the manure, (unitless).
 
         References
         ----------

--- a/RUFAS/biophysical/animal/growth/growth.py
+++ b/RUFAS/biophysical/animal/growth/growth.py
@@ -63,8 +63,9 @@ class Growth:
         Returns
         -------
         tuple[AnimalGrowthProperties, ReproductionProperties, GeneralProperties]
-            The updated animal growth properties, reproduction properties, and the general properties of the animal
-            after the growth-related routines for the current day.
+            - The updated animal growth properties after the growth-related routines for the current day.
+            - The updated reproduction properties after the growth-related routines for the current day.
+            - The updated general properties of the animal after the growth-related routines for the current day.
 
         Raises
         ------
@@ -230,7 +231,8 @@ class Growth:
         Returns
         -------
         tuple[float, float]
-            The daily body weight growth for pregnant heifers (kg), and the updated conceptus weight (kg).
+            - The daily body weight growth for pregnant heifers (kg).
+            - The updated conceptus weight (kg).
 
         References
         ----------
@@ -259,8 +261,9 @@ class Growth:
         Returns
         -------
         tuple[float, float, float]
-            The daily body weight growth for pregnant heifers (kg), the updated conceptus weight (kg), and the updated
-            tissue changed (kg).
+            - The daily body weight growth for pregnant heifers (kg).
+            - The updated conceptus weight (kg).
+            - The updated tissue changed (kg).
 
         References
         ----------
@@ -294,7 +297,8 @@ class Growth:
         Returns
         -------
         tuple[float, float]
-            The conceptus growth for pregnant heifers (kg), and the updated conceptus weight (kg).
+            - The conceptus growth for pregnant heifers (kg).
+            - The updated conceptus weight (kg).
 
         References
         ----------
@@ -330,8 +334,9 @@ class Growth:
         Returns
         -------
         tuple[float, float, float]
-            The conceptus growth for pregnant heifers (kg), the updated conceptus weight (kg), and the updated
-            tissue changed (kg).
+            - The conceptus growth for pregnant heifers (kg).
+            - The updated conceptus weight (kg).
+            - The updated tissue changed (kg).
 
         Referemces
         ----------
@@ -427,7 +432,8 @@ class Growth:
         Returns
         -------
         tuple[float, float]
-            The body weight tissue growth for cows (kg), and the updated tissue changed (kg).
+            - The body weight tissue growth for cows (kg).
+            - The updated tissue changed (kg).
 
         References
         ----------

--- a/RUFAS/biophysical/animal/nutrients/nasem_requirements_calculator.py
+++ b/RUFAS/biophysical/animal/nutrients/nasem_requirements_calculator.py
@@ -189,7 +189,9 @@ class NASEMRequirementsCalculator(NutritionRequirementsCalculator):
         Returns
         -------
         tuple[float, float, float]
-            Net energy requirement for maintenance (Mcal), gravid uterine weight (kg), and uterine weight (kg).
+            - Net energy requirement for maintenance (Mcal).
+            - Gravid uterine weight (kg).
+            - Uterine weight (kg).
 
         Notes
         -----
@@ -254,8 +256,9 @@ class NASEMRequirementsCalculator(NutritionRequirementsCalculator):
         Returns
         -------
         tuple[float, float, float]
-            Net energy requirement for frame growth (Mcal), average daily gain (g), and accretion of both fat and
-            protein in carcass (g)
+            - Net energy requirement for frame growth (Mcal).
+            - Average daily gain (g).
+            - Accretion of both fat and protein in carcass (g).
 
         Notes
         -----
@@ -324,8 +327,9 @@ class NASEMRequirementsCalculator(NutritionRequirementsCalculator):
         Returns
         -------
         tuple[float, float]
-            Net energy requirement for pregnancy (Mcal) and daily energy requirement associated to increased gain of
-            reproductive tissues as pregnancy advances (Mcal)
+            - Net energy requirement for pregnancy (Mcal).
+            - Daily energy requirement associated to increased gain of reproductive tissues as pregnancy advances
+            (Mcal).
 
         Notes
         -----

--- a/RUFAS/biophysical/animal/nutrients/nrc_requirements_calculator.py
+++ b/RUFAS/biophysical/animal/nutrients/nrc_requirements_calculator.py
@@ -199,7 +199,9 @@ class NRCRequirementsCalculator(NutritionRequirementsCalculator):
         Returns
         -------
         tuple[float, float, float]
-            Net energy requirement for maintenance (Mcal/day), conceptus weight (kg), and calf birth weight (kg).
+            - Net energy requirement for maintenance (Mcal/day).
+            - Conceptus weight (kg).
+            - Calf birth weight (kg).
 
         Notes
         -----
@@ -268,7 +270,9 @@ class NRCRequirementsCalculator(NutritionRequirementsCalculator):
         Returns
         -------
         tuple[float, float, float]
-            Net energy requirement for growth (Mcal/d), average daily gain (g/d), equivalent shrunk body weight (kg).
+            - Net energy requirement for growth (Mcal/d).
+            - Average daily gain (g/d).
+            - Equivalent shrunk body weight (kg).
 
         References
         ----------

--- a/RUFAS/biophysical/animal/nutrients/nutrition_evaluator.py
+++ b/RUFAS/biophysical/animal/nutrients/nutrition_evaluator.py
@@ -33,7 +33,7 @@ class NutritionEvaluator:
         -------
         tuple[bool, NutritionEvaluationResults]
             - Boolean indicating if the ration has an amount of energy and nutrients sufficient to meet the given
-            requirements. 
+            requirements.
             - An object containing a summary of all energy and nutrient surpluses and deficiencies.
 
         """

--- a/RUFAS/biophysical/animal/nutrients/nutrition_evaluator.py
+++ b/RUFAS/biophysical/animal/nutrients/nutrition_evaluator.py
@@ -32,8 +32,9 @@ class NutritionEvaluator:
         Returns
         -------
         tuple[bool, NutritionEvaluationResults]
-            Boolean indicating if the ration has an amount of energy and nutrients sufficient to meet the given
-            requirements, and an object containing a summary of all energy and nutrient surpluses and deficiencies.
+            - Boolean indicating if the ration has an amount of energy and nutrients sufficient to meet the given
+            requirements. 
+            - An object containing a summary of all energy and nutrient surpluses and deficiencies.
 
         """
         heifer_energy_nutrition_checkers = {

--- a/RUFAS/biophysical/animal/pen.py
+++ b/RUFAS/biophysical/animal/pen.py
@@ -728,7 +728,6 @@ class Pen:
         Returns
         -------
         tuple[float, float | None, ManureStream | None]
-            A tuple containing:
             - general_stream_proportion (float): The proportion of the general stream that remains.
             - parlor_stream_proportion (float or None): The proportion of the parlor stream, or None if not applicable.
             - parlor_stream (ManureStream or None): The resulting parlor stream, or None if not applicable.

--- a/RUFAS/biophysical/animal/ration/ration_optimizer.py
+++ b/RUFAS/biophysical/animal/ration/ration_optimizer.py
@@ -854,7 +854,7 @@ class RationOptimizer:
 
         Returns
         -------
-        tuple
+        tuple[OptimizeResult, RationConfig]
             - Scipy object with the result of the optimization.
             - RationConfig object containing the optimized ration.
 

--- a/RUFAS/biophysical/animal/reproduction/reproduction.py
+++ b/RUFAS/biophysical/animal/reproduction/reproduction.py
@@ -1812,11 +1812,8 @@ class Reproduction:
         Returns
         -------
         tuple[bool, ReproductionDataStream]
-            A tuple containing:
-            1. bool
-                Whether hormone delivery should be set up for presynch.
-            2. ReproductionDataStream
-                The updated reproduction data stream.
+            - Whether hormone delivery should be set up for presynch.
+            - The updated reproduction data stream.
 
         Notes
         -----
@@ -1889,11 +1886,8 @@ class Reproduction:
         Returns
         -------
         tuple[bool, ReproductionDataStream]
-            A tuple containing:
-            1. bool
-                Whether hormone delivery should be set up for OvSynch.
-            2. ReproductionDataStream
-                The updated reproduction data stream.
+            - Whether hormone delivery should be set up for OvSynch.
+            - The updated reproduction data stream.
 
         Notes
         -----
@@ -1913,6 +1907,7 @@ class Reproduction:
 
         If the cow is already in the IN_OVSYNCH state, this method returns True even
         if no new state transition occurs.
+
         """
         if reproduction_data_stream.is_pregnant:
             return False, reproduction_data_stream

--- a/RUFAS/biophysical/feed_storage/feed_manager.py
+++ b/RUFAS/biophysical/feed_storage/feed_manager.py
@@ -449,9 +449,9 @@ class FeedManager:
         Returns
         -------
         tuple[bool, FeedFulfillmentResults]
-            A tuple where the first element is ``True`` if the feed request can be fulfilled (``False`` otherwise), and
-            the second element is a ``FeedFulfillmentResults`` object containing the amounts of feed deducted from
-            purchased and farm-grown sources.
+            - ``True`` if the feed request can be fulfilled (``False`` otherwise).
+            - A ``FeedFulfillmentResults`` object containing the amounts of feed deducted from purchased and farm-grown
+            sources.
 
         """
         current_feed_totals = self._query_available_feed_totals(list(requested_feed.requested_feed.keys()))
@@ -945,7 +945,6 @@ class FeedManager:
         Returns
         -------
         tuple[dict[RUFAS_ID, list[HarvestedCrop]], dict[RUFAS_ID, list[PurchasedFeed]]]
-            A tuple of:
             - ``farmgrown_by_id``: ``{feed_id: [HarvestedCrop]}``, sorted by ``storage_time`` oldest to newest.
             - ``purchased_by_id``: ``{feed_id: [PurchasedFeed]}``, storage time not considered.
 

--- a/RUFAS/biophysical/field/field/field.py
+++ b/RUFAS/biophysical/field/field/field.py
@@ -707,7 +707,8 @@ class Field:
         Returns
         -------
         tuple[float, float]
-            The validated application depth and surface remainder fraction.
+            - The validated application depth.
+            - The surface remainder fraction.
 
         Raises
         ------
@@ -1216,8 +1217,8 @@ class Field:
         Returns
         -------
         Tuple
-            A tuple containing the list of all Events that will occur in this field after the current day, and a list of
-            Events that will occur on the current day.
+            - The list of all Events that will occur in this field after the current day.
+            = A list of Events that will occur on the current day.
 
         Notes
         -----

--- a/RUFAS/biophysical/field/field/field.py
+++ b/RUFAS/biophysical/field/field/field.py
@@ -1216,9 +1216,9 @@ class Field:
 
         Returns
         -------
-        Tuple
+        tuple[list[FieldManagementEventT], list[FieldManagementEventT]]
             - The list of all Events that will occur in this field after the current day.
-            = A list of Events that will occur on the current day.
+            - A list of Events that will occur on the current day.
 
         Notes
         -----

--- a/RUFAS/biophysical/field/manager/field_manager.py
+++ b/RUFAS/biophysical/field/manager/field_manager.py
@@ -250,7 +250,6 @@ class FieldManager:
         Returns
         -------
         tuple[list[PlantingEvent], list[HarvestEvent]]
-            A tuple containing two lists:
             - List of all planting events required by the crop rotation schedule.
             - List of all harvest events corresponding to the planting events.
 
@@ -278,7 +277,8 @@ class FieldManager:
         Returns
         -------
         tuple[dict[str, dict[str, float], FertilizerSchedule]
-            Dictionary containing the specifications of the available fertilizer mixes, and a FertilizerSchedule.
+            - Dictionary containing the specifications of the available fertilizer mixes.
+            - A FertilizerSchedule.
 
         Raises
         ------

--- a/RUFAS/biophysical/field/soil/manure_pool.py
+++ b/RUFAS/biophysical/field/soil/manure_pool.py
@@ -224,6 +224,12 @@ class ManurePool:
         field_size : float
             The size of the field (ha).
 
+        Returns
+        -------
+        tuple[float, float]
+            - The organic results for infiltrated phosphorous.
+            - The inorganic results for infiltrated phosphorous.
+
         """
         organic_results = self._determine_phosphorus_leached_from_surface(
             rainfall,
@@ -287,11 +293,10 @@ class ManurePool:
 
         Returns
         -------
-        Tuple[float, float]
-            decomposed_manure_mass_change: change in the mass of applied manure on the field surface
-                decomposed on this day (kg).
-            decomposed_manure_coverage_change: change in field coverage of applied manure on the field
-                surface (unitless).
+        tuple[float, float]
+            - The change in the mass of applied manure on the field surface decomposed on this day (kg).
+            - The change in field coverage of applied manure on the field surface (unitless).
+
         """
         manure_dry_matter_decomposition_rate = max(
             0.0, self._determine_dry_matter_decomposition_rate(temperature_factor)
@@ -299,8 +304,8 @@ class ManurePool:
         (
             decomposed_manure_mass_change,
             decomposed_manure_coverage_change,
-        ) = (0, 0)
-        if self.manure_dry_mass > 0 and self.manure_field_coverage > 0:
+        ) = (0.0, 0.0)
+        if self.manure_dry_mass > 0.0 and self.manure_field_coverage > 0.0:
             decomposed_manure_mass_change = min(
                 (self.manure_dry_mass * manure_dry_matter_decomposition_rate),
                 self.manure_dry_mass,
@@ -327,12 +332,12 @@ class ManurePool:
         Returns
         -------
         tuple[float, float]
-            assimilated_manure: Amount of manure that is assimilated on a given day (kg).
-            manure_coverage: Amount of decrease in the fraction of field covered by manure on a given day (unitless).
+            - Amount of manure that is assimilated on a given day (kg).
+            - Amount of decrease in the fraction of field covered by manure on a given day (unitless).
 
         """
-        assimilated_manure, manure_coverage = 0, 0
-        if self.manure_dry_mass > 0 and self.manure_field_coverage > 0:
+        assimilated_manure, manure_coverage = 0.0, 0.0
+        if self.manure_dry_mass > 0 and self.manure_field_coverage > 0.0:
             manure_cover_area = self.manure_field_coverage * field_size
             assimilated_manure = max(
                 0.0,

--- a/RUFAS/biophysical/manure/digester/continuous_mix.py
+++ b/RUFAS/biophysical/manure/digester/continuous_mix.py
@@ -120,11 +120,8 @@ class ContinuousMix(Digester):
         Returns
         -------
         tuple[float, float]
-            A tuple containing:
-            - generated_carbon_dioxide_mass : float
-                The calculated mass of generated carbon dioxide.
-            - generated_carbon_dioxide_volume : float
-                The calculated volume of generated carbon dioxide.
+            - The calculated mass of generated carbon dioxide.
+            - The calculated volume of generated carbon dioxide.
 
         Notes
         -----
@@ -148,9 +145,8 @@ class ContinuousMix(Digester):
         Returns
         -------
         tuple[float, float]
-            A tuple containing:
-            - generated_methane_mass (float): The mass of generated methane.
-            - generated_methane_volume (float): The volume of generated methane.
+            - The mass of generated methane.
+            - The volume of generated methane.
 
         Notes
         -----

--- a/RUFAS/biophysical/manure/handler/single_stream_handler.py
+++ b/RUFAS/biophysical/manure/handler/single_stream_handler.py
@@ -232,9 +232,9 @@ class SingleStreamHandler(Handler):
         Returns
         -------
         tuple[float, float, float]
-            The updated amount of degradable volatile solids (kg).
-            The updated amount of non-degradable volatile solids (kg).
-            The updated amount of total solids (kg).
+            - The updated amount of degradable volatile solids (kg).
+            - The updated amount of non-degradable volatile solids (kg).
+            - The updated amount of total solids (kg).
 
         """
         if self.manure_stream:

--- a/RUFAS/biophysical/manure/manure_manager.py
+++ b/RUFAS/biophysical/manure/manure_manager.py
@@ -1019,8 +1019,8 @@ class ManureManager:
         Returns
         -------
         tuple[Manure Stream, dict[str, Any]]
-            The stream after removal.
-            The detail of the amount of nutrients removed.
+            - The stream after removal.
+            - The detail of the amount of nutrients removed.
 
         """
         if is_nitrogen_limiting_nutrient:

--- a/RUFAS/biophysical/manure/manure_nutrient_manager.py
+++ b/RUFAS/biophysical/manure/manure_nutrient_manager.py
@@ -93,9 +93,8 @@ class ManureNutrientManager:
         Returns
         -------
         tuple[NutrientRequestResults | None, bool]
-            A tuple containing the results of the nutrient request and a boolean indicating whether additional
-            manure would be needed to fulfill the request. If the request cannot be fulfilled at all, the first
-            element of the tuple will be None.
+            - The results of the nutrient request; will be None if the request cannot be fulfilled at all.
+            - A boolean indicating whether additional manure would be needed to fulfill the request.
 
         Notes
         -----
@@ -119,9 +118,8 @@ class ManureNutrientManager:
         Returns
         -------
         tuple[NutrientRequestResults | None, bool]
-            A tuple containing the results of the nutrient request and a boolean indicating whether additional
-            manure would be needed to fulfill the request. If the request cannot be fulfilled at all, the first
-            element of the tuple will be None.
+            - The results of the nutrient request. Will be None if the request cannot be fulfilled at all.
+            - A boolean indicating whether additional manure would be needed to fulfill the request.
 
         """
         is_nutrient_request_fulfilled = False

--- a/RUFAS/biophysical/manure/storage/anaerobic_lagoon.py
+++ b/RUFAS/biophysical/manure/storage/anaerobic_lagoon.py
@@ -148,7 +148,6 @@ class AnaerobicLagoon(Storage):
         Returns
         -------
         tuple[float, float]
-            A tuple containing:
             - The methane burned from manure storage on the current day, (kg).
             - The methane emitted from manure storage on the current day, (kg).
 

--- a/RUFAS/biophysical/manure/storage/slurry_storage_outdoor.py
+++ b/RUFAS/biophysical/manure/storage/slurry_storage_outdoor.py
@@ -130,7 +130,6 @@ class SlurryStorageOutdoor(Storage):
         Returns
         -------
         tuple[float, float]
-            A tuple containing:
             - The methane burned from manure storage on the current day, (kg).
             - The methane emitted from manure storage on the current day, (kg).
 

--- a/RUFAS/biophysical/manure/storage/storage.py
+++ b/RUFAS/biophysical/manure/storage/storage.py
@@ -374,7 +374,8 @@ class Storage(Processor):
         Returns
         -------
         tuple[float, float]
-            The amount of storage methane burned and the adjusted methane loss (kg).
+            - The amount of storage methane burned (kg).
+            - The adjusted methane loss (kg).
 
         """
         storage_methane_burned = (

--- a/RUFAS/data_validator.py
+++ b/RUFAS/data_validator.py
@@ -217,8 +217,8 @@ class DataValidator:
         Returns
         -------
         tuple[bool, str]
-            Validation status and an error message describing the first failure encountered. The message is empty when
-            validation succeeds.
+            - Boolean representing validation status
+            - An error message describing the first failure encountered. The message is empty when validation succeeds.
 
         """
         info_map = {
@@ -319,10 +319,8 @@ class DataValidator:
         Returns
         -------
         tuple[bool, str]
-            Validation status and an associated error message.
-
-            - ``(True, "")`` if the metadata properties object is valid.
-            - ``(False, message)`` if validation fails.
+            - A boolean representing validation status.
+            - An error message if validation fails.
 
         Notes
         -----
@@ -406,10 +404,8 @@ class DataValidator:
         Returns
         -------
         tuple[bool, str]
-            Validation status and an associated error message.
-
-            - ``(True, "")`` if the metadata definition is valid.
-            - ``(False, message)`` if validation fails.
+            - A boolean representing validation status.
+            - An error message if validation fails.
 
         Notes
         -----
@@ -549,10 +545,8 @@ class DataValidator:
         Returns
         -------
         tuple[bool, str]
-            Validation status and an associated error message.
-
-            - ``(True, "")`` if the metadata definition is valid.
-            - ``(False, message)`` if validation fails.
+            - A boolean representing validation status.
+            - An error message if validation fails.
 
         Notes
         -----
@@ -666,10 +660,8 @@ class DataValidator:
         Returns
         -------
         tuple[bool, str]
-            Validation status and an associated error message.
-
-            - ``(True, "")`` if the metadata definition is valid.
-            - ``(False, message)`` if validation fails.
+            - A boolean representing validation status.
+            - An error message if validation fails.
 
         Notes
         -----
@@ -736,10 +728,8 @@ class DataValidator:
         Returns
         -------
         tuple[bool, str]
-            Validation status and an associated error message.
-
-            - ``(True, "")`` if the metadata definition is valid.
-            - ``(False, message)`` if validation fails.
+            - A boolean representing validation status.
+            - An error message if validation fails.
 
         Notes
         -----
@@ -850,8 +840,8 @@ class DataValidator:
         Returns
         -------
         tuple[bool, str]
-            Validation status and an associated error message. The message is
-            empty when validation succeeds.
+            - A boolean representing validation status.
+            - An error message if validation fails.
 
         """
         info_map = {
@@ -958,10 +948,8 @@ class DataValidator:
         Returns
         -------
         tuple[list[str] | None, str]
-            Tuple containing the validated list of paths and an associated error message.
-
-            - ``(paths, "")`` if all configured path values are valid.
-            - ``(None, message)`` if a configured path value is missing, empty, or not a string.
+            - A validated list of the paths.
+            - An associated error message if a configured path value is missing, empty, or not a string.
 
         Notes
         -----
@@ -2310,8 +2298,8 @@ class CrossValidator:
         Returns
         -------
         tuple[Any, bool]
-            Result of the expression evaluation and a boolean indicating whether
-            the expression was successfully evaluated.
+            - The result of the expression evaluation.
+            - A boolean indicating whether the expression was successfully evaluated.
 
         Raises
         ------
@@ -2377,7 +2365,8 @@ class CrossValidator:
         Returns
         -------
         tuple[Any, bool]
-            Aggregated result and ``True`` on success, or ``(None, False)`` on error.
+            - The aggregated result.
+            - A boolean representing the success or failure of the aggregation.
 
         Raises
         ------
@@ -2538,7 +2527,8 @@ class CrossValidator:
         Returns
         -------
         tuple[Any, bool]
-            ``(result, True)`` on success or ``(None, False)`` on error.
+            - The result of the evaluation.
+            - A boolean representing the success or failure of the evaluation.
 
         Notes
         -----

--- a/RUFAS/data_validator.py
+++ b/RUFAS/data_validator.py
@@ -320,7 +320,7 @@ class DataValidator:
         -------
         tuple[bool, str]
             - A boolean representing validation status.
-            - An error message if validation fails.
+            - An error message if validation fails and an empty string if validation succeeds.
 
         Notes
         -----
@@ -405,7 +405,7 @@ class DataValidator:
         -------
         tuple[bool, str]
             - A boolean representing validation status.
-            - An error message if validation fails.
+            - An error message if validation fails and an empty string if validation succeeds.
 
         Notes
         -----
@@ -546,7 +546,7 @@ class DataValidator:
         -------
         tuple[bool, str]
             - A boolean representing validation status.
-            - An error message if validation fails.
+            - An error message if validation fails and an empty string if validation succeeds.
 
         Notes
         -----
@@ -661,7 +661,7 @@ class DataValidator:
         -------
         tuple[bool, str]
             - A boolean representing validation status.
-            - An error message if validation fails.
+            - An error message if validation fails and an empty string if validation succeeds.
 
         Notes
         -----
@@ -729,7 +729,7 @@ class DataValidator:
         -------
         tuple[bool, str]
             - A boolean representing validation status.
-            - An error message if validation fails.
+            - An error message if validation fails and an empty string if validation succeeds.
 
         Notes
         -----
@@ -841,7 +841,7 @@ class DataValidator:
         -------
         tuple[bool, str]
             - A boolean representing validation status.
-            - An error message if validation fails.
+            - An error message if validation fails and an empty string if validation succeeds.
 
         """
         info_map = {

--- a/RUFAS/graph_generator.py
+++ b/RUFAS/graph_generator.py
@@ -338,10 +338,8 @@ class GraphGenerator:
         Returns
         -------
         tuple[dict[str, dict[str, list[Any]]], list[dict[str, str | dict[str, str]]]]
-            1. dict[str, dict[str, list[Any]]]
-                The updated data with units added.
-            2. list[dict[str, str | dict[str, str]]]
-                Logs if ``info_maps`` aren't found to get units.
+            - The updated data with units added.
+            - Logs if ``info_maps`` aren't found to get units.
         """
         updated_data = {}
         info_map = {
@@ -608,10 +606,9 @@ class GraphGenerator:
         Returns
         -------
         tuple[NDArray[Any], NDArray[np.float32]]
-            1. ``NDArray[Any]``
-                The indices of the masked data.
-            2. ``NDArray[np.float32]``
-                The actual masked data.
+            - The indices of the masked data.
+            - The actual masked data.
+
         """
         np_values = np.array(values)
         mask = ~np.isnan(np_values)

--- a/RUFAS/input_manager.py
+++ b/RUFAS/input_manager.py
@@ -1434,8 +1434,6 @@ class InputManager:
         Returns
         -------
         tuple[bool, bool]
-            Tuple containing:
-
             - Whether the input data was removed.
             - Whether the associated metadata was removed.
 
@@ -1643,8 +1641,8 @@ class InputManager:
         Returns
         -------
         tuple[dict[str, Any], dict[str, Any]]
-            Tuple containing the prepared input data and the metadata properties used
-            to validate it.
+            - The prepared input data.
+            - The metadata properties used to validate the input data.
 
         """
         element_hierarchy = variable_name.split(".")

--- a/RUFAS/output_manager.py
+++ b/RUFAS/output_manager.py
@@ -502,6 +502,7 @@ class OutputManager(object):
         overwrite_simulation_day: bool, default False
             Passed to ``add_variable()``. If ``True``, any ``simulation_day`` value provided in the ``info_maps`` is
             overwritten.
+
         """
         for variable, info_map in variables:
             name, value = list(variable.items())[0]
@@ -1371,12 +1372,10 @@ class OutputManager(object):
         Returns
         -------
         tuple[list[dict[str, str|int]], str | None]
-            1. list[dict[str, str|int]]
-                A list of dictionaries, each containing the loaded filter content, with keys and values depending on the
-                file type.
-            2. str | None
-                A string representing the output CSV direction, either "portrait" or "landscape". If no direction is
-                specified, ``None`` is returned.
+            - A list of dictionaries, each containing the loaded filter content, with keys and values depending on the
+            file type.
+            - A string representing the output CSV direction, either "portrait" or "landscape". If no direction is
+            specified, ``None`` is returned.
 
         Raises
         ------
@@ -2260,6 +2259,7 @@ class OutputManager(object):
             An iterable of pool descriptors. Each descriptor must provide a pool name and the
             path to the JSON file containing the pool to load. When dicts are provided they
             must include ``"name"`` and ``"path"`` keys.
+
         """
         info_map_base = {
             "class": self.__class__.__name__,
@@ -2376,12 +2376,10 @@ class OutputManager(object):
         Returns
         -------
         tuple[int, int, int]
-            1. int
-                Total number of errors in the ``OutputManager``'s errors pool.
-            2. int
-                Total number of warnings in the ``OutputManager``'s warnings pool.
-            3. int
-                Total number of logs in the ``OutputManager``'s logs pool.
+            - Total number of errors in the ``OutputManager``'s errors pool.
+            - Total number of warnings in the ``OutputManager``'s warnings pool.
+            - Total number of logs in the ``OutputManager``'s logs pool.
+
         """
 
         errors_count = sum([len(value_dict["values"]) for value_dict in self.errors_pool.values()])

--- a/RUFAS/report_generator.py
+++ b/RUFAS/report_generator.py
@@ -318,7 +318,7 @@ class ReportGenerator:
                     ``horizontal_first`` key in the filter content.
                 - If only horizontal aggregation is specified, the returned dictionary will have one key ``hor_agg``.
                 - If only vertical aggregation is specified, the returned dictionary will have one key ``ver_agg``.
-            - The event logs
+            - The event logs.
             - A boolean indicating whether the report data has been aggregated.
 
         Raises
@@ -387,10 +387,9 @@ class ReportGenerator:
         Returns
         -------
         tuple[dict[str, dict[str, list[Any]]] | dict[str, list[Any]], list[dict[str, str | dict[str, str]]]]
-            1. dict[str, dict[str, list[Any]]] | dict[str, list[Any]]
-                The aggregated data.
-            2. list[dict[str, str | dict[str, str]]]
-                The logs to be passed to ``OutputManager``.
+            - The aggregated data.
+            - The logs to be passed to ``OutputManager``.
+
         """
         aggregate_report: dict[str, dict[str, list[Any]]] | dict[str, list[Any]] = report_data
         event_logs: list[dict[str, str | dict[str, str]]] = []
@@ -499,15 +498,14 @@ class ReportGenerator:
         Returns
         -------
         tuple[str | Any, dict[str, str | dict[str, str]]]
-            1. str | Any
-                The expected units of aggregating the report data using the accompanying aggregator function.
-            2. dict[str, str | dict[str, str]]
-                The event logs.
+            - The expected units of aggregating the report data using the accompanying aggregator function.
+            - The event logs.
 
         Raises
         ------
         ValueError
             If there is an error extracting units from the report data.
+
         """
         event_log: dict[str, str | dict[str, str]] = {}
         if len(report_data) == 0:
@@ -570,12 +568,10 @@ class ReportGenerator:
         Returns
         -------
         tuple[dict[str, int], dict[str, int], dict[str, str | dict[str, str]]]
-            1. dict[str, int]
-                Combined numerator units.
-            2. dict[str, int]
-                Combined denominator units.
-            3. dict[str, str | dict[str, str]]
-                The event logs.
+            - Combined numerator units.
+            - Combined denominator units.
+            - The event logs.
+
         """
         info_map: dict[str, str] = {
             "class": ReportGenerator.__class__.__name__,
@@ -630,10 +626,9 @@ class ReportGenerator:
         Returns
         -------
         tuple[dict[str, list[Any]], list[dict[str, str | dict[str, str]]]]
-            1. dict[str, list[Any]]
-                The aggregated report data.
-            2. list[dict[str, str | dict[str, str]]]
-                The event logs.
+            - The aggregated report data.
+            - The event logs.
+
         """
 
         horizontal_first = self._get_horizontal_first_value(filter_content)
@@ -692,10 +687,9 @@ class ReportGenerator:
         Returns
         -------
         tuple[str | None, str | None]
-            1. str | None
-                The extracted horizontal aggregation key, or None if not specified.
-            2. str | None
-                The extracted vertical aggregation key, or None if not specified.
+            - The extracted horizontal aggregation key, or None if not specified.
+            - The extracted vertical aggregation key, or None if not specified.
+
         """
 
         horizontal_agg_key = filter_content.get("horizontal_aggregation")
@@ -727,17 +721,15 @@ class ReportGenerator:
         Returns
         -------
         tuple[list[float], str, list[dict[str, str | dict[str, str]]]]
-            1. list[float]
-                The aggregated data.
-            2. str
-                The aggregated units.
-            3. list[dict[str, str | dict[str, str]]]
-                The event logs.
+            - The aggregated data.
+            - The aggregated units.
+            - The event logs.
 
         Raises
         ------
         ValueError
             If the data to be aggregated has different lengths.
+
         """
 
         lengths = [len(report_data[key]) for key in report_data if any(loop_key in key for loop_key in loop_list)]
@@ -782,10 +774,9 @@ class ReportGenerator:
         Returns
         -------
         tuple[dict[str, list[float | None]], list[dict[str, str | dict[str, str]]]]
-            1. dict[str, list[float | None]]
-                The aggregated data.
-            2. list[dict[str, str | dict[str, str]]]
-                The event logs.
+            - The aggregated data.
+            - The event logs.
+
         """
 
         aggregated_data: dict[str, list[float | None]] = {}
@@ -818,10 +809,9 @@ class ReportGenerator:
         Returns
         -------
         tuple[float | None, dict[str, str | dict[str, str]]]
-            1. float | None
-                The aggregated data. If the data is empty, returns None.
-            2. dict[str, str | dict[str, str]]
-                The event logs. An error is logged if the data contains any values that cannot be aggregated.
+            - The aggregated data. If the data is empty, returns None.
+            - The event logs. An error is logged if the data contains any values that cannot be aggregated.
+
         """
         aggregated_data = None
         info_map: dict[str, str] = {
@@ -916,10 +906,9 @@ class ReportGenerator:
         Returns
         -------
         tuple[dict[str, int | float], list[dict[str, str | dict[str, str]]]]
-            1. dict[str, int | float]
-                The updated constants configuration.
-            2. list[dict[str, str | dict[str, str]]]
-                The event logs.
+            - The updated constants configuration.
+            - The event logs.
+
         """
         updated_constants_config: dict[str, int | float] = {}
         event_logs: list[dict[str, str | dict[str, str]]] = []

--- a/RUFAS/report_generator.py
+++ b/RUFAS/report_generator.py
@@ -311,18 +311,15 @@ class ReportGenerator:
         Returns
         -------
         tuple[dict[str, dict[str, list[Any]]] | dict[str, list[Any]], list[dict[str, str | dict[str, str]]], bool]
-            1. dict[str, dict[str, list[Any]]] | dict[str, list[Any]]
-                The aggregated report data.
+            - The aggregated report data.
                 - If no aggregation is specified, all the columns will be returned.
                 - If both horizontal and vertical aggregations are specified, the returned dictionary will have one key
                     that is either ``hor_ver_agg`` or ``ver_hor_agg`` depending on the value of the
                     ``horizontal_first`` key in the filter content.
                 - If only horizontal aggregation is specified, the returned dictionary will have one key ``hor_agg``.
                 - If only vertical aggregation is specified, the returned dictionary will have one key ``ver_agg``.
-            2. list[dict[str, str | dict[str, str]]]
-                The event logs
-            3. bool
-                A boolean indicating whether the report data has been aggregated.
+            - The event logs
+            - A boolean indicating whether the report data has been aggregated.
 
         Raises
         ------

--- a/RUFAS/simulation_engine.py
+++ b/RUFAS/simulation_engine.py
@@ -580,10 +580,10 @@ class SimulationEngine:
         Returns
         -------
         tuple[dict[str, ManureStream] | None, dict[str, float]]
-            A tuple containing:
             - A dictionary mapping pens to their corresponding ManureStream objects generated
               from the daily routines. If animals are not being simulated, this will be None.
             - A dictionary mapping feed types to the amount of purchased feed fed to the herd.
+
         """
         all_manure_data = self.herd_manager.execute_daily_routines(
             self.available_feeds,

--- a/RUFAS/task_manager.py
+++ b/RUFAS/task_manager.py
@@ -388,10 +388,9 @@ class TaskManager:
         Returns
         -------
         tuple[list[dict[str, Any]], list[dict[str, Any]]]
-            1. list[dict[str, Any]]
-                Parsed single-run task arguments.
-            2. list[dict[str, Any]]
-                Parsed multi-run task arguments.
+            - Parsed single-run task arguments.
+            - Parsed multi-run task arguments.
+
         """
         parsed_single_run_args: list[dict[str, Any]] = []
         parsed_multi_run_args: list[dict[str, Any]] = []

--- a/RUFAS/units.py
+++ b/RUFAS/units.py
@@ -140,10 +140,9 @@ class MeasurementUnits(Enum):
         Returns
         -------
         tuple[dict[str, int], dict[str, int]]
-            1. dict[str, int]
-                Numerator units, mapping unit names to exponents.
-            2. dict[str, int]
-                Denominator units. Empty dict if no denominator or no units are found.
+            - Numerator units, mapping unit names to exponents.
+            - Denominator units. Empty dict if no denominator or no units are found.
+
         """
         match = re.search(r"\((.*?)\)", key)
         if match:
@@ -201,11 +200,9 @@ class MeasurementUnits(Enum):
         Returns
         -------
         tuple[dict[str, int], dict[str, int]]
-            A tuple containing two dictionaries:
-            1. dict[str, int]
-                The simplified numerator units with non-zero exponents.
-            2. dict[str, int]
-                The the simplified denominator units with non-zero exponents.
+            - The simplified numerator units with non-zero exponents.
+            - The the simplified denominator units with non-zero exponents.
+
         """
         combined_numerator = numerator.copy()
         combined_denominator = denominator.copy()

--- a/RUFAS/util.py
+++ b/RUFAS/util.py
@@ -197,10 +197,8 @@ class Utility:
         Returns
         -------
         tuple[dict[str, dict[str, list[Any]]], list[dict[str, str | dict[str, str]]]]
-            1. dict[str, dict[str, list[Any]]]
-                The expanded data.
-            2. list[dict[str, str | dict[str, str]]]
-                The logs generated from the expansion process.
+            - The expanded data.
+            - The logs generated from the expansion process.
 
         Raises
         ------
@@ -210,6 +208,7 @@ class Utility:
             If there is no data to be filled.
             If the number of ``info_map`` does not match the number of values for a variable.
             If a value for ``simulation_day`` is not present in every ``info_map``.
+
         """
         if not data_to_expand:
             raise ValueError("Data Expansion error: Cannot fill empty dataset.")
@@ -396,10 +395,8 @@ class Utility:
         Returns
         -------
         tuple[int, float]
-            1. int
-                Updated number of values.
-            2. float
-                Updated average.
+            - Updated number of values.
+            - Updated average.
 
         """
         new_num_values = num_values + 1
@@ -862,16 +859,15 @@ class Utility:
         Returns
         -------
         tuple[float, float]
-            1. float
-                The first random number.
-            2. float
-                The second random number.
+            - The first random number.
+            - The second random number.
 
         Raises
         ------
         ValueError
             If either standard deviation is non-positive, or if ``rho`` is
             outside the range ``[-1, 1]``.
+
         """
         if sigma_x <= 0 or sigma_y <= 0:
             raise ValueError("The standard deviations for a bivariate distribution must be positive.")

--- a/changelog.md
+++ b/changelog.md
@@ -106,6 +106,7 @@ v1.0.0
 - [3070](https://github.com/RuminantFarmSystems/RuFaS/pull/3070) - [minor change] [Config] [InputChange] [NoOutputChange] Removes the `random_seed` field from all 6 config input files and from 3 config input files in helpful_scripts.
 - [3087](https://github.com/RuminantFarmSystems/RuFaS/pull/3087) - [minor change] [SimulationEngine] [NoInputChange] [NoOutputChange] Extracts post-loop logic from `SimulationEngine.simulate()` into `_post_loop_processing()`, `_post_loop_reporting()`, and `_post_loop_logging()`.
 - [3049](https://github.com/RuminantFarmSystems/RuFaS/pull/3049) - [minor change] [Utility] [NoInputChange] [NoOutputChange] Updates docstrings across 9 utility files to NumPy-style format.
+- [3100](https://github.com/RuminantFarmSystems/RuFaS/pull/3100) - [minor change] [Maintenance] [NoInputChange] [NoOutputChange] Aligns formatting on docstrings for `tuple` returns.
 
 ### v1.0.0
 


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #3038

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Aligns all tuple return docstrings to the same format:

```python
tuple[thing1, thing2]
    - Thing1 description
    - Thing2 description
```

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
Looks better and easier and more consistent to understand.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
Findall for `-> tuple[` and then went into the docstrings where applicable.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
N/A no code changes.

### Input Changes
<!-- Provide a short summary describing input modifications. -->
<!-- Please include the things that are added, deleted, or modified. -->


### Output Changes
<!-- List all the output variable/function modifications with a short summary. -->
<!-- """- `Class.Function.VariableName`: description""" -->
- N/A

#### Filter
<!-- Provide a filter that can be used to handle the output changes. -->

```json

```
