### PR TITLE
Update to version 1.0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,13 @@ output/output_filters/*
 *.vscode
 *.settings
 .idea/**
-env/
+
+# Virtual environments
+.venv/
+.venv*/
 venv/
+env/
+ENV/
 
 # ignore build files
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -44,13 +44,8 @@ output/output_filters/*
 *.vscode
 *.settings
 .idea/**
-
-# Virtual environments
-.venv/
-.venv*/
-venv/
 env/
-ENV/
+venv/
 
 # ignore build files
 dist/

--- a/RUFAS/biophysical/animal/animal.py
+++ b/RUFAS/biophysical/animal/animal.py
@@ -1093,6 +1093,15 @@ class Animal:
             parity=self.calves,
         )
 
+    @property
+    def enteric_methane(self) -> float:
+        """Returns unmitigated enteric methane for cows and mitigated enteric methane for non-cows."""
+        return (
+            self.digestive_system.enteric_methane_for_energy
+            if self.animal_type.is_cow
+            else self.digestive_system.enteric_methane_emission
+        )
+
     def _assign_sex_to_newborn_calf(self) -> None:
         """
         Assign a sex to a newborn calf based on the semen type and male calf rate.

--- a/RUFAS/biophysical/animal/digestive_system/digestive_system.py
+++ b/RUFAS/biophysical/animal/digestive_system/digestive_system.py
@@ -11,17 +11,33 @@ from RUFAS.output_manager import OutputManager
 
 class DigestiveSystem:
     """
-    This class serves as an entry point for the animal digestive systems.
+    An entry point for the animal digestive systems.
+
+    Attributes
+    ----------
+    manure_excretion : AnimalManureExcretions
+        A collection of the animal's manure excretion data.
+    phosphorous_excreted : float
+        The phosphorous excreted by the animal.
+    enteric_methane_emission : float
+        The CH₄ used for GHG reporting and downstream emissions calculations.
+        Represents mitigated enteric methane for cows.
+    enteric_methane_for_energy : float
+        The unmitigated CH₄ used in NASEM ME and ration optimization for cows.
+        Remains at 0.0 for other animals.
+
     """
 
     manure_excretion: AnimalManureExcretions
     phosphorus_excreted: float
     enteric_methane_emission: float
+    enteric_methane_for_energy: float
 
     def __init__(self) -> None:
         self.manure_excretion = AnimalManureExcretions()
         self.phosphorus_excreted = 0.0
         self.enteric_methane_emission: float = 0.0
+        self.enteric_methane_for_energy: float = 0.0
 
     def process_digestion(self, digestive_system_inputs: DigestiveSystemInputs) -> None:
         """
@@ -108,7 +124,7 @@ class DigestiveSystem:
             self.manure_excretion = excretion
 
         elif digestive_system_inputs.animal_type.is_cow:
-            methane_emission = EntericMethaneCalculator.calculate_cow_methane(
+            mitigated_methane_emission, unmitigated_methane_emission = EntericMethaneCalculator.calculate_cow_methane(
                 digestive_system_inputs.is_milking,
                 digestive_system_inputs.body_weight,
                 digestive_system_inputs.fat_content,
@@ -130,7 +146,8 @@ class DigestiveSystem:
                 digestive_system_inputs.nutrients,
             )
 
-            self.enteric_methane_emission = methane_emission
+            self.enteric_methane_emission = mitigated_methane_emission
+            self.enteric_methane_for_energy = unmitigated_methane_emission
             self.phosphorus_excreted = phosphorus
             self.manure_excretion = excretion
 

--- a/RUFAS/biophysical/animal/digestive_system/enteric_methane_calculator.py
+++ b/RUFAS/biophysical/animal/digestive_system/enteric_methane_calculator.py
@@ -87,7 +87,7 @@ class EntericMethaneCalculator:
         methane_mitigation_method: str,
         methane_mitigation_additive_amount: float,
         methane_models: dict[str, Any],
-    ) -> float:
+    ) -> tuple[float, float]:
         """
         Calculates the daily enteric emissions for cows.
 
@@ -118,8 +118,9 @@ class EntericMethaneCalculator:
 
         Returns
         -------
-        float
-            The daily enteric emissions for cows (g/day).
+        tuple[float, float]
+            - The daily mitigated enteric emissions for cows (g/day).
+            - The daily unmitigated enteric emissions for cows (g/day).
 
         """
         dry_matter_intake = nutrient_amounts.dry_matter
@@ -137,6 +138,7 @@ class EntericMethaneCalculator:
                 nutrient_amounts,
                 methane_models,
             )
+            unmitigated_methane = methane_emission
             if methane_mitigation_method:
                 methane_yield = 0.0
                 methane_yield_reduction = 0.0
@@ -160,8 +162,9 @@ class EntericMethaneCalculator:
             methane_emission = EntericMethaneCalculator._calculate_dry_cow_enteric_methane(
                 methane_models, metabolizable_energy_intake, nutrient_amounts
             )
+            unmitigated_methane = methane_emission
 
