### PR TITLE
[Bug][FeedStorage][Hay] Hay dm bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,13 @@ output/output_filters/*
 *.vscode
 *.settings
 .idea/**
-env/
+
+# Virtual environments
+.venv/
+.venv*/
 venv/
+env/
+ENV/
 
 # ignore build files
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -44,13 +44,8 @@ output/output_filters/*
 *.vscode
 *.settings
 .idea/**
-
-# Virtual environments
-.venv/
-.venv*/
-venv/
 env/
-ENV/
+venv/
 
 # ignore build files
 dist/

--- a/RUFAS/biophysical/feed_storage/hay.py
+++ b/RUFAS/biophysical/feed_storage/hay.py
@@ -156,7 +156,22 @@ class Hay(Storage):
 
         additional_loss = self._calculate_additional_dry_matter_loss(crop, weather_conditions)
 
-        return current_loss - processed_loss + additional_loss
+        raw_loss = current_loss - processed_loss + additional_loss
+        if raw_loss > crop.dry_matter_mass:
+            self.om.add_warning(
+                "Hay dry matter loss capped",
+                (
+                    f"Calculated dry matter loss ({raw_loss:.2f} kg) exceeded the remaining dry matter "
+                    f"({crop.dry_matter_mass:.2f} kg) for crop '{crop.config_name}' in field "
+                    f"'{crop.field_name}'. Capping loss to the remaining dry matter."
+                ),
+                info_map={
+                    "class": self.__class__.__name__,
+                    "function": self.calculate_dry_matter_loss_to_gas.__name__,
+                },
+            )
+
+        return min(crop.dry_matter_mass, max(0.0, raw_loss))
 
     def _calculate_initial_dry_matter_loss_to_gas(self, crop: HarvestedCrop, time: date) -> float:
         """
@@ -193,7 +208,11 @@ class Hay(Storage):
             14206 - 2433 * FINAL_MOISTURE_PERCENTAGE / (1 - FINAL_MOISTURE_PERCENTAGE)
         )
 
-        fraction_of_initial_dry_matter_lost = numerator / denominator * fraction_of_total_loss
+        fraction_of_initial_dry_matter_lost = (
+            numerator / denominator * fraction_of_total_loss
+            if denominator > 0.0
+            else 0
+        )
         return crop.initial_dry_matter_mass * fraction_of_initial_dry_matter_lost
 
     def _calculate_subsequent_dry_matter_loss_to_gas(self, crop: HarvestedCrop, time: date) -> float:

--- a/RUFAS/biophysical/feed_storage/storage.py
+++ b/RUFAS/biophysical/feed_storage/storage.py
@@ -827,7 +827,7 @@ class Storage:
         division by zero error.
 
         """
-        dry_matter_loss_fraction = dry_matter_loss / initial_dry_matter
+        dry_matter_loss_fraction = dry_matter_loss / initial_dry_matter if initial_dry_matter > 0.0 else 0.0
         initial_nutrient_fraction = initial_nutrient_percentage * GeneralConstants.PERCENTAGE_TO_FRACTION
 
         if dry_matter_loss_fraction == 1.0:

