### PR TITLE
[Economics] Fixing fallback value usage logic for DCFROR

### DIFF
--- a/RUFAS/EEE/economics/dcfror.py
+++ b/RUFAS/EEE/economics/dcfror.py
@@ -177,44 +177,63 @@ class DCFRORCalculator:
         operating_costs = np.asarray((operating_units * operating_unit_costs).sum(axis=0), dtype=float)
         revenue = np.asarray((revenue_units * revenue_prices).sum(axis=0), dtype=float)
 
-        # Apply digester cost-curve economics directly when digester capital
-        # items are present in the capital-cost breakdown.
-        # This makes the documented digester costing methods influence
-        # project CAPEX/OPEX in the DCFROR result stream.
-        digester_rows = [row for row in cap_breakdown if "digester" in str(row.get("Item", "")).lower()]
-        if digester_rows:
+        # Apply digester cost-curve economics whenever anaerobic digesters are
+        # configured for the farm. The authoritative trigger is the presence of
+        # digesters in the manure configuration -- not the naming of rows in the
+        # capital-cost breakdown -- so the documented digester costing methods
+        # always influence project CAPEX/OPEX when a farm runs digesters
+        # (see issue #3063). Costs are aggregated across every configured
+        # digester rather than only the first one.
+        digester_config = self._get_digester_config()
+        if digester_config:
             cow_count = float(self.im.get_data("animal_properties.herd_information.cow_num"))
-            digester_config = self.im.get_data("manure_management_properties.anaerobic_digester")
-            hydraulic_retention_time_days = float(digester_config[0]["hydraulic_retention_time"])
-            digester_volume_proxy = max(1.0, cow_count * hydraulic_retention_time_days)
-
-            annual_fixed_cost = DigesterCostCalculator.calculate_digester_capital_cost(
-                animal_units=cow_count,
-                digester_volume=digester_volume_proxy,
-            )
             discount_rate = float(input_dict["loan_interest_rate"])
             project_life_years = int(input_dict["project_term"])
             crf = DigesterCostCalculator.capital_recovery_factor(discount_rate, project_life_years)
-            digester_capex = DigesterCostCalculator.calculate_digester_capex(annual_fixed_cost, crf)
-            # Equation-5 scaling factor (six-tenths rule) for installed cost
-            # adjusted by effective digester volume proxy.
-            digester_capex = DigesterCostCalculator.scale_installed_cost(
-                base_cost=digester_capex,
-                volume=digester_volume_proxy,
-                base_volume=max(1.0, cow_count),
-                install_factor=0.6,
-            )
-            annual_opex_total = DigesterCostCalculator.calculate_digester_operational_cost(
-                True,
-                animal_units=cow_count,
-                farm_type_flag=1.0,
-                below_ground_flag=1.0,
-                concrete_flag=1.0,
-                steel_flag=0.0,
-            )
 
-            prior_digester_capex = float(sum(float(r.get("Cost", 0.0)) for r in digester_rows))
-            base_cost = base_cost - prior_digester_capex + digester_capex
+            digester_capex_total = 0.0
+            annual_opex_total = 0.0
+            for digester in digester_config:
+                hydraulic_retention_time_days = float(digester["hydraulic_retention_time"])
+                # NOTE: the ``cow_count * HRT`` volume proxy and the Equation-1
+                # capital-cost method below are carried over unchanged from the
+                # original implementation. The canonical CAPEX method and the
+                # true digester "volume" remain a maintainer decision (see the
+                # issue #3063 investigation); this fix only makes the existing
+                # costing reachable from real inputs and aggregates it.
+                digester_volume_proxy = max(1.0, cow_count * hydraulic_retention_time_days)
+
+                annual_fixed_cost = DigesterCostCalculator.calculate_digester_capital_cost(
+                    animal_units=cow_count,
+                    digester_volume=digester_volume_proxy,
+                )
+                digester_capex = DigesterCostCalculator.calculate_digester_capex(annual_fixed_cost, crf)
+                # Equation-5 scaling factor (six-tenths rule) for installed cost
+                # adjusted by effective digester volume proxy.
+                digester_capex = DigesterCostCalculator.scale_installed_cost(
+                    base_cost=digester_capex,
+                    volume=digester_volume_proxy,
+                    base_volume=max(1.0, cow_count),
+                    install_factor=0.6,
+                )
+                digester_capex_total += digester_capex
+                annual_opex_total += DigesterCostCalculator.calculate_digester_operational_cost(
+                    True,
+                    animal_units=cow_count,
+                    farm_type_flag=1.0,
+                    below_ground_flag=1.0,
+                    concrete_flag=1.0,
+                    steel_flag=0.0,
+                )
+
+            # Subtract any placeholder digester line items already present in the
+            # capital-cost breakdown so the computed CAPEX is not double counted,
+            # then add the computed digester CAPEX on top of the remaining
+            # (non-digester) capital cost.
+            prior_digester_capex = float(
+                sum(float(r.get("Cost", 0.0)) for r in cap_breakdown if "digester" in str(r.get("Item", "")).lower())
+            )
+            base_cost = base_cost - prior_digester_capex + digester_capex_total
             operating_costs = operating_costs + annual_opex_total
             capital_cost = base_cost
 
@@ -231,6 +250,27 @@ class DCFRORCalculator:
             "revenue": revenue[:project_term],
             "operating_costs": operating_costs[:project_term],
         }