-        return methane_emission
+        return methane_emission, unmitigated_methane
 
     @staticmethod
     def _calculate_lactating_cow_enteric_methane(

--- a/RUFAS/biophysical/animal/pen.py
+++ b/RUFAS/biophysical/animal/pen.py
@@ -515,7 +515,7 @@ class Pen:
                 feeds_used=available_feeds,
                 ration_formulation=self.ration,
                 body_weight=animal.body_weight,
-                enteric_methane=animal.digestive_system.enteric_methane_emission,
+                enteric_methane=animal.enteric_methane,
                 urinary_nitrogen=animal.digestive_system.manure_excretion.urine_nitrogen,
             )
             animal.nutrition_supply = nutrient_supply
@@ -915,7 +915,7 @@ class Pen:
                 feeds_used=feeds_used,
                 ration_formulation=ration_formulation,
                 body_weight=animal.body_weight,
-                enteric_methane=animal.digestive_system.enteric_methane_emission,
+                enteric_methane=animal.enteric_methane,
                 urinary_nitrogen=animal.digestive_system.manure_excretion.urine_nitrogen,
             )
             animal.nutrients.set_dry_matter_intake(animal.nutrition_supply.dry_matter)
@@ -1086,13 +1086,11 @@ class Pen:
         nutrient_standard = list(self.animals_in_pen.values())[0].nutrient_standard
 
         if nutrient_standard is NutrientStandard.NASEM:
-            enteric_methane_list = []
-            urine_nitrogen_list = []
-            for animal in self.animals_in_pen.values():
-                enteric_methane_list.append(animal.digestive_system.enteric_methane_emission)
-                urine_nitrogen_list.append(animal.digestive_system.manure_excretion.urine_nitrogen)
-            pen_average_enteric_methane = sum(enteric_methane_list) / len(enteric_methane_list)
-            pen_average_urine_nitrogen = sum(urine_nitrogen_list) / len(urine_nitrogen_list)
+            animals = list(self.animals_in_pen.values())
+            pen_average_enteric_methane = sum(a.enteric_methane for a in animals) / len(animals)
+            pen_average_urine_nitrogen = (
+                sum(a.digestive_system.manure_excretion.urine_nitrogen for a in animals) / len(animals)
+            )
         else:
             pen_average_enteric_methane = None
             pen_average_urine_nitrogen = None

--- a/RUFAS/biophysical/feed_storage/hay.py
+++ b/RUFAS/biophysical/feed_storage/hay.py
@@ -156,7 +156,22 @@ class Hay(Storage):
 
         additional_loss = self._calculate_additional_dry_matter_loss(crop, weather_conditions)
 
-        return current_loss - processed_loss + additional_loss
+        raw_loss = current_loss - processed_loss + additional_loss
+        if raw_loss > crop.dry_matter_mass:
+            self.om.add_warning(
+                "Hay dry matter loss capped",
+                (
+                    f"Calculated dry matter loss ({raw_loss:.2f} kg) exceeded the remaining dry matter "
+                    f"({crop.dry_matter_mass:.2f} kg) for crop '{crop.config_name}' in field "
+                    f"'{crop.field_name}'. Capping loss to the remaining dry matter."
+                ),
+                info_map={
+                    "class": self.__class__.__name__,
+                    "function": self.calculate_dry_matter_loss_to_gas.__name__,
+                },
+            )
+
+        return min(crop.dry_matter_mass, max(0.0, raw_loss))
 
     def _calculate_initial_dry_matter_loss_to_gas(self, crop: HarvestedCrop, time: date) -> float:
         """
@@ -193,7 +208,11 @@ class Hay(Storage):
             14206 - 2433 * FINAL_MOISTURE_PERCENTAGE / (1 - FINAL_MOISTURE_PERCENTAGE)
         )
 
-        fraction_of_initial_dry_matter_lost = numerator / denominator * fraction_of_total_loss
+        fraction_of_initial_dry_matter_lost = (
+            numerator / denominator * fraction_of_total_loss
+            if denominator > 0.0
+            else 0
+        )
         return crop.initial_dry_matter_mass * fraction_of_initial_dry_matter_lost
 
     def _calculate_subsequent_dry_matter_loss_to_gas(self, crop: HarvestedCrop, time: date) -> float:

--- a/RUFAS/biophysical/feed_storage/storage.py
+++ b/RUFAS/biophysical/feed_storage/storage.py
@@ -827,7 +827,7 @@ class Storage:
         division by zero error.
 
         """
-        dry_matter_loss_fraction = dry_matter_loss / initial_dry_matter
+        dry_matter_loss_fraction = dry_matter_loss / initial_dry_matter if initial_dry_matter > 0.0 else 0.0
         initial_nutrient_fraction = initial_nutrient_percentage * GeneralConstants.PERCENTAGE_TO_FRACTION
 
         if dry_matter_loss_fraction == 1.0:

--- a/RUFAS/weather.py
+++ b/RUFAS/weather.py
@@ -120,12 +120,18 @@ class Weather:
 
         From the fitted model, the method calculates and stores the fitted intercept term representing average air
         temperature, amplitude of the modeled cos/sin function, and phase shift (peak temperature). These parameters are
