### PR TITLE
[Weather] Fix to handle missing weather data (test, v1.0.3)

### DIFF
--- a/RUFAS/weather.py
+++ b/RUFAS/weather.py
@@ -120,12 +120,18 @@ class Weather:
 
         From the fitted model, the method calculates and stores the fitted intercept term representing average air
         temperature, amplitude of the modeled cos/sin function, and phase shift (peak temperature). These parameters are
-        simulation-wide, i.e., only weather data utilized in the simulation is used.
+        simulation-wide, i.e., only weather data utilized in the simulation is used. Days with missing (NaN) mean air
+        temperatures are excluded from the regression.
 
         """
         mean_temperatures = np.array(self.means, dtype=float)
         cosine_components = np.array(self.cos, dtype=float)
         sine_components = np.array(self.sin, dtype=float)
+
+        valid_days = ~np.isnan(mean_temperatures)
+        mean_temperatures = mean_temperatures[valid_days]
+        cosine_components = cosine_components[valid_days]
+        sine_components = sine_components[valid_days]
 
         design_matrix = np.column_stack((cosine_components, sine_components, np.ones_like(mean_temperatures)))
 
@@ -290,11 +296,19 @@ class Weather:
         float
             The average annual air temperature (degrees C).
 
+        Raises
+        ------
+        ValueError
+            If every daily average air temperature is missing.
+
         Notes
         -----
         This method calculates the average annual air temperature by taking the average of all daily average air
         temperatures provided in the weather input file. Previous implementations calculated the average annual
         temperature for individual years, which led to the value fluctuating more than desired.
+
+        Missing daily values (NaN) are excluded from the average, since weather stations commonly go offline for
+        short periods. A warning is recorded when any values are missing.
 
         This method is intended to approximate SWAT's method for calculating the average annual temperature. SWAT
         calculates average high and low temperatures for each month over every simulated year, then averages those
@@ -303,7 +317,29 @@ class Weather:
         <https://bitbucket.org/blacklandgrasslandmodels/swat_development/src/master/readwgn.f>`_
 
         """
-        return np.mean(np.array(daily_average_temperatures))
+        daily_temperatures = np.array(daily_average_temperatures, dtype=float)
+        missing_count = int(np.isnan(daily_temperatures).sum())
+        info_map = {
+            "class": Weather.__name__,
+            "function": Weather._calculate_average_annual_temperature.__name__,
+            "prefix": "Weather",
+        }
+        if missing_count == daily_temperatures.size:
+            OutputManager().add_error(
+                "No temperature data",
+                "All daily average air temperatures in the weather data are missing, so the average annual air"
+                " temperature cannot be calculated.",
+                info_map,
+            )
+            raise ValueError("All daily average air temperatures in the weather data are missing")
+        if missing_count > 0:
+            OutputManager().add_warning(
+                "Missing temperature data",
+                f"{missing_count} daily average air temperature value(s) are missing from the weather data and are"
+                " excluded from the average annual air temperature.",
+                info_map,
+            )
+        return float(np.nanmean(daily_temperatures))
 
     @staticmethod
     def check_adequate_weather_data(weather_file: dict, time: RufasTime) -> None:

--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,8 @@ v1.0.2
 
 - [3130](https://github.com/RuminantFarmSystems/RuFaS/pull/3020) - [minor change] [NoInputChange] [NoOutputChange] Fixes bug where stored Hay was projected to have negative dm.
 
+- [3141](https://github.com/RuminantFarmSystems/RuFaS/pull/3141) - [minor change] [Weather] [NoInputChange] [NoOutputChange] Excludes missing (NaN) daily temperatures from the average annual temperature and the seasonal temperature regression, so simulations with gaps in the weather data no longer crash. Similar changes made to `dev` branch on PR 3139
+
 ### v1.0.2
 
 - [3018](https://github.com/RuminantFarmSystems/RuFaS/pull/3018) - [minor change]  [NoInputChange] [OutputChange] Replicates 3020 on dev to correct manure application composition calculations

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -129,12 +129,34 @@ def test_weather_init(mock_weather_input: dict, mock_time: RufasTime, mocker: Mo
     [
         ([12.3, 20.4, 15.6, 20.5, 17.8], 17.32),
         ([-4.55, -3.22, -1.05, -0.3, 1.44, 3.99, 8.6], 0.7014285714285712),
+        ([12.3, float("nan"), 15.6, float("nan"), 17.8], 15.233333333333334),
+        ([float("nan"), -3.22, -1.05], -2.135),
     ],
 )
 def test_calculate_average_annual_temperature(avg_daily_temperatures: list[float], expected: float) -> None:
     """Tests that the annual average air temperature is correctly calculated based on average daily temperatures."""
     actual = Weather._calculate_average_annual_temperature(avg_daily_temperatures)
-    assert actual == expected
+    assert actual == pytest.approx(expected)
+
+
+def test_calculate_average_annual_temperature_warns_on_missing_values(mocker: MockerFixture) -> None:
+    """Tests that a warning is recorded when some daily average temperatures are missing."""
+    patch_add_warning = mocker.patch("RUFAS.output_manager.OutputManager.add_warning")
+
+    Weather._calculate_average_annual_temperature([12.3, float("nan"), 15.6])
+
+    patch_add_warning.assert_called_once()
+
+
+def test_calculate_average_annual_temperature_all_missing_error(mocker: MockerFixture) -> None:
+    """Tests that an error is raised when all daily average temperatures are missing."""
+    patch_add_error = mocker.patch("RUFAS.output_manager.OutputManager.add_error")
+
+    with pytest.raises(ValueError) as e:
+        Weather._calculate_average_annual_temperature([float("nan"), float("nan")])
+
+    assert str(e.value) == "All daily average air temperatures in the weather data are missing"
+    patch_add_error.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -422,3 +444,20 @@ def test_set_LINEST_temperature_factors(
     assert mock_weather.intercept_mean_temp == expected_intercept
     assert mock_weather.amplitude == expected_amplitude
     assert mock_weather.phase_shift == pytest.approx(expected_phase_shift, abs=1e-4)
+
+
+def test_set_linest_temperature_factors_excludes_missing_temperatures(
+    mock_weather: Weather, mocker: MockerFixture
+) -> None:
+    """Tests that days with missing mean air temperatures are excluded from the regression."""
+    lstsq = mocker.patch("numpy.linalg.lstsq", return_value=(np.array([10.0, 0.0, 20.0]), None, None, None))
+
+    mock_weather.means = [10.0, float("nan"), 30.0]
+    mock_weather.cos = [0.5, 0.6, 0.7]
+    mock_weather.sin = [0.1, 0.2, 0.3]
+
+    mock_weather.set_linest_temperature_factors()
+
+    design_matrix, mean_temperatures = lstsq.call_args.args
+    np.testing.assert_array_equal(mean_temperatures, np.array([10.0, 30.0]))
+    np.testing.assert_array_equal(design_matrix, np.column_stack(([0.5, 0.7], [0.1, 0.3], [1.0, 1.0])))


### PR DESCRIPTION
Makes the `Weather` statistics tolerant of missing daily temperature values so that weather files with short station outages no longer crash the simulation.

### Context
Issue(s) closed by this pull request: closes #3133

Replicated on `dev` by #3139.

### What
- `Weather._calculate_average_annual_temperature` now uses `np.nanmean`, records a warning stating how many daily values were missing, and raises a clear `ValueError` if all values are missing.
- `Weather.set_linest_temperature_factors` now excludes days with missing mean air temperatures from the least-squares regression, keeping the (cos, sin, temperature) rows aligned.

### Why
Missing cells in the weather CSV are parsed as NaN. A single missing daily average made `mean_annual_temperature` NaN, which crashed bedded-pack simulations in `calculate_bedded_pack_methane_conversion_factor` ("Temperature nan°C out of any defined bin"). The same NaNs also poisoned the seasonal regression (`intercept_mean_temp`, `amplitude`, `phase_shift` all NaN), which would have silently corrupted outdoor storage manure temperatures even with the annual-mean fix alone.

### How
Missing (NaN) values are excluded from both simulation-wide statistics; all remaining data is used unchanged. Results are identical to before when the weather file has no missing values.

### Test plan
- Run with updated unit tests.
- SME review.

### Input Changes
- N/A

### Output Changes
- N/A

#### Filter

```json

```