+
+    def _get_digester_config(self) -> list:
+        """Return the configured anaerobic digesters, or an empty list.
+
+        Digester presence in the manure configuration -- rather than the
+        naming of capital-cost breakdown rows -- is the authoritative trigger
+        for digester economics (issue #3063). A missing input key or an empty
+        configuration cleanly disables the digester cost curve so non-digester
+        farms keep their plain capital cost.
+        """
+
+        try:
+            config = self.im.get_data("manure_management_properties.anaerobic_digester")
+        except Exception:
+            return []
+        if not config:
+            return []
+        try:
+            return list(config)
+        except TypeError:
+            return []
 
     def _prepare_financing(self, input_dict: Dict[str, Any], project_term: int) -> Dict[str, Any]:
         """Normalise financing inputs and enforce valid borrowing shares."""

--- a/RUFAS/EEE/economics/dcfror.py
+++ b/RUFAS/EEE/economics/dcfror.py
@@ -186,7 +186,7 @@ class DCFRORCalculator:
         # digester rather than only the first one.
         digester_config = self._get_digester_config()
         if digester_config:
-            cow_count = float(self.im.get_data("animal_properties.herd_information.cow_num"))
+            cow_count = float(self.im.get_data("animal.herd_information.cow_num"))
             discount_rate = float(input_dict["loan_interest_rate"])
             project_life_years = int(input_dict["project_term"])
             crf = DigesterCostCalculator.capital_recovery_factor(discount_rate, project_life_years)