--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@ v1.0.0
 - [2998](https://github.com/RuminantFarmSystems/RuFaS/pull/2998) - [minor change] [NoInputChange] [OutputChange] Moved changelog entries to reflect what was in v1.0. Brought changes in 2994 and 2997 into one branch.
 - [3020](https://github.com/RuminantFarmSystems/RuFaS/pull/3020) - [minor change] [NoInputChange] [OutputChange] Corrected manure application ammonia composition calculation
 - [3091](https://github.com/RuminantFarmSystems/RuFaS/pull/3091) - [minor change] [InputChange] [OutputChange] Fixes large seedbed conditioner entry in `tractor_dataset.csv` input.
+- [3130](https://github.com/RuminantFarmSystems/RuFaS/pull/3020) - [minor change] [NoInputChange] [NoOutputChange] Fixes bug where stored Hay was projected to have negative dm.
   
 ### v1.0.0
 

--- a/tests/test_biophysical/test_feed_storage/test_hay.py
+++ b/tests/test_biophysical/test_feed_storage/test_hay.py
@@ -139,33 +139,87 @@ def test_project_degradations(
     project_degradations.assert_called_once_with(crops_with_moisture_loss, weather, time)
 
 
-@pytest.mark.parametrize("stored_day,current_day,expect_loss", [(1, 1, False), (1, 10, True)])
-def test_calculate_dry_matter_loss_to_gas(
+def test_calculate_dry_matter_loss_to_gas_caps_loss_and_warns(
     hay: Hay,
     harvested_crop: HarvestedCrop,
     time: RufasTime,
     mocker: MockerFixture,
-    stored_day: int,
-    current_day: int,
-    expect_loss: bool,
 ) -> None:
-    """Tests calculate_dry_matter_loss_to_gas in Hay."""
-    harvested_crop.storage_time = date(2024, 6, stored_day)
-    time.current_date = datetime(2024, 6, current_day)
-    mock_initial_loss = mocker.patch.object(hay, "_calculate_initial_dry_matter_loss_to_gas", side_effect=[10.0, 20.0])
-    mock_subsequent_loss = mocker.patch.object(
-        hay, "_calculate_subsequent_dry_matter_loss_to_gas", side_effect=[5.0, 10.0]
-    )
-    mock_additional_loss = mocker.patch.object(hay, "_calculate_additional_dry_matter_loss", return_value=3.0)
-    expected_loss = 18.0 if expect_loss else 0.0
-    expected_call_count = 2 if expect_loss else 0
+    """Tests that hay dry matter loss is capped and a warning is logged when raw loss exceeds available dry matter."""
+    harvested_crop.storage_time = date(2024, 6, 1)
+    harvested_crop.last_time_degraded = date(2024, 6, 1)
+    harvested_crop.dry_matter_mass = 12.0
+    harvested_crop.config_name = "test_hay"
+    harvested_crop.field_name = "test_field"
+    time.current_date = datetime(2024, 6, 10)
+
+    mocker.patch.object(hay, "_calculate_initial_dry_matter_loss_to_gas", side_effect=[0.0, 20.0])
+    mocker.patch.object(hay, "_calculate_subsequent_dry_matter_loss_to_gas", side_effect=[0.0, 10.0])
+    mocker.patch.object(hay, "_calculate_additional_dry_matter_loss", return_value=5.0)
+    mock_add_warning = mocker.patch.object(hay.om, "add_warning")
 
     actual = hay.calculate_dry_matter_loss_to_gas(harvested_crop, [], time)
 
-    assert actual == expected_loss
-    assert mock_initial_loss.call_count == expected_call_count
-    assert mock_subsequent_loss.call_count == expected_call_count
-    assert mock_additional_loss.call_count == (1 if expect_loss else 0)
+    assert actual == 12.0
+    mock_add_warning.assert_called_once_with(
+        "Hay dry matter loss capped",
+        (
+            "Calculated dry matter loss (35.00 kg) exceeded the remaining dry matter "
+            "(12.00 kg) for crop 'test_hay' in field "
+            "'test_field'. Capping loss to the remaining dry matter."
+        ),
+        info_map={
+            "class": hay.__class__.__name__,
+            "function": hay.calculate_dry_matter_loss_to_gas.__name__,
+        },
+    )
+
+
+def test_calculate_dry_matter_loss_to_gas_floors_negative_loss(
+    hay: Hay,
+    harvested_crop: HarvestedCrop,
+    time: RufasTime,
+    mocker: MockerFixture,
+) -> None:
+    """Tests that negative calculated hay dry matter loss is floored at zero."""
+    harvested_crop.storage_time = date(2024, 6, 1)
+    harvested_crop.last_time_degraded = date(2024, 6, 1)
+    harvested_crop.dry_matter_mass = 100.0
+    time.current_date = datetime(2024, 6, 10)
+
+    mocker.patch.object(hay, "_calculate_initial_dry_matter_loss_to_gas", side_effect=[20.0, 5.0])
+    mocker.patch.object(hay, "_calculate_subsequent_dry_matter_loss_to_gas", side_effect=[10.0, 2.0])
+    mocker.patch.object(hay, "_calculate_additional_dry_matter_loss", return_value=0.0)
+    mock_add_warning = mocker.patch.object(hay.om, "add_warning")
+
+    actual = hay.calculate_dry_matter_loss_to_gas(harvested_crop, [], time)
+
+    assert actual == 0.0
+    mock_add_warning.assert_not_called()
+
+
+def test_calculate_dry_matter_loss_to_gas_returns_zero_when_stored_today(
+    hay: Hay,
+    harvested_crop: HarvestedCrop,
+    time: RufasTime,
+    mocker: MockerFixture,
+) -> None:
+    """Tests that no dry matter loss is calculated on the crop storage date."""
+    harvested_crop.storage_time = date(2024, 6, 1)
+    time.current_date = datetime(2024, 6, 1)
+
+    mock_initial_loss = mocker.patch.object(hay, "_calculate_initial_dry_matter_loss_to_gas")
+    mock_subsequent_loss = mocker.patch.object(hay, "_calculate_subsequent_dry_matter_loss_to_gas")
+    mock_additional_loss = mocker.patch.object(hay, "_calculate_additional_dry_matter_loss")
+    mock_add_warning = mocker.patch.object(hay.om, "add_warning")
+
+    actual = hay.calculate_dry_matter_loss_to_gas(harvested_crop, [], time)
+
+    assert actual == 0.0
+    mock_initial_loss.assert_not_called()
+    mock_subsequent_loss.assert_not_called()
+    mock_additional_loss.assert_not_called()
+    mock_add_warning.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -181,7 +235,7 @@ def test_calculate_dry_matter_loss_to_gas(
     ],
 )
 def test_calculate_initial_dry_matter_loss(
-    hay: Hay, mocker: MockerFixture, harvested_crop: HarvestedCrop, days: int, expected: float
+    hay: Hay, harvested_crop: HarvestedCrop, days: int, expected: float
 ) -> None:
     """Tests _calculate_initial_dry_matter_loss in Hay."""
     harvested_crop.storage_time = (storage_date := date(2024, 6, 1))
@@ -193,6 +247,24 @@ def test_calculate_initial_dry_matter_loss(
     actual = hay._calculate_initial_dry_matter_loss_to_gas(harvested_crop, current_date)
 
     assert pytest.approx(actual) == expected
+
+
+@pytest.mark.parametrize("initial_dry_matter_percentage", [0.0, -1.0])
+def test_calculate_initial_dry_matter_loss_zero_or_negative_denominator(
+    hay: Hay,
+    harvested_crop: HarvestedCrop,
+    initial_dry_matter_percentage: float,
+) -> None:
+    """Tests that initial dry matter loss is zero when the denominator is not positive."""
+    harvested_crop.storage_time = date(2024, 6, 1)
+    harvested_crop.initial_dry_matter_percentage = initial_dry_matter_percentage
+    harvested_crop.initial_dry_matter_mass = 1_000.0
+    harvested_crop.total_sensible_heat_generated = 500.0
+    current_date = harvested_crop.storage_time + timedelta(days=10)
+
+    actual = hay._calculate_initial_dry_matter_loss_to_gas(harvested_crop, current_date)
+
+    assert actual == 0.0
 
 
 @pytest.mark.parametrize("days,expected", [(15, 0.0), (30, 0.0), (31, 0.0001), (35, 0.0005), (130, 0.01)])

--- a/tests/test_biophysical/test_feed_storage/test_storage.py
+++ b/tests/test_biophysical/test_feed_storage/test_storage.py
@@ -566,6 +566,7 @@ def test_calculate_moisture_loss(
         (0.5, 0.7, 100.0, 200.0, 0.0, True),
         (3.4, 0.8, 0.0, 200.0, 3.4, False),
         (5.8, 0.08, 100.0, 100.0, 0.0, False),
+        (4.5, 0.5, 10.0, 0.0, 4.5, False),
     ],
 )
 def test_recalculate_nutrient_percentage(


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->
Fixes a bug where we were seeing negative dm amounts for `Hay` in storage.

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #3114
### What
<!-- Add more detail about the changes that are being made in the pull request. -->
1. Caps dm loss to gas for hay so it can't exceed what's left in storage or go below zero.
2. Prevents 2 other divide by 0 errors that could be caused by capping those losses.
3. Adds more comprehensive virtual environment gitignore protection - useful for switching between different venvs set up for different RuFaS versions using incompatible dependencies (e.g. RuFaS on `test` vs. RuFaS on `dev`).

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
With the right combination of harvest schedule for hay and a large enough herd eating through the stored hay, we were seeing instances where the degradations calculations were creating projected losses greater than the amount left in storage which led to an error because that was not capped and negative dry matter makes no sense.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
In `Hay`.`calculate_dry_matter_loss_to_gas()`, it used to return this:
```python
return current_loss - processed_loss + additional_loss
```

That's now been bound between 0.0 and the available dry matter mass in storage, so instead we have:
```python
raw_loss = current_loss - processed_loss + additional_loss

return min(crop.dry_matter_mass, max(0.0, raw_loss))
```

With this fixed, 2 other related issues came up that were addressed here defensively:
- one (or more) of the harvests in the provided schedule input files yielded a 0.0 mass crop which meant it had 0.0% dm and 0.0 `initial_dry_matter`.
- Each of those was referenced as a denominator for a calculation in the `Storage` and `Hay` classes. Those have now been guarded against divide-by-zero errors.
- IMPORTANT TO NOTE FOR SMEs: please look at the `storage.py` `recalculate_nutrient_percentage()` divide-by-zero catch. I set the `dry_matter_loss_fraction` to 0.0 if the `initial_dry_matter` is <= 0.0. Just want to make sure that's correct since we have different returns for the if the fraction is 1.0 and I wasn't sure what a good substitute would be with 0.0 `initial_dry_matter`.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
Have run this with the provided private test files and it was successful. Updating unit tests accordingly.

Need SME confirmation the science is correct in the fix.

### Input Changes
<!-- Provide a short summary describing input modifications. -->
<!-- Please include the things that are added, deleted, or modified. -->


### Output Changes
<!-- List all the output variable/function modifications with a short summary. -->
<!-- """- `Class.Function.VariableName`: description""" -->
- N/A

#### Filter
<!-- Provide a filter that can be used to handle the output changes. -->

```json

```
