### PR TITLE
[E2E Testing] Fix update e2e bottleneck

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-1164%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Flake8](https://img.shields.io/badge/Flake8-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
+[![Flake8](https://img.shields.io/badge/Flake8-failed-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Pytest](https://img.shields.io/badge/Pytest-passed-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)
 [![Mypy](https://img.shields.io/badge/Mypy-1164%20errors-red)](https://github.com/RuminantFarmSystems/MASM/actions/workflows/combined_format_lint_test_mypy.yml)

--- a/RUFAS/e2e_test_results_handler.py
+++ b/RUFAS/e2e_test_results_handler.py
@@ -691,24 +691,24 @@ class E2ETestResultsHandler:
                 with open(expected_results_path, "r") as expected_results_file:
                     expected_results = json.load(expected_results_file)
 
-                diff = DeepDiff(
-                    expected_results["expected_results"], actual_results, ignore_order=True, verbose_level=2
-                )
-                is_difference_in_results: bool = False if (diff == {}) else True
-                if is_difference_in_results:
-                    om.add_warning(
-                        "End-to-end testing expected results different from new actual results",
-                        f"Differences will be saved in {output_dir} for {path_set.domain} domain.",
-                        info_map,
-                    )
-                    save_path = output_dir / f"{path_set.domain}_update_diff.json"
-                    om.dict_to_file_json(data_dict=diff, path=save_path)
-                else:
-                    om.add_log(
-                        "End-to-end testing expected results matched new actual results",
-                        f"No differences detected in actual and expected results for {path_set.domain} domain.",
-                        info_map,
-                    )
+                # diff = DeepDiff(
+                #     expected_results["expected_results"], actual_results, ignore_order=True, verbose_level=2
+                # )
+                # is_difference_in_results: bool = False if (diff == {}) else True
+                # if is_difference_in_results:
+                #     om.add_warning(
+                #         "End-to-end testing expected results different from new actual results",
+                #         f"Differences will be saved in {output_dir} for {path_set.domain} domain.",
+                #         info_map,
+                #     )
+                # save_path = output_dir / f"{path_set.domain}_update_diff.json"
+                # om.dict_to_file_json(data_dict=diff, path=save_path)
+                # else:
+                #     om.add_log(
+                #         "End-to-end testing expected results matched new actual results",
+                #         f"No differences detected in actual and expected results for {path_set.domain} domain.",
+                #         info_map,
+                #     )
                 minified_actual_results = Utility.make_serializable(
                     actual_results, max_depth=om.JSON_OUTPUT_MAX_RECURSIVE_DEPTH
                 )

--- a/RUFAS/e2e_test_results_handler.py
+++ b/RUFAS/e2e_test_results_handler.py
@@ -691,24 +691,6 @@ class E2ETestResultsHandler:
                 with open(expected_results_path, "r") as expected_results_file:
                     expected_results = json.load(expected_results_file)
 
-                # diff = DeepDiff(
-                #     expected_results["expected_results"], actual_results, ignore_order=True, verbose_level=2
-                # )
-                # is_difference_in_results: bool = False if (diff == {}) else True
-                # if is_difference_in_results:
-                #     om.add_warning(
-                #         "End-to-end testing expected results different from new actual results",
-                #         f"Differences will be saved in {output_dir} for {path_set.domain} domain.",
-                #         info_map,
-                #     )
-                # save_path = output_dir / f"{path_set.domain}_update_diff.json"
-                # om.dict_to_file_json(data_dict=diff, path=save_path)
-                # else:
-                #     om.add_log(
-                #         "End-to-end testing expected results matched new actual results",
-                #         f"No differences detected in actual and expected results for {path_set.domain} domain.",
-                #         info_map,
-                #     )
                 minified_actual_results = Utility.make_serializable(
                     actual_results, max_depth=om.JSON_OUTPUT_MAX_RECURSIVE_DEPTH
                 )

--- a/changelog_WIP.md
+++ b/changelog_WIP.md
@@ -121,3 +121,4 @@ This **WIP Changelog** records development changes in progress and not yet inclu
 - [3235](https://github.com/RuminantFarmSystems/RuFaS/pull/3235) - [minor change] [Dependabot] [NoInputChange] [NoOutputChange] Updates file-target of dependabot-change PRs for tagging dev-team members for review.
 - [3256](https://github.com/RuminantFarmSystems/RuFaS/pull/3256) - [minor change] [Branch Alignment] [NoInputChange] [NoOutputChange] Aligning `dev` branch with bug-fixing code from PR 3214 that was merged into `test`.
 - [3260](https://github.com/RuminantFarmSystems/RuFaS/pull/3260) - [minor change] [OutputManager] [NoInputChange] [NoOutputChange] Removes duplicative `report` naming mechanism in `OutputManager`.
+- [3275](https://github.com/RuminantFarmSystems/RuFaS/pull/3260) - [minor change] [E2E Testing] [NoInputChange] [NoOutputChange] Removes `deepdiff` check from the process to update e2e expected results.

--- a/tests/test_e2e_test_results_handler.py
+++ b/tests/test_e2e_test_results_handler.py
@@ -516,7 +516,6 @@ def test_update_expected_test_results(
     output_dir = Path("output_dir")
     mocker.patch("RUFAS.e2e_test_results_handler.OutputManager.__init__", return_value=None)
     add_log = mocker.patch("RUFAS.e2e_test_results_handler.OutputManager.add_log")
-    add_warning = mocker.patch("RUFAS.e2e_test_results_handler.OutputManager.add_warning")
     add_error = mocker.patch("RUFAS.e2e_test_results_handler.OutputManager.add_error")
 
     results_path = mocker.MagicMock()

--- a/tests/test_e2e_test_results_handler.py
+++ b/tests/test_e2e_test_results_handler.py
@@ -564,11 +564,8 @@ def test_update_expected_test_results(
             mock_move.assert_called_once_with(Path(expected_backup_path), results_path.expected_results_path)
         else:
             assert add_error.call_count == 0
-            expected_log_count = 3 if should_update else 2
-            assert add_log.call_count == expected_log_count
+            assert add_log.call_count == 1
             mock_write_json.assert_called_once()
-            if diff:
-                add_warning.assert_called_once()
     else:
         assert add_error.call_count == 1
         assert add_log.call_count == 1

--- a/tests/test_e2e_test_results_handler.py
+++ b/tests/test_e2e_test_results_handler.py
@@ -495,19 +495,18 @@ def test_filter_nested() -> None:
 
 
 @pytest.mark.parametrize(
-    "diff, should_update, matching_path, raise_exception",
+    "diff, matching_path, raise_exception",
     [
-        ({}, False, "output_dir/actual_results.json", None),
-        ({"diff": "some_differences"}, True, "output_dir/actual_results.json", None),
-        ({}, False, None, None),
-        ({}, False, "output_dir/actual_results.json", IOError("File read error")),
-        ({}, False, "output_dir/actual_results.json", json.JSONDecodeError("Invalid JSON", doc="", pos=0)),
+        ({}, "output_dir/actual_results.json", None),
+        ({"diff": "some_differences"}, "output_dir/actual_results.json", None),
+        ({}, None, None),
+        ({}, "output_dir/actual_results.json", IOError("File read error")),
+        ({}, "output_dir/actual_results.json", json.JSONDecodeError("Invalid JSON", doc="", pos=0)),
     ],
 )
 def test_update_expected_test_results(
     mocker: MockerFixture,
     diff: dict[str, str],
-    should_update: bool,
     matching_path: str | None,
     raise_exception: Exception | None,
 ) -> None:


### PR DESCRIPTION
<!-- Provide a short summary of the changes this pull request contains. -->

### Context
<!-- Use this section to link this pull request to other issues, other pull requests, or mention people. -->
Issue(s) closed by this pull request: closes #3224

### What
<!-- Add more detail about the changes that are being made in the pull request. -->
Removes the `deepdiff` comparison of results from e2e test simulation runs from old expected results in the step prior to overwriting those results as the new expected e2e results.

### Why
<!-- Discuss why the changes in this pull request are needed or important. -->
There has been a bottleneck/outright stall out on certain machines (windows/linux primarily) in updating the e2e expected results. Initial indications were that this was occurring at the deepdiff comparison stage. Upon further investigation and reflection, this comparison is not a value add for the process of updating the expected results so it's been removed here to hopefully speed up the process.

### How
<!-- Give an explanation of how this pull request addresses needed changes. -->
In the update expected results code, there was a `deepdiff` comparison of the results from the run that just completed. This step has been removed here.

### Test plan
<!-- Explain how you tested the changes and how you know the code functions as expected. -->
- Run the update expected e2e results task.
- Check that the results are passing with e2e testing.

### Input Changes
<!-- Provide a short summary describing input modifications. -->
<!-- Please include the things that are added, deleted, or modified. -->


### Output Changes
<!-- List all the output variable/function modifications with a short summary. -->
<!-- """- `Class.Function.VariableName`: description""" -->
- N/A

#### Filter
<!-- Provide a filter that can be used to handle the output changes. -->

```json

```