-        simulation-wide, i.e., only weather data utilized in the simulation is used.
+        simulation-wide, i.e., only weather data utilized in the simulation is used. Days with missing (NaN) mean air
+        temperatures are excluded from the regression.
 
         """
         mean_temperatures = np.array(self.means, dtype=float)
         cosine_components = np.array(self.cos, dtype=float)
         sine_components = np.array(self.sin, dtype=float)
+
+        valid_days = ~np.isnan(mean_temperatures)
+        mean_temperatures = mean_temperatures[valid_days]
+        cosine_components = cosine_components[valid_days]
+        sine_components = sine_components[valid_days]
 
         design_matrix = np.column_stack((cosine_components, sine_components, np.ones_like(mean_temperatures)))
 
@@ -290,11 +296,19 @@ class Weather:
         float
             The average annual air temperature (degrees C).
 
+        Raises
+        ------
+        ValueError
+            If every daily average air temperature is missing.
+
         Notes
         -----
         This method calculates the average annual air temperature by taking the average of all daily average air
         temperatures provided in the weather input file. Previous implementations calculated the average annual
         temperature for individual years, which led to the value fluctuating more than desired.
+
+        Missing daily values (NaN) are excluded from the average, since weather stations commonly go offline for
+        short periods. A warning is recorded when any values are missing.
 
         This method is intended to approximate SWAT's method for calculating the average annual temperature. SWAT
         calculates average high and low temperatures for each month over every simulated year, then averages those
@@ -303,7 +317,29 @@ class Weather:
         <https://bitbucket.org/blacklandgrasslandmodels/swat_development/src/master/readwgn.f>`_
 
         """
-        return np.mean(np.array(daily_average_temperatures))
+        daily_temperatures = np.array(daily_average_temperatures, dtype=float)
+        missing_count = int(np.isnan(daily_temperatures).sum())
+        info_map = {
+            "class": Weather.__name__,
+            "function": Weather._calculate_average_annual_temperature.__name__,
+            "prefix": "Weather",
+        }
+        if missing_count == daily_temperatures.size:
+            OutputManager().add_error(
+                "No temperature data",
+                "All daily average air temperatures in the weather data are missing, so the average annual air"
+                " temperature cannot be calculated.",
+                info_map,
+            )
+            raise ValueError("All daily average air temperatures in the weather data are missing")
+        if missing_count > 0:
+            OutputManager().add_warning(
+                "Missing temperature data",
+                f"{missing_count} daily average air temperature value(s) are missing from the weather data and are"
+                " excluded from the average annual air temperature.",
+                info_map,
+            )
+        return float(np.nanmean(daily_temperatures))
 
     @staticmethod
     def check_adequate_weather_data(weather_file: dict, time: RufasTime) -> None:

--- a/changelog.md
+++ b/changelog.md
@@ -343,6 +343,7 @@ v1.0.0
 - [2872](https://github.com/RuminantFarmSystems/RuFaS/pull/2872) - [minor change] [NoInputChange] [NoOutputChange] Adds information and links for onboarding videos.
 - [2850](https://github.com/RuminantFarmSystems/RuFaS/pull/2850) - [minor change] [NoInputChange] [NoOutputChange] Refactor `Pen.get_manure_stream()`.
 - [2908](https://github.com/RuminantFarmSystems/RuFaS/pull/2908) - [minor change] [NoInputChange] [OutputChange] Fix the FarmGrownFeed Emissions Unit issue on `test` branch.
+- [3091](https://github.com/RuminantFarmSystems/RuFaS/pull/3091) - [minor change] [InputChange] [OutputChange] Fixes large seedbed conditioner entry in `tractor_dataset.csv` input.
 
 ### v0.9.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@ v1.0.0
 - [2998](https://github.com/RuminantFarmSystems/RuFaS/pull/2998) - [minor change] [NoInputChange] [OutputChange] Moved changelog entries to reflect what was in v1.0. Brought changes in 2994 and 2997 into one branch.
 - [3020](https://github.com/RuminantFarmSystems/RuFaS/pull/3020) - [minor change] [NoInputChange] [OutputChange] Corrected manure application ammonia composition calculation
 - [3091](https://github.com/RuminantFarmSystems/RuFaS/pull/3091) - [minor change] [InputChange] [OutputChange] Fixes large seedbed conditioner entry in `tractor_dataset.csv` input.
+- [3121](https://github.com/RuminantFarmSystems/RuFaS/pull/3121) - [minor change] [Animal] [InputChange] [OutputChange] Adds separate tracking for unmitigated vs. mitigated enteric methane for cows. Similar changes made to `dev` branch on PR #3115.
   
 ### v1.0.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -29,7 +29,8 @@ v1.0.0
 - [2997](https://github.com/RuminantFarmSystems/RuFaS/pull/2997) - [minor change] [NoInputChange] [OutputChange] Updates throughput in tractor dataset for combine headers.
 - [2998](https://github.com/RuminantFarmSystems/RuFaS/pull/2998) - [minor change] [NoInputChange] [OutputChange] Moved changelog entries to reflect what was in v1.0. Brought changes in 2994 and 2997 into one branch.
 - [3020](https://github.com/RuminantFarmSystems/RuFaS/pull/3020) - [minor change] [NoInputChange] [OutputChange] Corrected manure application ammonia composition calculation
-
+- [3091](https://github.com/RuminantFarmSystems/RuFaS/pull/3091) - [minor change] [InputChange] [OutputChange] Fixes large seedbed conditioner entry in `tractor_dataset.csv` input.
+  
 ### v1.0.0
 
 - [2081](https://github.com/RuminantFarmSystems/RuFaS/pull/2081) - [minor change] [Crop & Soil] Break down the `_setup_field()` function in `FieldManager`.
@@ -343,7 +344,6 @@ v1.0.0
 - [2872](https://github.com/RuminantFarmSystems/RuFaS/pull/2872) - [minor change] [NoInputChange] [NoOutputChange] Adds information and links for onboarding videos.
 - [2850](https://github.com/RuminantFarmSystems/RuFaS/pull/2850) - [minor change] [NoInputChange] [NoOutputChange] Refactor `Pen.get_manure_stream()`.
 - [2908](https://github.com/RuminantFarmSystems/RuFaS/pull/2908) - [minor change] [NoInputChange] [OutputChange] Fix the FarmGrownFeed Emissions Unit issue on `test` branch.
-- [3091](https://github.com/RuminantFarmSystems/RuFaS/pull/3091) - [minor change] [InputChange] [OutputChange] Fixes large seedbed conditioner entry in `tractor_dataset.csv` input.
 
 ### v0.9.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@ v1.0.0
 - [2998](https://github.com/RuminantFarmSystems/RuFaS/pull/2998) - [minor change] [NoInputChange] [OutputChange] Moved changelog entries to reflect what was in v1.0. Brought changes in 2994 and 2997 into one branch.
 - [3020](https://github.com/RuminantFarmSystems/RuFaS/pull/3020) - [minor change] [NoInputChange] [OutputChange] Corrected manure application ammonia composition calculation
 - [3091](https://github.com/RuminantFarmSystems/RuFaS/pull/3091) - [minor change] [InputChange] [OutputChange] Fixes large seedbed conditioner entry in `tractor_dataset.csv` input.
+- [3130](https://github.com/RuminantFarmSystems/RuFaS/pull/3020) - [minor change] [NoInputChange] [NoOutputChange] Fixes bug where stored Hay was projected to have negative dm.
   
 ### v1.0.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -23,7 +23,7 @@ This **changelog** file keeps a record of updates included in existing version r
 
 ### Current version
 
-v1.0.2
+v1.0.3
 
 ### v1.0.3
 

--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,8 @@ v1.0.2
 
 - [3130](https://github.com/RuminantFarmSystems/RuFaS/pull/3020) - [minor change] [NoInputChange] [NoOutputChange] Fixes bug where stored Hay was projected to have negative dm.
 
+- [3141](https://github.com/RuminantFarmSystems/RuFaS/pull/3141) - [minor change] [Weather] [NoInputChange] [NoOutputChange] Excludes missing (NaN) daily temperatures from the average annual temperature and the seasonal temperature regression, so simulations with gaps in the weather data no longer crash. Similar changes made to `dev` branch on PR 3139
+
 ### v1.0.2
 
 - [3018](https://github.com/RuminantFarmSystems/RuFaS/pull/3018) - [minor change]  [NoInputChange] [OutputChange] Replicates 3020 on dev to correct manure application composition calculations

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 A **changelog** is a structured record of changes made to the codebase over time. It documents new features, bug fixes, and improvements, giving both developers and users a transparent view of how the project evolves across versions. A changelog ensures that the entire development process is **trackable**, improves **collaboration** by clearly communicating changes across team members, and offers **transparency** to users and stakeholders. Additionally, it helps with **debugging** by highlighting specific updates or changes that could potentially introduce new issues.
 
+This **changelog** file keeps a record of updates included in existing version releases.
+
 ### Each changelog entry must include
 
 - PR #. Just the number, omit "PR" and "#". Include a link to the Pull Request using the format "\[<PR #>\]\(\<link to PR\>\)" (see the example below).
@@ -21,16 +23,19 @@ A **changelog** is a structured record of changes made to the codebase over time
 
 ### Current version
 
-v1.0.0
+v1.0.2
 
-### Next Version Updates
+### v1.0.3
 
-- [2994](https://github.com/RuminantFarmSystems/RuFaS/pull/2994) - [minor change] [NoInputChange] [OutputChange] Adds minimums to urine nitrogen equation.
-- [2997](https://github.com/RuminantFarmSystems/RuFaS/pull/2997) - [minor change] [NoInputChange] [OutputChange] Updates throughput in tractor dataset for combine headers.
-- [2998](https://github.com/RuminantFarmSystems/RuFaS/pull/2998) - [minor change] [NoInputChange] [OutputChange] Moved changelog entries to reflect what was in v1.0. Brought changes in 2994 and 2997 into one branch.
-- [3020](https://github.com/RuminantFarmSystems/RuFaS/pull/3020) - [minor change] [NoInputChange] [OutputChange] Corrected manure application ammonia composition calculation
-- [3091](https://github.com/RuminantFarmSystems/RuFaS/pull/3091) - [minor change] [InputChange] [OutputChange] Fixes large seedbed conditioner entry in `tractor_dataset.csv` input.
-- [3121](https://github.com/RuminantFarmSystems/RuFaS/pull/3121) - [minor change] [Animal] [InputChange] [OutputChange] Adds separate tracking for unmitigated vs. mitigated enteric methane for cows. Similar changes made to `dev` branch on PR #3115.
+- [3121](https://github.com/RuminantFarmSystems/RuFaS/pull/3121) - [minor change] [Animal] [NoInputChange] [OutputChange] Adds separate tracking for unmitigated vs. mitigated enteric methane for cows. Similar changes made to `dev` branch on PR 3115
+
+### v1.0.2
+
+- [3018](https://github.com/RuminantFarmSystems/RuFaS/pull/3018) - [minor change]  [NoInputChange] [OutputChange] Replicates 3020 on dev to correct manure application composition calculations
+
+### v1.0.1
+
+- [3013](https://github.com/RuminantFarmSystems/RuFaS/pull/3013) - [minor change] [NoInputChange] [OutputChange] Replicates 2998, 2997, and 2994: Adds minimums to urine nitrogen excretion, updates tractor dataset, corrects changelog typos
   
 ### v1.0.0
 

--- a/input/data/EEE/tractor_dataset.csv
+++ b/input/data/EEE/tractor_dataset.csv
@@ -230,5 +230,5 @@ ID,Crop Type or Tillage Implement,Tractor Size,Operation,Operation,Depth,Tractor
 929,Cultivator,large,Tilling,,0,Cultivator; 25 ft (7.6 m),46,2.8,0,7.6,2650,0,0,0,TRUE,
 930,Disk-harrow,large,Tilling,,0,Disk-harrow; 21 ft (6.4 m),309,16,0,6.4,3100,0,0,0,TRUE,
 931,Moldboard-plow,large,Tilling,,0,Moldboard plow; 7-18 in (3.2 m),652,0,5.1,3.2,2300,0,0,0,TRUE,
-932,Seedbed conditioner,large,Tilling,,0,Seedbed conditioner; 25 ft (7.6 m),225,14,0,7.6,3950,0,0,0,TRUE,
+932,Seedbed-conditioner,large,Tilling,,0,Seedbed conditioner; 25 ft (7.6 m),225,14,0,7.6,3950,0,0,0,TRUE,
 933,Subsoiler,large,Tilling,,0,Subsoiler; 4-shank (4.6 m),226,0,1.8,4.6,1800,0,0,0,TRUE,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "RuFaS"
-version = "1.0.2"
+version = "1.0.3"
 description = "Ruminant Farm Systems Model"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/tests/test_biophysical/test_animal/test_animal/test_animal.py
+++ b/tests/test_biophysical/test_animal/test_animal/test_animal.py
@@ -1150,6 +1150,30 @@ def test_future_death_date_setter(
 
 
 @pytest.mark.parametrize(
+    "animal_fixture_name, expected_methane",
+    [
+        ("mock_calf", 9.0),
+        ("mock_heiferI", 9.0),
+        ("mock_heiferII", 9.0),
+        ("mock_heiferIII", 9.0),
+        ("mock_lactating_cow", 8.0),
+    ],
+)
+def test_enteric_methane_uses_correct_digestive_system_value(
+    request: pytest.FixtureRequest,
+    animal_fixture_name: str,
+    expected_methane: float,
+) -> None:
+    """enteric_methane returns unmitigated methane for cows and mitigated methane otherwise."""
+    animal: Animal = request.getfixturevalue(animal_fixture_name)
+
+    animal.digestive_system.enteric_methane_for_energy = 8.0
+    animal.digestive_system.enteric_methane_emission = 9.0
+
+    assert animal.enteric_methane == pytest.approx(expected_methane)
+
+
+@pytest.mark.parametrize(
     "is_cow, daily_distance, expected",
     [
         (True, 5.5, 5.5),

--- a/tests/test_biophysical/test_animal/test_digestive_system/test_digestive_system.py
+++ b/tests/test_biophysical/test_animal/test_digestive_system/test_digestive_system.py
@@ -117,7 +117,7 @@ def test_process_digestion_cow(mocker: MockerFixture) -> None:
     )
 
     mock_manure_excretion = mocker.MagicMock(spec=AnimalManureExcretions)
-    mock_methane = mocker.patch.object(EntericMethaneCalculator, "calculate_cow_methane", return_value=8.0)
+    mock_methane = mocker.patch.object(EntericMethaneCalculator, "calculate_cow_methane", return_value=(8.0, 9.0))
     mock_manure = mocker.patch.object(
         ManureExcretionCalculator, "calculate_cow_manure", return_value=(0.6, mock_manure_excretion)
     )
@@ -127,6 +127,7 @@ def test_process_digestion_cow(mocker: MockerFixture) -> None:
     mock_methane.assert_called()
     mock_manure.assert_called()
     assert digestive_system.enteric_methane_emission == 8.0
+    assert digestive_system.enteric_methane_for_energy == 9.0
     assert digestive_system.phosphorus_excreted == 0.6
     assert digestive_system.manure_excretion is mock_manure_excretion
 

--- a/tests/test_biophysical/test_animal/test_digestive_system/test_enteric_methane_calculator.py
+++ b/tests/test_biophysical/test_animal/test_digestive_system/test_enteric_methane_calculator.py
@@ -98,11 +98,11 @@ def test_heifer_methane_no_model(nutrient_concentrations: NutritionSupply, expec
 
 @pytest.mark.parametrize(
     "is_lactating, methane_mitigation_method, methane_mitigation_additive_amount, "
-    "expected_methane, expected_mitigation_called",
+    "expected_mitigated_methane, expected_unmitigated_methane, expected_mitigation_called",
     [
-        (True, "3-NOP", 500.0, 299.7, True),
-        (True, "", 0.0, 300.0, False),
-        (False, "", 0.0, 180.0, False),
+        (True, "3-NOP", 500.0, 299.7, 300.0, True),
+        (True, "", 0.0, 300.0, 300.0, False),
+        (False, "", 0.0, 180.0, 180.0, False),
     ],
 )
 def test_calculate_cow_methane(
@@ -110,7 +110,8 @@ def test_calculate_cow_methane(
     is_lactating: bool,
     methane_mitigation_method: str,
     methane_mitigation_additive_amount: float,
-    expected_methane: float,
+    expected_mitigated_methane: float,
+    expected_unmitigated_methane: float,
     expected_mitigation_called: bool,
 ) -> None:
     """
@@ -135,7 +136,7 @@ def test_calculate_cow_methane(
         MethaneMitigationCalculator, "mitigate_methane", return_value=mock_methane_yield_reduction
     )
 
-    result = EntericMethaneCalculator.calculate_cow_methane(
+    mitigated_em_result, unmitigated_em_result = EntericMethaneCalculator.calculate_cow_methane(
         is_lactating=is_lactating,
         body_weight=650.0,
         milk_fat=3.5,
@@ -156,7 +157,8 @@ def test_calculate_cow_methane(
     else:
         mock_mitigation.assert_not_called()
 
-    assert result == expected_methane
+    assert mitigated_em_result == expected_mitigated_methane
+    assert unmitigated_em_result == expected_unmitigated_methane
 
 
 @pytest.mark.parametrize(

--- a/tests/test_biophysical/test_animal/test_pen/test_pen.py
+++ b/tests/test_biophysical/test_animal/test_pen/test_pen.py
@@ -104,6 +104,7 @@ def animals_in_pen() -> dict[int, Animal]:
         milk_production=milk_production,
         daily_distance=10,
         nutrition_supply=nutrition_supply,
+        enteric_methane=8.5,
     )
     animal_2 = MagicMock(spec=Animal)
     animal_2.configure_mock(
@@ -116,6 +117,7 @@ def animals_in_pen() -> dict[int, Animal]:
         body_weight=50,
         daily_distance=10,
         nutrition_supply=nutrition_supply,
+        enteric_methane=8.5,
     )
     return {1: animal_1, 2: animal_2}
 
@@ -1532,7 +1534,7 @@ def test_attempt_formulation_user_defined_and_nasem(
 
     assert kwargs["user_defined_ration_dictionary"] == user_defined_for_combo
     assert kwargs["user_defined_ration_tolerance"] == pytest.approx(0.123)
-    assert kwargs["pen_average_enteric_methane"] == pytest.approx(69.4)
+    assert kwargs["pen_average_enteric_methane"] == pytest.approx(8.5)
     assert kwargs["pen_average_urine_nitrogen"] == pytest.approx(15.0)
 
 

--- a/tests/test_biophysical/test_feed_storage/test_hay.py
+++ b/tests/test_biophysical/test_feed_storage/test_hay.py
@@ -139,33 +139,87 @@ def test_project_degradations(
     project_degradations.assert_called_once_with(crops_with_moisture_loss, weather, time)
 
 
-@pytest.mark.parametrize("stored_day,current_day,expect_loss", [(1, 1, False), (1, 10, True)])
-def test_calculate_dry_matter_loss_to_gas(
+def test_calculate_dry_matter_loss_to_gas_caps_loss_and_warns(
     hay: Hay,
     harvested_crop: HarvestedCrop,
     time: RufasTime,
     mocker: MockerFixture,
-    stored_day: int,
-    current_day: int,
-    expect_loss: bool,
 ) -> None:
-    """Tests calculate_dry_matter_loss_to_gas in Hay."""
-    harvested_crop.storage_time = date(2024, 6, stored_day)
-    time.current_date = datetime(2024, 6, current_day)
-    mock_initial_loss = mocker.patch.object(hay, "_calculate_initial_dry_matter_loss_to_gas", side_effect=[10.0, 20.0])
-    mock_subsequent_loss = mocker.patch.object(
-        hay, "_calculate_subsequent_dry_matter_loss_to_gas", side_effect=[5.0, 10.0]
-    )
-    mock_additional_loss = mocker.patch.object(hay, "_calculate_additional_dry_matter_loss", return_value=3.0)
-    expected_loss = 18.0 if expect_loss else 0.0
-    expected_call_count = 2 if expect_loss else 0
+    """Tests that hay dry matter loss is capped and a warning is logged when raw loss exceeds available dry matter."""
+    harvested_crop.storage_time = date(2024, 6, 1)
+    harvested_crop.last_time_degraded = date(2024, 6, 1)
+    harvested_crop.dry_matter_mass = 12.0
+    harvested_crop.config_name = "test_hay"
+    harvested_crop.field_name = "test_field"
+    time.current_date = datetime(2024, 6, 10)
+
+    mocker.patch.object(hay, "_calculate_initial_dry_matter_loss_to_gas", side_effect=[0.0, 20.0])
+    mocker.patch.object(hay, "_calculate_subsequent_dry_matter_loss_to_gas", side_effect=[0.0, 10.0])
+    mocker.patch.object(hay, "_calculate_additional_dry_matter_loss", return_value=5.0)
+    mock_add_warning = mocker.patch.object(hay.om, "add_warning")
 
     actual = hay.calculate_dry_matter_loss_to_gas(harvested_crop, [], time)
 
-    assert actual == expected_loss
-    assert mock_initial_loss.call_count == expected_call_count
-    assert mock_subsequent_loss.call_count == expected_call_count
-    assert mock_additional_loss.call_count == (1 if expect_loss else 0)
+    assert actual == 12.0
+    mock_add_warning.assert_called_once_with(
+        "Hay dry matter loss capped",
+        (
+            "Calculated dry matter loss (35.00 kg) exceeded the remaining dry matter "
+            "(12.00 kg) for crop 'test_hay' in field "
+            "'test_field'. Capping loss to the remaining dry matter."
+        ),
+        info_map={
+            "class": hay.__class__.__name__,
+            "function": hay.calculate_dry_matter_loss_to_gas.__name__,
+        },
+    )
+
+
+def test_calculate_dry_matter_loss_to_gas_floors_negative_loss(
+    hay: Hay,
+    harvested_crop: HarvestedCrop,
+    time: RufasTime,
+    mocker: MockerFixture,
+) -> None:
+    """Tests that negative calculated hay dry matter loss is floored at zero."""
+    harvested_crop.storage_time = date(2024, 6, 1)
+    harvested_crop.last_time_degraded = date(2024, 6, 1)
+    harvested_crop.dry_matter_mass = 100.0
+    time.current_date = datetime(2024, 6, 10)
+
+    mocker.patch.object(hay, "_calculate_initial_dry_matter_loss_to_gas", side_effect=[20.0, 5.0])
+    mocker.patch.object(hay, "_calculate_subsequent_dry_matter_loss_to_gas", side_effect=[10.0, 2.0])
+    mocker.patch.object(hay, "_calculate_additional_dry_matter_loss", return_value=0.0)
+    mock_add_warning = mocker.patch.object(hay.om, "add_warning")
+
+    actual = hay.calculate_dry_matter_loss_to_gas(harvested_crop, [], time)
+
+    assert actual == 0.0
+    mock_add_warning.assert_not_called()
+
+
+def test_calculate_dry_matter_loss_to_gas_returns_zero_when_stored_today(
+    hay: Hay,
+    harvested_crop: HarvestedCrop,
+    time: RufasTime,
+    mocker: MockerFixture,
+) -> None:
+    """Tests that no dry matter loss is calculated on the crop storage date."""
+    harvested_crop.storage_time = date(2024, 6, 1)
+    time.current_date = datetime(2024, 6, 1)
+
+    mock_initial_loss = mocker.patch.object(hay, "_calculate_initial_dry_matter_loss_to_gas")
+    mock_subsequent_loss = mocker.patch.object(hay, "_calculate_subsequent_dry_matter_loss_to_gas")
+    mock_additional_loss = mocker.patch.object(hay, "_calculate_additional_dry_matter_loss")
+    mock_add_warning = mocker.patch.object(hay.om, "add_warning")
+
+    actual = hay.calculate_dry_matter_loss_to_gas(harvested_crop, [], time)
+
+    assert actual == 0.0
+    mock_initial_loss.assert_not_called()
+    mock_subsequent_loss.assert_not_called()
+    mock_additional_loss.assert_not_called()
+    mock_add_warning.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -181,7 +235,7 @@ def test_calculate_dry_matter_loss_to_gas(
     ],
 )
 def test_calculate_initial_dry_matter_loss(
-    hay: Hay, mocker: MockerFixture, harvested_crop: HarvestedCrop, days: int, expected: float
+    hay: Hay, harvested_crop: HarvestedCrop, days: int, expected: float
 ) -> None:
     """Tests _calculate_initial_dry_matter_loss in Hay."""
     harvested_crop.storage_time = (storage_date := date(2024, 6, 1))
@@ -193,6 +247,24 @@ def test_calculate_initial_dry_matter_loss(
     actual = hay._calculate_initial_dry_matter_loss_to_gas(harvested_crop, current_date)
 
     assert pytest.approx(actual) == expected
+
+
+@pytest.mark.parametrize("initial_dry_matter_percentage", [0.0, -1.0])
+def test_calculate_initial_dry_matter_loss_zero_or_negative_denominator(
+    hay: Hay,
+    harvested_crop: HarvestedCrop,
+    initial_dry_matter_percentage: float,
+) -> None:
+    """Tests that initial dry matter loss is zero when the denominator is not positive."""
+    harvested_crop.storage_time = date(2024, 6, 1)
+    harvested_crop.initial_dry_matter_percentage = initial_dry_matter_percentage
+    harvested_crop.initial_dry_matter_mass = 1_000.0
+    harvested_crop.total_sensible_heat_generated = 500.0
+    current_date = harvested_crop.storage_time + timedelta(days=10)
+
+    actual = hay._calculate_initial_dry_matter_loss_to_gas(harvested_crop, current_date)
+
+    assert actual == 0.0
 
 
 @pytest.mark.parametrize("days,expected", [(15, 0.0), (30, 0.0), (31, 0.0001), (35, 0.0005), (130, 0.01)])

--- a/tests/test_biophysical/test_feed_storage/test_storage.py
+++ b/tests/test_biophysical/test_feed_storage/test_storage.py
@@ -566,6 +566,7 @@ def test_calculate_moisture_loss(
         (0.5, 0.7, 100.0, 200.0, 0.0, True),
         (3.4, 0.8, 0.0, 200.0, 3.4, False),
         (5.8, 0.08, 100.0, 100.0, 0.0, False),
+        (4.5, 0.5, 10.0, 0.0, 4.5, False),
     ],
 )
 def test_recalculate_nutrient_percentage(

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -129,12 +129,34 @@ def test_weather_init(mock_weather_input: dict, mock_time: RufasTime, mocker: Mo
     [
         ([12.3, 20.4, 15.6, 20.5, 17.8], 17.32),
         ([-4.55, -3.22, -1.05, -0.3, 1.44, 3.99, 8.6], 0.7014285714285712),
+        ([12.3, float("nan"), 15.6, float("nan"), 17.8], 15.233333333333334),
+        ([float("nan"), -3.22, -1.05], -2.135),
     ],
 )
 def test_calculate_average_annual_temperature(avg_daily_temperatures: list[float], expected: float) -> None:
     """Tests that the annual average air temperature is correctly calculated based on average daily temperatures."""
     actual = Weather._calculate_average_annual_temperature(avg_daily_temperatures)
-    assert actual == expected
+    assert actual == pytest.approx(expected)
+
+
+def test_calculate_average_annual_temperature_warns_on_missing_values(mocker: MockerFixture) -> None:
+    """Tests that a warning is recorded when some daily average temperatures are missing."""
+    patch_add_warning = mocker.patch("RUFAS.output_manager.OutputManager.add_warning")
+
+    Weather._calculate_average_annual_temperature([12.3, float("nan"), 15.6])
+
+    patch_add_warning.assert_called_once()
+
+
+def test_calculate_average_annual_temperature_all_missing_error(mocker: MockerFixture) -> None:
+    """Tests that an error is raised when all daily average temperatures are missing."""
+    patch_add_error = mocker.patch("RUFAS.output_manager.OutputManager.add_error")
+
+    with pytest.raises(ValueError) as e:
+        Weather._calculate_average_annual_temperature([float("nan"), float("nan")])
+
+    assert str(e.value) == "All daily average air temperatures in the weather data are missing"
+    patch_add_error.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -422,3 +444,20 @@ def test_set_LINEST_temperature_factors(
     assert mock_weather.intercept_mean_temp == expected_intercept
     assert mock_weather.amplitude == expected_amplitude
     assert mock_weather.phase_shift == pytest.approx(expected_phase_shift, abs=1e-4)
+
+
+def test_set_linest_temperature_factors_excludes_missing_temperatures(
+    mock_weather: Weather, mocker: MockerFixture
+) -> None:
+    """Tests that days with missing mean air temperatures are excluded from the regression."""
+    lstsq = mocker.patch("numpy.linalg.lstsq", return_value=(np.array([10.0, 0.0, 20.0]), None, None, None))
+
+    mock_weather.means = [10.0, float("nan"), 30.0]
+    mock_weather.cos = [0.5, 0.6, 0.7]
+    mock_weather.sin = [0.1, 0.2, 0.3]
+
+    mock_weather.set_linest_temperature_factors()
+
+    design_matrix, mean_temperatures = lstsq.call_args.args
+    np.testing.assert_array_equal(mean_temperatures, np.array([10.0, 30.0]))
+    np.testing.assert_array_equal(design_matrix, np.column_stack(([0.5, 0.7], [0.1, 0.3], [1.0, 1.0])))


### PR DESCRIPTION
This Patch version bump includes 3 patches:

1.[ PR 3121 fixes](https://github.com/RuminantFarmSystems/RuFaS/pull/3121) the way enteric methane energy is included in nutrient requirement calculations when an enteric methane mitigation supplement is included: 
2. [PR 3137](https://github.com/RuminantFarmSystems/RuFaS/pull/3137) prevents feed storage dry matter mass from going negative in an edge case for hay storage
3. [PR 3141](https://github.com/RuminantFarmSystems/RuFaS/pull/3141) updates the method for averaging and modeling weather temperature data used by the manure model to accomodate missing values