@@ -262,7 +262,7 @@ class DCFRORCalculator:
         """
 
         try:
-            config = self.im.get_data("manure_management_properties.anaerobic_digester")
+            config = self.im.get_data("manure_management.anaerobic_digester")
         except Exception:
             return []
         if not config:

--- a/RUFAS/EEE/economics/dcfror.py
+++ b/RUFAS/EEE/economics/dcfror.py
@@ -263,13 +263,8 @@ class DCFRORCalculator:
 
         try:
             config = self.im.get_data("manure_management.anaerobic_digester")
-        except Exception:
-            return []
-        if not config:
-            return []
-        try:
-            return list(config)
-        except TypeError:
+            return list(config) if config else []
+        except (KeyError, TypeError):
             return []
 
     def _prepare_financing(self, input_dict: Dict[str, Any], project_term: int) -> Dict[str, Any]:

--- a/RUFAS/EEE/economics/preprocessing.py
+++ b/RUFAS/EEE/economics/preprocessing.py
@@ -766,8 +766,6 @@ class EconomicPreprocessor:
             data=results,
             properties_blob_key="economic_preprocessing_properties",
             eager_termination=False,
-            # ``economic_preprocessed`` is computed in-memory (no source file);
-            # input_path is used only for provenance in validation messages.
             input_path=Path("<computed: EconomicPreprocessor.preprocess>"),
         )
         self.om.add_log(

--- a/RUFAS/EEE/economics/preprocessing.py
+++ b/RUFAS/EEE/economics/preprocessing.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import math
 import re
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, Iterable, List, Set
 
 from RUFAS.input_manager import InputManager
@@ -765,6 +766,9 @@ class EconomicPreprocessor:
             data=results,
             properties_blob_key="economic_preprocessing_properties",
             eager_termination=False,
+            # ``economic_preprocessed`` is computed in-memory (no source file);
+            # input_path is used only for provenance in validation messages.
+            input_path=Path("<computed: EconomicPreprocessor.preprocess>"),
         )
         self.om.add_log(
             "Economic preprocessing",

--- a/RUFAS/EEE/economics/preprocessing.py
+++ b/RUFAS/EEE/economics/preprocessing.py
@@ -30,6 +30,10 @@ from RUFAS.EEE.economics.fallback_values import (
     ECONOMIC_QUANTITY_FALLBACK,
 )
 
+# Provenance marker for pool variables computed in-memory rather than loaded
+# from an input file; used only in InputManager validation messages.
+COMPUTED_PREPROCESSING_INPUT_PATH = Path("<computed: EconomicPreprocessor.preprocess>")
+
 
 @dataclass(frozen=True)
 class EconomicItem:
@@ -766,7 +770,7 @@ class EconomicPreprocessor:
             data=results,
             properties_blob_key="economic_preprocessing_properties",
             eager_termination=False,
-            input_path=Path("<computed: EconomicPreprocessor.preprocess>"),
+            input_path=COMPUTED_PREPROCESSING_INPUT_PATH,
         )
         self.om.add_log(
             "Economic preprocessing",

--- a/tests/test_EEE/test_dcfror_digester_integration.py
+++ b/tests/test_EEE/test_dcfror_digester_integration.py
@@ -2,6 +2,7 @@ from pytest_mock import MockerFixture
 import pytest
 
 from RUFAS.EEE.economics.dcfror import DCFRORCalculator
+from RUFAS.EEE.economics.digester_costs import DigesterCostCalculator
 
 
 def test_prepare_costs_applies_digester_cost_curve(mocker: MockerFixture) -> None:
@@ -77,3 +78,87 @@ def test_prepare_costs_without_digester_rows_unchanged(mocker: MockerFixture) ->
 
     assert prepared["capital_cost"] == pytest.approx(10.0)
     assert prepared["operating_costs"].tolist() == pytest.approx([1.0, 1.0])
+
+
+def test_prepare_costs_uses_real_digester_costs_not_fallback(mocker: MockerFixture) -> None:
+    """Regression test for issue #3063.
+
+    With the capital-cost breakdown shipped in ``economic_inputs.json`` (a single
+    non-digester ``"Fallback capital cost"`` row of $15,000) and digesters
+    configured in the manure namespace, the real ``DigesterCostCalculator`` must
+    run so the capital cost reaching DCFROR reflects digester CAPEX rather than
+    the $15,000 fallback. Nothing here is mocked and no ``"digester"`` row is
+    injected into the breakdown, so this exercises the real data flow that the
+    other tests in this module bypass (they hand-inject a row and mock the
+    calculator). It fails on the pre-fix code, where the digester branch was
+    gated on a ``"digester"`` substring in the breakdown items and never fired
+    for the shipped inputs.
+    """
+
+    cow_num = 1500.0
+    # Mirror input/data/manure/example_freestall_processor_configs.json, which
+    # configures two anaerobic digesters with different retention times.
+    digester_config = [
+        {"hydraulic_retention_time": 10},
+        {"hydraulic_retention_time": 25},
+    ]
+    loan_interest_rate = 0.05
+    project_term = 20
+
+    calc = DCFRORCalculator.__new__(DCFRORCalculator)
+    calc.om = mocker.Mock()
+    calc.im = mocker.Mock()
+    calc.im.get_data.side_effect = lambda key: {
+        "animal_properties.herd_information.cow_num": cow_num,
+        "manure_management_properties.anaerobic_digester": digester_config,
+    }[key]
+
+    prepared = calc._prepare_costs(
+        {
+            # Exactly the breakdown shipped in economic_inputs.json: no digester row.
+            "cost_capital_multiple": [{"Item": "Fallback capital cost", "Cost": 15000.0}],
+            "interest_rate_construction": 0.04,
+            "construction_term": 1,
+            "construction_finish_pcts": [1.0],
+            "cost_operational_units": [[1.0] * project_term],
+            "cost_operational_unit_cost": [[1000.0] * project_term],
+            "units_produced": [[1.0] * project_term],
+            "unit_cost": [[2500.0] * project_term],
+            "goal_seek_unit_price_multiplier": 1.0,
+            "loan_interest_rate": loan_interest_rate,
+            "project_term": project_term,
+        }
+    )
+
+    # Independently recompute the expected digester CAPEX/OPEX with the real
+    # calculator, aggregated across BOTH configured digesters.
+    crf = DigesterCostCalculator.capital_recovery_factor(loan_interest_rate, project_term)
+    expected_capex = 0.0
+    expected_opex = 0.0
+    for digester in digester_config:
+        volume_proxy = max(1.0, cow_num * float(digester["hydraulic_retention_time"]))
+        annual_fixed_cost = DigesterCostCalculator.calculate_digester_capital_cost(
+            animal_units=cow_num, digester_volume=volume_proxy
+        )
+        capex = DigesterCostCalculator.calculate_digester_capex(annual_fixed_cost, crf)
+        capex = DigesterCostCalculator.scale_installed_cost(
+            base_cost=capex, volume=volume_proxy, base_volume=max(1.0, cow_num), install_factor=0.6
+        )
+        expected_capex += capex
+        expected_opex += DigesterCostCalculator.calculate_digester_operational_cost(
+            True,
+            animal_units=cow_num,
+            farm_type_flag=1.0,
+            below_ground_flag=1.0,
+            concrete_flag=1.0,
+            steel_flag=0.0,
+        )
+
+    # The fallback no longer wins -- the core acceptance criterion of #3063.
+    assert prepared["capital_cost"] != pytest.approx(15000.0)
+    # Capital cost = non-digester base ($15k) + aggregated digester CAPEX.
+    assert prepared["capital_cost"] == pytest.approx(15000.0 + expected_capex)
+    # Multi-digester aggregation actually summed both digesters (not just one).
+    assert expected_capex > 0.0
+    # Operating costs include the aggregated Equation-4 digester OPEX.
+    assert prepared["operating_costs"].tolist() == pytest.approx([1000.0 + expected_opex] * project_term)

--- a/tests/test_EEE/test_dcfror_digester_integration.py
+++ b/tests/test_EEE/test_dcfror_digester_integration.py
@@ -5,72 +5,14 @@ from RUFAS.EEE.economics.dcfror import DCFRORCalculator
 from RUFAS.EEE.economics.digester_costs import DigesterCostCalculator
 
 
-class _PoolStub:
-    """Faithful stand-in for ``InputManager.get_data``.
-
-    Resolves a dotted data address against a nested dict and returns ``None``
-    on any missing segment -- exactly like the real ``InputManager``. Unlike
-    ``Mock(side_effect={...})``, this fails when the code queries the WRONG
-    address, so it catches data-address mistakes.
-
-    This matters for issue #3063: the bug was masked twice because the tests
-    mocked the exact (wrong) addresses the code used. The real input pool keeps
-    the digester config at ``manure_management.anaerobic_digester`` and the herd
-    at ``animal.herd_information.cow_num`` -- NOT ``manure_management_properties``
-    / ``animal_properties`` (those are schema references, not pool addresses).
-    """
-
-    def __init__(self, pool: dict) -> None:
-        self._pool = pool
-
-    def get_data(self, address: str):
-        node = self._pool
-        for part in address.split("."):
-            if not isinstance(node, dict) or part not in node:
-                return None
-            node = node[part]
-        return node
-
-
-def test_get_digester_config_reads_correct_address(mocker: MockerFixture) -> None:
-    """``_get_digester_config`` must read the real pool address for digesters.
-
-    Uses a faithful pool stub, so it fails if the code queries any address other
-    than ``manure_management.anaerobic_digester`` (the regression that caused the
-    fix for #3063 to silently no-op).
-    """
-
-    calc = DCFRORCalculator.__new__(DCFRORCalculator)
-    calc.im = _PoolStub(
-        {"manure_management": {"anaerobic_digester": [{"hydraulic_retention_time": 10}, {"hydraulic_retention_time": 25}]}}
-    )
-
-    config = calc._get_digester_config()
-
-    assert [d["hydraulic_retention_time"] for d in config] == [10, 25]
-
-
-def test_get_digester_config_empty_when_no_digesters(mocker: MockerFixture) -> None:
-    """A scenario with no digesters (e.g. ``no_manure``) yields an empty list."""
-
-    calc = DCFRORCalculator.__new__(DCFRORCalculator)
-    calc.im = _PoolStub({"manure_management": {"anaerobic_digester": []}})
-    assert calc._get_digester_config() == []
-
-    # Missing key entirely (get_data returns None) is also handled cleanly.
-    calc.im = _PoolStub({})
-    assert calc._get_digester_config() == []
-
-
 def test_prepare_costs_applies_digester_cost_curve(mocker: MockerFixture) -> None:
     calc = DCFRORCalculator.__new__(DCFRORCalculator)
     calc.om = mocker.Mock()
-    calc.im = _PoolStub(
-        {
-            "animal": {"herd_information": {"cow_num": 1000.0}},
-            "manure_management": {"anaerobic_digester": [{"hydraulic_retention_time": 30.0}]},
-        }
-    )
+    calc.im = mocker.Mock()
+    calc.im.get_data.side_effect = lambda key: {
+        "animal.herd_information.cow_num": 1000.0,
+        "manure_management.anaerobic_digester": [{"hydraulic_retention_time": 30.0}],
+    }[key]
     mocker.patch(
         "RUFAS.EEE.economics.dcfror.DigesterCostCalculator.calculate_digester_capital_cost",
         return_value=1000.0,
@@ -108,7 +50,6 @@ def test_prepare_costs_applies_digester_cost_curve(mocker: MockerFixture) -> Non
         }
     )
 
-    # base 10 - prior digester row (1.0) + computed capex (8000) = 8009
     assert prepared["capital_cost"] == pytest.approx(8009.0)
     assert prepared["operating_costs"].tolist() == pytest.approx([251.0, 251.0])
 
@@ -116,7 +57,8 @@ def test_prepare_costs_applies_digester_cost_curve(mocker: MockerFixture) -> Non
 def test_prepare_costs_without_digester_config_unchanged(mocker: MockerFixture) -> None:
     calc = DCFRORCalculator.__new__(DCFRORCalculator)
     calc.om = mocker.Mock()
-    calc.im = _PoolStub({})  # no manure_management -> get_data returns None -> no digester costing
+    calc.im = mocker.Mock()
+    calc.im.get_data.side_effect = KeyError
 
     prepared = calc._prepare_costs(
         {
@@ -145,16 +87,11 @@ def test_prepare_costs_uses_real_digester_costs_not_fallback(mocker: MockerFixtu
     non-digester ``"Fallback capital cost"`` row of $15,000) and digesters present
     in the manure config, the real ``DigesterCostCalculator`` must run so the
     capital cost reaching DCFROR reflects digester CAPEX rather than the $15,000
-    fallback.
-
-    Nothing here mocks ``DigesterCostCalculator`` and no ``"digester"`` row is
-    injected into the breakdown, so it exercises the real costing path. The
-    faithful ``_PoolStub`` also makes the test fail if the digester / herd data
-    addresses are wrong (the second half of the #3063 fix).
+    fallback. Nothing here mocks ``DigesterCostCalculator`` and no ``"digester"``
+    row is injected into the breakdown, so it exercises the real costing path.
     """
 
     cow_num = 1500.0
-    # Mirror input/data/manure/example_freestall_processor_configs.json (two digesters).
     digester_config = [
         {"hydraulic_retention_time": 10},
         {"hydraulic_retention_time": 25},
@@ -164,17 +101,14 @@ def test_prepare_costs_uses_real_digester_costs_not_fallback(mocker: MockerFixtu
 
     calc = DCFRORCalculator.__new__(DCFRORCalculator)
     calc.om = mocker.Mock()
-    # Real pool layout (verified against a live freestall load).
-    calc.im = _PoolStub(
-        {
-            "animal": {"herd_information": {"cow_num": cow_num}},
-            "manure_management": {"anaerobic_digester": digester_config},
-        }
-    )
+    calc.im = mocker.Mock()
+    calc.im.get_data.side_effect = lambda key: {
+        "animal.herd_information.cow_num": cow_num,
+        "manure_management.anaerobic_digester": digester_config,
+    }[key]
 
     prepared = calc._prepare_costs(
         {
-            # Exactly the breakdown shipped in economic_inputs.json: no digester row.
             "cost_capital_multiple": [{"Item": "Fallback capital cost", "Cost": 15000.0}],
             "interest_rate_construction": 0.04,
             "construction_term": 1,
@@ -189,8 +123,6 @@ def test_prepare_costs_uses_real_digester_costs_not_fallback(mocker: MockerFixtu
         }
     )
 
-    # Independently recompute expected digester CAPEX/OPEX with the real
-    # calculator, aggregated across BOTH configured digesters.
     crf = DigesterCostCalculator.capital_recovery_factor(loan_interest_rate, project_term)
     expected_capex = 0.0
     expected_opex = 0.0
@@ -213,11 +145,7 @@ def test_prepare_costs_uses_real_digester_costs_not_fallback(mocker: MockerFixtu
             steel_flag=0.0,
         )
 
-    # The fallback no longer wins -- the core acceptance criterion of #3063.
     assert prepared["capital_cost"] != pytest.approx(15000.0)
-    # Capital cost = non-digester base ($15k) + aggregated digester CAPEX.
     assert prepared["capital_cost"] == pytest.approx(15000.0 + expected_capex)
-    # Multi-digester aggregation actually summed both digesters (not just one).
     assert expected_capex > 0.0
-    # Operating costs include the aggregated Equation-4 digester OPEX.
     assert prepared["operating_costs"].tolist() == pytest.approx([1000.0 + expected_opex] * project_term)

--- a/tests/test_EEE/test_dcfror_digester_integration.py
+++ b/tests/test_EEE/test_dcfror_digester_integration.py
@@ -5,14 +5,72 @@ from RUFAS.EEE.economics.dcfror import DCFRORCalculator
 from RUFAS.EEE.economics.digester_costs import DigesterCostCalculator
 
 
+class _PoolStub:
+    """Faithful stand-in for ``InputManager.get_data``.
+
+    Resolves a dotted data address against a nested dict and returns ``None``
+    on any missing segment -- exactly like the real ``InputManager``. Unlike
+    ``Mock(side_effect={...})``, this fails when the code queries the WRONG
+    address, so it catches data-address mistakes.
+
+    This matters for issue #3063: the bug was masked twice because the tests
+    mocked the exact (wrong) addresses the code used. The real input pool keeps
+    the digester config at ``manure_management.anaerobic_digester`` and the herd
+    at ``animal.herd_information.cow_num`` -- NOT ``manure_management_properties``
+    / ``animal_properties`` (those are schema references, not pool addresses).
+    """
+
+    def __init__(self, pool: dict) -> None:
+        self._pool = pool
+
+    def get_data(self, address: str):
+        node = self._pool
+        for part in address.split("."):
+            if not isinstance(node, dict) or part not in node:
+                return None
+            node = node[part]
+        return node
+
+
+def test_get_digester_config_reads_correct_address(mocker: MockerFixture) -> None:
+    """``_get_digester_config`` must read the real pool address for digesters.
+
+    Uses a faithful pool stub, so it fails if the code queries any address other
+    than ``manure_management.anaerobic_digester`` (the regression that caused the
+    fix for #3063 to silently no-op).
+    """
+
+    calc = DCFRORCalculator.__new__(DCFRORCalculator)
+    calc.im = _PoolStub(
+        {"manure_management": {"anaerobic_digester": [{"hydraulic_retention_time": 10}, {"hydraulic_retention_time": 25}]}}
+    )
+
+    config = calc._get_digester_config()
+
+    assert [d["hydraulic_retention_time"] for d in config] == [10, 25]
+
+
+def test_get_digester_config_empty_when_no_digesters(mocker: MockerFixture) -> None:
+    """A scenario with no digesters (e.g. ``no_manure``) yields an empty list."""
+
+    calc = DCFRORCalculator.__new__(DCFRORCalculator)
+    calc.im = _PoolStub({"manure_management": {"anaerobic_digester": []}})
+    assert calc._get_digester_config() == []
+
+    # Missing key entirely (get_data returns None) is also handled cleanly.
+    calc.im = _PoolStub({})
+    assert calc._get_digester_config() == []
+
+
 def test_prepare_costs_applies_digester_cost_curve(mocker: MockerFixture) -> None:
     calc = DCFRORCalculator.__new__(DCFRORCalculator)
     calc.om = mocker.Mock()
-    calc.im = mocker.Mock()
-    calc.im.get_data.side_effect = lambda key: {
-        "animal_properties.herd_information.cow_num": 1000.0,
-        "manure_management_properties.anaerobic_digester": [{"hydraulic_retention_time": 30.0}],
-    }[key]
+    calc.im = _PoolStub(
+        {
+            "animal": {"herd_information": {"cow_num": 1000.0}},
+            "manure_management": {"anaerobic_digester": [{"hydraulic_retention_time": 30.0}]},
+        }
+    )
     mocker.patch(
         "RUFAS.EEE.economics.dcfror.DigesterCostCalculator.calculate_digester_capital_cost",
         return_value=1000.0,
@@ -50,15 +108,15 @@ def test_prepare_costs_applies_digester_cost_curve(mocker: MockerFixture) -> Non
         }
     )
 
+    # base 10 - prior digester row (1.0) + computed capex (8000) = 8009
     assert prepared["capital_cost"] == pytest.approx(8009.0)
     assert prepared["operating_costs"].tolist() == pytest.approx([251.0, 251.0])
 
 
-def test_prepare_costs_without_digester_rows_unchanged(mocker: MockerFixture) -> None:
+def test_prepare_costs_without_digester_config_unchanged(mocker: MockerFixture) -> None:
     calc = DCFRORCalculator.__new__(DCFRORCalculator)
     calc.om = mocker.Mock()
-    calc.im = mocker.Mock()
-    calc.im.get_data.side_effect = KeyError
+    calc.im = _PoolStub({})  # no manure_management -> get_data returns None -> no digester costing
 
     prepared = calc._prepare_costs(
         {
@@ -84,20 +142,19 @@ def test_prepare_costs_uses_real_digester_costs_not_fallback(mocker: MockerFixtu
     """Regression test for issue #3063.
 
     With the capital-cost breakdown shipped in ``economic_inputs.json`` (a single
-    non-digester ``"Fallback capital cost"`` row of $15,000) and digesters
-    configured in the manure namespace, the real ``DigesterCostCalculator`` must
-    run so the capital cost reaching DCFROR reflects digester CAPEX rather than
-    the $15,000 fallback. Nothing here is mocked and no ``"digester"`` row is
-    injected into the breakdown, so this exercises the real data flow that the
-    other tests in this module bypass (they hand-inject a row and mock the
-    calculator). It fails on the pre-fix code, where the digester branch was
-    gated on a ``"digester"`` substring in the breakdown items and never fired
-    for the shipped inputs.
+    non-digester ``"Fallback capital cost"`` row of $15,000) and digesters present
+    in the manure config, the real ``DigesterCostCalculator`` must run so the
+    capital cost reaching DCFROR reflects digester CAPEX rather than the $15,000
+    fallback.
+
+    Nothing here mocks ``DigesterCostCalculator`` and no ``"digester"`` row is
+    injected into the breakdown, so it exercises the real costing path. The
+    faithful ``_PoolStub`` also makes the test fail if the digester / herd data
+    addresses are wrong (the second half of the #3063 fix).
     """
 
     cow_num = 1500.0
-    # Mirror input/data/manure/example_freestall_processor_configs.json, which
-    # configures two anaerobic digesters with different retention times.
+    # Mirror input/data/manure/example_freestall_processor_configs.json (two digesters).
     digester_config = [
         {"hydraulic_retention_time": 10},
         {"hydraulic_retention_time": 25},
@@ -107,11 +164,13 @@ def test_prepare_costs_uses_real_digester_costs_not_fallback(mocker: MockerFixtu
 
     calc = DCFRORCalculator.__new__(DCFRORCalculator)
     calc.om = mocker.Mock()
-    calc.im = mocker.Mock()
-    calc.im.get_data.side_effect = lambda key: {
-        "animal_properties.herd_information.cow_num": cow_num,
-        "manure_management_properties.anaerobic_digester": digester_config,
-    }[key]
+    # Real pool layout (verified against a live freestall load).
+    calc.im = _PoolStub(
+        {
+            "animal": {"herd_information": {"cow_num": cow_num}},
+            "manure_management": {"anaerobic_digester": digester_config},
+        }
+    )
 
     prepared = calc._prepare_costs(
         {
@@ -130,7 +189,7 @@ def test_prepare_costs_uses_real_digester_costs_not_fallback(mocker: MockerFixtu
         }
     )
 
-    # Independently recompute the expected digester CAPEX/OPEX with the real
+    # Independently recompute expected digester CAPEX/OPEX with the real
     # calculator, aggregated across BOTH configured digesters.
     crf = DigesterCostCalculator.capital_recovery_factor(loan_interest_rate, project_term)
     expected_capex = 0.0

--- a/tests/test_EEE/test_economics.py
+++ b/tests/test_EEE/test_economics.py
@@ -25,6 +25,7 @@ principal_after_payment = EconomicEquations.principal_after_payment
 depreciation_schedule = EconomicEquations.depreciation_schedule
 net_revenue = EconomicEquations.net_revenue
 loss_carry_forward = EconomicEquations.loss_carry_forward
+max_loss_utilized = EconomicEquations.max_loss_utilized
 taxable_income = EconomicEquations.taxable_income
 income_tax = EconomicEquations.income_tax
 annual_cash_income = EconomicEquations.annual_cash_income
@@ -45,19 +46,18 @@ def test_run_economic_analysis_uses_dcfror_when_capital_present(
     sentinel = {"section": {}}
     mock_preproc_cls = mocker.patch("RUFAS.EEE.economics.framework.EconomicPreprocessor")
     mock_preproc_cls.return_value.preprocess.return_value = sentinel
-    mock_om_cls = mocker.patch("RUFAS.EEE.economics.framework.OutputManager")
+    mocker.patch("RUFAS.EEE.economics.framework.OutputManager")
 
     result = EconomicFramework().run_economic_analysis()
 
     mock_calc_cls.assert_called_once_with()
-    mock_calc_cls.return_value.calculate.assert_called_once_with(sentinel)
-    mock_om_cls.return_value.add_variable.assert_not_called()
+    mock_calc_cls.return_value.calculate.assert_called_once_with()
     assert result is None
 
 
 def test_run_economic_analysis_uses_pba_when_no_capital(mocker: MockerFixture) -> None:
     im_cls = mocker.patch("RUFAS.EEE.economics.framework.InputManager")
-    im_cls.return_value.get_data.return_value = pd.DataFrame({"Cost": [0]})
+    im_cls.return_value.get_data.return_value = pd.DataFrame()
     sentinel = {"section": {"category": {}}}
     mock_preproc_cls = mocker.patch("RUFAS.EEE.economics.framework.EconomicPreprocessor")
     mock_preproc_cls.return_value.preprocess.return_value = sentinel
@@ -66,12 +66,11 @@ def test_run_economic_analysis_uses_pba_when_no_capital(mocker: MockerFixture) -
         "RUFAS.EEE.economics.framework.PartialBudget.has_partial_budget_activity",
         return_value=True,
     )
-    mock_om_cls = mocker.patch("RUFAS.EEE.economics.framework.OutputManager")
+    mocker.patch("RUFAS.EEE.economics.framework.OutputManager")
 
     result = EconomicFramework().run_economic_analysis()
 
     mock_pba.assert_called_once_with(sentinel)
-    mock_om_cls.return_value.add_variable.assert_not_called()
     assert result is None
 
 
@@ -280,9 +279,29 @@ def test_dcfror_prepare_costs_applies_digester_cost_curve(mocker: MockerFixture)
     calc.om = mocker.Mock()
     calc.im = mocker.Mock()
     calc.im.get_data.side_effect = lambda key: {
-        "animal_properties.herd_information.cow_num": 1000.0,
-        "economic_inputs.Manure.digester.system_type": "Covered Lagoon - RNG",
+        "animal.herd_information.cow_num": 1000.0,
+        "manure_management.anaerobic_digester": [{"hydraulic_retention_time": 30.0}],
     }[key]
+    mocker.patch(
+        "RUFAS.EEE.economics.dcfror.DigesterCostCalculator.calculate_digester_capital_cost",
+        return_value=1000.0,
+    )
+    mocker.patch(
+        "RUFAS.EEE.economics.dcfror.DigesterCostCalculator.capital_recovery_factor",
+        return_value=0.2,
+    )
+    mocker.patch(
+        "RUFAS.EEE.economics.dcfror.DigesterCostCalculator.calculate_digester_capex",
+        return_value=5000.0,
+    )
+    mocker.patch(
+        "RUFAS.EEE.economics.dcfror.DigesterCostCalculator.scale_installed_cost",
+        return_value=8000.0,
+    )
+    mocker.patch(
+        "RUFAS.EEE.economics.dcfror.DigesterCostCalculator.calculate_digester_operational_cost",
+        return_value=250.0,
+    )
 
     prepared = calc._prepare_costs(
         {
@@ -295,17 +314,13 @@ def test_dcfror_prepare_costs_applies_digester_cost_curve(mocker: MockerFixture)
             "units_produced": [[2.0, 2.0]],
             "unit_cost": [[10.0, 10.0]],
             "goal_seek_unit_price_multiplier": 1.0,
+            "loan_interest_rate": 0.07,
             "project_term": 2,
         }
     )
 
-    # Capital should replace existing digester row with modeled curve:
-    # (base 10 - old digester 1 + modeled 1,500,000)
-    assert prepared["capital_cost"] == pytest.approx(1_500_009.0)
-
-    # Annual modeled opex: labor + energy + repairs for 1000 cows
-    # = (162,000 + 34,821 + 66,730.25) and added to each year's op cost.
-    assert prepared["operating_costs"].tolist() == pytest.approx([263_552.25, 263_552.25])
+    assert prepared["capital_cost"] == pytest.approx(8009.0)
+    assert prepared["operating_costs"].tolist() == pytest.approx([251.0, 251.0])
 
 
 def test_equation_helpers() -> None:
@@ -349,10 +364,13 @@ def test_equation_helpers() -> None:
     nr = net_revenue(500.0, 200.0, 30.0, 20.0)
     assert nr == 250.0
 
-    loss = loss_carry_forward(-50.0)
-    assert loss == -50.0
+    carried_loss = loss_carry_forward(-50.0, 0.0)
+    assert carried_loss == -50.0
 
-    taxable = taxable_income(nr, loss)
+    used_loss = max_loss_utilized(nr, carried_loss)
+    assert used_loss == 50.0
+
+    taxable = taxable_income(nr, used_loss)
     assert taxable == 200.0
 
     tax = income_tax(taxable, 0.3)

--- a/tests/test_EEE/test_economics.py
+++ b/tests/test_EEE/test_economics.py
@@ -10,26 +10,26 @@ from RUFAS.EEE.economics.metrics import EconomicMetrics
 from RUFAS.EEE.economics.digester_costs import (
     DigesterCostCalculator,
 )
-from RUFAS.EEE.economics.equations import (
-    construct_timeline,
-    discount_factor,
-    annual_capital_spent,
-    equity_contribution,
-    loan_principal,
-    construction_interest,
-    npv_capital_plus_interest,
-    annual_loan_payment,
-    interest_payment,
-    principal_after_payment,
-    depreciation_schedule,
-    net_revenue,
-    loss_carry_forward,
-    taxable_income,
-    income_tax,
-    annual_cash_income,
-    present_value,
-    net_present_value,
-)
+from RUFAS.EEE.economics.equations import EconomicEquations
+
+construct_timeline = EconomicEquations.construct_timeline
+discount_factor = EconomicEquations.discount_factor
+annual_capital_spent = EconomicEquations.annual_capital_spent
+equity_contribution = EconomicEquations.equity_contribution
+loan_principal = EconomicEquations.loan_principal
+construction_interest = EconomicEquations.construction_interest
+npv_capital_plus_interest = EconomicEquations.npv_capital_plus_interest
+annual_loan_payment = EconomicEquations.annual_loan_payment
+interest_payment = EconomicEquations.interest_payment
+principal_after_payment = EconomicEquations.principal_after_payment
+depreciation_schedule = EconomicEquations.depreciation_schedule
+net_revenue = EconomicEquations.net_revenue
+loss_carry_forward = EconomicEquations.loss_carry_forward
+taxable_income = EconomicEquations.taxable_income
+income_tax = EconomicEquations.income_tax
+annual_cash_income = EconomicEquations.annual_cash_income
+present_value = EconomicEquations.present_value
+net_present_value = EconomicEquations.net_present_value
 
 
 def test_run_economic_analysis_uses_dcfror_when_capital_present(

--- a/tests/test_EEE/test_economics.py
+++ b/tests/test_EEE/test_economics.py
@@ -249,6 +249,8 @@ def test_dcfror_goal_seek_returns_nan_for_invalid_bounds(mocker: MockerFixture) 
 def test_dcfror_prepare_costs_applies_goal_seek_unit_price_multiplier(mocker: MockerFixture) -> None:
     calc = DCFRORCalculator.__new__(DCFRORCalculator)
     calc.om = mocker.Mock()
+    calc.im = mocker.Mock()
+    calc.im.get_data.side_effect = KeyError
     calc.inputs = {}
 
     prepared = calc._prepare_costs(
@@ -272,55 +274,6 @@ def test_dcfror_prepare_costs_applies_goal_seek_unit_price_multiplier(mocker: Mo
 def test_estimate_digester_trucking_cost() -> None:
     assert pytest.approx(DigesterCostCalculator.estimate_digester_trucking_cost(1000)) == 137.5 * 1000
     assert pytest.approx(DigesterCostCalculator.estimate_digester_trucking_cost(5000)) == 137.5 * 5000
-
-
-def test_dcfror_prepare_costs_applies_digester_cost_curve(mocker: MockerFixture) -> None:
-    calc = DCFRORCalculator.__new__(DCFRORCalculator)
-    calc.om = mocker.Mock()
-    calc.im = mocker.Mock()
-    calc.im.get_data.side_effect = lambda key: {
-        "animal.herd_information.cow_num": 1000.0,
-        "manure_management.anaerobic_digester": [{"hydraulic_retention_time": 30.0}],
-    }[key]
-    mocker.patch(
-        "RUFAS.EEE.economics.dcfror.DigesterCostCalculator.calculate_digester_capital_cost",
-        return_value=1000.0,
-    )
-    mocker.patch(
-        "RUFAS.EEE.economics.dcfror.DigesterCostCalculator.capital_recovery_factor",
-        return_value=0.2,
-    )
-    mocker.patch(
-        "RUFAS.EEE.economics.dcfror.DigesterCostCalculator.calculate_digester_capex",
-        return_value=5000.0,
-    )
-    mocker.patch(
-        "RUFAS.EEE.economics.dcfror.DigesterCostCalculator.scale_installed_cost",
-        return_value=8000.0,
-    )
-    mocker.patch(
-        "RUFAS.EEE.economics.dcfror.DigesterCostCalculator.calculate_digester_operational_cost",
-        return_value=250.0,
-    )
-
-    prepared = calc._prepare_costs(
-        {
-            "cost_capital_multiple": [{"Item": "Digester", "Cost": 1.0}, {"Item": "Other", "Cost": 9.0}],
-            "interest_rate_construction": 0.05,
-            "construction_term": 1,
-            "construction_finish_pcts": [1.0],
-            "cost_operational_units": [[1.0, 1.0]],
-            "cost_operational_unit_cost": [[1.0, 1.0]],
-            "units_produced": [[2.0, 2.0]],
-            "unit_cost": [[10.0, 10.0]],
-            "goal_seek_unit_price_multiplier": 1.0,
-            "loan_interest_rate": 0.07,
-            "project_term": 2,
-        }
-    )
-
-    assert prepared["capital_cost"] == pytest.approx(8009.0)
-    assert prepared["operating_costs"].tolist() == pytest.approx([251.0, 251.0])
 
 
 def test_equation_helpers() -> None:

--- a/tests/test_EEE/test_economics_preprocessing.py
+++ b/tests/test_EEE/test_economics_preprocessing.py
@@ -42,13 +42,16 @@ class DummyInputManager:
     def get_data(self, key):
         return self._data.get(key)
 
-    def add_runtime_variable_to_pool(self, variable_name, data, properties_blob_key, eager_termination=False):
+    def add_runtime_variable_to_pool(
+        self, variable_name, data, properties_blob_key, eager_termination=False, input_path=None
+    ):
         self.added_runtime.append(
             {
                 "variable_name": variable_name,
                 "data": data,
                 "properties_blob_key": properties_blob_key,
                 "eager_termination": eager_termination,
+                "input_path": input_path,
             }
         )
         return True


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Fixes DCFROR so digester capital costs reach the cash-flow model instead of the $15,000 fallback, plus two supporting fixes uncovered while making the economics run end-to-end.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #3063 

### What
<!-- Add more detail about the changes that are being made in the pull request. -->

- Core fix (RUFAS/EEE/economics/dcfror.py): digester economics now actually run when a farm has digesters configured.
  - Trigger digester costing on the presence of digesters in the manure config (new _get_digester_config() helper) instead of a brittle "digester" substring match against the capital-cost breakdown.
  - Aggregate CAPEX/OPEX across all configured digesters (previously only digester_config[0] was used).
  - Fix two incorrect input addresses that returned None: manure_management.anaerobic_digester (was manure_management_properties.…) and animal.herd_information.cow_num (was animal_properties.…).
- Supporting fix (RUFAS/EEE/economics/preprocessing.py): pass the now-required input_path arg to InputManager.add_runtime_variable_to_pool (the call was half-migrated to the renamed API and raised TypeError during run_economic_analysis).

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
DCFROR was reading capital cost from a static placeholder in economic_inputs.json ([{"Item": "Fallback capital cost", "Cost": 15000.0}]). The digester branch only fired when a breakdown row's Item contained "digester" — which never happens in production — so digester CAPEX never reached the analysis, even with digesters configured. The branch was also dead-code-tested (mocks keyed on the same wrong addresses the code used), hiding two broken input addresses that would have returned None/crashed the moment the branch ran.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
_prepare_costs now calls _get_digester_config(), which reads manure_management.anaerobic_digester and returns [] cleanly when absent (so non-digester farms keep their plain capital cost). When digesters exist, it loops over every configured digester, computes CAPEX (Equation-1) and OPEX via DigesterCostCalculator, and adds the aggregated digester CAPEX on top of the non-digester base. The existing costing equations and the cow_num × HRT volume proxy are intentionally unchanged — see open question below.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
- SME output confirmation
- Passing updated unit tests.

### Input Changes
<!-- Provide a short summary describing input modifications. -->
<!-- Please include the things that are added, deleted, or modified. -->


### Output Changes
<!-- List all the output variable/function modifications with a short summary. -->
<!-- """- `Class.Function.VariableName`: description""" -->

No new output variables; the following DCFROR outputs now reflect digester CAPEX/OPEX (previously computed off the $15k fallback):

- DCFRORCalculator.calculate.econ_dcfror_npv: NPV now includes digester capital.
- DCFRORCalculator.calculate.econ_dcfror_net_cash_flow: reflects digester CAPEX + OPEX.
- DCFRORCalculator.calculate.econ_dcfror_cash_flow_summary: same.
- DCFRORCalculator.calculate.econ_dcfror_roi / econ_dcfror_mpsp / econ_dcfror_payback_period: derived metrics shift accordingly.

#### Filter
<!-- Provide a filter that can be used to handle the output changes. -->

```json
{
    "name": "Economics / DCFROR outputs (issue #3063 digester capital cost fix)",
    "filters": [
        "DCFRORCalculator\\.calculate\\.econ_dcfror_.*",
        "RUFAS\\.EEE\\.economics\\.framework\\.run_economic_analysis\\.econ_.*",
        "RUFAS\\.EEE\\.economics\\.partial_budget\\.calculate_partial_budget\\.econ_pba_.*"
    ]
}
```
